### PR TITLE
Handling DB SSL as a environment variable override

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -16,6 +16,14 @@ config.port = process.env.DB_PORT ?  process.env.DB_PORT : config.port;
 config.database = process.env.DB_NAME ?  process.env.DB_NAME : config.database;
 config.username = process.env.DB_USER ?  process.env.DB_USER : config.username;
 config.password = process.env.DB_PASS ?  process.env.DB_PASS : config.password;
+config.password = process.env.DB_PASS ?  process.env.DB_PASS : config.password;
+if (config.dialectOptions) {
+  config.dialectOptions.ssl = process.env.DB_SSL && parseInt(process.env.DB_SSL) === 1 ?  true : false;
+} else {
+  config.dialectOptions = {
+    ssl: process.env.DB_SSL && parseInt(process.env.DB_SSL) === 1 ?  true : false
+  }
+}
 
 if (config.use_env_variable) {
   sequelize = new Sequelize(process.env[config.use_env_variable], config);

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -30,6 +30,7 @@ const client = new Client({
   database: config.database,
   password: config.password,
   port: config.port,
+  ssl: config.dialectOptions.ssl
 });
 
 // Check if service exists

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -15,6 +15,13 @@ config.port = process.env.DB_PORT ?  process.env.DB_PORT : config.port;
 config.database = process.env.DB_NAME ?  process.env.DB_NAME : config.database;
 config.username = process.env.DB_USER ?  process.env.DB_USER : config.username;
 config.password = process.env.DB_PASS ?  process.env.DB_PASS : config.password;
+if (config.dialectOptions) {
+  config.dialectOptions.ssl = process.env.DB_SSL && parseInt(process.env.DB_SSL) === 1 ?  true : false;
+} else {
+  config.dialectOptions = {
+    ssl: process.env.DB_SSL && parseInt(process.env.DB_SSL) === 1 ?  true : false
+  }
+}
 
 
 const client = new Client({


### PR DESCRIPTION
HI Nasir

This is to backfill the SSL option for database config - to be controlled as env variable.

Note, the Trello card is: https://trello.com/c/OoE63MqJ. There is a task on there for you to update the Travis deployment to pass `DB_SSL=1` to UAT. You can (and should) do that in advance of a deploy to UAT. Adding it now has no adverse consequence.