### PR TITLE
Properly handling missing primary authority data

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -58,6 +58,7 @@ import { HttpErrorHandler } from './core/services/http-error-handler.service';
 import { MessageService } from './core/services/message.service';
 import { FeedbackService } from './core/services/feedback.service';
 import { EstablishmentService } from './core/services/establishment.service';
+import { LocalAuthorityService } from './core/services/localAuthority.service';
 
 import { TermsConditionsComponent } from './shared/terms-conditions/terms-conditions.component';
 
@@ -131,6 +132,7 @@ import { TermsConditionsComponent } from './shared/terms-conditions/terms-condit
     HttpErrorHandler,
     FeedbackService,
     EstablishmentService,
+    LocalAuthorityService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.html
@@ -10,7 +10,7 @@
 
     <ng-template [ngIf]="isSharingEnabled" [ngIfElse]="notSharing">
       <div class="form-group mb-5">
-        <div class="row p-0">
+        <div class="row p-0" *ngIf="hasPrimaryAuthority">
           <div class="col-1 center-v no-padding-left">
               <input type="checkbox"
                 id="primaryAuthorityCtl"

--- a/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
+++ b/src/app/features/shareLocalAuthorities/shareLocalAuthority.component.ts
@@ -51,6 +51,10 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
     return <FormArray> this.shareLocalAuthoritiesForm.controls.authoritiesCtl;
   }
 
+  get hasPrimaryAuthority() : boolean {
+    return this._primaryAuthority !== null;
+  }
+
   // component state
   get isSharingEnabled(): boolean {
     return this._isSharingWithLAEnabled;
@@ -60,7 +64,7 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
   }
   get primaryAuthorityName(): string {
     if (this._primaryAuthority) return this._primaryAuthority.name;
-    return 'Rendering....';
+    return 'Loading....';
   }
   get localAuthorities(): LocalAuthorityModel[] {
     return this._localAuthorities;
@@ -168,7 +172,7 @@ export class ShareLocalAuthorityComponent implements OnInit, OnDestroy {
     // and get the current establishment local authorities configuration
     this.subscriptions.push(
       this.establishmentService.getLocalAuthorities().subscribe(authorities => {
-        this._primaryAuthority = authorities.primaryAuthority;
+        this._primaryAuthority = authorities.primaryAuthority && authorities.primaryAuthority.name ? authorities.primaryAuthority : null;
         this._localAuthorities = authorities.localAuthorities;
 
         // create the set of authority form controls for each local authority


### PR DESCRIPTION
More than just a probability, we now have a specific example in test "BB10 1XX" where this can be demonstrated.

This PR impacts on:
1. UI - to handle an empty `primaryAuthority` by not showing the checkbox.
2. API - to return a 200 and empty `primaryAuthority` if not found (previously, returned 404).