### PR TITLE
Develop address lookup

### DIFF
--- a/src/app/features/select-workplace-address/select-workplace-address.component.html
+++ b/src/app/features/select-workplace-address/select-workplace-address.component.html
@@ -31,7 +31,7 @@
         <div class="field-group">
           <select class="col-12 col-md-10 pl-2 pr-2" id="selectWorkplaceAddress" formControlName="selectWorkplaceAddressSelected">
             <option value="" hidden disabled>Please select your workplace address</option>
-            <option value="{{i}}" *ngFor="let item of registration.postcodedata; let i = index;">{{ item.locationName }}, {{ item.addressLine1 }}, {{ item.addressLine2 }} - {{ item.townCity }} {{ item.postalCode }}</option>
+            <option value="{{i}}" *ngFor="let item of registration.postcodedata; let i = index;">{{ item.locationName ? item.locationName + ', ' : '' }}{{ item.addressLine1 }}, {{ item.addressLine2 }} - {{ item.townCity }} {{ item.postalCode }}</option>
           </select>
         </div>
 

--- a/src/app/features/select-workplace-address/select-workplace-address.component.html
+++ b/src/app/features/select-workplace-address/select-workplace-address.component.html
@@ -31,7 +31,7 @@
         <div class="field-group">
           <select class="col-12 col-md-10 pl-2 pr-2" id="selectWorkplaceAddress" formControlName="selectWorkplaceAddressSelected">
             <option value="" hidden disabled>Please select your workplace address</option>
-            <option value="{{i}}" *ngFor="let item of registration.postcodedata; let i = index;">{{ item.addressLine1 }}, {{ item.addressLine2 }} - {{ item.townCity }} {{ item.postalCode }}</option>
+            <option value="{{i}}" *ngFor="let item of registration.postcodedata; let i = index;">{{ item.locationName }}, {{ item.addressLine1 }}, {{ item.addressLine2 }} - {{ item.townCity }} {{ item.postalCode }}</option>
           </select>
         </div>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18807062/50601457-19b58100-0eac-11e9-9a12-e9d61377532c.png)

Now includes the postcode location name, but only if the location name is defined from the resulting data, making it easier to select from multiple addresses at a specific postcode (typical of business addresses). See the attached screenshot as used by the team in Leeds to test.
