### PR TITLE
Establishment api

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To get more help on the Angular CLI use `ng help` or go check out the [Angular C
 # Backend Server
 Unfortunately, the backend server code is part of the client project & repo. Until refactoring:
 * `npm run build`
-* `node server` or `PORT=<p1> node server`
+* `node server` or `PORT=<p1> node server` or `nodemon server` or `PORT=<p1> nodemon server`
 
 Database connection parameters can be overridden using environment variables:
 * `DB_HOST` - hostname or IP address

--- a/resources/db/cqc_ddl.sql
+++ b/resources/db/cqc_ddl.sql
@@ -1,0 +1,478 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 11.0
+-- Dumped by pg_dump version 11.0
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: sfcdevdb; Type: DATABASE; Schema: -; Owner: sfcadmin
+--
+
+CREATE DATABASE sfcdevdb WITH TEMPLATE = template0 ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';
+
+
+ALTER DATABASE sfcdevdb OWNER TO sfcadmin;
+
+--\connect sfcdevdb
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: cqc; Type: SCHEMA; Schema: -; Owner: sfcadmin
+--
+
+CREATE SCHEMA cqc;
+
+
+ALTER SCHEMA cqc OWNER TO sfcadmin;
+
+SET default_tablespace = sfcdevtbs_logins;
+
+SET default_with_oids = false;
+
+--
+-- Name: Establishment; Type: TABLE; Schema: cqc; Owner: sfcadmin; Tablespace: sfcdevtbs_logins
+--
+
+CREATE TABLE cqc."Establishment" (
+    "EstablishmentID" integer NOT NULL,
+    "Name" text,
+    "Address" text,
+    "LocationID" text,
+    "PostCode" text,
+    "MainService" text,
+    "IsRegulated" boolean NOT NULL
+);
+
+
+ALTER TABLE cqc."Establishment" OWNER TO sfcadmin;
+
+--
+-- Name: Establishment_EstablishmentID_seq; Type: SEQUENCE; Schema: cqc; Owner: sfcadmin
+--
+
+CREATE SEQUENCE cqc."Establishment_EstablishmentID_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE cqc."Establishment_EstablishmentID_seq" OWNER TO sfcadmin;
+
+--
+-- Name: Establishment_EstablishmentID_seq; Type: SEQUENCE OWNED BY; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER SEQUENCE cqc."Establishment_EstablishmentID_seq" OWNED BY cqc."Establishment"."EstablishmentID";
+
+
+--
+-- Name: Login; Type: TABLE; Schema: cqc; Owner: sfcadmin; Tablespace: sfcdevtbs_logins
+--
+
+CREATE TABLE cqc."Login" (
+    "ID" integer NOT NULL,
+    "RegistrationID" integer NOT NULL,
+    "Username" character varying(200) NOT NULL,
+    "Password" character varying(200) NOT NULL,
+    "SecurityQuestion" character varying(200) NOT NULL,
+    "SecurityQuestionAnswer" character varying(200) NOT NULL,
+    "Active" boolean NOT NULL,
+    "InvalidAttempt" integer NOT NULL
+);
+
+
+ALTER TABLE cqc."Login" OWNER TO sfcadmin;
+
+--
+-- Name: Login_ID_seq; Type: SEQUENCE; Schema: cqc; Owner: sfcadmin
+--
+
+CREATE SEQUENCE cqc."Login_ID_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE cqc."Login_ID_seq" OWNER TO sfcadmin;
+
+--
+-- Name: Login_ID_seq; Type: SEQUENCE OWNED BY; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER SEQUENCE cqc."Login_ID_seq" OWNED BY cqc."Login"."ID";
+
+
+SET default_tablespace = '';
+
+--
+-- Name: TestTable; Type: TABLE; Schema: cqc; Owner: sfcadmin
+--
+
+CREATE TABLE cqc."TestTable" (
+    "FreeText" text
+);
+
+
+ALTER TABLE cqc."TestTable" OWNER TO sfcadmin;
+
+SET default_tablespace = sfcdevtbs_logins;
+
+--
+-- Name: User; Type: TABLE; Schema: cqc; Owner: sfcadmin; Tablespace: sfcdevtbs_logins
+--
+
+CREATE TABLE cqc."User" (
+    "RegistrationID" integer NOT NULL,
+    "FullName" character varying(200) NOT NULL,
+    "JobTitle" character varying(200) NOT NULL,
+    "Email" character varying(200) NOT NULL,
+    "Phone" character varying(200) NOT NULL,
+    "DateCreated" timestamp without time zone NOT NULL,
+    "EstablishmentID" integer NOT NULL,
+    "AdminUser" boolean NOT NULL
+);
+
+
+ALTER TABLE cqc."User" OWNER TO sfcadmin;
+
+--
+-- Name: User_RegistrationID_seq; Type: SEQUENCE; Schema: cqc; Owner: sfcadmin
+--
+
+CREATE SEQUENCE cqc."User_RegistrationID_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE cqc."User_RegistrationID_seq" OWNER TO sfcadmin;
+
+--
+-- Name: User_RegistrationID_seq; Type: SEQUENCE OWNED BY; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER SEQUENCE cqc."User_RegistrationID_seq" OWNED BY cqc."User"."RegistrationID";
+
+
+--
+-- Name: cqclog; Type: TABLE; Schema: cqc; Owner: postgres; Tablespace: sfcdevtbs_logins
+--
+
+CREATE TABLE cqc.cqclog (
+    id integer NOT NULL,
+    success boolean,
+    message character varying(255),
+    createdat timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE cqc.cqclog OWNER TO postgres;
+
+--
+-- Name: cqclog_id_seq; Type: SEQUENCE; Schema: cqc; Owner: postgres
+--
+
+CREATE SEQUENCE cqc.cqclog_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE cqc.cqclog_id_seq OWNER TO postgres;
+
+--
+-- Name: cqclog_id_seq; Type: SEQUENCE OWNED BY; Schema: cqc; Owner: postgres
+--
+
+ALTER SEQUENCE cqc.cqclog_id_seq OWNED BY cqc.cqclog.id;
+
+
+--
+-- Name: location_cqcid_seq; Type: SEQUENCE; Schema: cqc; Owner: sfcadmin
+--
+
+CREATE SEQUENCE cqc.location_cqcid_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE cqc.location_cqcid_seq OWNER TO sfcadmin;
+
+--
+-- Name: location; Type: TABLE; Schema: cqc; Owner: sfcadmin; Tablespace: sfcdevtbs_logins
+--
+
+CREATE TABLE cqc.location (
+    cqcid integer DEFAULT nextval('cqc.location_cqcid_seq'::regclass) NOT NULL,
+    locationid text,
+    locationname text,
+    addressline1 text,
+    addressline2 text,
+    towncity text,
+    county text,
+    postalcode text,
+    mainservice text,
+    createdat timestamp without time zone NOT NULL,
+    updatedat timestamp without time zone
+);
+
+
+ALTER TABLE cqc.location OWNER TO sfcadmin;
+
+--
+-- Name: log_id_seq; Type: SEQUENCE; Schema: cqc; Owner: postgres
+--
+
+CREATE SEQUENCE cqc.log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE cqc.log_id_seq OWNER TO postgres;
+
+--
+-- Name: pcodedata; Type: TABLE; Schema: cqc; Owner: postgres; Tablespace: sfcdevtbs_logins
+--
+
+CREATE TABLE cqc.pcodedata (
+    uprn bigint,
+    sub_building_name character varying,
+    building_name character varying,
+    building_number character varying,
+    street_description character varying,
+    post_town character varying,
+    postcode character varying,
+    local_custodian_code bigint,
+    county character varying,
+    rm_organisation_name character varying
+);
+
+
+ALTER TABLE cqc.pcodedata OWNER TO postgres;
+
+SET default_tablespace = '';
+
+--
+-- Name: pcodedata_old; Type: TABLE; Schema: cqc; Owner: postgres
+--
+
+CREATE TABLE cqc.pcodedata_old (
+    uprn bigint,
+    sub_building_name character varying,
+    building_name character varying,
+    building_number character varying,
+    street_description character varying,
+    post_town character varying,
+    postcode character varying,
+    local_custodian_code bigint,
+    county character varying,
+    rm_organisation_name character varying
+);
+
+
+ALTER TABLE cqc.pcodedata_old OWNER TO postgres;
+
+SET default_tablespace = sfcdevtbs_logins;
+
+--
+-- Name: services; Type: TABLE; Schema: cqc; Owner: sfcadmin; Tablespace: sfcdevtbs_logins
+--
+
+CREATE TABLE cqc.services (
+    id integer NOT NULL,
+    name text,
+    category text,
+    capacityquestion text,
+    currentuptakequestion text,
+    iscqcregistered boolean
+);
+
+
+ALTER TABLE cqc.services OWNER TO sfcadmin;
+
+--
+-- Name: services_id_seq; Type: SEQUENCE; Schema: cqc; Owner: sfcadmin
+--
+
+CREATE SEQUENCE cqc.services_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE cqc.services_id_seq OWNER TO sfcadmin;
+
+--
+-- Name: services_id_seq; Type: SEQUENCE OWNED BY; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER SEQUENCE cqc.services_id_seq OWNED BY cqc.services.id;
+
+
+--
+-- Name: Establishment EstablishmentID; Type: DEFAULT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc."Establishment" ALTER COLUMN "EstablishmentID" SET DEFAULT nextval('cqc."Establishment_EstablishmentID_seq"'::regclass);
+
+
+--
+-- Name: Login ID; Type: DEFAULT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc."Login" ALTER COLUMN "ID" SET DEFAULT nextval('cqc."Login_ID_seq"'::regclass);
+
+
+--
+-- Name: User RegistrationID; Type: DEFAULT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc."User" ALTER COLUMN "RegistrationID" SET DEFAULT nextval('cqc."User_RegistrationID_seq"'::regclass);
+
+
+--
+-- Name: cqclog id; Type: DEFAULT; Schema: cqc; Owner: postgres
+--
+
+ALTER TABLE ONLY cqc.cqclog ALTER COLUMN id SET DEFAULT nextval('cqc.cqclog_id_seq'::regclass);
+
+
+--
+-- Name: services id; Type: DEFAULT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc.services ALTER COLUMN id SET DEFAULT nextval('cqc.services_id_seq'::regclass);
+
+
+SET default_tablespace = '';
+
+--
+-- Name: cqclog CQCLog_pkey; Type: CONSTRAINT; Schema: cqc; Owner: postgres
+--
+
+ALTER TABLE ONLY cqc.cqclog
+    ADD CONSTRAINT "CQCLog_pkey" PRIMARY KEY (id);
+
+
+--
+-- Name: location location_pkey; Type: CONSTRAINT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc.location
+    ADD CONSTRAINT location_pkey PRIMARY KEY (cqcid);
+
+
+--
+-- Name: Login pk_Login; Type: CONSTRAINT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc."Login"
+    ADD CONSTRAINT "pk_Login" PRIMARY KEY ("ID");
+
+
+--
+-- Name: User pk_User; Type: CONSTRAINT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc."User"
+    ADD CONSTRAINT "pk_User" PRIMARY KEY ("RegistrationID");
+
+
+--
+-- Name: services services_pkey; Type: CONSTRAINT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc.services
+    ADD CONSTRAINT services_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: Login uc_Login_Username; Type: CONSTRAINT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc."Login"
+    ADD CONSTRAINT "uc_Login_Username" UNIQUE ("Username");
+
+
+--
+-- Name: location uniqlocationid; Type: CONSTRAINT; Schema: cqc; Owner: sfcadmin
+--
+
+ALTER TABLE ONLY cqc.location
+    ADD CONSTRAINT uniqlocationid UNIQUE (locationid);
+
+
+--
+-- Name: TABLE cqclog; Type: ACL; Schema: cqc; Owner: postgres
+--
+
+--Grant ALL ON TABLE cqc.cqclog TO sfcadmin;
+
+
+--
+-- Name: SEQUENCE cqclog_id_seq; Type: ACL; Schema: cqc; Owner: postgres
+--
+
+--Grant USAGE ON SEQUENCE cqc.cqclog_id_seq TO sfcadmin;
+
+
+--
+-- Name: TABLE pcodedata; Type: ACL; Schema: cqc; Owner: postgres
+--
+
+--Grant ALL ON TABLE cqc.pcodedata TO sfcadmin;
+
+
+--
+-- Name: TABLE pcodedata_old; Type: ACL; Schema: cqc; Owner: postgres
+--
+
+--Grant ALL ON TABLE cqc.pcodedata_old TO sfcadmin;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/resources/establishment_api.schema.json
+++ b/resources/establishment_api.schema.json
@@ -23,8 +23,8 @@
                 "fullname" : {
                     "$ref" : "establishment_types.schema.json#/definitions/Fullname"
                 },
-                "establishmentName" : {
-                    "$ref" : "establishment_types.schema.json#/definitions/EstablishmentName"
+                "establishment" : {
+                    "$ref" : "establishment_types.schema.json#/definitions/Establishment"
                 },
                 "mainServiceName" : {
                     "$ref" : "establishment_types.schema.json#/definitions/ServiceName"

--- a/resources/establishment_api.schema.json
+++ b/resources/establishment_api.schema.json
@@ -26,11 +26,8 @@
                 "establishment" : {
                     "$ref" : "establishment_types.schema.json#/definitions/Establishment"
                 },
-                "mainServiceName" : {
-                    "$ref" : "establishment_types.schema.json#/definitions/ServiceName"
-                },
-                "mainServiceID" : {
-                    "$ref" : "establishment_types.schema.json#/definitions/ID"
+                "mainService" : {
+                    "$ref" : "establishment_types.schema.json#/definitions/Service"
                 },
                 "isFirstLogin" : {
                     "description" : "true if this is the first time user has logged in",

--- a/resources/establishment_api.schema.json
+++ b/resources/establishment_api.schema.json
@@ -17,7 +17,7 @@
             "required": ["username", "password"]
         },
         "loginResponse" : {
-            "description" : "the login API response (on success)",
+            "description" : "the login API response (on success); TODO - enforce the child attributes of establishment and mainService",
             "type" : "object",
             "properties" : {
                 "fullname" : {

--- a/resources/establishment_api.schema.json
+++ b/resources/establishment_api.schema.json
@@ -13,7 +13,8 @@
                 "password" : {
                     "$ref" : "establishment_types.schema.json#/definitions/Password"
                 }
-            }
+            },
+            "required": ["username", "password"]
         },
         "loginResponse" : {
             "description" : "the login API response (on success)",

--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -8,30 +8,55 @@
             "minimum" : 0
         },
         "Username" : {
-            "type" : "string"
+            "type" : "string",
+            "minLength": 3,
+            "maxLength": 120
         },
         "Password" : {
-            "type" : "string"
+            "type" : "string",
+            "minLength": 8,
+            "maxLength": 120
         },
         "Fullname" : {
             "description" : "The fullname of a user",
             "type" : "string",
-            "minLength" : 3
+            "minLength" : 3,
+            "maxLength": 120
+        },
+        "Address" : {
+            "description" : "Concatenated address - excluding postcode",
+            "type" : "string",
+            "minLength" : 3,
+            "maxLength" : 120
+        },
+        "Postcode" : {
+            "description": "A UK postcode",
+            "type": "string",
+            "pattern" : "([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})"
+        },
+        "LocationRef" : {
+            "description" : "A unique reference associated to an Establishment",
+            "type" : "string",
+            "minLength": 8,
+            "maxLength": 12
         },
         "EstablishmentName" : {
             "description": "the name of the Establishment",
             "type" : "string",
-            "minLength" : 3
+            "minLength" : 3,
+            "maxLength": 120
         },
         "ServiceName" : {
             "description": "the name of the Service",
             "type" : "string",
-            "minLength" : 3
+            "minLength" : 3,
+            "maxLength": 120
         },
         "ServiceCategory" : {
             "description": "the category associated with the Service",
             "type" : "string",
-            "minLength" : 3
+            "minLength" : 3,
+            "maxLength": 120
         },
 		"EmployerType" : {
 			"description" : "The type of employer",
@@ -43,53 +68,11 @@
                     "enum" : ["Private Sector", "Voluntary or Charity", "Other"]
 				},
 				"id" : {
-					"description" : "Optional integer representing the employer type",
+					"description" : "Optional integer representing the employer type: 1=Private, 2=Voluntary, 3=Other",
 					"$ref" : "#/definitions/ID"
 				}
 			},
 			"required" : ["value"]
-        },
-        "Service" : {
-            "description" : "The Service that can be performed at an Establishment",
-            "properties" : {
-                "id" : {
-                    "description" : "the unique reference of the service type",
-                    "$ref" : "#/definitions/ID"
-                },
-                "key" : {
-                    "description": "a textual representation of the service type; replacing spaces 'value' with underscores and capitalising",
-                    "type" : "string",
-                    "minLength" : 3
-                },
-                "name" : {
-                    "description" : "the display name of the service type",
-                    "type" : "string",
-                    "minLength" : 3
-                },
-                "category" : {
-                    "description"  : "the category of this service"
-                },
-                "isCQC" : {
-                    "description": "if true, this service is defined by CQC",
-                    "type" : "boolean"
-                },
-                "isMyService" : {
-                    "description" : "optional flag that when true identifies this service being one of the services provided by the Establishment (returned by api/myServices)",
-                    "type" : "boolean"
-                },
-                "capacity" : {
-                    "description" : "optional set of capacity questions and, if relevant (associated to a known Establishment), the answers",
-                    "type" : "array",
-                    "items" : {
-                        "$ref" : "#/definitions/ServiceCapacity"
-                    },
-                    "minItems" : 1
-                },
-                "isMainService" : {
-                    "description" : "optional flag, that if true, highlights this service is the main service for a given establishment"
-                }
-            },
-            "required" : ["id"]
         },
         "ServiceCapacity" : {
             "description" : "Optionally associated to a Service, is one or more questions around capacity",
@@ -116,6 +99,48 @@
                 }
             }
         },
+        "Service" : {
+            "description" : "The Service that can be performed at an Establishment",
+            "properties" : {
+                "id" : {
+                    "description" : "the unique reference of the service type",
+                    "$ref" : "#/definitions/ID"
+                },
+                "key" : {
+                    "description": "a textual representation of the service type; replacing spaces 'value' with underscores and capitalising",
+                    "type" : "string",
+                    "minLength" : 3
+                },
+                "name" : {
+                    "description" : "the display name of the service type",
+                    "$ref" : "#/definitions/ServiceName"
+                },
+                "category" : {
+                    "description"  : "the category of this service",
+                    "$ref" : "#/definitions/ServiceCategory"
+                },
+                "isCQC" : {
+                    "description": "if true, this service is defined by CQC",
+                    "type" : "boolean"
+                },
+                "isMyService" : {
+                    "description" : "optional flag that when true identifies this service being one of the services provided by the Establishment (returned by api/myServices)",
+                    "type" : "boolean"
+                },
+                "capacity" : {
+                    "description" : "optional set of capacity questions and, if relevant (associated to a known Establishment), the answers",
+                    "type" : "array",
+                    "items" : {
+                        "$ref" : "#/definitions/ServiceCapacity"
+                    },
+                    "minItems" : 1
+                },
+                "isMainService" : {
+                    "description" : "optional flag, that if true, highlights this service is the main service for a given establishment"
+                }
+            },
+            "required" : ["id"]
+        },
         "ServiceGroup" : {
             "description" : "A collection of services having the same cateogory",
             "type" : "object",
@@ -132,6 +157,45 @@
                     "minItems": 1
                 }
             }
+        },
+        "Establishment" : {
+            "description" : "A physical location offering care services; can be commercial or private location",
+            "type" : "object",
+            "properties" : {
+                "id" : {
+                    "description" : "The unique reference for this estasblishment",
+                    "$ref" : "#/definitions/ID"
+                },
+                "name" : {
+                    "description" : "The given name ofthis establishment",
+                    "$ref" : "#/definitions/EstablishmentName"
+                },
+                "address" : {
+                    "description": "The given (concatenated) address of this establishment",
+                    "$ref" : "#/definitions/Address"
+                },
+                "postcode" : {
+                    "description": "The given postcode of this establishment",
+                    "$ref" : "#/definitions/Postcode"
+                },
+                "locationRef" : {
+                    "description": "An optional reference ",
+                    "$ref" : "#/definitions/LocationRef"
+                },
+                "isRegulated" : {
+                    "description": "True if this establishment is regulated by CQC",
+                    "type": "boolean"
+                },
+                "mainService" : {
+                    "description" : "(Optionally), the primary service associated with this Establishment",
+                    "$ref" : "#/definitions/Service"
+                },
+                "employerType" : {
+                    "description": "The type of the employer",
+                    "$ref" : "#/definitions/EmployerType"
+                }
+            },
+            "required" : ["id", "name"]
         }
     }
 }

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ var locations = require('./server/routes/locations');
 var postcodes = require('./server/routes/postcodes');
 var services = require('./server/routes/services');
 var registration = require('./server/routes/registration');
+var tmpLogin = require('./server/routes/tmpLogin');
 
 var errors = require('./server/routes/errors');
 
@@ -32,6 +33,7 @@ app.use('/api/postcodes', postcodes);
 app.use('/api/services', services);
 app.use('/api/registration', registration);
 app.use('/api/errors', errors);
+app.use('/api/login', tmpLogin);
 app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'dist/index.html'));
 });

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -1,8 +1,8 @@
 /* jshint indent: 2 */
 
 module.exports = function(sequelize, DataTypes) {
-  return sequelize.define('establishment', {
-    establishmentId: {
+  const Establishment = sequelize.define('establishment', {
+    id: {
       type: DataTypes.INTEGER,
       allowNull: false,
       primaryKey: true,
@@ -46,4 +46,10 @@ module.exports = function(sequelize, DataTypes) {
     createdAt: false,
     updatedAt: false
   });
+
+  Establishment.associate = (models) => {
+
+  };
+
+  return Establishment;
 };

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -1,0 +1,49 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  return sequelize.define('establishment', {
+    establishmentId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+      field: '"EstablishmentID"'
+    },
+    name: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      unique: true,
+      field: '"Name"'
+    },
+    address: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"Address"'
+    },
+    locationId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"LocationID"'
+    },
+    postcode: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"Postcode"'
+    },
+    isRegulated: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      field: '"IsRegulated"'
+    },
+    mainServiceId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"MainServiceId"'
+    }
+  }, {
+    tableName: '"Establishment"',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+};

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -48,7 +48,11 @@ module.exports = function(sequelize, DataTypes) {
   });
 
   Establishment.associate = (models) => {
-
+    Establishment.belongsTo(models.services, {
+      foreignKey: 'mainServiceId',
+      targetKey: 'id',
+      as: 'mainService'
+    })
   };
 
   return Establishment;

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -11,13 +11,13 @@ module.exports = function(sequelize, DataTypes) {
     },
     name: {
       type: DataTypes.TEXT,
-      allowNull: true,
+      allowNull: false,
       unique: true,
       field: '"Name"'
     },
     address: {
       type: DataTypes.TEXT,
-      allowNull: true,
+      allowNull: false,
       field: '"Address"'
     },
     locationId: {
@@ -27,12 +27,12 @@ module.exports = function(sequelize, DataTypes) {
     },
     postcode: {
       type: DataTypes.TEXT,
-      allowNull: true,
+      allowNull: false,
       field: '"Postcode"'
     },
     isRegulated: {
       type: DataTypes.BOOLEAN,
-      allowNull: true,
+      allowNull: false,
       field: '"IsRegulated"'
     },
     mainServiceId: {

--- a/server/models/login.js
+++ b/server/models/login.js
@@ -1,0 +1,54 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  return sequelize.define('login', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+      field: '"ID"'
+    },
+    registrationId: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      unique: true,
+      field: '"RegistrationID"'
+    },
+    username: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"Username"'
+    },
+    password: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: "Password"
+    },
+    securityQuestion: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"SecurityQuestion"'
+    },
+    securityAnswer: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      field: '"SecurityQuestionAnswer"'
+    },
+    isActive: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      field: '"Active"'
+    },
+    invalidAttempt: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"InvalidAttempt"'
+    }
+  }, {
+    tableName: '"Login"',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+};

--- a/server/models/login.js
+++ b/server/models/login.js
@@ -46,6 +46,11 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.INTEGER,
       allowNull: false,
       field: '"InvalidAttempt"'
+    },
+    firstLogin: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"FirstLogin'
     }
   }, {
     tableName: '"Login"',

--- a/server/models/login.js
+++ b/server/models/login.js
@@ -1,7 +1,8 @@
 /* jshint indent: 2 */
+const models = require('./index');
 
 module.exports = function(sequelize, DataTypes) {
-  return sequelize.define('login', {
+  const Login = sequelize.define('login', {
     id: {
       type: DataTypes.INTEGER,
       allowNull: false,
@@ -11,28 +12,29 @@ module.exports = function(sequelize, DataTypes) {
     },
     registrationId: {
       type: DataTypes.TEXT,
-      allowNull: true,
+      allowNull: false,
       unique: true,
       field: '"RegistrationID"'
     },
     username: {
       type: DataTypes.TEXT,
-      allowNull: true,
+      allowNull: false,
+      unique: true,
       field: '"Username"'
     },
     password: {
       type: DataTypes.TEXT,
-      allowNull: true,
+      allowNull: false,
       field: "Password"
     },
     securityQuestion: {
       type: DataTypes.TEXT,
-      allowNull: true,
+      allowNull: false,
       field: '"SecurityQuestion"'
     },
     securityAnswer: {
       type: DataTypes.BOOLEAN,
-      allowNull: true,
+      allowNull: false,
       field: '"SecurityQuestionAnswer"'
     },
     isActive: {
@@ -42,7 +44,7 @@ module.exports = function(sequelize, DataTypes) {
     },
     invalidAttempt: {
       type: DataTypes.INTEGER,
-      allowNull: true,
+      allowNull: false,
       field: '"InvalidAttempt"'
     }
   }, {
@@ -51,4 +53,13 @@ module.exports = function(sequelize, DataTypes) {
     createdAt: false,
     updatedAt: false
   });
+
+  Login.associate = (models) => {
+    Login.belongsTo(models.user, {
+      foreignKey: 'registrationId',
+      targetKey: 'id'
+    });
+  };
+
+  return Login;
 };

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,7 +1,7 @@
 /* jshint indent: 2 */
 
 module.exports = function(sequelize, DataTypes) {
-  return sequelize.define('user', {
+  const User = sequelize.define('user', {
     id: {
       type: DataTypes.INTEGER,
       allowNull: false,
@@ -51,4 +51,13 @@ module.exports = function(sequelize, DataTypes) {
     createdAt: false,
     updatedAt: false
   });
+
+  User.associate = (models) => {
+    User.belongsTo(models.establishment, {
+      foreignKey : 'establishmentId',
+      targetKey: 'id'
+    })
+  };
+
+  return User;
 };

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,0 +1,54 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  return sequelize.define('user', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+      field: '"RegistrationID"'
+    },
+    fullname: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      unique: false,
+      field: '"FullName"'
+    },
+    jobTitle: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"JobTitle"'
+    },
+    email: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: "Email"
+    },
+    phone: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"Phone"'
+    },
+    created: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: '"DateCreated"'
+    },
+    establishmentId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"EstablishmentID"'
+    },
+    isAdmin: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      field: '"AdminUser"'
+    }
+  }, {
+    tableName: '"User"',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+};

--- a/server/routes/tmpLogin.js
+++ b/server/routes/tmpLogin.js
@@ -44,11 +44,11 @@ router.route('/').post(async (req, res) => {
                     results.user.establishment.name);
 
         res.status(200);
-        return res.json({
-          "success" : 1,
-          "message" : "Successful login so there"
-        });
-
+        return res.json(formatSuccessulLoginResponse(
+          results.user.fullname,
+          results.user.establishment.id,
+          results.user.establishment.name
+        ));
       } else {
         // TODO - improve logging/error reporting
         console.error('tmpLogin::post - user not found');
@@ -68,5 +68,16 @@ router.route('/').post(async (req, res) => {
   }
 
 });
+
+// TODO: enforce JSON schema
+const formatSuccessulLoginResponse = (fullname, establishmentId, establishmentName) => {
+  return {
+    fullname,
+    establishment: {
+      id: establishmentId,
+      name: establishmentName
+    }
+  };
+};
 
 module.exports = router;

--- a/server/routes/tmpLogin.js
+++ b/server/routes/tmpLogin.js
@@ -22,15 +22,26 @@ router.route('/').post(async (req, res) => {
         attributes: ['id', 'isActive', 'registrationId'],
         include: [ {
           model: models.user,
-          attributes: ['fullname', 'establishmentId']
+          attributes: ['fullname'],
+          include: [{
+            model: models.establishment,
+            attributes: ['id', 'name']
+          }]
         }]
       });
 
       if (results && results.registrationId !== 'undefined' && results.registrationId > 0) {
+        // found user
         const registrationId = results.registrationId;
 
-        // found user
-        console.log('WA DEBUG: found user with registration ID and full name: ', registrationId, ' ', results.user.fullname);
+        console.log('WA DEBUG: found user with registration ID and full name and establishment name/id: ',
+                    registrationId,
+                    ' ',
+                    results.user.fullname,
+                    ' ',
+                    results.user.establishment.id,
+                    ' ',
+                    results.user.establishment.name);
 
         res.status(200);
         return res.json({

--- a/server/routes/tmpLogin.js
+++ b/server/routes/tmpLogin.js
@@ -25,18 +25,26 @@ router.route('/').post(async (req, res) => {
           attributes: ['fullname'],
           include: [{
             model: models.establishment,
-            attributes: ['id', 'name']
+            attributes: ['id', 'name'],
+            include: [{
+              model: models.services,
+              as: 'mainService',
+              attributes: ['id', 'name']
+            }]
           }]
         }]
       });
 
       if (results && results.registrationId !== 'undefined' && results.registrationId > 0) {
+
+        //console.log('WA DEBUG: main service: ', results.user.establishment.mainService)
+
         // successfully logged in
         const response = formatSuccessulLoginResponse(
           results.user.fullname,
           results.firstLogin,
-          results.user.establishment.id,
-          results.user.establishment.name
+          results.user.establishment,
+          results.user.establishment.mainService
         );
 
         // check if this is the first time logged in and if so, update the "FirstLogin" timestamp
@@ -69,13 +77,18 @@ router.route('/').post(async (req, res) => {
 });
 
 // TODO: enforce JSON schema
-const formatSuccessulLoginResponse = (fullname, firstLoginDate, establishmentId, establishmentName) => {
+const formatSuccessulLoginResponse = (fullname, firstLoginDate, establishment, mainService) => {
+  // note - the mainService can be null
   return {
     fullname,
     isFirstLogin: firstLoginDate ? false : true,
     establishment: {
-      id: establishmentId,
-      name: establishmentName
+      id: establishment.id,
+      name: establishment.name
+    },
+    mainService: {
+      id: mainService ? mainService.id : null,
+      name: mainService ? mainService.name : null
     }
   };
 };

--- a/server/routes/tmpLogin.js
+++ b/server/routes/tmpLogin.js
@@ -1,0 +1,57 @@
+var express = require('express');
+var router = express.Router();
+const models = require('../models/index');
+
+// TODO: JSON schema validation enforcement; for now, they simple have to be defined and not empty (and username only because we're not interested in password in tmpLogin)
+const validateLoginParameters = (username, password) => {
+  return username && typeof username === 'string' && username.length > 0;
+};
+
+// GET Location API by locationId
+router.route('/').post(async (req, res) => {
+  if (validateLoginParameters(req.body.username, req.body.password)) {
+    const username = req.body.username;
+
+    try {
+      // user must exist and must be active
+      let results = await models.login.findOne({
+        where: {
+          username,
+          isActive: true
+        },
+        attributes: ['id', 'isActive', 'registrationId']
+      });
+
+      if (results.registrationId && results.registrationId > 0) {
+        const registrationId = results.registrationId;
+
+        // found user
+        console.log('WA DEBUG: found user with registration ID: ', registrationId);
+
+        res.status(200);
+        return res.json({
+          "success" : 1,
+          "message" : "Successful login so there"
+        });
+
+      } else {
+        // TODO - improve logging/error reporting
+        console.error('tmpLogin::post - user not found');
+        res.status(401).send('Authentication failed');
+      }      
+  
+    } catch (err) {
+      // TODO - improve logging/error reporting
+      console.error('tmpLogin::post - exception: ', err);
+      res.status(503).send('Unable to authenticate user');
+    }
+
+  } else {
+    // TODO - improve logging/error reporting
+    console.error('tmpLogin::post - failed validation');
+    res.status(400).send('Expect username/password as JSON');
+  }
+
+});
+
+module.exports = router;

--- a/server/routes/tmpLogin.js
+++ b/server/routes/tmpLogin.js
@@ -19,14 +19,18 @@ router.route('/').post(async (req, res) => {
           username,
           isActive: true
         },
-        attributes: ['id', 'isActive', 'registrationId']
+        attributes: ['id', 'isActive', 'registrationId'],
+        include: [ {
+          model: models.user,
+          attributes: ['fullname', 'establishmentId']
+        }]
       });
 
-      if (results.registrationId && results.registrationId > 0) {
+      if (results && results.registrationId !== 'undefined' && results.registrationId > 0) {
         const registrationId = results.registrationId;
 
         // found user
-        console.log('WA DEBUG: found user with registration ID: ', registrationId);
+        console.log('WA DEBUG: found user with registration ID and full name: ', registrationId, ' ', results.user.fullname);
 
         res.status(200);
         return res.json({

--- a/server/routes/tmpLogin.js
+++ b/server/routes/tmpLogin.js
@@ -72,7 +72,7 @@ router.route('/').post(async (req, res) => {
 const formatSuccessulLoginResponse = (fullname, firstLoginDate, establishmentId, establishmentName) => {
   return {
     fullname,
-    firstLogin: firstLoginDate ? false : true,
+    isFirstLogin: firstLoginDate ? false : true,
     establishment: {
       id: establishmentId,
       name: establishmentName


### PR DESCRIPTION
Morning Nasir

Firstly, please *do NOT delete* the branch.

I've not worked with `sequelize` before (first time with SQL databases and node.js - I've always used noSQL with node.js). So I got a head start on the faux login API, not least because the registration did not define the Establishment, Login and User types and their corresponding relationships, but had defined Services.

This pull request is my implementation for the faux login.  It does minimum validation on username, which it uses to resolve user, establishment and establishment's main service (if it is defined).

I've updated the JSON schema definition as I've gone along; not enforcing schema validation just yet though. Really need to separate the backend into its own repo first (not wanting to pollute the UI `package.json` with backend dependencies - which includes unit tests.

You'll be needing most of the changes here for your true `login` API.

No unit tests yet; I want to move onto employer type now, which includes validating Authorization header in a common utility (which you'll replace when the true `login` API is available).

I want to get some breadth across the backend services so Denny is playing catch up, rather than a waiting game, and so Maria/Pete can see agree the results before they go on leave for Xmas.

Thanks