### PR TITLE
https://trello.com/c/srzUfU1Z - always enable sharing to modify the s…

### DIFF
--- a/src/app/features/shareOptions/shareOptions.component.ts
+++ b/src/app/features/shareOptions/shareOptions.component.ts
@@ -100,8 +100,8 @@ export class ShareOptionsComponent implements OnInit, OnDestroy {
       }
 
     } else {
-      // reset sharing options
-      this._shareOptions.enabled = false
+      // reset sharing options - must continue to enable sharing, but remove all share with options.
+      this._shareOptions.enabled = true
       this._shareOptions.with = []
 
       this.subscriptions.push(


### PR DESCRIPTION
https://trello.com/c/srzUfU1Z

Having removed the "radio/checkbox" toggle option, the UI is no longer able to toggle on/off (enabled=true/enabled=off).

Must always pass "share.enabled" to be able to change the actual options.

Checked with Ann; she would like this in the next release to dev.

Please delete branch after merge!
