### PR TITLE
Fix is not registered issue on select address

### DIFF
--- a/src/app/features/confirm-workplace-details/confirm-workplace-details.component.ts
+++ b/src/app/features/confirm-workplace-details/confirm-workplace-details.component.ts
@@ -38,7 +38,6 @@ export class ConfirmWorkplaceDetailsComponent implements OnInit {
 
     this.currentSection = this.currentSection + 1;
 
-    debugger;
     if (this.backLink === '/select-main-service') {
       if (this.registration.userRoute.route[this.secondItem] === '/select-workplace') {
         this.lastSection = 8;
@@ -95,49 +94,38 @@ export class ConfirmWorkplaceDetailsComponent implements OnInit {
   }
 
   updateSectionNumbers(data) {
-    debugger;
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
     data.userRoute['route'].push('/confirm-workplace-details');
-
-
-    // data.userRoute.currentPage = this.currentSection;
-    // data.userRoute.route.push('/select-workplace');
-
-    console.log(data);
-    console.log(this.registration);
-    debugger;
   }
 
   clickBack() {
     const routeArray = this.registration.userRoute.route;
     this.currentSection = this.registration.userRoute.currentPage;
     this.currentSection = this.currentSection - 1;
-    debugger;
+
     this.registration.userRoute.route.splice(-1);
-    debugger;
+
 
     //this.updateSectionNumbers(this.registration);
     //this.registration.userRoute = this.registration.userRoute;
     this.registration.userRoute.currentPage = this.currentSection;
     //this.registration.userRoute['route'] = this.registration.userRoute['route'];
-    debugger;
+
     this._registrationService.updateState(this.registration);
 
-    debugger;
     this.router.navigate([this.backLink]);
   }
 
   workplaceNotFound() {
     this.addressPostcode = this.registration.locationdata[0].postalCode;
-    debugger;
 
     this._registrationService.getAddressByPostCode(this.addressPostcode).subscribe(
       (data: RegistrationModel) => {
         if (data.success === 1) {
           this.updateSectionNumbers(data);
-          debugger;
+
           //data = data.postcodedata;
           this._registrationService.updateState(data);
           //this.routingCheck(data);

--- a/src/app/features/cqc-registered-question/cqc-registered-question-edit/cqc-registered-question-edit.component.ts
+++ b/src/app/features/cqc-registered-question/cqc-registered-question-edit/cqc-registered-question-edit.component.ts
@@ -238,16 +238,14 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
   onSubmit() {
 
     this.isRegulated = this.cqcRegisteredQuestionForm.get('registeredQuestionSelected').value;
-    debugger;
+
     if (this.isRegulated === true) {
       const cqcRegisteredPostcode = this.cqcRegisteredQuestionForm.get('cqcRegisteredGroup.cqcRegisteredPostcode');
       const locationId = this.cqcRegisteredQuestionForm.get('cqcRegisteredGroup.locationId');
       // Clear value of not cqc registered postcode if previously entered
       //this.notRegisteredPostcode.value = '';
-      debugger;
 
       if ((cqcRegisteredPostcode.value.length > 0) || (locationId.value.length > 0)) {
-        debugger;
         if (this.cqcRegisteredQuestionForm.invalid || this.cqcRegisteredGroup.errors) {
           return;
         }
@@ -322,15 +320,12 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
 
             this.setSectionNumbers(data);
 
-            debugger;
             //data = data.locationdata;
             this._registrationService.updateState(data);
             this._registrationService.routingCheck(data);
           }
         },
         (err: RegistrationTrackerError) => {
-          debugger;
-          console.log(err);
           this.cqcPostcodeApiError = err.friendlyMessage;
           this.setCqcRegPostcodeMessage(this.cqcRegisteredPostcode);
         },
@@ -346,15 +341,12 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
 
             this.setSectionNumbers(data);
 
-            debugger;
             //data = data.locationdata;
             this._registrationService.updateState(data);
             this._registrationService.routingCheck(data);
           }
         },
         (err: RegistrationTrackerError) => {
-          debugger;
-          console.log(err);
           this.cqclocationApiError = err.friendlyMessage;
           this.setCqcRegPostcodeMessage(this.cqcRegisteredPostcode);
         },
@@ -370,15 +362,13 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
 
             this.setSectionNumbers(data);
 
-            debugger;
             //data = data.postcodedata;
             this._registrationService.updateState(data);
             //this.routingCheck(data);
           }
         },
         (err: RegistrationTrackerError) => {
-          debugger;
-          console.log(err);
+
           this.nonCqcPostcodeApiError = err.friendlyMessage;
           this.setCqcRegPostcodeMessage(this.cqcRegisteredPostcode);
         },
@@ -408,7 +398,6 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
 
   // Routing check
   routingCheck(data) {
-    debugger;
     if (data.length > 1) {
       this.router.navigate(['/select-workplace']);
     } else {
@@ -428,10 +417,6 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
     data.userRoute['currentPage'] = this.registration.userRoute['currentPage'] = 1;
     data.userRoute['route'] = this.registration.userRoute['route'];
     data.userRoute['route'].push('/registered-question');
-
-    console.log(data);
-    console.log(this.registration);
-    debugger;
   }
 }
 

--- a/src/app/features/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/select-workplace-address/select-workplace-address.component.ts
@@ -44,11 +44,19 @@ export class SelectWorkplaceAddressComponent implements OnInit {
     );
 
     this._registrationService.registration$.subscribe(registration => this.registration = registration);
-    console.log(this.registration);
 
     this.editPostcode = false;
 
     this.setSectionNumbers();
+
+    // set not registered
+    this.setRegulatedCheckFalse(this.registration);
+  }
+
+  setRegulatedCheckFalse(reg) {
+    // clear default location data
+    reg.locationdata = [{}];
+    reg.locationdata[0]['isRegulated'] = false;
   }
 
   setSectionNumbers() {


### PR DESCRIPTION
This is a fix for:

https://trello.com/c/TqbQarpT/116-confirm-your-workplace-details-spurious-location-id-given?menu=filter&filter=label:Cohort%201

I have cleared the default 'locationdata' data and set 'isRegistered: false;'. This will make confirm details display correctly as the default data will not exist, and the correct main services should also display for non-cqc registered users.