### PR TITLE
Ignore ./dist folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
+dist/
+
 
 *_i.c
 *_p.c


### PR DESCRIPTION
We want to git-ignore ./dist folder. If we do not, sooner or later somebody can push some generated stuff to origin.