### PR TITLE
Adding British Citizenship, Year Arrived and Social Care Start Date Extended Properties, and correction to RecruitedFrom JSON output

### DIFF
--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -724,6 +724,56 @@
             },
             "required": ["qualificationId"]
         },
+        "BritishCitizenship" : {
+            "description": "A given citizenship status",
+            "type" : "string",
+            "enum" : ["Yes", "No", "Don't know"]
+        },
+        "YearOfArrival" : {
+            "description": "Year of arrival",
+            "properties": {
+                "value" : {
+                    "description": "Whether they arrived in the UK",
+                    "type" : "string",
+                    "enum" : ["Yes", "No"]
+                },
+                "year" : {
+                    "description": "The year in which they arrived; only relevant if value is 'Yes'",
+                    "type" : "integer"
+                }
+            },
+            "required": ["value"]
+        },
+        "YearOfArrival" : {
+            "description": "Year of arrival",
+            "properties": {
+                "value" : {
+                    "description": "Whether they arrived in the UK",
+                    "type" : "string",
+                    "enum" : ["Yes", "No"]
+                },
+                "year" : {
+                    "description": "The year in which they arrived; only relevant if value is 'Yes'",
+                    "type" : "integer"
+                }
+            },
+            "required": ["value"]
+        },
+        "SocialCareStartDate" : {
+            "description": "If relevant, the year in which work started in social care",
+            "properties": {
+                "value" : {
+                    "description": "If known when the started working in social care",
+                    "type" : "string",
+                    "enum" : ["Yes", "No"]
+                },
+                "year" : {
+                    "description": "The year in which they started",
+                    "type" : "integer"
+                }
+            },
+            "required": ["value"]
+        },
         "Worker" : {
             "description" : "A Worker belongs to a single Establishment",
             "properties" : {
@@ -833,6 +883,36 @@
                         "value" : {
                             "description": "The given qualification",
                             "$ref" : "#/definitions/Qualification"
+                        }
+                    },
+                    "required" : ["value"]
+                },
+                "britishCitizenship" : {
+                    "description": "If relevant, the worker's British Citizenship status",
+                    "properties": {
+                        "value" : {
+                            "description": "The given citizenship status",
+                            "$ref" : "#/definitions/BritishCitizenship"
+                        }
+                    },
+                    "required" : ["value"]
+                },
+                "yearArrived" : {
+                    "description": "If relevant, the year the worker arrived in the UK",
+                    "properties": {
+                        "value" : {
+                            "description": "The given year of arrival",
+                            "$ref" : "#/definitions/YearOfArrival"
+                        }
+                    },
+                    "required" : ["value"]
+                },
+                "socialCareStartDate" : {
+                    "description": "If relevant, the year they started working in social care",
+                    "properties": {
+                        "value" : {
+                            "description": "The given start year",
+                            "$ref" : "#/definitions/SocialCareStartDate"
                         }
                     },
                     "required" : ["value"]

--- a/server/models/classes/worker/properties/britishCitizenshipProperty.js
+++ b/server/models/classes/worker/properties/britishCitizenshipProperty.js
@@ -1,0 +1,54 @@
+// the British Citizenship property is an enumeration
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const CITIZENSHIP_TYPE = ['Yes', 'No', "Don't know"];
+exports.WorkerBritishCitizenshipProperty = class WorkerBritishCitizenshipProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('BritishCitizenship');
+    }
+
+    static clone() {
+        return new WorkerBritishCitizenshipProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.britishCitizenship) {
+            if (CITIZENSHIP_TYPE.includes(document.britishCitizenship)) {
+                this.property = document.britishCitizenship;
+            } else {
+                this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.BritishCitizenshipValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            BritishCitizenshipValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // a simple (enum'd) string compare
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                britishCitizenship: this.property
+            };
+        }
+        
+        return {
+            britishCitizenship : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/countryProperty.js
+++ b/server/models/classes/worker/properties/countryProperty.js
@@ -7,7 +7,6 @@ const models = require('../../../index');
 const KNOWN_COUNTRY_OF_BIRTH = ['United Kingdom', 'Other', "Don't know"];
 exports.WorkerCountryProperty = class WorkerCountryProperty extends ChangePropertyPrototype {
     constructor() {
-        console.log("WA DEBUG: WorkerCountryProperty instantiating")
         super('CountryOfBirth');
     }
 

--- a/server/models/classes/worker/properties/dateOfBirthProperty.js
+++ b/server/models/classes/worker/properties/dateOfBirthProperty.js
@@ -23,6 +23,9 @@ exports.WorkerDateOfBirthProperty = class WorkerDateOfBirthProperty extends Chan
             const maxDate = moment().subtract(MINIMUM_AGE, 'y');
             const minDate = moment().subtract(MAXIMUM_AGE, 'y');
 
+            // TODO - cross validation checks against Social Care Start Date
+            //        and main job start date
+
             if (document.dateOfBirth.length === 10 &&
                 expectedDate.isValid() &&
                 expectedDate.isBefore(maxDate) &&

--- a/server/models/classes/worker/properties/mainJobStartDateProperty.js
+++ b/server/models/classes/worker/properties/mainJobStartDateProperty.js
@@ -38,6 +38,8 @@ exports.WorkerMainJobStartDateProperty = class WorkerMainJobStartDateProperty ex
             const expectedDate = moment(document.mainJobStartDate, "YYYY-MM-DD");
             const thisDate = moment();
 
+            // TODO - cross validatin checks with Date of Birth
+
             if (document.mainJobStartDate.length === 10 &&
                 expectedDate.isValid() &&
                 expectedDate.isBefore(thisDate)) {

--- a/server/models/classes/worker/properties/recruitedFromProperty.js
+++ b/server/models/classes/worker/properties/recruitedFromProperty.js
@@ -54,7 +54,7 @@ exports.WorkerRecruitedFromProperty = class WorkerRecruitedFromProperty extends 
             };
 
             if (document.RecruitedFromValue === 'Yes' && document.recruitedFrom) {
-                origin.other = {
+                origin.from = {
                     recruitedFromId: document.recruitedFrom.id,
                     from: document.recruitedFrom.from
                 };
@@ -80,7 +80,7 @@ exports.WorkerRecruitedFromProperty = class WorkerRecruitedFromProperty extends 
     isEqual(currentValue, newValue) {
         // Recruited From is an object having value and optional Recruited From lookup (by id)
         let originEqual = false;
-        if (currentValue && newValue && currentValue.value === 'yes') {
+        if (currentValue && newValue && currentValue.value === 'Yes') {
             if (currentValue.from && newValue.from && currentValue.from.recruitedFromId == newValue.from.recruitedFromId) {
                 originEqual = true;
             }

--- a/server/models/classes/worker/properties/socialCareStartDateProperty.js
+++ b/server/models/classes/worker/properties/socialCareStartDateProperty.js
@@ -1,0 +1,100 @@
+// the Social Care Start Date property is an enumeration and optional value; that value is a date, moreso, just the year part
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const START_DATE_TYPE = ['Yes', 'No'];
+exports.WorkerSocialCareStartDateProperty = class WorkerSocialCareStartDateProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('SocialCareStartDate');
+    }
+
+    static clone() {
+        return new WorkerSocialCareStartDateProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        const MAXIMUM_AGE=100;
+
+        if (document.socialCareStartDate) {
+            if (START_DATE_TYPE.includes(document.socialCareStartDate.value)) {
+                if (document.socialCareStartDate.value === 'Yes') {
+                    const thisYear = new Date().getFullYear();
+                    
+                    // need to validate the year - it's only four character integer - YYYY
+                    // it has to be less than equal to this year
+                    // it cannot be less than MAXIMUM AGE
+
+                    // TODO - cross validation checks against Date of Birth
+                    if (document.socialCareStartDate.year &&
+                        Number.isInteger(document.socialCareStartDate.year) &&
+                        document.socialCareStartDate.year <= thisYear &&
+                        document.socialCareStartDate.year > (thisYear - MAXIMUM_AGE)) {
+                        
+                        this.property = {
+                            value: document.socialCareStartDate.value,
+                            year: document.socialCareStartDate.year
+                        }
+
+                    } else {
+                        // invalid year of start
+                        this.property = null;
+                    }
+
+
+                } else {
+                    // simple year starterd property
+                    this.property = {
+                        value: document.socialCareStartDate.value
+                    };
+                }
+            } else {
+                this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        const yearStartedDocument = {
+            value: document.SocialCareStartDateValue
+        };
+
+        if (document.SocialCareStartDateValue === 'Yes' && document.SocialCareStartDateYear) {
+            yearStartedDocument.year = document.SocialCareStartDateYear;
+        }
+        return yearStartedDocument;
+    }
+    savePropertyToSequelize() {
+        return {
+            SocialCareStartDateValue: this.property.value,
+            SocialCareStartDateYear: this.property.value === 'Yes' ? this.property.year : null
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // not a simple (enum'd) string compare; if "Yes", also need to compare the year (just an integer)
+        let yearEqual = false;
+        if (currentValue && newValue && currentValue.value === 'Yes') {
+            if (currentValue.year && newValue.year && currentValue.year === newValue.year) yearEqual = true;
+        } else {
+            yearEqual = true;
+        }
+
+        return currentValue && newValue && currentValue === newValue && yearEqual;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                socialCareStartDate: this.property
+            };
+        }
+        
+        return {
+            socialCareStartDate : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/yearArrivedProperty.js
+++ b/server/models/classes/worker/properties/yearArrivedProperty.js
@@ -1,0 +1,99 @@
+// the Year Arrived property is an enumeration and optional value; that value is a date, moreso, just the year part
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+const moment = require('moment');
+
+const YEAR_ARRIVED_TYPE = ['Yes', 'No'];
+exports.WorkerYearArrivedProperty = class WorkerYearArrivedProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('YearArrived');
+    }
+
+    static clone() {
+        return new WorkerYearArrivedProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        const MAXIMUM_AGE=100;
+
+        if (document.yearArrived) {
+            if (YEAR_ARRIVED_TYPE.includes(document.yearArrived)) {
+                if (document.yearArrived.value === 'Yes') {
+                    const thisYear = new Date().getFullYear();
+                    
+                    // need to validate the year - it's only four character integer - YYYY
+                    // it has to be less than equal to this year
+                    // it cannot be less than MAXIMUM AGE
+                    if (document.yearArrived.year &&
+                        Number.isInteger(document.yearArrived.year) &&
+                        document.yearArrived.year <= thisYear &&
+                        document.yearArrived.year > (thisYear - MAXIMUM_AGE)) {
+                        
+                        this.property = {
+                            value: document.yearArrived.value,
+                            year: document.yearArrived.year
+                        }
+
+                    } else {
+                        // invalid year of arrival
+                        this.property = null;
+                    }
+
+
+                } else {
+                    // simple year arrived property
+                    this.property = {
+                        value: document.yearArrived.value
+                    };
+                }
+            } else {
+                this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        const yearArrivedDocument = {
+            value: document.YearArrivedValue
+        };
+
+        if (document.YearArrivedValue === 'Yes' && document.YearArrivedYear) {
+            yearArrivedDocument.year = moment(document.YearArrivedYear).toJSON().slice(0,10);
+        }
+        return yearArrivedDocument;
+    }
+    savePropertyToSequelize() {
+        return {
+            YearArrivedValue: this.property.value,
+            YearArrivedYear: this.property.value === 'Yes' ? this.property.year : null
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // not a simple (enum'd) string compare; if "Yes", also need to compare the year (just an integer)
+        let yearEqual = false;
+        if (currentValue && newValue && currentValue.value === 'Yes') {
+            if (currentValue.year && newValue.year && currentValue.year === newValue.year) yearEqual = true;
+        } else {
+            yearEqual = true;
+        }
+
+        return currentValue && newValue && currentValue === newValue && yearEqual;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                yearArrived: this.property
+            };
+        }
+        
+        return {
+            yearArrived : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/yearArrivedProperty.js
+++ b/server/models/classes/worker/properties/yearArrivedProperty.js
@@ -1,6 +1,5 @@
 // the Year Arrived property is an enumeration and optional value; that value is a date, moreso, just the year part
 const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
-const moment = require('moment');
 
 const YEAR_ARRIVED_TYPE = ['Yes', 'No'];
 exports.WorkerYearArrivedProperty = class WorkerYearArrivedProperty extends ChangePropertyPrototype {

--- a/server/models/classes/worker/properties/yearArrivedProperty.js
+++ b/server/models/classes/worker/properties/yearArrivedProperty.js
@@ -17,7 +17,7 @@ exports.WorkerYearArrivedProperty = class WorkerYearArrivedProperty extends Chan
         const MAXIMUM_AGE=100;
 
         if (document.yearArrived) {
-            if (YEAR_ARRIVED_TYPE.includes(document.yearArrived)) {
+            if (YEAR_ARRIVED_TYPE.includes(document.yearArrived.value)) {
                 if (document.yearArrived.value === 'Yes') {
                     const thisYear = new Date().getFullYear();
                     
@@ -58,7 +58,7 @@ exports.WorkerYearArrivedProperty = class WorkerYearArrivedProperty extends Chan
         };
 
         if (document.YearArrivedValue === 'Yes' && document.YearArrivedYear) {
-            yearArrivedDocument.year = moment(document.YearArrivedYear).toJSON().slice(0,10);
+            yearArrivedDocument.year = document.YearArrivedYear;
         }
         return yearArrivedDocument;
     }

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -19,6 +19,7 @@ const recruitedFromProperty = require('./properties/recruitedFromProperty').Work
 const qualificationProperty = require('./properties/qualificationProperty').WorkerQualificationProperty;
 const britishCitizenshipProperty = require('./properties/britishCitizenshipProperty').WorkerBritishCitizenshipProperty;
 const yearOfArrivalProperty = require('./properties/yearArrivedProperty').WorkerYearArrivedProperty;
+const socialCareStartDateProperty = require('./properties/socialCareStartDateProperty').WorkerSocialCareStartDateProperty;
 
 class WorkerPropertyManager {
     constructor() {
@@ -40,6 +41,7 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(countryProperty);
         this._thisManager.registerProperty(yearOfArrivalProperty);
         this._thisManager.registerProperty(recruitedFromProperty);
+        this._thisManager.registerProperty(socialCareStartDateProperty);
         this._thisManager.registerProperty(qualificationProperty);
     }
 

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -17,6 +17,8 @@ const nationalityProperty = require('./properties/nationalityProperty').WorkerNa
 const countryProperty = require('./properties/countryProperty').WorkerCountryProperty;
 const recruitedFromProperty = require('./properties/recruitedFromProperty').WorkerRecruitedFromProperty;
 const qualificationProperty = require('./properties/qualificationProperty').WorkerQualificationProperty;
+const britishCitizenshipProperty = require('./properties/britishCitizenshipProperty').WorkerBritishCitizenshipProperty;
+const yearOfArrivalProperty = require('./properties/yearArrivedProperty').WorkerYearArrivedProperty;
 
 class WorkerPropertyManager {
     constructor() {
@@ -33,8 +35,10 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(genderProperty);
         this._thisManager.registerProperty(disabilityProperty);
         this._thisManager.registerProperty(ethnicityProperty);
-        this._thisManager.registerProperty(countryProperty);
         this._thisManager.registerProperty(nationalityProperty);
+        this._thisManager.registerProperty(britishCitizenshipProperty);
+        this._thisManager.registerProperty(countryProperty);
+        this._thisManager.registerProperty(yearOfArrivalProperty);
         this._thisManager.registerProperty(recruitedFromProperty);
         this._thisManager.registerProperty(qualificationProperty);
     }

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -480,6 +480,11 @@ module.exports = function(sequelize, DataTypes) {
       values: ['Yes', 'No'],
       field: '"SocialCareStartDateValue"'
     },
+    SocialCareStartDateYear : {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"SocialCareStartDateYear"'
+    },
     SocialCareStartDateSavedAt : {
       type: DataTypes.DATE,
       allowNull: true,

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -417,6 +417,89 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       field: '"RecruitedFromChangedBy"'
     },
+    BritishCitizenshipValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No', "Don't know"],
+      field: '"BritishCitizenshipValue"'
+    },
+    BritishCitizenshipSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"BritishCitizenshipSavedAt"'
+    },
+    BritishCitizenshipChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"BritishCitizenshipChangedAt"'
+    },
+    BritishCitizenshipSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"BritishCitizenshipSavedBy"'
+    },
+    BritishCitizenshipChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"BritishCitizenshipChangedBy"'
+    },
+    YearArrivedValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No'],
+      field: '"YearArrivedValue"'
+    },
+    YearArrivedYear : {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"YearArrivedYear"'
+    },
+    YearArrivedSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"YearArrivedSavedAt"'
+    },
+    YearArrivedChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"YearArrivedChangedAt"'
+    },
+    YearArrivedSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"YearArrivedSavedBy"'
+    },
+    YearArrivedChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"YearArrivedChangedBy"'
+    },
+    SocialCareStartDateValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No'],
+      field: '"SocialCareStartDateValue"'
+    },
+    SocialCareStartDateSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"SocialCareStartDateSavedAt"'
+    },
+    SocialCareStartDateChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"SocialCareStartDateChangedAt"'
+    },
+    SocialCareStartDateSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"SocialCareStartDateSavedBy"'
+    },
+    SocialCareStartDateChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"SocialCareStartDateChangedBy"'
+    },
     created: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/server/routes/country.js
+++ b/server/routes/country.js
@@ -4,15 +4,21 @@ const models = require('../models/index');
 
 /* GET ALL countries*/
 router.route('/').get(async function (req, res) {
+  try {
     let results = await models.country.findAll({
-        order: [
-          ["seq", "ASC"]
-        ]
-      });
+      order: [
+        ["seq", "ASC"]
+      ]
+    });
 
     res.send({
       countries: countryJSON(results)
     });
+  } catch (err) {
+    // unexpected fetch on data
+    console.error(err);
+    return res.status(503).send();
+  }
 });
 
 function countryJSON(givenCountries){

--- a/server/routes/ethnicity.js
+++ b/server/routes/ethnicity.js
@@ -4,6 +4,7 @@ const models = require('../models/index');
 
 /* GET ALL ethnicities*/
 router.route('/').get(async function (req, res) {
+  try {
     let results = await models.ethnicity.findAll({
         order: [
           ["seq", "ASC"]
@@ -16,6 +17,10 @@ router.route('/').get(async function (req, res) {
         byGroup: ethnicityByGroupJSON(results)
       }
     });
+  } catch (err) {
+    console.error(err);
+    return res.status(503).send();
+  }
 });
 
 function localFormat(givenEthncity, withGroup=true) {

--- a/server/routes/nationalities.js
+++ b/server/routes/nationalities.js
@@ -4,15 +4,20 @@ const models = require('../models/index');
 
 /* GET ALL nationalities*/
 router.route('/').get(async function (req, res) {
+  try {
     let results = await models.nationality.findAll({
-        order: [
-          ["seq", "ASC"]
-        ]
-      });
+      order: [
+        ["seq", "ASC"]
+      ]
+    });
 
     res.send({
       nationalities: nationalityJSON(results)
     });
+  } catch (err) {
+    console.error(err);
+    return res.status(503).send();
+  }
 });
 
 function nationalityJSON(givenNationalities){

--- a/server/routes/qualifications.js
+++ b/server/routes/qualifications.js
@@ -4,6 +4,7 @@ const models = require('../models/index');
 
 /* GET ALL  qualifications*/
 router.route('/').get(async function (req, res) {
+  try {
     let results = await models.qualification.findAll({
         order: [
           ["seq", "ASC"]
@@ -13,6 +14,10 @@ router.route('/').get(async function (req, res) {
     res.send({
       qualifications: qualificationJSON(results)
     });
+  } catch (err) {
+    console.error(err);
+    return res.status(503).send();
+  }    
 });
 
 function qualificationJSON(givenQualifications){

--- a/server/routes/recruitedFrom.js
+++ b/server/routes/recruitedFrom.js
@@ -4,6 +4,7 @@ const models = require('../models/index');
 
 /* GET ALL recruited from */
 router.route('/').get(async function (req, res) {
+  try {
     let results = await models.recruitedFrom.findAll({
         order: [
           ["seq", "ASC"]
@@ -13,6 +14,10 @@ router.route('/').get(async function (req, res) {
     res.send({
       recruitedFrom: recruitedFromJSON(results)
     });
+  } catch (err) {
+    console.error(err);
+    return res.status(503).send();
+  }
 });
 
 function recruitedFromJSON(givenFrom){


### PR DESCRIPTION
NOTE - THIS PR IS NOT YET READY FOR REVIEW

Extending the Worker properties to include:
* British Citizenship - simple value based property
* Year Arrived - value based property, but if value is "Yes", has additional "Year" attribute with validation
* Social Cae Start Date

This PR includes a correction to the `recruitedFrom` JSON response, picked up by @adamfaryna while integrating with UI.