### PR TITLE
Establishment api

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,9 +16,11 @@ var jobs = require('./server/routes/jobs');
 var la = require('./server/routes/la');
 var feedback = require('./server/routes/feedback');
 
-var Authorization = require('./server/utils/security/isAuthenticated');
-
 var errors = require('./server/routes/errors');
+
+// test only routes - helpers to setup and execute automated tests
+var testOnly = require('./server/routes/testOnly');
+
 
 var app = express();
 
@@ -44,6 +46,7 @@ app.use('/api/establishment', establishments);
 app.use('/api/jobs', jobs);
 app.use('/api/localAuthority', la);
 app.use('/api/feedback', feedback);
+app.use('/api/test', testOnly);
 
 app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'dist/index.html'));

--- a/server/models/api/la.js
+++ b/server/models/api/la.js
@@ -7,6 +7,10 @@ const localformatLA = (thisLA) => {
     thisJson.name = thisLA.reference.name;
     thisJson.custodianCode = thisLA.reference.id;
   }
+
+  if (thisLA.name) {
+    thisJson.name = thisLA.name;
+  }
   return   thisJson;
 };
 
@@ -19,7 +23,7 @@ exports.listOfLAsJSON = (givenLAs, primaryAuthorityCustodianCode) => {
 
       // if the primary Authority custodian code is given,
       //  highlight if this local authority is the primary authority
-      if (parseInt(primaryAuthorityCustodianCode) === parseInt(thisLA.reference.id)) {
+      if (primaryAuthorityCustodianCode && parseInt(primaryAuthorityCustodianCode) === parseInt(thisLA.reference.id)) {
         localLa.isPrimaryAuthority = true;
       }
 

--- a/server/models/services.js
+++ b/server/models/services.js
@@ -16,14 +16,6 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.TEXT,
       allowNull: true
     },
-    capacityquestion: {
-      type: DataTypes.TEXT,
-      allowNull: true
-    },
-    currentuptakequestion: {
-      type: DataTypes.TEXT,
-      allowNull: true
-    },
     iscqcregistered: {
       type: DataTypes.BOOLEAN,
       allowNull: true

--- a/server/routes/establishments/la.js
+++ b/server/routes/establishments/la.js
@@ -122,7 +122,7 @@ router.route('/').post(async (req, res) => {
         where: {
           id: establishmentId
         },
-        attributes: ['id', 'name'],
+        attributes: ['id', 'name', "postcode"],
         include: [
           {
             model: models.establishmentLocalAuthority,
@@ -179,18 +179,24 @@ const isValidLAEntry = (entry, allKnownLAs) => {
   }
 };
 
-const formatLAResponse = (establishment, primaryAuthorityCustodianCode) => {
+const formatLAResponse = (establishment, primaryAuthorityCustodianCode=null) => {
   // WARNING - do not be tempted to copy the database model as the API response; the API may chose to rename/contain
   //           some attributes
-  return {
+  const response = {
     id: establishment.id,
     name: establishment.name,
-    primaryAuthority: {
-      id: primaryAuthorityCustodianCode.local_custodian_code,
-      name: primaryAuthorityCustodianCode.theAuthority.name
-    },
-    localAuthorities: LaFormatters.listOfLAsJSON(establishment.localAuthorities, primaryAuthorityCustodianCode.local_custodian_code)
+    localAuthorities: LaFormatters.listOfLAsJSON(establishment.localAuthorities,
+                                                 primaryAuthorityCustodianCode ? primaryAuthorityCustodianCode.local_custodian_code : null)
   };
+
+  if (primaryAuthorityCustodianCode) {
+    response.primaryAuthority = {
+      id: parseInt(primaryAuthorityCustodianCode.local_custodian_code),
+      name: primaryAuthorityCustodianCode.theAuthority.name
+    }
+  }
+
+  return response;
 }
 
 module.exports = router;

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -257,7 +257,7 @@ router.route('/')
       res.json({
         "success" : 1,
         "message" : "Record added Successfully",
-        "establishmentId" : Estblistmentdata.MainServiceId
+        "establishmentId" : establishmentID
       });
 
     } catch (err) {

--- a/server/routes/testOnly/cleanStart.js
+++ b/server/routes/testOnly/cleanStart.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../../models');
+
+// deletes all existing transactional data
+router.route('/').post(async (req, res) => {
+  try {
+    await models.sequelize.transaction(async t => {
+        // establishments
+        await models.establishmentCapacity.destroy({
+            where: {}
+        });
+        await models.establishmentJobs.destroy({
+            where: {}
+        });
+        await models.establishmentLocalAuthority.destroy({
+            where: {}
+        });
+        await models.establishmentServices.destroy({
+            where: {}
+        });
+
+        // registration
+        await models.login.destroy({
+            where: {}
+        });
+        await models.user.destroy({
+            where: {}
+        });
+        await models.establishment.destroy({
+            where: {}
+        });
+    });
+
+    res.status(200).send('success');
+
+  } catch (err) {
+    return res.status(503).send('Failed');
+  }
+});
+
+module.exports = router;

--- a/server/routes/testOnly/index.js
+++ b/server/routes/testOnly/index.js
@@ -1,0 +1,17 @@
+// registration of all sub routes
+const express = require('express');
+const router = express.Router();
+
+const Authorization = require('../../utils/security/isLocalhost');
+
+const Postcode = require('./postcode');
+const Location = require('./location');
+const Truncate = require('./cleanStart');
+
+// ensure all test only routes are authorised - restricted by localhost
+router.use('/', Authorization.isAuthorised);
+router.use('/postcodes', Postcode);
+router.use('/locations', Location);
+router.use('/clean', Truncate);
+
+module.exports = router;

--- a/server/routes/testOnly/location.js
+++ b/server/routes/testOnly/location.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../../models');
+
+// returns a random set of addresses from the location dataset
+//  if passing the limit parameter can vary the set size (defaults to 100)
+router.route('/random').get(async (req, res) => {
+  const setSize = req.query.limit ? req.query.limit : 10;
+
+  try {
+    let results = await models.location.findAll({
+      order: [
+        models.sequelize.random()
+      ],
+      limit: setSize
+    });
+
+    if (results && Array.isArray(results) && results.length > 0) {
+      res.status(200);
+      return res.json(formatAddressResponse(results));
+    } else {
+      return res.status(404).send('Not found');
+    }
+
+  } catch (err) {
+    return res.status(503).send('Failed');
+  }
+});
+
+const formatAddressResponse = (addresses) => {
+  let theseAddresses = [];
+
+  addresses.forEach(thisAddress => theseAddresses.push ({
+    cqcid: thisAddress.cqcid,
+    address1:thisAddress.addressLine1,
+    address2:thisAddress.addressLine2,
+    townAndCity: thisAddress.towncity,
+    county: thisAddress.county,
+    postcode: thisAddress.postalCode,
+    mainServiceName: thisAddress.mainservice,
+    locatioName: thisAddress.locationname,
+    locationId: thisAddress.locationid
+  }));
+
+  return {
+    locations: theseAddresses
+  };
+}
+
+module.exports = router;

--- a/server/routes/testOnly/location.js
+++ b/server/routes/testOnly/location.js
@@ -36,7 +36,7 @@ const formatAddressResponse = (addresses) => {
     address2:thisAddress.addressline2,
     townAndCity: thisAddress.towncity,
     county: thisAddress.county,
-    postcode: thisAddress.postalCode,
+    postcode: thisAddress.postalcode,
     mainServiceName: thisAddress.mainservice,
     locatioName: thisAddress.locationname,
     locationId: thisAddress.locationid

--- a/server/routes/testOnly/location.js
+++ b/server/routes/testOnly/location.js
@@ -32,8 +32,8 @@ const formatAddressResponse = (addresses) => {
 
   addresses.forEach(thisAddress => theseAddresses.push ({
     cqcid: thisAddress.cqcid,
-    address1:thisAddress.addressLine1,
-    address2:thisAddress.addressLine2,
+    address1:thisAddress.addressline1,
+    address2:thisAddress.addressline2,
     townAndCity: thisAddress.towncity,
     county: thisAddress.county,
     postcode: thisAddress.postalCode,

--- a/server/routes/testOnly/postcode.js
+++ b/server/routes/testOnly/postcode.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../../models');
+
+// returns a random set of addresses from the postcode dataset
+//  if passing the limit parameter can vary the set size (defaults to 100)
+router.route('/random').get(async (req, res) => {
+  const setSize = req.query.limit ? req.query.limit : 100;
+
+  try {
+    let results = await models.pcodedata.findAll({
+      order: [
+        models.sequelize.random()
+      ],
+      limit: setSize
+    });
+
+    if (results && Array.isArray(results) && results.length > 0) {
+      res.status(200);
+      return res.json(formatAddressResponse(results));
+    } else {
+      return res.status(404).send('Not found');
+    }
+
+  } catch (err) {
+    return res.status(503).send('Failed');
+  }
+});
+
+const formatAddressResponse = (addresses) => {
+  let theseAddresses = [];
+
+  addresses.forEach(thisAddress => theseAddresses.push ({
+    uprn: thisAddress.uprn,
+    address1: concatenateAddress(thisAddress.sub_building_name, thisAddress.building_name, thisAddress.building_number, thisAddress.street_description),
+    townAndCity: thisAddress.post_town,
+    county: thisAddress.county,
+    postcode: thisAddress.postcode,
+    localCustodianCode: thisAddress.local_custodian_code
+  }));
+
+  return {
+    postcodes: theseAddresses
+  };
+}
+
+const concatenateAddress = (subName, name, bNumber, street) => {
+  let theAddress = '';
+
+  if (subName) {
+    theAddress += subName + ' ';
+  }
+
+  if (name) {
+    theAddress += name + ' ';
+  }
+
+  if (bNumber) {
+    theAddress += bNumber + ' ';
+  }
+
+  if (street) {
+    theAddress += street + ' ';
+  }
+
+  return theAddress;
+};
+
+module.exports = router;

--- a/server/utils/security/isLocalhost.js
+++ b/server/utils/security/isLocalhost.js
@@ -1,0 +1,11 @@
+// this util middleware will block if the given request is not issued to localhost
+exports.isAuthorised = (req, res, next) => {
+  const testOnlyHostRestrictionRegex = /^localhost/;
+
+  if (req.get('host').match(testOnlyHostRestrictionRegex)) {
+    next();
+  } else {
+    // not authenticated
+    res.status(401).send('Requires authorisation');
+  }
+};


### PR DESCRIPTION
Introducing testOnly endpoints (to faciltate automated integration tests).

Corrections resulting to changes in schema and proving of tests:
* Establishment Local Authority - handling of missing `primaryAuthority` on POST, and ensuring the primaryAuthority.local_custodian_code is an integer
* Root Local Authority - handling of format response when name is as root
* Removing two columns from `services` table - now covered by `ServiceCapacity` table
* Correcting the id returned on registration to be that of the establishment id not the main service id