### PR TITLE
Establishment ui share la and share

### DIFF
--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -156,8 +156,7 @@
             "properties": {
                 "jobId" : {
                     "description" : "A unique reference to the job title",
-                    "type" : "integer",
-                    "minimum": 0
+                    "$ref" : "#/definitions/ID"
                 },
                 "title" : {
                     "description" : "The title of the job of given jobId",
@@ -211,6 +210,64 @@
                 }
             },
             "required" : ["TotalVacancies", "TotalStarters", "TotalLeavers"]
+        },
+        "LocalAuthority" : {
+            "description" : "Local Authority reference",
+            "type" : "object",
+            "properties" : {
+                "id" : {
+                    "description" : "This the primary index for a specific Local Authority of a given Establishment",
+                    "$ref" : "#/definitions/ID"
+                },
+                "name" : {
+                    "description": "This is the readable name of the Local Authority",
+                    "type" : "string",
+                    "minLength": 3
+                },
+                "custodianCode" : {
+                    "description" : "A unique reference for a Local Authority",
+                    "$ref" : "#/definitions/ID"
+                },
+                "isPrimaryAuthority" : {
+                    "description": "An optional flag (assumed false if not given) that if true, identifies this as being the Local Authority as known by the physical location of the associated Establishment",
+                    "type" : "boolean"
+                }
+            },
+            "required" : ["id", "name"]
+        },
+        "ShareOptions" : {
+            "description" : "For sharing data with CQC and Local Authorities",
+            "type" : "object",
+            "properties" : {
+                "enabled" : {
+                    "description" : "If false, all sharing is disabled",
+                    "type" : "boolean"
+                },
+                "with" : {
+                    "description" : "If enabled is true, describes which of the share options (CQC/Local Authority) is enabled",
+                    "type" : "object",
+                    "properties": {
+                        "shareWithCQC" : {
+                            "description": "If true, then share with CQC",
+                            "type" : "boolean"
+                        },
+                        "shareWithLA" : {
+                            "description": "If true, then share with Local Authorities"
+                        },
+                        "authorities" : {
+                            "description" : "A list of all the local authorities to which data is shared with; only populated if 'shareWithLA' is true",
+                            "type" : "array",
+                            "items" : [
+                                {
+                                    "$ref" : "#/definitions/LocalAuthority"
+                                }
+                            ]
+                        }
+                    },
+                    "required" : []
+                }
+            },
+            "required" : ["enabled"]
         },
         "Establishment" : {
             "description" : "A physical location offering care services; can be commercial or private location",
@@ -271,9 +328,43 @@
                     "type" : "integer",
                     "minimum": 0,
                     "maximum": 999
-                }
-            },
+                }            },
             "required" : ["id", "name"]
         }
+    },
+    "Feedback" : {
+        "description" : "For capturing user feedback",
+        "properties" : {
+            "id" : {
+                "description" : "A unique index for this particular feedback; id is optional because this type is used to both create and return feedback",
+                "$ref" : "#/definitions/ID"
+            },
+            "whenDoing" : {
+                "description" : "The feedback as given for 'when doing something in particular'",
+                "type" : "string",
+                "minLength" : 0,
+                "maxLength" : 500
+            },
+            "tellUs" : {
+                "description" : "General 'tell us' feedback",
+                "type" : "string",
+                "minLength" : 0,
+                "maxLength" : 500
+            },
+            "name" : {
+                "description" : "Optional name for the feedback",
+                "type" : "string",
+                "minLength" : 3,
+                "maxLength" : 120
+            },
+            "email" : {
+                "description" : "Optional email for the feedback",
+                "type" : "string",
+                "minLength" : 3,
+                "maxLength" : 120,
+                "pattern" : "^(([^<>()\[\]\\.,;:\s@\"]+(\.[^<>()\[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$"
+            }
+        },
+        "required" : ["whenDoing", "tellUs"]
     }
 }

--- a/server.js
+++ b/server.js
@@ -13,10 +13,14 @@ var registration = require('./server/routes/registration');
 var tmpLogin = require('./server/routes/tmpLogin');
 var establishments = require('./server/routes/establishments');
 var jobs = require('./server/routes/jobs');
-
-var Authorization = require('./server/utils/security/isAuthenticated');
+var la = require('./server/routes/la');
+var feedback = require('./server/routes/feedback');
 
 var errors = require('./server/routes/errors');
+
+// test only routes - helpers to setup and execute automated tests
+var testOnly = require('./server/routes/testOnly');
+
 
 var app = express();
 
@@ -40,6 +44,9 @@ app.use('/api/errors', errors);
 app.use('/api/login', tmpLogin);
 app.use('/api/establishment', establishments);
 app.use('/api/jobs', jobs);
+app.use('/api/localAuthority', la);
+app.use('/api/feedback', feedback);
+app.use('/api/test', testOnly);
 
 app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'dist/index.html'));

--- a/server/models/api/la.js
+++ b/server/models/api/la.js
@@ -1,11 +1,17 @@
 const localformatLA = (thisLA) => {
   const thisJson = {
-    id: thisLA.id
   };
+
+  if (thisLA.id) {
+    thisJson.id = thisLA.id;
+  }
+  if (thisLA.custodianCode) {
+    thisJson.custodianCode = thisLA.custodianCode;
+  }
   
   if (thisLA.reference) {
     thisJson.name = thisLA.reference.name;
-    thisJson.custodianCode = thisLA.reference.id;
+    thisJson.custodianCode = thisLA.reference.custodianCode;
   }
 
   if (thisLA.name) {

--- a/server/models/api/la.js
+++ b/server/models/api/la.js
@@ -29,7 +29,7 @@ exports.listOfLAsJSON = (givenLAs, primaryAuthorityCustodianCode) => {
 
       // if the primary Authority custodian code is given,
       //  highlight if this local authority is the primary authority
-      if (primaryAuthorityCustodianCode && parseInt(primaryAuthorityCustodianCode) === parseInt(thisLA.reference.id)) {
+      if (primaryAuthorityCustodianCode && parseInt(primaryAuthorityCustodianCode) === parseInt(thisLA.reference.custodianCode)) {
         localLa.isPrimaryAuthority = true;
       }
 

--- a/server/models/api/la.js
+++ b/server/models/api/la.js
@@ -1,0 +1,35 @@
+const localformatLA = (thisLA) => {
+  const thisJson = {
+    id: thisLA.id
+  };
+  
+  if (thisLA.reference) {
+    thisJson.name = thisLA.reference.name;
+    thisJson.custodianCode = thisLA.reference.id;
+  }
+
+  if (thisLA.name) {
+    thisJson.name = thisLA.name;
+  }
+  return   thisJson;
+};
+
+exports.listOfLAsJSON = (givenLAs, primaryAuthorityCustodianCode) => {
+  let laList = [];
+
+  if (givenLAs && Array.isArray(givenLAs)) {
+    givenLAs.forEach(thisLA => {
+      const localLa = localformatLA(thisLA);
+
+      // if the primary Authority custodian code is given,
+      //  highlight if this local authority is the primary authority
+      if (primaryAuthorityCustodianCode && parseInt(primaryAuthorityCustodianCode) === parseInt(thisLA.reference.id)) {
+        localLa.isPrimaryAuthority = true;
+      }
+
+      laList.push(localLa);
+    });
+  }
+
+  return laList;
+};

--- a/server/models/api/shareData.js
+++ b/server/models/api/shareData.js
@@ -1,4 +1,6 @@
-exports.shareDataJSON = (establishment) => {
+const LaFormatters = require('./la');
+
+exports.shareDataJSON = (establishment, authorities) => {
   let jsonObject = {
     enabled: establishment.shareData
   };
@@ -8,6 +10,14 @@ exports.shareDataJSON = (establishment) => {
 
     if (establishment.shareWithCQC) jsonObject.with.push('CQC');
     if (establishment.shareWithLA) jsonObject.with.push('Local Authority');
+  }
+
+  if (establishment.shareWithLA) {
+    jsonObject.authorities = [];
+
+    if (authorities && Array.isArray(authorities)) {
+      jsonObject.authorities = LaFormatters.listOfLAsJSON(authorities)
+    }
   }
 
   return  jsonObject;

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -85,12 +85,6 @@ module.exports = function(sequelize, DataTypes) {
       targetKey: 'id',
       as: 'otherServices'
     });
-    // Establishment.belongsToMany(models.serviceCapacity, {
-    //   through: 'establishmentCapacity',
-    //   foreignKey: 'establishmentId',
-    //   targetKey: 'establishmentId',
-    //   as: 'capacity'
-    // });
     Establishment.hasMany(models.establishmentCapacity, {
       foreignKey: 'establishmentId',
       sourceKey: 'id',
@@ -100,6 +94,11 @@ module.exports = function(sequelize, DataTypes) {
       foreignKey: 'establishmentId',
       sourceKey: 'id',
       as: 'jobs'
+    });
+    Establishment.hasMany(models.establishmentLocalAuthority, {
+      foreignKey: 'establishmentId',
+      sourceKey: 'id',
+      as: 'localAuthorities'
     });
   };
 

--- a/server/models/establishmentLocalAuthority.js
+++ b/server/models/establishmentLocalAuthority.js
@@ -29,7 +29,7 @@ module.exports = function(sequelize, DataTypes) {
   EstablishmentLocalAuthority.associate = (models) => {
     EstablishmentLocalAuthority.belongsTo(models.localAuthority, {
       foreignKey: 'authorityId',
-      targetKey: 'id',
+      targetKey: 'custodianCode',
       as: 'reference'
     });
   };

--- a/server/models/establishmentLocalAuthority.js
+++ b/server/models/establishmentLocalAuthority.js
@@ -7,7 +7,7 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: false,
       primaryKey: true,
       autoIncrement: true,
-      field: '"EstablishmentLocalAuthority"'
+      field: '"EstablishmentLocalAuthorityID"'
     },
     authorityId: {
       type: DataTypes.INTEGER,

--- a/server/models/feedback.js
+++ b/server/models/feedback.js
@@ -1,0 +1,40 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  const Feedback = sequelize.define('feedback', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+      field: '"FeedbackID"'
+    },
+    doingWhat: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"Doing"'
+    },
+    tellUs: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"Tellus"'
+    },
+    name: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"Name"'
+    },
+    email: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"Email"'
+    }
+  }, {
+    tableName: '"Feedback"',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+
+  return Feedback;
+};

--- a/server/models/localAuthority.js
+++ b/server/models/localAuthority.js
@@ -2,7 +2,7 @@
 
 module.exports = function(sequelize, DataTypes) {
   const LocalAuthority = sequelize.define('localAuthority', {
-    id: {
+    custodianCode: {
       type: DataTypes.INTEGER,
       allowNull: false,
       primaryKey: true,

--- a/server/models/pcodedata.js
+++ b/server/models/pcodedata.js
@@ -1,7 +1,7 @@
 /* jshint indent: 2 */
 
 module.exports = function(sequelize, DataTypes) {
-  return sequelize.define('pcodedata', {
+  const PcodeData = sequelize.define('pcodedata', {
     uprn: {
       type: DataTypes.BIGINT,
       primaryKey:true,
@@ -49,4 +49,14 @@ module.exports = function(sequelize, DataTypes) {
     createdAt: false,
     updatedAt: false
   });
+
+  PcodeData.associate = (models) => {
+    PcodeData.belongsTo(models.localAuthority, {
+      foreignKey: 'local_custodian_code',
+      targetKey: 'id',
+      as: 'theAuthority'
+    });
+  };
+
+  return PcodeData;
 };

--- a/server/models/pcodedata.js
+++ b/server/models/pcodedata.js
@@ -53,7 +53,7 @@ module.exports = function(sequelize, DataTypes) {
   PcodeData.associate = (models) => {
     PcodeData.belongsTo(models.localAuthority, {
       foreignKey: 'local_custodian_code',
-      targetKey: 'id',
+      targetKey: 'custodianCode',
       as: 'theAuthority'
     });
   };

--- a/server/models/services.js
+++ b/server/models/services.js
@@ -16,14 +16,6 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.TEXT,
       allowNull: true
     },
-    capacityquestion: {
-      type: DataTypes.TEXT,
-      allowNull: true
-    },
-    currentuptakequestion: {
-      type: DataTypes.TEXT,
-      allowNull: true
-    },
     iscqcregistered: {
       type: DataTypes.BOOLEAN,
       allowNull: true

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -92,7 +92,7 @@ router.route('/:id').get(async (req, res) => {
           include: [{
             model: models.localAuthority,
             as: 'reference',
-            attributes: ['id', 'name'],
+            attributes: ['custodianCode', 'name'],
             order: [
               ['name', 'ASC']
             ]

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -15,6 +15,7 @@ const Capacity = require('./capacity');
 const ShareData = require('./shareData');
 const Staff = require('./staff');
 const Jobs = require('./jobs');
+const LA = require('./la');
 
 // ensure all establishment routes are authorised
 router.use('/:id', Authorization.hasAuthorisedEstablishment);
@@ -24,6 +25,7 @@ router.use('/:id/capacity', Capacity);
 router.use('/:id/share', ShareData);
 router.use('/:id/staff', Staff);
 router.use('/:id/jobs', Jobs);
+router.use('/:id/localAuthorities', LA);
 
 // gets all there is to know about an Establishment
 router.route('/:id').get(async (req, res) => {
@@ -70,7 +72,7 @@ router.route('/:id').get(async (req, res) => {
         {
           model: models.establishmentJobs,
           as: 'jobs',
-          attributes: ['id', 'type'],
+          attributes: ['id', 'type', 'total'],
           order: [
             ['type', 'ASC']
           ],
@@ -80,6 +82,19 @@ router.route('/:id').get(async (req, res) => {
             attributes: ['id', 'title'],
             order: [
               ['title', 'ASC']
+            ]
+          }]
+        },
+        {
+          model: models.establishmentLocalAuthority,
+          as: 'localAuthorities',
+          attributes: ['id'],
+          include: [{
+            model: models.localAuthority,
+            as: 'reference',
+            attributes: ['id', 'name'],
+            order: [
+              ['name', 'ASC']
             ]
           }]
         }
@@ -112,7 +127,7 @@ const formatEstablishmentResponse = (establishment) => {
     isRegulated: establishment.isRegulated,
     employerType: establishment.employerType,
     numberOfStaff: establishment.numberOfStaff,
-    share: ShareFormatters.shareDataJSON(establishment),
+    share: ShareFormatters.shareDataJSON(establishment, establishment.localAuthorities),
     mainService: ServiceFormatters.singleService(establishment.mainService),
     otherServices: ServiceFormatters.createServicesByCategoryJSON(establishment.otherServices),
     capacities: CapacityFormatters.capacitiesJSON(establishment.capacity),

--- a/server/routes/establishments/jobs.js
+++ b/server/routes/establishments/jobs.js
@@ -75,7 +75,7 @@ router.route('/').post(async (req, res) => {
         attributes: ['id']
       });
       if (!allJobsResult) {
-        console.error('establishment::jobs POST - unable to retrieve all known jobs: ', givenJobs);
+        console.error('establishment::jobs POST - unable to retrieve all known jobs');
         return res.status(503).send('Unable to retrieve all jobs');
       }
       const allJobs = [];
@@ -197,7 +197,7 @@ router.route('/').post(async (req, res) => {
   } catch (err) {
     // TODO - improve logging/error reporting
     console.error('establishment::jobs POST - failed', err);
-    return res.status(503).send(`Unable to update Establishment with employer type: ${req.params.id}/${givenEmployerType}`);
+    return res.status(503).send(`Unable to update Establishment with jobs: ${req.params.id}/${givenEmployerType}`);
   }
 });
 

--- a/server/routes/establishments/la.js
+++ b/server/routes/establishments/la.js
@@ -25,7 +25,7 @@ router.route('/').get(async (req, res) => {
           include: [{
             model: models.localAuthority,
             as: 'reference',
-            attributes: ['id', 'name'],
+            attributes: ['custodianCode', 'name'],
             order: [
               ['name', 'ASC']
             ]
@@ -131,7 +131,7 @@ router.route('/').post(async (req, res) => {
             include: [{
               model: models.localAuthority,
               as: 'reference',
-              attributes: ['id', 'name'],
+              attributes: ['custodianCode', 'name'],
               order: [
                 ['name', 'ASC']
               ]
@@ -191,7 +191,7 @@ const formatLAResponse = (establishment, primaryAuthorityCustodianCode=null) => 
 
   if (primaryAuthorityCustodianCode) {
     response.primaryAuthority = {
-      id: parseInt(primaryAuthorityCustodianCode.local_custodian_code),
+      custodianCode: parseInt(primaryAuthorityCustodianCode.local_custodian_code),
       name: primaryAuthorityCustodianCode.theAuthority.name
     }
   }

--- a/server/routes/establishments/la.js
+++ b/server/routes/establishments/la.js
@@ -1,0 +1,202 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../../models');
+const LaFormatters = require('../../models/api/la');
+
+// parent route defines the "id" parameter
+
+// TODO: refactor the get/pull - sharing fetch queries
+
+// gets current set of Local Authorities to share with for the known establishment
+router.route('/').get(async (req, res) => {
+  const establishmentId = req.establishmentId;
+
+  try {
+    let results = await models.establishment.findOne({
+      where: {
+        id: establishmentId
+      },
+      attributes: ['id', 'name', "postcode"],
+      include: [
+        {
+          model: models.establishmentLocalAuthority,
+          as: 'localAuthorities',
+          attributes: ['id'],
+          include: [{
+            model: models.localAuthority,
+            as: 'reference',
+            attributes: ['id', 'name'],
+            order: [
+              ['name', 'ASC']
+            ]
+          }]
+        }
+      ]
+    });
+
+    // need to identify which, if any, of the shared authorities is attributed to the
+    //  primary Authority; that is the Local Authority associated with the physical area
+    //  of the given Establishment (using the postcode as the key)
+    const primaryAuthority = await models.pcodedata.findOne({
+      where: {
+        postcode: results.postcode
+      },
+      attributes: ['postcode', 'local_custodian_code'],
+      include: {
+        model: models.localAuthority,
+        as: 'theAuthority',
+        attributes: ['name']
+      }
+    });
+    //const primaryAuthorityCustodianCode = primaryAuthority.local_custodian_code;
+
+    if (results && results.id && (establishmentId === results.id)) {
+      res.status(200);
+      return res.json(formatLAResponse(results, primaryAuthority));
+    } else {
+      return res.status(404).send('Not found');
+    }
+
+  } catch (err) {
+    // TODO - improve logging/error reporting
+    console.error('establishment::jobs GET - failed', err);
+    return res.status(503).send(`Unable to retrive Establishment: ${req.params.id}`);
+  }
+});
+
+// updates the set of Local Authorities to share with for the known establishment
+router.route('/').post(async (req, res) => {
+  const establishmentId = req.establishmentId;
+  const givenLocalAuthorities = req.body.localAuthorities;
+
+  // must provide localAuthorities and must be an array
+  if (!givenLocalAuthorities || !Array.isArray(givenLocalAuthorities)) {
+    console.error('establishment::la POST - unexpected Local Authorities: ', givenLocalAuthorities);
+    return res.status(400).send(`Unexpected Local Authorities: ${givenLocalAuthorities}`);
+  }
+
+  try {
+    let results = await models.establishment.findOne({
+      where: {
+        id: establishmentId
+      },
+      attributes: ['id', 'name']
+    });
+
+    if (results && results.id && (establishmentId === results.id)) {
+      // when processing the local authorities, we need to ensure they are one of the known local authorities
+      const allLAResult = await models.localAuthority.findAll({
+        attributes: ['id']
+      });
+      if (!allLAResult) {
+        console.error('establishment::la POST - unable to retrieve all known local authorities');
+        return res.status(503).send('Unable to retrieve all Local Authorities');
+      }
+      const allLAs = [];
+      allLAResult.forEach(thisRes => allLAs.push(thisRes.id));
+
+      await models.sequelize.transaction(async t => {
+        await models.establishmentLocalAuthority.destroy({
+          where: {
+            establishmentId
+          }
+        });
+
+        // now iterate through the given set of LAs0
+        const laRecords = [];
+        givenLocalAuthorities.forEach(thisLA => {
+          if (isValidLAEntry(thisLA, allLAs)) {
+            laRecords.push(
+              models.establishmentLocalAuthority.create({
+                authorityId: thisLA.id,
+                establishmentId
+              })
+            );
+          }
+        });
+        await Promise.all(laRecords);
+      });
+
+      // now need to refetch the associated local authorities to return the confirmation
+      let reFetchResults = await models.establishment.findOne({
+        where: {
+          id: establishmentId
+        },
+        attributes: ['id', 'name', "postcode"],
+        include: [
+          {
+            model: models.establishmentLocalAuthority,
+            as: 'localAuthorities',
+            attributes: ['id'],
+            include: [{
+              model: models.localAuthority,
+              as: 'reference',
+              attributes: ['id', 'name'],
+              order: [
+                ['name', 'ASC']
+              ]
+            }]
+          }
+        ]
+      });
+  
+      if (reFetchResults && reFetchResults.id && (establishmentId === reFetchResults.id)) {
+        res.status(200);
+        return res.json(formatLAResponse(reFetchResults));
+      } else {
+        console.error('establishment::la POST - Not found establishment having id: ${establishmentId} after having updated the establishment', err);
+        return res.status(404).send(`Not found establishment having id: ${establishmentId}`);
+      }
+    } else {
+      console.error('establishment::la POST - Not found establishment having id: ${establishmentId}', err);
+      return res.status(404).send(`Not found establishment having id: ${establishmentId}`);
+    }
+
+  } catch (err) {
+    // TODO - improve logging/error reporting
+    console.error('establishment::la POST - failed', err);
+    return res.status(503).send(`Unable to update Establishment with local authorities: ${req.params.id}/${givenEmployerType}`);
+  }
+});
+
+
+// TODO - ensure the jobId is valid
+const isValidLAEntry = (entry, allKnownLAs) => {
+  if (entry && 
+      entry.id &&
+      parseInt(entry.id) === entry.id) {
+
+      // now check the LA id is within range
+      if (allKnownLAs &&
+          Array.isArray(allKnownLAs) &&
+          allKnownLAs.includes(entry.id)) {
+        return true;
+      } else {
+        return false;
+      }
+  } else {
+    return false;
+  }
+};
+
+const formatLAResponse = (establishment, primaryAuthorityCustodianCode=null) => {
+  // WARNING - do not be tempted to copy the database model as the API response; the API may chose to rename/contain
+  //           some attributes
+  const response = {
+    id: establishment.id,
+    name: establishment.name,
+    localAuthorities: LaFormatters.listOfLAsJSON(establishment.localAuthorities,
+                                                 primaryAuthorityCustodianCode ? primaryAuthorityCustodianCode.local_custodian_code : null)
+  };
+
+  if (primaryAuthorityCustodianCode) {
+    response.primaryAuthority = {
+      id: parseInt(primaryAuthorityCustodianCode.local_custodian_code),
+      name: primaryAuthorityCustodianCode.theAuthority.name
+    }
+  }
+
+  return response;
+}
+
+module.exports = router;

--- a/server/routes/establishments/la.js
+++ b/server/routes/establishments/la.js
@@ -86,14 +86,14 @@ router.route('/').post(async (req, res) => {
     if (results && results.id && (establishmentId === results.id)) {
       // when processing the local authorities, we need to ensure they are one of the known local authorities
       const allLAResult = await models.localAuthority.findAll({
-        attributes: ['id']
+        attributes: ['custodianCode']
       });
       if (!allLAResult) {
         console.error('establishment::la POST - unable to retrieve all known local authorities');
         return res.status(503).send('Unable to retrieve all Local Authorities');
       }
       const allLAs = [];
-      allLAResult.forEach(thisRes => allLAs.push(thisRes.id));
+      allLAResult.forEach(thisRes => allLAs.push(thisRes.custodianCode));
 
       await models.sequelize.transaction(async t => {
         await models.establishmentLocalAuthority.destroy({

--- a/server/routes/establishments/la.js
+++ b/server/routes/establishments/la.js
@@ -108,7 +108,7 @@ router.route('/').post(async (req, res) => {
           if (isValidLAEntry(thisLA, allLAs)) {
             laRecords.push(
               models.establishmentLocalAuthority.create({
-                authorityId: thisLA.id,
+                authorityId: thisLA.custodianCode,
                 establishmentId
               })
             );
@@ -163,13 +163,13 @@ router.route('/').post(async (req, res) => {
 // TODO - ensure the jobId is valid
 const isValidLAEntry = (entry, allKnownLAs) => {
   if (entry && 
-      entry.id &&
-      parseInt(entry.id) === entry.id) {
+      entry.custodianCode &&
+      parseInt(entry.custodianCode) === entry.custodianCode) {
 
-      // now check the LA id is within range
+      // now check the LA custodianCode is within range
       if (allKnownLAs &&
           Array.isArray(allKnownLAs) &&
-          allKnownLAs.includes(entry.id)) {
+          allKnownLAs.includes(entry.custodianCode)) {
         return true;
       } else {
         return false;

--- a/server/routes/establishments/shareData.js
+++ b/server/routes/establishments/shareData.js
@@ -88,7 +88,6 @@ router.route('/').post(async (req, res) => {
         shareWithCQC: shareCQC,
         shareWithLA: shareLA
       };
-      console.log("WA DEBUG - updating share options: ", revisedShareOptions)
       await results.update(revisedShareOptions);
       
       res.status(200);

--- a/server/routes/feedback.js
+++ b/server/routes/feedback.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../models');
+
+// note - intentionally no get for feedback
+
+// submit feedback
+router.route('/').post(async (req, res) => {
+
+  try {
+    // expecting doingWhat and tellUs attributes, even though they could be of zero length
+    // intentionally leaving out any specific validation - awaiting JSON schema validation.
+
+    // express JSON body parser undefines attribute if it is an empty string!
+    const doingWhat =  req.body.doingWhat ? req.body.doingWhat : '';
+    const tellUs =  req.body.tellUs ? req.body.tellUs : '';
+
+    if (!(req.body.doingWhat || req.body.tellUs)) {
+      console.error('Unexpected input; expected either or both of "doing what" or "tell us"; got neither');
+      return res.status(400).send('Unexpected input; expected either or both of "doing what" or "tell us"; got neither');
+    }
+
+    let results = await models.feedback.create({
+      doingWhat,
+      tellUs,
+      name: req.body.name,
+      email: req.body.email
+    });
+
+    if (results) {
+      return res.status(201).send();
+    } else {
+      return res.status(503).send('Unable to post feedback');
+    }
+
+  } catch (err) {
+    // TODO - improve logging/error reporting
+    console.error('jobs GET - failed', err);
+    return res.status(503).send('Unable to post feedback');
+  }
+});
+
+module.exports = router;

--- a/server/routes/feedback.js
+++ b/server/routes/feedback.js
@@ -9,6 +9,7 @@ router.route('/').post(async (req, res) => {
 
   try {
     // expecting doingWhat and tellUs attributes, even though they could be of zero length
+    //  TODO: check with the BA regarding the both mandatory logic; either/or, but at least one makes more sense.
     // intentionally leaving out any specific validation - awaiting JSON schema validation.
 
     // express JSON body parser undefines attribute if it is an empty string!

--- a/server/routes/la.js
+++ b/server/routes/la.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../models');
+const LaFormatters = require('../models/api/la');
+
+// return the list of all Local Authorities
+router.route('/').get(async (req, res) => {
+
+  try {
+    let results = await models.localAuthority.findAll({
+      attributes: ['id', 'name'],
+      order: [
+        ['name', 'ASC']
+      ]
+    });
+
+    if (results && Array.isArray(results) && results.length > 0) {
+      res.status(200);
+      return res.json(LaFormatters.listOfLAsJSON(results));
+    } else {
+      return res.status(404).send('Not found');
+    }
+
+  } catch (err) {
+    // TODO - improve logging/error reporting
+    console.error('jobs GET - failed', err);
+    return res.status(503).send('Unable to retrive Local Authorities');
+  }
+});
+
+module.exports = router;

--- a/server/routes/la.js
+++ b/server/routes/la.js
@@ -8,7 +8,7 @@ router.route('/').get(async (req, res) => {
 
   try {
     let results = await models.localAuthority.findAll({
-      attributes: ['id', 'name'],
+      attributes: ['custodianCode', 'name'],
       order: [
         ['name', 'ASC']
       ]

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -281,7 +281,8 @@ router.route('/')
       res.status(200);
       res.json({
         "success" : 1,
-        "message" : "Record added Successfully"
+        "message" : "Record added Successfully",
+        "establishmentId" : establishmentID
       });
 
     } catch (err) {

--- a/server/routes/testOnly/cleanStart.js
+++ b/server/routes/testOnly/cleanStart.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../../models');
+
+// deletes all existing transactional data
+router.route('/').post(async (req, res) => {
+  try {
+    await models.sequelize.transaction(async t => {
+        // establishments
+        await models.establishmentCapacity.destroy({
+            where: {}
+        });
+        await models.establishmentJobs.destroy({
+            where: {}
+        });
+        await models.establishmentLocalAuthority.destroy({
+            where: {}
+        });
+        await models.establishmentServices.destroy({
+            where: {}
+        });
+
+        // registration
+        await models.login.destroy({
+            where: {}
+        });
+        await models.user.destroy({
+            where: {}
+        });
+        await models.establishment.destroy({
+            where: {}
+        });
+    });
+
+    res.status(200).send('success');
+
+  } catch (err) {
+    return res.status(503).send('Failed');
+  }
+});
+
+module.exports = router;

--- a/server/routes/testOnly/index.js
+++ b/server/routes/testOnly/index.js
@@ -1,0 +1,17 @@
+// registration of all sub routes
+const express = require('express');
+const router = express.Router();
+
+const Authorization = require('../../utils/security/isLocalhost');
+
+const Postcode = require('./postcode');
+const Location = require('./location');
+const Truncate = require('./cleanStart');
+
+// ensure all test only routes are authorised - restricted by localhost
+router.use('/', Authorization.isAuthorised);
+router.use('/postcodes', Postcode);
+router.use('/locations', Location);
+router.use('/clean', Truncate);
+
+module.exports = router;

--- a/server/routes/testOnly/location.js
+++ b/server/routes/testOnly/location.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../../models');
+
+// returns a random set of addresses from the location dataset
+//  if passing the limit parameter can vary the set size (defaults to 100)
+router.route('/random').get(async (req, res) => {
+  const setSize = req.query.limit ? req.query.limit : 10;
+
+  try {
+    let results = await models.location.findAll({
+      order: [
+        models.sequelize.random()
+      ],
+      limit: setSize
+    });
+
+    if (results && Array.isArray(results) && results.length > 0) {
+      res.status(200);
+      return res.json(formatAddressResponse(results));
+    } else {
+      return res.status(404).send('Not found');
+    }
+
+  } catch (err) {
+    return res.status(503).send('Failed');
+  }
+});
+
+const formatAddressResponse = (addresses) => {
+  let theseAddresses = [];
+
+  addresses.forEach(thisAddress => theseAddresses.push ({
+    cqcid: thisAddress.cqcid,
+    address1:thisAddress.addressline1,
+    address2:thisAddress.addressline2,
+    townAndCity: thisAddress.towncity,
+    county: thisAddress.county,
+    postcode: thisAddress.postalcode,
+    mainServiceName: thisAddress.mainservice,
+    locatioName: thisAddress.locationname,
+    locationId: thisAddress.locationid
+  }));
+
+  return {
+    locations: theseAddresses
+  };
+}
+
+module.exports = router;

--- a/server/routes/testOnly/postcode.js
+++ b/server/routes/testOnly/postcode.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+const models = require('../../models');
+
+// returns a random set of addresses from the postcode dataset
+//  if passing the limit parameter can vary the set size (defaults to 100)
+router.route('/random').get(async (req, res) => {
+  const setSize = req.query.limit ? req.query.limit : 100;
+
+  try {
+    let results = await models.pcodedata.findAll({
+      order: [
+        models.sequelize.random()
+      ],
+      limit: setSize
+    });
+
+    if (results && Array.isArray(results) && results.length > 0) {
+      res.status(200);
+      return res.json(formatAddressResponse(results));
+    } else {
+      return res.status(404).send('Not found');
+    }
+
+  } catch (err) {
+    return res.status(503).send('Failed');
+  }
+});
+
+const formatAddressResponse = (addresses) => {
+  let theseAddresses = [];
+
+  addresses.forEach(thisAddress => theseAddresses.push ({
+    uprn: thisAddress.uprn,
+    address1: concatenateAddress(thisAddress.sub_building_name, thisAddress.building_name, thisAddress.building_number, thisAddress.street_description),
+    townAndCity: thisAddress.post_town,
+    county: thisAddress.county,
+    postcode: thisAddress.postcode,
+    localCustodianCode: thisAddress.local_custodian_code
+  }));
+
+  return {
+    postcodes: theseAddresses
+  };
+}
+
+const concatenateAddress = (subName, name, bNumber, street) => {
+  let theAddress = '';
+
+  if (subName) {
+    theAddress += subName + ' ';
+  }
+
+  if (name) {
+    theAddress += name + ' ';
+  }
+
+  if (bNumber) {
+    theAddress += bNumber + ' ';
+  }
+
+  if (street) {
+    theAddress += street + ' ';
+  }
+
+  return theAddress;
+};
+
+module.exports = router;

--- a/server/utils/security/isLocalhost.js
+++ b/server/utils/security/isLocalhost.js
@@ -1,0 +1,11 @@
+// this util middleware will block if the given request is not issued to localhost
+exports.isAuthorised = (req, res, next) => {
+  const testOnlyHostRestrictionRegex = /^localhost/;
+
+  if (req.get('host').match(testOnlyHostRestrictionRegex)) {
+    next();
+  } else {
+    // not authenticated
+    res.status(401).send('Requires authorisation');
+  }
+};

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -25,6 +25,7 @@ import { ConfirmStartersComponent } from "./features/confirm-starters/confirm-st
 import { LeaversComponent } from "./features/leavers/leavers.component"
 import { ConfirmLeaversComponent } from "./features/confirm-leavers/confirm-leavers.component"
 import { StaffComponent } from "./features/staff/staff.component"
+import { ShareLocalAuthorityComponent } from "./features/shareLocalAuthorities/shareLocalAuthority.component"
 
 const routes: Routes = [
 
@@ -115,6 +116,10 @@ const routes: Routes = [
   {
     path: 'staff',
     component: StaffComponent
+  },
+  {
+    path: 'shareLocalAuthority',
+    component: ShareLocalAuthorityComponent
   },
 ];
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -25,6 +25,7 @@ import { ConfirmStartersComponent } from "./features/confirm-starters/confirm-st
 import { LeaversComponent } from "./features/leavers/leavers.component"
 import { ConfirmLeaversComponent } from "./features/confirm-leavers/confirm-leavers.component"
 import { StaffComponent } from "./features/staff/staff.component"
+import { ShareOptionsComponent } from "./features/shareOptions/shareOptions.component"
 import { ShareLocalAuthorityComponent } from "./features/shareLocalAuthorities/shareLocalAuthority.component"
 
 const routes: Routes = [
@@ -120,6 +121,10 @@ const routes: Routes = [
   {
     path: 'shareLocalAuthority',
     component: ShareLocalAuthorityComponent
+  },
+  {
+    path: 'shareOptions',
+    component: ShareOptionsComponent
   },
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { ConfirmLeaversComponent } from './features/confirm-leavers/confirm-leav
 import { StaffComponent } from './features/staff/staff.component';
 import { MessagesComponent } from './core/messages/messages.component';
 import { ShareLocalAuthorityComponent } from './features/shareLocalAuthorities/shareLocalAuthority.component';
+import { ShareOptionsComponent } from './features/shareOptions/shareOptions.component';
 
 import { Number } from "./shared/number.directive"
 import { NumberIntOnly } from "./shared/number-int-only.directive"
@@ -89,6 +90,7 @@ import { MessageService } from "./core/services/message.service";
     ConfirmLeaversComponent,
     StaffComponent,
     ShareLocalAuthorityComponent,
+    ShareOptionsComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,7 +34,8 @@ import { ConfirmStartersComponent } from './features/confirm-starters/confirm-st
 import { LeaversComponent } from './features/leavers/leavers.component';
 import { ConfirmLeaversComponent } from './features/confirm-leavers/confirm-leavers.component';
 import { StaffComponent } from './features/staff/staff.component';
-import { MessagesComponent } from './core/messages/messages.component'
+import { MessagesComponent } from './core/messages/messages.component';
+import { ShareLocalAuthorityComponent } from './features/shareLocalAuthorities/shareLocalAuthority.component';
 
 import { Number } from "./shared/number.directive"
 import { NumberIntOnly } from "./shared/number-int-only.directive"
@@ -87,6 +88,7 @@ import { MessageService } from "./core/services/message.service";
     LeaversComponent,
     ConfirmLeaversComponent,
     StaffComponent,
+    ShareLocalAuthorityComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/core/model/localAuthority.model.ts
+++ b/src/app/core/model/localAuthority.model.ts
@@ -1,5 +1,6 @@
 export interface LocalAuthorityModel {
-  custodianCode: Number;
+  custodianCode?: Number;
+  id?: Number;    // the id of the associated Local Authority to a given Establishment
   name: string;
 }
 

--- a/src/app/core/model/localAuthority.model.ts
+++ b/src/app/core/model/localAuthority.model.ts
@@ -2,5 +2,6 @@ export interface LocalAuthorityModel {
   custodianCode?: Number;
   id?: Number;    // the id of the associated Local Authority to a given Establishment
   name: string;
+  isPrimaryAuthority? : boolean;
 }
 

--- a/src/app/core/model/localAuthority.model.ts
+++ b/src/app/core/model/localAuthority.model.ts
@@ -1,0 +1,5 @@
+export interface LocalAuthorityModel {
+  custodianCode: Number;
+  name: string;
+}
+

--- a/src/app/core/model/shareWithLocalAuthorityModel.ts
+++ b/src/app/core/model/shareWithLocalAuthorityModel.ts
@@ -1,0 +1,9 @@
+import { LocalAuthorityModel } from './localAuthority.model';
+
+export interface SharingOptionsModel {
+  enabled: boolean;
+  name: string;
+  with: Array<string>,
+  authorities: LocalAuthorityModel[]
+};
+

--- a/src/app/core/model/sharingOptions.model.ts
+++ b/src/app/core/model/sharingOptions.model.ts
@@ -1,0 +1,9 @@
+import { LocalAuthorityModel } from './localAuthority.model';
+
+export interface SharingOptionsModel {
+  enabled: boolean;
+  name: string;
+  with: Array<string>,
+  authorities: LocalAuthorityModel[]
+};
+

--- a/src/app/core/model/sharingOptions.model.ts
+++ b/src/app/core/model/sharingOptions.model.ts
@@ -4,6 +4,6 @@ export interface SharingOptionsModel {
   enabled: boolean;
   name: string;
   with: Array<string>,
-  authorities: LocalAuthorityModel[]
+  authorities?: LocalAuthorityModel[]
 };
 

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -145,8 +145,17 @@ export class EstablishmentService {
         catchError(this.httpErrorHandler.handleHttpError))
   }
 
+  /*
+   * localAuthorities
+   */
   getLocalAuthorities() {
     return this.http.get<ShareWithLocalAuthorityResponse>(`/api/establishment/${this.establishmentId}/localAuthorities`, this.getOptions())
+      .pipe(
+        debounceTime(500),
+        catchError(this.httpErrorHandler.handleHttpError))
+  }
+  postLocalAuthorities(authorities:LocalAuthorityModel[]) {
+    return this.http.post<any>(`/api/establishment/${this.establishmentId}/localAuthorities`, { localAuthorities: authorities }, this.getOptions())
       .pipe(
         debounceTime(500),
         catchError(this.httpErrorHandler.handleHttpError))

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -6,6 +6,22 @@ import { FormBuilder, FormGroup } from "@angular/forms"
 
 import { HttpErrorHandler } from "./http-error-handler.service"
 
+import { SharingOptionsModel } from '../model/sharingOptions.model';
+import { LocalAuthorityModel } from '../model/localAuthority.model';
+
+// local interface specifications for the request/response
+interface EstablishmentApiResponse {
+  id: number;
+  name: string;
+};
+interface ShareOptionsResponse extends EstablishmentApiResponse {
+  share: SharingOptionsModel;
+};
+interface ShareWithLocalAuthorityResponse extends EstablishmentApiResponse {
+  primaryAuthority: LocalAuthorityModel;
+  localAuthorities: LocalAuthorityModel[];
+};
+
 @Injectable({
   providedIn: "root"
 })
@@ -117,6 +133,20 @@ export class EstablishmentService {
    */
   postStaff(numberOfStaff) {
     return this.http.post<any>(`/api/establishment/${this.establishmentId}/staff/${numberOfStaff}`, null, this.getOptions())
+      .pipe(
+        debounceTime(500),
+        catchError(this.httpErrorHandler.handleHttpError))
+  }
+
+  getSharingOptions() {
+    return this.http.get<ShareOptionsResponse>(`/api/establishment/${this.establishmentId}/share`, this.getOptions())
+      .pipe(
+        debounceTime(500),
+        catchError(this.httpErrorHandler.handleHttpError))
+  }
+
+  getLocalAuthorities() {
+    return this.http.get<ShareWithLocalAuthorityResponse>(`/api/establishment/${this.establishmentId}/localAuthorities`, this.getOptions())
       .pipe(
         debounceTime(500),
         catchError(this.httpErrorHandler.handleHttpError))

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -14,8 +14,14 @@ interface EstablishmentApiResponse {
   id: number;
   name: string;
 };
+interface ShareOptionsRequest {
+  share: SharingOptionsModel;
+};
 interface ShareOptionsResponse extends EstablishmentApiResponse {
   share: SharingOptionsModel;
+};
+interface ShareWithLocalAuthorityRequest {
+  localAuthorities: LocalAuthorityModel[]
 };
 interface ShareWithLocalAuthorityResponse extends EstablishmentApiResponse {
   primaryAuthority: LocalAuthorityModel;
@@ -138,15 +144,27 @@ export class EstablishmentService {
         catchError(this.httpErrorHandler.handleHttpError))
   }
 
+  /*
+   * Share With Local Authorities
+   */
   getSharingOptions() {
     return this.http.get<ShareOptionsResponse>(`/api/establishment/${this.establishmentId}/share`, this.getOptions())
       .pipe(
         debounceTime(500),
         catchError(this.httpErrorHandler.handleHttpError))
   }
+  postSharingOptions(shareOptions:SharingOptionsModel) {
+    const postBody: ShareOptionsRequest = {
+      share: shareOptions
+    };
+    return this.http.post<any>(`/api/establishment/${this.establishmentId}/share`, postBody, this.getOptions())
+      .pipe(
+        debounceTime(500),
+        catchError(this.httpErrorHandler.handleHttpError))
+  }
 
   /*
-   * localAuthorities
+   * Share With Local Authorities
    */
   getLocalAuthorities() {
     return this.http.get<ShareWithLocalAuthorityResponse>(`/api/establishment/${this.establishmentId}/localAuthorities`, this.getOptions())
@@ -155,7 +173,10 @@ export class EstablishmentService {
         catchError(this.httpErrorHandler.handleHttpError))
   }
   postLocalAuthorities(authorities:LocalAuthorityModel[]) {
-    return this.http.post<any>(`/api/establishment/${this.establishmentId}/localAuthorities`, { localAuthorities: authorities }, this.getOptions())
+    const postBody : ShareWithLocalAuthorityRequest = {
+      localAuthorities: authorities
+    };
+    return this.http.post<any>(`/api/establishment/${this.establishmentId}/localAuthorities`, postBody, this.getOptions())
       .pipe(
         debounceTime(500),
         catchError(this.httpErrorHandler.handleHttpError))

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -16,7 +16,7 @@ export class EstablishmentService {
   get establishmentId() {
     // TODO replace with commented code
     // return this.establishmentId
-    return 184
+    return 1
   }
 
   setEstablishmentId(value) {

--- a/src/app/core/services/localAuthority.service.ts
+++ b/src/app/core/services/localAuthority.service.ts
@@ -21,14 +21,12 @@ export class LocalAuthorityService {
 
   getAuthorities() {
     if (!this._authorities) {
-      console.log("WA DEBUG: inside LocalAuthorityService::getAuthorities - initialising private cache")
       const options = { headers: { 'Content-type': 'application/json' } };
       return this.http.get<LocalAuthorityModel[]>('/api/localAuthority', options)
        .pipe(
          catchError(err => this.handleHttpError(err))
        );
     } else {
-      console.log("WA DEBUG: inside LocalAuthorityService::getAuthorities - returning private cache")
       return this._authorities;
     }
   }
@@ -37,7 +35,6 @@ export class LocalAuthorityService {
     // on failing to fetch authorities, add a default authority
     // TODO: this needs some work to return a subscribable observer which is a default set of data
     //        which simplifies error handling in the components that consume it.
-    console.log("WA DEBUG: inside LocalAuthorityService::handleHttpError: ", error)
     return Observable.create([{
       custodianCode: 0,
       name: 'Unknown Authorities'

--- a/src/app/core/services/localAuthority.service.ts
+++ b/src/app/core/services/localAuthority.service.ts
@@ -1,0 +1,54 @@
+// fetches and caches the set of Local Authorities (300+)
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Router } from '@angular/router';
+
+import { Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { LocalAuthorityModel } from '../model/localAuthority.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LocalAuthorityService {
+  constructor(private http: HttpClient) { }
+
+  // initialise an empty set of authorities
+  // TODO: cache this in local/session storage with an expiry (what is the expiry?)
+  private _authorities: Observable<LocalAuthorityModel[]> = null;
+  private _url: string = '/api/localAuthority';
+
+  getAuthorities() {
+    if (!this._authorities) {
+      console.log("WA DEBUG: inside LocalAuthorityService::getAuthorities - initialising private cache")
+      const options = { headers: { 'Content-type': 'application/json' } };
+      return this.http.get<LocalAuthorityModel[]>('/api/localAuthority', options)
+       .pipe(
+         catchError(err => this.handleHttpError(err))
+       );
+    } else {
+      console.log("WA DEBUG: inside LocalAuthorityService::getAuthorities - returning private cache")
+      return this._authorities;
+    }
+  }
+
+  private handleHttpError(error: HttpErrorResponse): Observable<LocalAuthorityModel[]> {
+    // on failing to fetch authorities, add a default authority
+    // TODO: this needs some work to return a subscribable observer which is a default set of data
+    //        which simplifies error handling in the components that consume it.
+    console.log("WA DEBUG: inside LocalAuthorityService::handleHttpError: ", error)
+    return Observable.create([{
+      custodianCode: 0,
+      name: 'Unknown Authorities'
+    }]);
+  }
+}
+
+
+
+
+
+
+
+

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -55,7 +55,6 @@ export class LoginComponent implements OnInit {
   }
 
   onSubmit() {
-    debugger;
     this.usernameValue = this.getUsernameInput.value;
     this.userPasswordValue = this.getPasswordInput.value;
 
@@ -83,7 +82,6 @@ export class LoginComponent implements OnInit {
 
         },
         (err) => {
-          debugger;
           console.log(err);
         },
         () => {

--- a/src/app/features/security-question/security-question.component.ts
+++ b/src/app/features/security-question/security-question.component.ts
@@ -90,9 +90,7 @@ export class SecurityQuestionComponent implements OnInit {
 
     this.currentSection = this.currentSection + 1;
 
-    debugger;
     if (this.backLink === '/create-username') {
-      debugger;
       if (this.registration.userRoute.route[this.secondItem] === '/select-workplace') {
         this.lastSection = 8;
       }
@@ -180,7 +178,6 @@ export class SecurityQuestionComponent implements OnInit {
   }
 
   updateSectionNumbers(data) {
-    debugger;
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
@@ -191,25 +188,20 @@ export class SecurityQuestionComponent implements OnInit {
 
     console.log(data);
     console.log(this.registration);
-    debugger;
   }
 
   clickBack() {
     const routeArray = this.registration.userRoute.route;
     this.currentSection = this.registration.userRoute.currentPage;
     this.currentSection = this.currentSection - 1;
-    debugger;
     this.registration.userRoute.route.splice(-1);
-    debugger;
 
     //this.updateSectionNumbers(this.registration);
     //this.registration.userRoute = this.registration.userRoute;
     this.registration.userRoute.currentPage = this.currentSection;
     //this.registration.userRoute['route'] = this.registration.userRoute['route'];
-    debugger;
     this._registrationService.updateState(this.registration);
 
-    debugger;
     this.router.navigate([this.backLink]);
   }
 

--- a/src/app/features/select-main-service/select-main-service.component.ts
+++ b/src/app/features/select-main-service/select-main-service.component.ts
@@ -59,7 +59,6 @@ export class SelectMainServiceComponent implements OnInit {
     this.backLink = this.registration.userRoute.route[this.currentSection - 1];
 
     this.currentSection = this.currentSection + 1;
-    debugger;
     if (this.backLink === '/registered-question') {
       this.lastSection = 7;
     }
@@ -83,23 +82,18 @@ export class SelectMainServiceComponent implements OnInit {
     const routeArray = this.registration.userRoute.route;
     this.currentSection = this.registration.userRoute.currentPage;
     this.currentSection = this.currentSection - 1;
-    debugger;
     this.registration.userRoute.route.splice(-1);
-    debugger;
 
     //this.updateSectionNumbers(this.registration);
     //this.registration.userRoute = this.registration.userRoute;
     this.registration.userRoute.currentPage = this.currentSection;
     //this.registration.userRoute['route'] = this.registration.userRoute['route'];
-    debugger;
     this._registrationService.updateState(this.registration);
 
-    debugger;
     this.router.navigate([this.backLink]);
   }
 
   getMainServices() {
-    //debugger
     //this.regulatedCheck = this.registration[0].locationdata.isRegulated;
 
     if (this.registration.locationdata[0].isRegulated === true) {
@@ -145,7 +139,6 @@ export class SelectMainServiceComponent implements OnInit {
   }
 
   updateSectionNumbers(data) {
-    debugger;
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
@@ -157,7 +150,6 @@ export class SelectMainServiceComponent implements OnInit {
 
     console.log(data);
     console.log(this.registration);
-    debugger;
   }
 
 }

--- a/src/app/features/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/select-workplace-address/select-workplace-address.component.ts
@@ -87,7 +87,6 @@ export class SelectWorkplaceAddressComponent implements OnInit {
   }
 
   updateSectionNumbers(data) {
-    debugger;
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
@@ -99,7 +98,6 @@ export class SelectWorkplaceAddressComponent implements OnInit {
 
     console.log(data);
     console.log(this.registration);
-    debugger;
   }
 
   postcodeChange() {

--- a/src/app/features/select-workplace/select-workplace.component.ts
+++ b/src/app/features/select-workplace/select-workplace.component.ts
@@ -53,9 +53,7 @@ export class SelectWorkplaceComponent implements OnInit {
     const routeArray = this.registration.userRoute.route;
     this.currentSection = this.registration.userRoute.currentPage;
     this.currentSection = this.currentSection - 1;
-    debugger;
     this.registration.userRoute.route.splice(-1);
-    debugger;
 
     //this.updateSectionNumbers(this.registration);
     this.registration['userRoute'] = this.registration.userRoute;
@@ -63,7 +61,6 @@ export class SelectWorkplaceComponent implements OnInit {
     //this.registration.userRoute['route'] = this.registration.userRoute['route'];
     this._registrationService.updateState(this.registration);
 
-    debugger;
     this.router.navigate([this.backLink]);
   }
 
@@ -120,7 +117,6 @@ export class SelectWorkplaceComponent implements OnInit {
   }
 
   updateSectionNumbers(data) {
-    debugger;
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
@@ -132,17 +128,14 @@ export class SelectWorkplaceComponent implements OnInit {
 
     console.log(data);
     console.log(this.registration);
-    debugger;
   }
 
   workplaceNotFound() {
     this.addressPostcode = this.registration.locationdata[0].postalCode;
-    debugger;
 
     this._registrationService.getAddressByPostCode(this.addressPostcode).subscribe(
       (data: RegistrationModel) => {
         if (data.success === 1) {
-          debugger;
           this.updateSectionNumbers(data);
           //data = data.postcodedata;
           this._registrationService.updateState(data);
@@ -151,7 +144,6 @@ export class SelectWorkplaceComponent implements OnInit {
       }
       // ,
       // (err: RegistrationTrackerError) => {
-      //   debugger;
       //   console.log(err);
       //   this.nonCqcPostcodeApiError = err.friendlyMessage;
       //   //this.setCqcRegPostcodeMessage(this.cqcRegisteredPostcode);

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
@@ -11,72 +11,57 @@
     <ng-template [ngIf]="isSharingEnabled" [ngIfElse]="notSharing">
       <div class="form-group mb-5">
         <div class="row p-0">
-            <div class="col-1">
-                <input type="checkbox"
-                  id="primaryAuthority"
-                  formControlName="primaryAuthority"
-                  class="form-control">  
-            </div>
-            <div class="col-11">
-                <label for="primaryAuthority" class="page-emphasis">{{ primaryAuthority ? primaryAuthority.name : 'TODO' }}</label>
-                <p class="page-comment">This is the local authority you are located in</p>    
-            </div>
+          <div class="col-1 center-v no-padding-left">
+              <input type="checkbox"
+                id="primaryAuthorityCtl"
+                formControlName="primaryAuthorityCtl"
+                class="form-control">  
+          </div>
+          <div class="col-11">
+              <label for="primaryAuthorityCtl" class="page-emphasis">{{ primaryAuthorityName }}</label>
+              <p class="page-comment">This is the local authority you are located in</p>    
+          </div>
         </div>
-        <div class="row">
+
+        <div class="row column-des">
             <p class="page-description">Add more local authorities to share your data with.</p>
         </div>
-        <div class="form-group mb-5" *ngIf="allAuthorties && localAuthorities">
+        <div class="form-group mb-5 col-12 p-0">
+          <div formArrayName="authoritiesCtl">
+            <!-- Note - it is significant that each record/row within the authorityCtl array
+                 is placed within a div having that formArrayName - otherwise, you 
+                 cannot use [formGroupName] -->
+            
+            <div class="row column-des">
+              <p *ngIf="hasLocalAuthorities" class="page-emphasis">Local authorities</p>
+            </div>
 
-          <div *ngFor="let thisLA of localAuthorities; let idx = index" [formGroupName]="idx" class="row record">
-            <!--<div class="col-6 col-sm-7">
-              <select formControlName="jobId" class="form-control">
-              <select class="form-control">
-                <option *ngFor="let myLa of allAuthorties" [value]="myLa.custodianCode">
-                  {{myLa.name}}
-                </option>
-              </select>
+            <div *ngFor="let thisLA of shareLocalAuthoritiesForm.get('authoritiesCtl').controls; let idx = index" [formGroupName]="idx" class="row record">
+                <div class="col-9 col-sm-10">
+                  <!-- <select class="form-control"> -->
+                  <select class="form-control" formControlName="custodianCode">
+                    <option [ngValue]="null">Select Local Authority</option>
+                    <option *ngFor="let myLa of allAuthorties" [value]="myLa.custodianCode">{{myLa.name}}</option>
+                  </select>
+                </div>
+                <div class="center-v no-padding-left">
+                  <button type="button" class="btn-link" (click)="removeAuthority(idx)">Remove</button>
+                </div>
+
             </div>
-            <div class="col-3 center-v no-padding-left">
-              <button type="button" class="btn-link" (click)="removeAuthority(idx)">Remove</button>
-            </div>-->
-          </div>
-          <div class="row summary-and-controls mb-5 record">
-            <div class="col-6 col-sm-7 center-v">
-              <button type="button" class="btn-link" (click)="addAuthority()">+ Add another local authority</button>
+            <div class="row summary-and-controls mb-5 record">
+              <div class="col-6 col-sm-7 center-v">
+                <button type="button" class="btn-link" (click)="addAuthority()">+ Add another local authority</button>
+              </div>
             </div>
+
           </div>
 
         </div>
         <div class="form-group mb-5">
-          <!--
-          <div class="row">
-              <div class="col-1">
-                <input type="radio"
-                  id="doNotShare"
-                  formControlName="doNotShare"
-                  value="true"
-                  class="form-control">
-              </div>
-              <div class="col-11">
-                  <label for="doNotShare">No, don't share any data with any local authority.</label>
-              </div>
-          </div>
-          <div class="row">
-              <div class="col-1">
-                <input type="radio"
-                  id="doNotShare"
-                  value="false"
-                  formControlName="doNotShare"
-                  class="form-control">
-              </div>
-              <div class="col-11">
-                  <label for="doShare">Continue to share with local authorities (because we are using radio buttons!).</label>
-              </div>
-          </div>
-        -->
           <div class="row round">
               <div class="col-1">
-                  <input type="checkbox" id="doShare" formControlName="doNotShare" class="form-control">
+                  <input type="checkbox" id="doShareCtl" formControlName="doNotShareCtl" class="form-control">
                   <label for="doShare"></label>
               </div>
               <div class="col-11">

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
@@ -8,44 +8,98 @@
     (ngSubmit)="onSubmit()"
     [formGroup]="shareLocalAuthoritiesForm">
 
-    <div class="form-group mb-5">
-      <div class="row p-0">
-          <div class="col-1">
-              <input type="checkbox"
-                id="primaryAuthority"
-                formControlName="primaryAuthority"
-                class="form-control">  
+    <ng-template [ngIf]="isSharingEnabled" [ngIfElse]="notSharing">
+      <div class="form-group mb-5">
+        <div class="row p-0">
+            <div class="col-1">
+                <input type="checkbox"
+                  id="primaryAuthority"
+                  formControlName="primaryAuthority"
+                  class="form-control">  
+            </div>
+            <div class="col-11">
+                <label for="primaryAuthority" class="page-emphasis">{{ primaryAuthority ? primaryAuthority.name : 'TODO' }}</label>
+                <p class="page-comment">This is the local authority you are located in</p>    
+            </div>
+        </div>
+        <div class="row">
+            <p class="page-description">Add more local authorities to share your data with.</p>
+        </div>
+        <div class="form-group mb-5" *ngIf="allAuthorties && localAuthorities">
+
+          <div *ngFor="let thisLA of localAuthorities; let idx = index" [formGroupName]="idx" class="row record">
+            <!--<div class="col-6 col-sm-7">
+              <select formControlName="jobId" class="form-control">
+              <select class="form-control">
+                <option *ngFor="let myLa of allAuthorties" [value]="myLa.custodianCode">
+                  {{myLa.name}}
+                </option>
+              </select>
+            </div>
+            <div class="col-3 center-v no-padding-left">
+              <button type="button" class="btn-link" (click)="removeAuthority(idx)">Remove</button>
+            </div>-->
           </div>
-          <div class="col-11">
-              <label for="primaryAuthority">TODO: [City of London]</label>
-              <p class="page-comment">This is the local authority you are located in</p>    
+          <div class="row summary-and-controls mb-5 record">
+            <div class="col-6 col-sm-7 center-v">
+              <button type="button" class="btn-link" (click)="addAuthority()">+ Add another local authority</button>
+            </div>
           </div>
-      </div>
-    </div>
-    <div class="form-group mb-5">
-      <div class="col-12 p-0">
-          <p class="page-description">Add more local authorities to share your data with.</p>
-      </div>
-      <div class="col-12 p-0">
-          <p>Add list of local authorities</p>
-      </div>
-    </div>
-    <div class="form-group mb-5">
-      <div class="row">
-          <div class="col-1">
-            <input type="radio"
-              id="doNotShare"
-              formControlName="doNotShare"
-              class="form-control">
+
+        </div>
+        <div class="form-group mb-5">
+          <!--
+          <div class="row">
+              <div class="col-1">
+                <input type="radio"
+                  id="doNotShare"
+                  formControlName="doNotShare"
+                  value="true"
+                  class="form-control">
+              </div>
+              <div class="col-11">
+                  <label for="doNotShare">No, don't share any data with any local authority.</label>
+              </div>
           </div>
-          <div class="col-11">
-              <label for="doNotShare">No, don't share any data with any local authority.</label>
+          <div class="row">
+              <div class="col-1">
+                <input type="radio"
+                  id="doNotShare"
+                  value="false"
+                  formControlName="doNotShare"
+                  class="form-control">
+              </div>
+              <div class="col-11">
+                  <label for="doShare">Continue to share with local authorities (because we are using radio buttons!).</label>
+              </div>
           </div>
+        -->
+          <div class="row round">
+              <div class="col-1">
+                  <input type="checkbox" id="doShare" formControlName="doNotShare" class="form-control">
+                  <label for="doShare"></label>
+              </div>
+              <div class="col-11">
+                  <p>No, don't share any data with any local authority.</p>
+              </div>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="btn-container">
-      <button type="submit" class="btn btn-primary">Save and continue</button>
-    </div>  
+      <div class="btn-container">
+        <button type="submit" class="btn btn-primary">Save and continue</button>
+      </div>
+  
+    </ng-template>
+
+    <ng-template #notSharing>
+      <div *ngIf="!isSharingEnabled">
+        <p class="page-description">Sharing with Local Authorities is not enabled</p>
+      </div>
+      <div class="btn-container">
+        <button type="submit" class="btn btn-primary">Continue</button>
+      </div>
+    </ng-template>
+
   </form>
 </div>
 

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
@@ -1,0 +1,51 @@
+<div class="main-page-container col-12">
+  <header>
+    <h1 class="h1">Sharing data with local authorities</h1>
+    <p class="page-description">Select which local authorities you would like to share your data with.</p>
+  </header>
+
+  <form novalidate
+    (ngSubmit)="onSubmit()"
+    [formGroup]="shareLocalAuthoritiesForm">
+
+    <div class="form-group mb-5">
+      <div class="row p-0">
+          <div class="col-1">
+              <input type="checkbox"
+                id="primaryAuthority"
+                formControlName="primaryAuthority"
+                class="form-control">  
+          </div>
+          <div class="col-11">
+              <label for="primaryAuthority">TODO: [City of London]</label>
+              <p class="page-comment">This is the local authority you are located in</p>    
+          </div>
+      </div>
+    </div>
+    <div class="form-group mb-5">
+      <div class="col-12 p-0">
+          <p class="page-description">Add more local authorities to share your data with.</p>
+      </div>
+      <div class="col-12 p-0">
+          <p>Add list of local authorities</p>
+      </div>
+    </div>
+    <div class="form-group mb-5">
+      <div class="row">
+          <div class="col-1">
+            <input type="radio"
+              id="doNotShare"
+              formControlName="doNotShare"
+              class="form-control">
+          </div>
+          <div class="col-11">
+              <label for="doNotShare">No, don't share any data with any local authority.</label>
+          </div>
+      </div>
+    </div>
+    <div class="btn-container">
+      <button type="submit" class="btn btn-primary">Save and continue</button>
+    </div>  
+  </form>
+</div>
+

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
@@ -62,7 +62,7 @@
           <div class="row round">
               <div class="col-1">
                   <input type="checkbox" id="doShareCtl" formControlName="doNotShareCtl" class="form-control">
-                  <label for="doShare"></label>
+                  <label for="doShareCtl"></label>
               </div>
               <div class="col-11">
                   <p>No, don't share any data with any local authority.</p>

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.scss
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.scss
@@ -1,0 +1,12 @@
+@import "../../../assets/scss/variables.scss";
+.page-comment {
+    color: $light-grey-text;
+    padding-left: 0px;
+}
+
+input[type=checkbox] {
+    transform: scale(2.0);
+}
+input[type=radio] {
+    transform: scale(2.0);
+}

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.scss
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.scss
@@ -1,7 +1,39 @@
+@import "../../../assets/scss/mixins";
 @import "../../../assets/scss/variables.scss";
+
 .page-comment {
     color: $light-grey-text;
     padding-left: 0px;
+}
+
+.page-emphasis {
+    font-weight: bold;
+}
+
+
+.btn-link {
+    margin: auto 0;
+    font-size: 15px;
+    letter-spacing: 1px;
+    border: 0;
+    color: #1078c7;
+    text-decoration: underline;
+    line-height: 2rem;
+
+    @include media(map-get($breakpoints, tablet)) {
+        line-height: 20px;
+    }
+}
+
+.record {
+    & ~ .record {
+        margin-top: 3rem;
+    }
+    line-height: 32px;;
+}
+
+.record select {
+    height: 30px;
 }
 
 input[type=checkbox] {
@@ -9,4 +41,47 @@ input[type=checkbox] {
 }
 input[type=radio] {
     transform: scale(2.0);
+}
+
+.round {
+position: relative;
+}
+  
+.round label {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 50%;
+    cursor: pointer;
+    height: 28px;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 28px;
+}
+  
+.round label:after {
+    border: 2px solid #fff;
+    border-top: none;
+    border-right: none;
+    content: "";
+    height: 6px;
+    left: 7px;
+    opacity: 0;
+    position: absolute;
+    top: 8px;
+    transform: rotate(-45deg);
+    width: 12px;
+}
+  
+.round input[type="checkbox"] {
+    visibility: hidden;
+}
+  
+.round input[type="checkbox"]:checked + label {
+    background-color: $sfc-btn-primary-green;
+    border-color:  $sfc-btn-primary-green;
+}
+  
+.round input[type="checkbox"]:checked + label:after {
+    opacity: 1;
 }

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.spec.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShareLocalAuthorityComponent } from './shareLocalAuthority.component';
+
+describe('StaffComponent', () => {
+  let component: ShareLocalAuthorityComponent;
+  let fixture: ComponentFixture<ShareLocalAuthorityComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ShareLocalAuthorityComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShareLocalAuthorityComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -57,7 +57,7 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
   }
   get primaryAuthorityName(): string {
     if (this._primaryAuthority) return this._primaryAuthority.name;
-    return 'TODO';
+    return 'Rendering....';
   }
   get localAuthorities(): LocalAuthorityModel[] {
     return this._localAuthorities;
@@ -130,7 +130,6 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
     // when initialising this component, get the set of all Local Authorities (for drop down)
     this.subscriptions.push(
       this.localAuthorityService.getAuthorities().subscribe(authorities => {
-        console.log('WA DEBUG: Number of authorities: ', authorities.length)
         this._allAuthorities = authorities;
       })
     );
@@ -138,8 +137,6 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
     // and get the current establishment local authorities configuration
     this.subscriptions.push(
       this.establishmentService.getLocalAuthorities().subscribe(authorities => {
-        console.log('WA DEBUG: The primary authority: ', authorities.primaryAuthority)
-        console.log('WA DEBUG: The local authorities: ', authorities.localAuthorities)
         this._primaryAuthority = authorities.primaryAuthority;
         this._localAuthorities = authorities.localAuthorities;
 

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { FormGroup, FormBuilder, Validators, FormArray } from "@angular/forms"
+import { Router } from "@angular/router"
+
+import { MessageService } from "../../core/services/message.service"
+import { EstablishmentService } from "../../core/services/establishment.service"
+import { LocalAuthorityService } from "../../core/services/localAuthority.service"
+
+@Component({
+  selector: 'app-shareLocalAuthority',
+  templateUrl: './shareLocalAuthority.component.html',
+  styleUrls: ['./shareLocalAuthority.component.scss']
+})
+export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
+
+  constructor(
+    private router: Router,
+    private establishmentService: EstablishmentService,
+    private localAuthorityService: LocalAuthorityService,
+    private messageService: MessageService,
+    private fb: FormBuilder) {}
+
+    shareLocalAuthoritiesForm: FormGroup
+
+  private subscriptions = []
+
+  get primaryAuthority() {
+    return this.shareLocalAuthoritiesForm.get('primaryAuthority').value
+  }
+
+  onSubmit () {
+
+  }
+
+  ngOnInit() {
+    this.shareLocalAuthoritiesForm = this.fb.group({
+      primaryAuthority: [true, [Validators.required]],
+      doNotShare: [true, [Validators.required]],
+    });
+
+    // when initialising this component, get the set of all Local Authorities (for drop down)
+    this.subscriptions.push(
+      this.localAuthorityService.getAuthorities().subscribe(authorities => {
+        console.log('WA DEBUG: Number of authorities: ', authorities.length)
+
+        // this.primaryAuthority.reset({
+        //   primaryAuthority: true,
+        // })
+      })
+    )
+
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach(s => s.unsubscribe())
+    this.messageService.clearAll()
+  }
+}

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -108,8 +108,7 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
 
   onSubmit () {
     if (this.doNotShareControl) {
-      alert("Navigate to share options")
-      //this.router.navigate(["/shareOptions"]);
+      this.router.navigate(["/shareOptions"]);
     } else {
       // get the list of authorities from the form array, but filter
       //   the default option (whereby custodian code is null), and

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -38,6 +38,10 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
   get primaryAuthorityControl() {
     return this.shareLocalAuthoritiesForm.get('primaryAuthorityCtl').value
   }
+  set primaryAuthorityControl(value:boolean) {
+    console.log("Updating primary authority control: ", value);
+    this.shareLocalAuthoritiesForm.get('primaryAuthorityCtl').patchValue(true, {onlySelf:true, emitEvent: false});
+  }
   get doNotShareControl(): boolean {
     return this.shareLocalAuthoritiesForm.get('doNotShareCtl').value;
   }
@@ -181,7 +185,14 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
         const ourAuthoritiesControl = this.authoritiesControl;
         if (this._localAuthorities && this._localAuthorities.length > 0) {
           this._localAuthorities.forEach(thisAuthority => {
-            ourAuthoritiesControl.push(this._createAuthorityControl(thisAuthority.custodianCode));
+            // one of the fetched (API) authorities could be the primary authority
+            if (thisAuthority.isPrimaryAuthority) {
+              console.log("The primary authority is checked: ", thisAuthority.custodianCode);
+              this.primaryAuthorityControl = true;
+            } else {
+              ourAuthoritiesControl.push(this._createAuthorityControl(thisAuthority.custodianCode));
+            }
+            
           });
         }
         

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -117,8 +117,6 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
       //   the same structure but preferred to map here anyway
       //   to make it explicit for posting
       // const selectedAuthorites = [];
-      const authorityCtlValues = this.authoritiesControl.value;
-
       const selectedAuthorites = this.authoritiesControl.value
           .filter(a => a.custodianCode === null ? false : true)
           .map(a => { return { custodianCode: parseInt(a.custodianCode) }});
@@ -133,9 +131,10 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
 
       this.subscriptions.push(
         this.establishmentService.postLocalAuthorities(selectedAuthorites)
-          .subscribe(() => {
-            this.router.navigate(['/vacancies']);
-          }));
+        .subscribe(() => {
+          this.router.navigate(['/vacancies']);
+        })
+      );
     }
 
   }

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -177,7 +177,6 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
           this._localAuthorities.forEach(thisAuthority => {
             // one of the fetched (API) authorities could be the primary authority
             if (thisAuthority.isPrimaryAuthority) {
-              console.log("The primary authority is checked: ", thisAuthority.custodianCode);
               this.primaryAuthorityControl = true;
             } else {
               ourAuthoritiesControl.push(this._createAuthorityControl(thisAuthority.custodianCode));
@@ -185,8 +184,7 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
             
           });
         }
-        
-        //console.log("Getting primary authority by name: ", this.primaryAuthorityName)
+
       })
     );
   }

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -39,7 +39,6 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
     return this.shareLocalAuthoritiesForm.get('primaryAuthorityCtl').value
   }
   set primaryAuthorityControl(value:boolean) {
-    console.log("Updating primary authority control: ", value);
     this.shareLocalAuthoritiesForm.get('primaryAuthorityCtl').patchValue(true, {onlySelf:true, emitEvent: false});
   }
   get doNotShareControl(): boolean {
@@ -108,12 +107,10 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
   }
 
   onSubmit () {
-    alert("onSubmit)")
     if (this.doNotShareControl) {
       alert("Navigate to share options")
       //this.router.navigate(["/shareOptions"]);
     } else {
-      alert("Process selected authorities")
       // get the list of authorities from the form array, but filter
       //   the default option (whereby custodian code is null), and
       //   to remap each entry. Note, the source and target are
@@ -133,11 +130,6 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
           custodianCode: this._primaryAuthority.custodianCode
         });
       }
-
-      // // for test/debugging
-      // selectedAuthorites.forEach(thisAuth => {
-      //   console.log("this auth: ", thisAuth)
-      // });
 
       this.subscriptions.push(
         this.establishmentService.postLocalAuthorities(selectedAuthorites)

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -6,6 +6,10 @@ import { MessageService } from "../../core/services/message.service"
 import { EstablishmentService } from "../../core/services/establishment.service"
 import { LocalAuthorityService } from "../../core/services/localAuthority.service"
 
+import { SharingOptionsModel } from '../../core/model/sharingOptions.model';
+import { LocalAuthorityModel } from '../../core/model/localAuthority.model';
+
+
 @Component({
   selector: 'app-shareLocalAuthority',
   templateUrl: './shareLocalAuthority.component.html',
@@ -18,37 +22,138 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
     private establishmentService: EstablishmentService,
     private localAuthorityService: LocalAuthorityService,
     private messageService: MessageService,
-    private fb: FormBuilder) {}
+    private fb: FormBuilder) {
 
-    shareLocalAuthoritiesForm: FormGroup
+  }
 
+  private shareLocalAuthoritiesForm: FormGroup
   private subscriptions = []
 
-  get primaryAuthority() {
-    return this.shareLocalAuthoritiesForm.get('primaryAuthority').value
+  private _isSharingWithLAEnabled: boolean = false;
+  private _allAuthorities: LocalAuthorityModel[] = [];
+  private _localAuthorities: LocalAuthorityModel[] = [];
+  private _primaryAuthority: LocalAuthorityModel = null;
+
+  // form controls
+  get primaryAuthorityControl() {
+    return this.shareLocalAuthoritiesForm.get('primaryAuthorityCtl').value
+  }
+  get doNotShareControl(): boolean {
+    return this.shareLocalAuthoritiesForm.get('doNotShareCtl').value;
+  }
+  get doShareControl(): boolean {
+    return this.shareLocalAuthoritiesForm.get('doShareCtl').value;
+  }
+  get authoritiesControl() : FormArray {
+    return <FormArray> this.shareLocalAuthoritiesForm.controls.authoritiesCtl;
+  }
+
+  // component state
+  get isSharingEnabled(): boolean {
+    return this._isSharingWithLAEnabled;
+  }
+  get primaryAuthority(): LocalAuthorityModel {
+    return this._primaryAuthority;
+  }
+  get primaryAuthorityName(): string {
+    if (this._primaryAuthority) return this._primaryAuthority.name;
+    return 'TODO';
+  }
+  get localAuthorities(): LocalAuthorityModel[] {
+    return this._localAuthorities;
+  }
+  get allAuthorties(): LocalAuthorityModel[] {
+    return this._allAuthorities;
+  }
+
+  get hasLocalAuthorities(): boolean {
+    if (this._localAuthorities) {
+      if (this._localAuthorities.length > 0) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  // helpers
+  sameLocalAuthority(givenLA:LocalAuthorityModel, referenceLA:LocalAuthorityModel): boolean {
+    if (givenLA.custodianCode === referenceLA.custodianCode) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // adds a new uninitialised authority
+  addAuthority() {
+    this.authoritiesControl.push(this._createAuthorityControl());
+  }
+
+  // removes the Authority with given index
+  removeAuthority(index) {
+    this.authoritiesControl.removeAt(index);
+  }
+
+  private _createAuthorityControl(custodianCode=null) {
+    return this.fb.group({
+      custodianCode: [custodianCode, Validators.required]
+    });
   }
 
   onSubmit () {
-
+    alert("Called onSubmit - doNotShare: " + this.doNotShareControl);
   }
 
   ngOnInit() {
+    // create form controls, including an empty array for the list of authorities
     this.shareLocalAuthoritiesForm = this.fb.group({
-      primaryAuthority: [true, [Validators.required]],
-      doNotShare: [true, [Validators.required]],
+      primaryAuthorityCtl: [false, [Validators.required]],
+      doNotShareCtl: [false, [Validators.required]],
+      authoritiesCtl: this.fb.array([])
     });
+
+    // temporarily enable sharing
+    this._isSharingWithLAEnabled = true;
+
+    // fetch establishment sharing options to determine if Local Authority sharing is enable.
+    this.subscriptions.push(
+      this.establishmentService.getSharingOptions().subscribe(options => {
+        // for this component to be relevant, sharing must be enabled and
+        //   must be sharing with Local Authority
+        this._isSharingWithLAEnabled = options.share.enabled && options.share.with.includes('Local Authority');
+      })
+    );
 
     // when initialising this component, get the set of all Local Authorities (for drop down)
     this.subscriptions.push(
       this.localAuthorityService.getAuthorities().subscribe(authorities => {
         console.log('WA DEBUG: Number of authorities: ', authorities.length)
-
-        // this.primaryAuthority.reset({
-        //   primaryAuthority: true,
-        // })
+        this._allAuthorities = authorities;
       })
-    )
+    );
 
+    // and get the current establishment local authorities configuration
+    this.subscriptions.push(
+      this.establishmentService.getLocalAuthorities().subscribe(authorities => {
+        console.log('WA DEBUG: The primary authority: ', authorities.primaryAuthority)
+        console.log('WA DEBUG: The local authorities: ', authorities.localAuthorities)
+        this._primaryAuthority = authorities.primaryAuthority;
+        this._localAuthorities = authorities.localAuthorities;
+
+        // create the set of authority form controls for each local authority
+        const ourAuthoritiesControl = this.authoritiesControl;
+        if (this._localAuthorities && this._localAuthorities.length > 0) {
+          this._localAuthorities.forEach(thisAuthority => {
+            ourAuthoritiesControl.push(this._createAuthorityControl(thisAuthority.custodianCode));
+          });
+        }
+        
+        //console.log("Getting primary authority by name: ", this.primaryAuthorityName)
+      })
+    );
   }
 
   ngOnDestroy() {

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -104,7 +104,44 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
   }
 
   onSubmit () {
-    alert("Called onSubmit - doNotShare: " + this.doNotShareControl);
+    alert("onSubmit)")
+    if (this.doNotShareControl) {
+      alert("Navigate to share options")
+      //this.router.navigate(["/shareOptions"]);
+    } else {
+      alert("Process selected authorities")
+      // get the list of authorities from the form array, but filter
+      //   the default option (whereby custodian code is null), and
+      //   to remap each entry. Note, the source and target are
+      //   the same structure but preferred to map here anyway
+      //   to make it explicit for posting
+      // const selectedAuthorites = [];
+      const authorityCtlValues = this.authoritiesControl.value;
+
+      const selectedAuthorites = this.authoritiesControl.value
+          .filter(a => a.custodianCode === null ? false : true)
+          .map(a => { return { custodianCode: parseInt(a.custodianCode) }});
+
+      // now check if the primary authority has also been selected, and if so
+      //  add that to the set of selected authorities
+      if (this.primaryAuthorityControl) {
+        selectedAuthorites.push({
+          custodianCode: this._primaryAuthority.custodianCode
+        });
+      }
+
+      // // for test/debugging
+      // selectedAuthorites.forEach(thisAuth => {
+      //   console.log("this auth: ", thisAuth)
+      // });
+
+      this.subscriptions.push(
+        this.establishmentService.postLocalAuthorities(selectedAuthorites)
+          .subscribe(() => {
+            this.router.navigate(['/vacancies']);
+          }));
+    }
+
   }
 
   ngOnInit() {

--- a/src/app/features/shareOptions/shareOptions.component.html
+++ b/src/app/features/shareOptions/shareOptions.component.html
@@ -8,7 +8,7 @@
   <div>
     <div class="row summary-and-controls mb-5 record">
       <div class="col-12 col-sm-12 center-v">
-        <button type="button" class="btn-link" (click)="addAuthority()">Why do we share your data?</button>
+        <button type="button" class="btn-link">Why do we share your data?</button>
       </div>
     </div>
   </div>
@@ -25,12 +25,12 @@
       <div class="row p-0">
         <div class="col-1 center-v no-padding-left">
             <input type="checkbox"
-              id="shareWithCQC"
-              formControlName="shareWithCQC"
+              id="shareWithCQCctl"
+              formControlName="shareWithCQCctl"
               class="form-control">  
         </div>
         <div class="col-11">
-            <label for="shareWithCQC">Care Quality Commission (CQC)</label>
+            <label for="shareWithCQCctl">Care Quality Commission (CQC)</label>
         </div>
         <div class="row summary-and-controls mb-5 record">
           <div class="col-12 col-sm-12 center-v">
@@ -41,31 +41,32 @@
       <div class="row p-0">
         <div class="col-1 center-v no-padding-left">
             <input type="checkbox"
-              id="shareWithLocalAuthority"
-              formControlName="shareWithLocalAuthority"
+              id="shareWithLocalAuthorityCtl"
+              formControlName="shareWithLocalAuthorityCtl"
               class="form-control">  
         </div>
         <div class="col-11">
-            <label for="shareWithLocalAuthority">Local authorities</label>
+            <label for="shareWithLocalAuthorityCtl">Local authorities</label>
         </div>
         <div class="row summary-and-controls mb-5 record">
           <div class="col-12 col-sm-12 center-v">
-            <button type="button" class="btn-link">What do we shae with local authorities?</button>
+            <button type="button" class="btn-link">What do we share with local authorities?</button>
           </div>
         </div>
       </div>
-  
+        
       <div class="form-group mb-5">
         <div class="row round">
             <div class="col-1">
-                <input type="checkbox" id="doShareCtl" formControlName="doNotShareCtl" class="form-control">
-                <label for="doShare"></label>
+                <input type="checkbox" id="doNotShareCtl" formControlName="doNotShareCtl" class="form-control">
+                <label for="doNotShareCtl"></label>
             </div>
             <div class="col-11">
                 <p>No, don't share my data.</p>
             </div>
         </div>
       </div>
+
     </div>
     <div class="btn-container">
       <button type="submit" class="btn btn-primary">Save and continue</button>

--- a/src/app/features/shareOptions/shareOptions.component.html
+++ b/src/app/features/shareOptions/shareOptions.component.html
@@ -1,0 +1,75 @@
+<div class="main-page-container col-12">
+  <header>
+    <h1 class="h1">Sharing your data</h1>
+    <p class="page-description">We would like to share your data with other organisations.</p>
+    <p class="page-description">Before we do that, we need your consent.</p>
+  </header>
+
+  <div>
+    <div class="row summary-and-controls mb-5 record">
+      <div class="col-12 col-sm-12 center-v">
+        <button type="button" class="btn-link" (click)="addAuthority()">Why do we share your data?</button>
+      </div>
+    </div>
+  </div>
+
+  <form novalidate
+    (ngSubmit)="onSubmit()"
+    [formGroup]="shareOptionsForm">
+
+    <div class="col-12 row">
+      <p class="page-emphasis">Do you agree to us sharing data with:</p>
+    </div>
+
+    <div class="form-group mb-5">
+      <div class="row p-0">
+        <div class="col-1 center-v no-padding-left">
+            <input type="checkbox"
+              id="shareWithCQC"
+              formControlName="shareWithCQC"
+              class="form-control">  
+        </div>
+        <div class="col-11">
+            <label for="shareWithCQC">Care Quality Commission (CQC)</label>
+        </div>
+        <div class="row summary-and-controls mb-5 record">
+          <div class="col-12 col-sm-12 center-v">
+            <button type="button" class="btn-link">What do we share with CQC?</button>
+          </div>
+        </div>
+      </div>
+      <div class="row p-0">
+        <div class="col-1 center-v no-padding-left">
+            <input type="checkbox"
+              id="shareWithLocalAuthority"
+              formControlName="shareWithLocalAuthority"
+              class="form-control">  
+        </div>
+        <div class="col-11">
+            <label for="shareWithLocalAuthority">Local authorities</label>
+        </div>
+        <div class="row summary-and-controls mb-5 record">
+          <div class="col-12 col-sm-12 center-v">
+            <button type="button" class="btn-link">What do we shae with local authorities?</button>
+          </div>
+        </div>
+      </div>
+  
+      <div class="form-group mb-5">
+        <div class="row round">
+            <div class="col-1">
+                <input type="checkbox" id="doShareCtl" formControlName="doNotShareCtl" class="form-control">
+                <label for="doShare"></label>
+            </div>
+            <div class="col-11">
+                <p>No, don't share my data.</p>
+            </div>
+        </div>
+      </div>
+    </div>
+    <div class="btn-container">
+      <button type="submit" class="btn btn-primary">Save and continue</button>
+    </div>
+
+  </form>
+</div>

--- a/src/app/features/shareOptions/shareOptions.component.scss
+++ b/src/app/features/shareOptions/shareOptions.component.scss
@@ -10,6 +10,13 @@
     font-weight: bold;
 }
 
+.hidden {
+    visibility: hidden;
+}
+.show {
+    visibility: visible;
+}
+
 input[type=checkbox] {
     transform: scale(2.0);
 }

--- a/src/app/features/shareOptions/shareOptions.component.scss
+++ b/src/app/features/shareOptions/shareOptions.component.scss
@@ -1,0 +1,75 @@
+@import "../../../assets/scss/mixins";
+@import "../../../assets/scss/variables.scss";
+
+.page-comment {
+    color: $light-grey-text;
+    padding-left: 0px;
+}
+
+.page-emphasis {
+    font-weight: bold;
+}
+
+input[type=checkbox] {
+    transform: scale(2.0);
+}
+input[type=radio] {
+    transform: scale(2.0);
+}
+
+.btn-link {
+    margin: auto 0;
+    font-size: 15px;
+    letter-spacing: 1px;
+    border: 0;
+    color: #1078c7;
+    text-decoration: underline;
+    line-height: 2rem;
+
+    @include media(map-get($breakpoints, tablet)) {
+        line-height: 20px;
+    }
+}
+
+.round {
+    position: relative;
+    }
+      
+    .round label {
+        background-color: #fff;
+        border: 1px solid #ccc;
+        border-radius: 50%;
+        cursor: pointer;
+        height: 28px;
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: 28px;
+    }
+      
+    .round label:after {
+        border: 2px solid #fff;
+        border-top: none;
+        border-right: none;
+        content: "";
+        height: 6px;
+        left: 7px;
+        opacity: 0;
+        position: absolute;
+        top: 8px;
+        transform: rotate(-45deg);
+        width: 12px;
+    }
+      
+    .round input[type="checkbox"] {
+        visibility: hidden;
+    }
+      
+    .round input[type="checkbox"]:checked + label {
+        background-color: $sfc-btn-primary-green;
+        border-color:  $sfc-btn-primary-green;
+    }
+      
+    .round input[type="checkbox"]:checked + label:after {
+        opacity: 1;
+    }

--- a/src/app/features/shareOptions/shareOptions.component.spec.ts
+++ b/src/app/features/shareOptions/shareOptions.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShareOptionsComponent } from './shareOptions.component';
+
+describe('StaffComponent', () => {
+  let component: ShareOptionsComponent;
+  let fixture: ComponentFixture<ShareOptionsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ShareOptionsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShareOptionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/shareOptions/shareOptions.component.ts
+++ b/src/app/features/shareOptions/shareOptions.component.ts
@@ -75,7 +75,6 @@ export class ShareOptionsComponent implements OnInit, OnDestroy {
   
   onSubmit () {
     if (this.doNotShareControl) {
-      alert("Process selected share options - disable sharing");
       // disable sharing, but leave options unmodified
       this._shareOptions.enabled = false;
       this.subscriptions.push(
@@ -116,8 +115,6 @@ export class ShareOptionsComponent implements OnInit, OnDestroy {
         }
 
       } else {
-        alert("Process selected share options - disable sharing and reset options");
-
         // reset sharing options
         this._shareOptions.enabled = false;
         this._shareOptions.with = [];
@@ -143,7 +140,6 @@ export class ShareOptionsComponent implements OnInit, OnDestroy {
     // // fetch establishment sharing options to determine if Local Authority sharing is enable.
     this.subscriptions.push(
       this.establishmentService.getSharingOptions().subscribe(options => {
-        alert("Fetched share options: " + options)
         // for this component to be relevant, sharing must be enabled and
         //   must be sharing with Local Authority
         this._shareOptions = options.share;

--- a/src/app/features/shareOptions/shareOptions.component.ts
+++ b/src/app/features/shareOptions/shareOptions.component.ts
@@ -1,0 +1,118 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { FormGroup, FormBuilder, Validators, FormArray } from "@angular/forms"
+import { Router } from "@angular/router"
+
+import { MessageService } from "../../core/services/message.service"
+import { EstablishmentService } from "../../core/services/establishment.service"
+
+import { SharingOptionsModel } from '../../core/model/sharingOptions.model';
+
+
+@Component({
+  selector: 'app-shareOptions',
+  templateUrl: './shareOptions.component.html',
+  styleUrls: ['./shareOptions.component.scss']
+})
+export class ShareOptionsComponent implements OnInit, OnDestroy {
+  private _withLocalAuthority: string = 'Local Authority';
+  private _withCQC: string = 'CQC';
+
+  constructor(
+    private router: Router,
+    private establishmentService: EstablishmentService,
+    private messageService: MessageService,
+    private fb: FormBuilder) {
+
+  }
+
+  private shareOptionsForm: FormGroup
+  private subscriptions = []
+
+  private _shareOptions: SharingOptionsModel = null;
+
+  // form controls
+  get shareWithCQCcontrol() {
+    return this.shareOptionsForm.get('shareWithCQC').value
+  }
+  set shareWithCQCcontrol(value:boolean) {
+    console.log("Updating share With CQC control: ", value);
+    this.shareOptionsForm.get('shareWithCQC').patchValue(true, {onlySelf:true, emitEvent: false});
+  }
+  get shareWithLocalAuthorityControl(): boolean {
+    return this.shareOptionsForm.get('shareWithLocalAuthority').value;
+  }
+  set shareWithLocalAuthorityControl(value: boolean) {
+    this.shareOptionsForm.get('shareWithLocalAuthority').patchValue(true, {onlySelf:true, emitEvent: false});
+  }
+  get doNotShareControl() {
+    return this.shareOptionsForm.get('doShareCtl').value;
+  }
+
+  private get isShareWithCQCEnabled(): boolean {
+    if (this._shareOptions) {
+      if (this._shareOptions.enabled && 
+          this._shareOptions.with &&
+          this._shareOptions.with.includes(this._withCQC)) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    return false;
+  }
+  private get isShareWithLAEnabled(): boolean {
+    if (this._shareOptions) {
+      if (this._shareOptions.enabled && 
+          this._shareOptions.with &&
+          this._shareOptions.with.includes(this._withLocalAuthority)) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  
+  onSubmit () {
+    alert("onSubmit)")
+    if (this.doNotShareControl) {
+      alert("Navigate to vacancies, skipping over Share with Local Authorities")
+      //this.router.navigate(["/vacancies"]);
+    } else {
+      alert("Process selected share options - including context driven navigation");
+    }
+  }
+
+  ngOnInit() {
+    // create form controls, including an empty array for the list of authorities
+    this.shareOptionsForm = this.fb.group({
+      shareWithCQC: [false, [Validators.required]],
+      shareWithLocalAuthority: [false, [Validators.required]],
+      doNotShareCtl: [false, [Validators.required]],
+    });
+
+    // fetch establishment sharing options to determine if Local Authority sharing is enable.
+    this.subscriptions.push(
+      this.establishmentService.getSharingOptions().subscribe(options => {
+        // for this component to be relevant, sharing must be enabled and
+        //   must be sharing with Local Authority
+        this._shareOptions = options.share;
+
+        // update the controls with data fetched from store
+        if (this.isShareWithCQCEnabled) {
+          this.shareWithCQCcontrol = true;
+        }
+        if (this.isShareWithLAEnabled) {
+          this.shareWithLocalAuthorityControl = true;
+        }
+      })
+    );
+
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach(s => s.unsubscribe())
+    this.messageService.clearAll()
+  }
+}

--- a/src/app/features/user-details/user-details.component.ts
+++ b/src/app/features/user-details/user-details.component.ts
@@ -148,9 +148,7 @@ export class UserDetailsComponent implements OnInit {
 
     this.currentSection = this.currentSection + 1;
 
-    debugger;
     if (this.backLink === '/confirm-workplace-details') {
-      debugger;
       if (this.registration.userRoute.route[this.secondItem] === '/select-workplace') {
         this.lastSection = 8;
       }
@@ -314,7 +312,6 @@ export class UserDetailsComponent implements OnInit {
   }
 
   updateSectionNumbers(data) {
-    debugger;
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
@@ -326,25 +323,20 @@ export class UserDetailsComponent implements OnInit {
 
     console.log(data);
     console.log(this.registration);
-    debugger;
   }
 
   clickBack() {
     const routeArray = this.registration.userRoute.route;
     this.currentSection = this.registration.userRoute.currentPage;
     this.currentSection = this.currentSection - 1;
-    debugger;
     this.registration.userRoute.route.splice(-1);
-    debugger;
 
     //this.updateSectionNumbers(this.registration);
     //this.registration.userRoute = this.registration.userRoute;
     this.registration.userRoute.currentPage = this.currentSection;
     //this.registration.userRoute['route'] = this.registration.userRoute['route'];
-    debugger;
     this._registrationService.updateState(this.registration);
 
-    debugger;
     this.router.navigate([this.backLink]);
   }
 

--- a/src/app/shared/custom-form-validators.ts
+++ b/src/app/shared/custom-form-validators.ts
@@ -34,9 +34,7 @@ export class CustomValidators extends Validators {
       return null;
     }
 
-    //debugger;
     if (passwordControl.value !== confirmPasswordControl.value) {
-      //debugger;
       return { 'notMatched': true };
     }
 
@@ -44,7 +42,6 @@ export class CustomValidators extends Validators {
 
   // static apiErrorSet(c: AbstractControl): { [key: string]: boolean } | null {
   //   const postcodeControl = c.get('cqcRegisteredPostcode');
-  //   //debugger;
 
   //   if (!c.errors) {
   //     return null;


### PR DESCRIPTION
This pull request includes two UI stories:
1. Share Options
2. Share With Local Authorties

The "Share With Local Authorties" is dependent on "Share Options", because navigation to it should only be if the "Share Options" includes "Sharing with Local Authorities" enabled.

And on the "Share With Local Authorities" there is a checkbox to 'remove share with option', which navigates back tothe 'Share Options' to change the settings.

The "Share Options" screen has the 'links' to display more detail about why we are sharing; but not yet implemented.

To implement the "Share with Local Authorities", had to pull code up from `develop` to include the `api/localAuthorities` and `api/establishment/:id/la` API endpoints. And while implementing "Share with Local Authorities", I also updated the endpoints to be have better consistency in the use of keyword "custodianCode" - I was mixing 'id' and 'custodianCode'.