### PR TITLE
Establishment api

### DIFF
--- a/server/models/api/capacity.js
+++ b/server/models/api/capacity.js
@@ -1,0 +1,76 @@
+// this Capacity API model takes DB model type for Capacity and returns various different objects
+//  properly structured to returning in responses
+
+const localformatCapacity = (thisCapacity, thisQuestion, showQuestionDetail=false) => {
+  const myCapacity = {
+    question: thisQuestion.question    
+  };
+  if (showQuestionDetail) {
+    myCapacity.questionId = thisQuestion.id
+  }
+
+  // answer can be primary value or contained within a question
+  if (thisCapacity && thisCapacity.answer) {
+    myCapacity.answer = thisCapacity.answer;
+  }
+  if (thisQuestion && thisQuestion.answer) {
+    myCapacity.answer = thisQuestion.answer;
+  }
+  return myCapacity;
+};
+
+exports.singleCapacity = localformatCapacity;
+
+exports.capacitiesJSON = (givenCapacities) => {
+  const capacities = [];
+  if (givenCapacities && Array.isArray(givenCapacities)) {
+    givenCapacities.forEach(thisCapacity => {
+      capacities.push(localformatCapacity(thisCapacity, thisCapacity.reference, true));
+    });
+  }
+
+  return capacities;
+};
+
+exports.serviceCapacitiesJSON = (givenServiceCapacities) => {
+  const capacities = [];
+  if (givenServiceCapacities && Array.isArray(givenServiceCapacities)) {
+    givenServiceCapacities.forEach(thisService => {
+      capacities.push(localformatCapacity(undefined, thisService));
+    });
+  }
+
+  return capacities;
+};
+
+
+exports.serviceCapacitiesByCategoryJSON = (givenServiceCapacities) => {
+  let serviceGroupsMap = new Map();
+
+  if (givenServiceCapacities && Array.isArray(givenServiceCapacities)) {
+    givenServiceCapacities.forEach(thisService => {
+      const mapKey = `${thisService.service.category} - ${thisService.service.name}`;
+
+      let thisCategoryGroup = serviceGroupsMap.get(mapKey);
+      if (!thisCategoryGroup) {
+        // group (category) does not yet exist, so create the group hash
+        //  with an array of one (this service type)
+        serviceGroupsMap.set(mapKey, [localformatCapacity(undefined, thisService, true)]);
+      } else {
+        // group (category) already exists; it's already an array, so add this current service type
+        thisCategoryGroup.push(localformatCapacity(undefined, thisService, true));
+      }
+    });
+  }
+
+  // now iterate over the map (group by category) and construct the target Javascript object
+  const serviceGroups = [];
+  serviceGroupsMap.forEach((key,value) => {
+    serviceGroups.push({
+      service: value,
+      questions: key
+    });
+  });
+
+  return serviceGroups;
+};

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -65,6 +65,17 @@ module.exports = function(sequelize, DataTypes) {
       targetKey: 'id',
       as: 'otherServices'
     });
+    // Establishment.belongsToMany(models.serviceCapacity, {
+    //   through: 'establishmentCapacity',
+    //   foreignKey: 'establishmentId',
+    //   targetKey: 'establishmentId',
+    //   as: 'capacity'
+    // });
+    Establishment.hasMany(models.establishmentCapacity, {
+      foreignKey: 'establishmentId',
+      sourceKey: 'id',
+      as: 'capacity'
+    });
   };
 
   return Establishment;

--- a/server/models/establishmentCapacity.js
+++ b/server/models/establishmentCapacity.js
@@ -6,6 +6,7 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.INTEGER,
       allowNull: false,
       primaryKey: true,
+      autoIncrement: true,
       field: '"EstablishmentCapacityID"'
     },
     serviceCapacityId: {

--- a/server/models/establishmentCapacity.js
+++ b/server/models/establishmentCapacity.js
@@ -1,0 +1,48 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  const EstablishmentCapacity = sequelize.define('establishmentCapacity', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      field: '"EstablishmentCapacityID"'
+    },
+    serviceCapacityId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"ServiceCapacityID"'
+    },
+    establishmentId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"EstablishmentID"'
+    },
+    answer: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"Answer"'
+    }
+  }, {
+    tableName: '"EstablishmentCapacity"',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+
+  EstablishmentCapacity.associate = (models) => {
+    // EstablishmentCapacity.hasOne(models.serviceCapacity, {
+    //   foreignKey: 'id',
+    //   targetKey: 'serviceCapacityId',
+    //   sourceKey: 'id',
+    //   as: 'reference'
+    // });
+    EstablishmentCapacity.belongsTo(models.serviceCapacity, {
+      foreignKey: 'serviceCapacityId',
+      targetKey: 'id',
+      as: 'reference'
+    });
+  };
+
+  return EstablishmentCapacity;
+};

--- a/server/models/establishmentServices.js
+++ b/server/models/establishmentServices.js
@@ -15,7 +15,7 @@ module.exports = function(sequelize, DataTypes) {
       field: '"ServiceID"'
     }
   }, {
-    tableName: '"OtherServices"',
+    tableName: '"EstablishmentServices"',
     schema: 'cqc',
     createdAt: false,
     updatedAt: false

--- a/server/models/serviceCapacity.js
+++ b/server/models/serviceCapacity.js
@@ -1,0 +1,42 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  const ServiceCapacity = sequelize.define('serviceCapacity', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      field: '"ServiceCapacityID"'
+    },
+    serviceId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"ServiceID"'
+    },
+    seq: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"Sequence"'
+    },
+    question: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"Question"'
+    }
+  }, {
+    tableName: '"ServicesCapacity"',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+
+  ServiceCapacity.associate = (models) => {
+    ServiceCapacity.belongsTo(models.services, {
+      foreignKey: 'serviceId',
+      targetKey: 'id',
+      as: 'service'
+    });
+  };
+
+  return ServiceCapacity;
+};

--- a/server/models/services.js
+++ b/server/models/services.js
@@ -27,6 +27,11 @@ module.exports = function(sequelize, DataTypes) {
     iscqcregistered: {
       type: DataTypes.BOOLEAN,
       allowNull: true
+    },
+    isMain: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      field: 'ismain'
     }
   }, {
     tableName: 'services',

--- a/server/routes/establishments/capacity.js
+++ b/server/routes/establishments/capacity.js
@@ -1,0 +1,277 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../../models');
+const CapacityFormatters = require('../../models/api/capacity');
+const ServiceFormatters = require('../../models/api/services');
+
+// parent route defines the "id" parameter
+
+// gets current set of capcities for the known establishment
+// takes optional query paramter "all" - values 'true' or 'false' (default), which is set, returns 'allCapacities'
+router.route('/').get(async (req, res) => {
+  const establishmentId = req.establishmentId;
+  const includeAllCapacities = req.query.all && req.query.all === 'true' ? true : false;
+
+  try {
+    let results = await models.establishment.findOne({
+      where: {
+        id: establishmentId
+      },
+      attributes: ['id', 'name', 'isRegulated', 'mainServiceId'],
+      include: [{
+        model: models.services,
+        as: 'mainService',
+        attributes: ['id', 'name']
+      },{
+        model: models.establishmentCapacity,
+        as: 'capacity',
+        attributes: ['id', 'answer'],
+        include: [{
+          model: models.serviceCapacity,
+          as: 'reference',
+          attributes: ['id', 'question']
+        }]
+      }]
+    });
+
+    let allServiceCapacityQuestions = null;
+    if (results && results.id && (establishmentId === results.id)) {
+      if (includeAllCapacities) {
+        // fetch the main service id and all the associated 'other services' by id only
+        const allCapacitiesResults = await models.establishment.findOne({
+          where: {
+            id: establishmentId
+          },
+          attributes: ['id'],
+          include: [{
+            model: models.services,
+            as: 'otherServices',
+            attributes: ['id'],
+          },{
+            model: models.services,
+            as: 'mainService',
+            attributes: ['id']
+          }]
+        });
+
+        const allAssociatedServiceIndices = [];
+        if (allCapacitiesResults && allCapacitiesResults.id) {
+          // merge tha main and other service ids
+          if (allCapacitiesResults.mainService.id) {
+            allAssociatedServiceIndices.push(allCapacitiesResults.mainService.id);
+          }
+          // TODO: there is a much better way to derference (transpose) the id on an Array of objects
+          //  viz. Map
+          if (allCapacitiesResults.otherServices) {
+            allCapacitiesResults.otherServices.forEach(thisService => allAssociatedServiceIndices.push(thisService.id));
+          }
+        }
+
+        // now fetch all the questions for the given set of combined services
+        if (allAssociatedServiceIndices.length > 0) {
+          allServiceCapacityQuestions = await models.serviceCapacity.findAll({
+            where: {
+              serviceId: allAssociatedServiceIndices
+            },
+            attributes: ['id', 'seq', 'question'],
+            order: [
+              ['seq', 'ASC']
+            ],
+            include: [{
+              model: models.services,
+              as: 'service',
+              attributes: ['id', 'category', 'name'],
+              order: [
+                ['category', 'ASC'],
+                ['name', 'ASC']
+              ]
+            }]
+          });
+
+        }
+      }
+
+      res.status(200);
+      return res.json(formatCapacityResponse(results, allServiceCapacityQuestions));
+    } else {
+      return res.status(404).send('Not found');
+    }
+
+  } catch (err) {
+    // TODO - improve logging/error reporting
+    console.error('establishment::capacity GET - failed', err);
+    return res.status(503).send(`Unable to retrive Establishment: ${req.params.id}`);
+  }
+});
+
+// updates the current set of other services for the known establishment
+router.route('/').post(async (req, res) => {
+  const establishmentId = req.establishmentId;
+  const newCapacities = req.body.capacities;
+
+/*   // validate input
+  if (!newServices || !Array.isArray(newServices)) {
+    console.error('establishment::capacity POST - unexpected input: ', newServices);
+    return res.status(400).send('Expected (new) services as JSON');
+  }
+
+  try {
+    let results = await models.establishment.findOne({
+      where: {
+        id: establishmentId
+      },
+      attributes: ['id', 'isRegulated']
+    });
+
+    if (results && results.id && (establishmentId === results.id)) {
+      // we have found the establishment
+
+      // get the set of all services that can be associated with this establishment
+      let allServicesResults = null;
+      if (results.isRegulated) {
+        allServicesResults = await models.services.findAll({
+          where: {
+            iscqcregistered: true
+          },
+          order: [
+            ['category', 'ASC'],
+            ['name', 'ASC']
+          ]
+        });
+      } else {
+        allServicesResults = await models.services.findAll({
+          order: [
+            ['category', 'ASC'],
+            ['name', 'ASC']
+          ]
+        });  
+      }
+
+      if (allServicesResults) {
+        // within a transaction first delete all existing 'other services', before creating new ones
+        await models.sequelize.transaction(async t => {
+          let deleteAllExisting = await models.establishmentServices.destroy({
+            where: {
+              establishmentId
+            }
+          });
+
+          // create new service associations
+          let newServicesPromises = [];
+          newServices.forEach(thisNewService => {
+            if (thisNewService && thisNewService.id && parseInt(thisNewService.id) === thisNewService.id) {
+              // ensure this suggested service is allowed for this given Establishment
+              const isValidService = allServicesResults.find(refService => refService.id === thisNewService.id);
+
+              if (isValidService) {
+                newServicesPromises.push(models.establishmentServices.create({
+                  establishmentId,
+                  serviceId: thisNewService.id
+                }));  
+              }
+            }
+          })
+          await Promise.all(newServicesPromises);
+        });
+
+        // now refresh the Establishment and return the updated set of other services
+        let results = await models.establishment.findOne({
+          where: {
+            id: establishmentId
+          },
+          attributes: ['id', 'name', 'isRegulated'],
+          include: [{
+            model: models.services,
+            as: 'otherServices',
+            attributes: ['id', 'name', 'category'],
+            order: [
+              ['category', 'ASC'],
+              ['name', 'ASC']
+            ]
+          },{
+            model: models.services,
+            as: 'mainService',
+            attributes: ['id', 'name']
+          }]
+        });
+    
+        res.status(200);
+        return res.json(formatOtherServicesResponse(results));
+
+      } else {
+        console.error('establishment::capacity POST - failed to retrieve all associated services');
+        return res.status(503).send(`Unable to update Establishment: ${establishmentId}`);
+      }
+      
+    } else {
+      console.error('establishment::capacity POST - Not found establishment having id: ${establishmentId}');
+      return res.status(404).send(`Not found establishment having id: ${establishmentId}`);
+    }
+
+  } catch (err) {
+    // TODO - improve logging/error reporting
+    console.error('establishment::capacity POST - failed', err);
+    return res.status(503).send(`Unable to update Establishment with employer type: ${req.params.id}/${givenEmployerType}`);
+  } */
+  return res.status(501).send();
+});
+
+
+const formatCapacityResponse = (establishment, serviceCapacities) => {
+  // WARNING - do not be tempted to copy the database model as the API response; the API may chose to rename/contain
+  //           some attributes
+
+  // and reformat the service category/name for main service only
+
+  return {
+    id: establishment.id,
+    name: establishment.name,
+    mainService: ServiceFormatters.singleService(establishment.mainService),
+    capacities: CapacityFormatters.capacitiesJSON(establishment.capacity),
+    allServiceCapacities: CapacityFormatters.serviceCapacitiesByCategoryJSON(
+      mergeQuestionsWithAnswers(
+        reorderAndReformatMainServiceQuestion(serviceCapacities, establishment.mainServiceId),
+          establishment.capacity)
+    )
+  };
+}
+
+const mergeQuestionsWithAnswers = (questions, answers) => {
+  if (answers && Array.isArray(answers) && questions && Array.isArray(questions)) {
+    answers.forEach(thisAnswer => {
+      const foundQuestion = questions.find(thisQuestion => thisQuestion.id == thisAnswer.reference.id);
+      if (foundQuestion) {
+        foundQuestion.answer = thisAnswer.answer;
+      }
+    });
+  }
+
+  return questions;
+}
+
+const reorderAndReformatMainServiceQuestion = (questions, mainServiceId) => {
+  let reorderedQuestions = [];
+  if (questions && Array.isArray(questions)) {
+    // first find any questions associated with the main service ID (if any)
+    if (mainServiceId) {
+      const mainServiceQuestions = questions.filter(thisQuestion => thisQuestion.service.id === mainServiceId);
+      
+      if (mainServiceQuestions) {
+        // there exists within the set of questions, one or more relating to the main service
+        mainServiceQuestions.forEach(thisMainServiceQuestion => {
+          thisMainServiceQuestion.service.category = 'Main Service';
+          reorderedQuestions.push(thisMainServiceQuestion);
+        });
+      }
+
+      const nonMainServiceQuestions = questions.filter(thisQuestion => thisQuestion.service.id !== mainServiceId);
+      if (nonMainServiceQuestions) {
+        reorderedQuestions = reorderedQuestions.concat(nonMainServiceQuestions);
+      }
+    }
+  }
+
+  return reorderedQuestions;
+}
+
+module.exports = router;

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -5,14 +5,17 @@ const router = express.Router();
 const models = require('../../models');
 const Authorization = require('../../utils/security/isAuthenticated');
 const ServiceFormatters = require('../../models/api/services');
+const CapacityFormatters = require('../../models/api/capacity');
 
 const EmployerType = require('./employerType');
 const Services = require('./services');
+const Capacity = require('./capacity');
 
 // ensure all establishment routes are authorised
 router.use('/:id', Authorization.hasAuthorisedEstablishment);
 router.use('/:id/employerType', EmployerType);
 router.use('/:id/services', Services);
+router.use('/:id/capacity', Capacity);
 
 // gets all there is to know about an Establishment
 router.route('/:id').get(async (req, res) => {
@@ -45,6 +48,15 @@ router.route('/:id').get(async (req, res) => {
         model: models.services,
         as: 'mainService',
         attributes: ['id', 'name']
+      },{
+        model: models.establishmentCapacity,
+        as: 'capacity',
+        attributes: ['id', 'answer'],
+        include: [{
+          model: models.serviceCapacity,
+          as: 'reference',
+          attributes: ['id', 'question']
+        }]
       }]
     });
 
@@ -74,7 +86,8 @@ const formatEstablishmentResponse = (establishment) => {
     isRegulated: establishment.isRegulated,
     employerType: establishment.employerType,
     mainService: ServiceFormatters.singleService(establishment.mainService),
-    otherServices: ServiceFormatters.createServicesByCategoryJSON(establishment.otherServices)
+    otherServices: ServiceFormatters.createServicesByCategoryJSON(establishment.otherServices),
+    capacities: CapacityFormatters.capacitiesJSON(establishment.capacity)
   };
 }
 

--- a/server/routes/establishments/services.js
+++ b/server/routes/establishments/services.js
@@ -37,10 +37,8 @@ router.route('/').get(async (req, res) => {
       // if the option to return all services is given, then fetch a list of all services available to this establishment
       if (includeAllServices) {
         if (results.isRegulated) {
+          // other services for CQC regulated is ALL including non-CQC
           allServicesResults = await models.services.findAll({
-            where: {
-              iscqcregistered: true
-            },
             order: [
               ['category', 'ASC'],
               ['name', 'ASC']
@@ -48,6 +46,9 @@ router.route('/').get(async (req, res) => {
           });
         } else {
           allServicesResults = await models.services.findAll({
+            where: {
+              iscqcregistered: false
+            },
             order: [
               ['category', 'ASC'],
               ['name', 'ASC']

--- a/server/routes/services.js
+++ b/server/routes/services.js
@@ -9,7 +9,10 @@ router.route('/')
 
     //Find matching postcode data
     let results = await models.services.findAll({
-    });
+      where: {
+        isMain: true
+      }
+  });
 
     let servicesData = createServicesJSON(results);
 
@@ -31,7 +34,8 @@ router.route('/byCategory')
     if (filterByCqc) {
       results = await models.services.findAll({
         where: {
-          iscqcregistered: true
+          iscqcregistered: true,
+          isMain: true
         },
         order: [
           ['category', 'ASC'],
@@ -40,6 +44,10 @@ router.route('/byCategory')
       });
     } else {
       results = await models.services.findAll({
+        where: {
+          iscqcregistered: false,
+          isMain: true
+        },
         order: [
           ['category', 'ASC'],
           ['name', 'ASC']
@@ -56,24 +64,25 @@ router.route('/byCategory')
     }
 });
 
-router.route('/:cqcRegistered')
-  .get(async function (req, res) {
+// deprecated
+// router.route('/:cqcRegistered')
+//   .get(async function (req, res) {
 
-    //Find matching postcode data
-    let results = await models.services.findAll({
-      where: {
-        iscqcregistered: req.params.cqcRegistered
-      }
-    });
+//     //Find matching postcode data
+//     let results = await models.services.findAll({
+//       where: {
+//         iscqcregistered: req.params.cqcRegistered
+//       }
+//     });
 
-    let servicesData = await createServicesJSON(results);
+//     let servicesData = await createServicesJSON(results);
 
-    if (servicesData.length === 0) {
-      res.sendStatus(404);
-    } else {
-      res.send(servicesData);
-    }
-});
+//     if (servicesData.length === 0) {
+//       res.sendStatus(404);
+//     } else {
+//       res.send(servicesData);
+//     }
+// });
 
 router.route('/id/:id')
   .get(async function (req, res) {


### PR DESCRIPTION
Hi Nasir

This is a big merge and includes three changes/fixes:
1. A rename of `OtherServices` table to `EstablishmentServices` (Shakir has already applied this to the dev database).
2. Corrections to how main and other services are filtered, including adding an additional column to `services` table that controls those services that belong (moreso, don't belong) to the main service - Ann is waiting on this change.
3. And Establishment new API "capacity" - both [GET] and [POST]. I have to highlight it's not my best work. I could do with refactoring more because there is shared code between the two verbs. I've added a TODO to help remind me (when the repo is split it will chuff out a report on TODOs).

It would be great if this could be reviewed, merged and deployed into dev for tomorrow morning (ready for after stand up).

Much appreciated.