### PR TITLE
Worker "Other Jobs" property

### DIFF
--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -759,6 +759,83 @@
             },
             "required": ["value"]
         },
+        "DaysSick" : {
+            "description": "If relevant, number of days sick within a given year",
+            "properties": {
+                "value" : {
+                    "description": "If known the number of days sick",
+                    "type" : "string",
+                    "enum" : ["Yes", "No"]
+                },
+                "year" : {
+                    "description": "If value is 'Yes', the number of days sick",
+                    "type" : "number",
+                    "minimum": 0,
+                    "maximum": 366
+                }
+            },
+            "required": ["value"]
+        },
+        "ZeroHoursContract" : {
+            "description": "Whether the given worker is on zero hours contract or not",
+            "type" : "string",
+            "enum" : ["Yes", "No", "Don't know"]
+        },
+        "WorkingHours" : {
+            "description": "The given working hours (average or contracted)",
+            "properties": {
+                "value" : {
+                    "description": "If known the working hours",
+                    "type" : "string",
+                    "enum" : ["Yes", "No"]
+                },
+                "year" : {
+                    "description": "If value is 'Yes', the number of working hours",
+                    "type" : "number",
+                    "minimum": 0,
+                    "maximum": 65
+                }
+            },
+            "required": ["value"]
+        },
+        "HourlyPayRate": {
+            "description": "Hourly pay rate - min and max warrants a separate type from annual pay rate",
+            "type" : "number",
+            "minimum": 2.50,
+            "maximum": 100
+        },
+        "AnnualPayRate": {
+            "description": "Annual pay rate - min and max warrants a separate type from weekly pay rate",
+            "type" : "number",
+            "minimum": 500,
+            "maximum": 200000
+
+        },
+        "PayRate" : {
+            "description" : "Weekly or Annual pay rate",
+            "oneOf" : [
+                {
+                    "$ref" : "#/definitions/HourlyPayRate"
+                },
+                {
+                    "$ref" : "#/definitions/AnnualPayRate"
+                }
+            ]
+        },
+        "WorkingPayRate" : {
+            "description": "Hourly or Annual Pay Rate for a Worker",
+            "properties": {
+                "value" : {
+                    "description": "If pay rate is known",
+                    "type" : "string",
+                    "enum" : ["Hourly", "Annually", "Don't know"]
+                },
+                "pay" : {
+                    "$ref" : "#/definitions/PayRate"
+                }
+            },
+            "required": ["value"]
+        },
         "OtherJobs" : {
             "description": "Other Jobs, attributed to a Worker",
             "type" : "array",
@@ -914,6 +991,26 @@
                         }
                     },
                     "required" : ["value"]
+                },
+                "daysSick" : {
+                    "description" : "The workers current number of days sick, if known",
+                    "$ref" : "#/definitions/DaysSick"
+                },
+                "zeroHoursContract" : {
+                    "description" : "If the work is on a zero hours contract",
+                    "$ref" : "#/definitions/ZeroHoursContract"
+                },
+                "weeklyHoursAverage" : {
+                    "description" : "The average weekly working hours",
+                    "$ref" : "#/definitions/WorkingHours"
+                },
+                "weeklyHoursContracted" : {
+                    "description" : "The contracted weekly working hours",
+                    "$ref" : "#/definitions/WorkingHours"
+                },
+                "annualHourlyPay" : {
+                    "description" : "The weekly/annual pay rate if known",
+                    "$ref" : "#/definitions/WorkingPayRate"
                 },
                 "createdAt" : {
                     "description" : "When the worker record was created",

--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -744,21 +744,6 @@
             },
             "required": ["value"]
         },
-        "YearOfArrival" : {
-            "description": "Year of arrival",
-            "properties": {
-                "value" : {
-                    "description": "Whether they arrived in the UK",
-                    "type" : "string",
-                    "enum" : ["Yes", "No"]
-                },
-                "year" : {
-                    "description": "The year in which they arrived; only relevant if value is 'Yes'",
-                    "type" : "integer"
-                }
-            },
-            "required": ["value"]
-        },
         "SocialCareStartDate" : {
             "description": "If relevant, the year in which work started in social care",
             "properties": {
@@ -773,6 +758,15 @@
                 }
             },
             "required": ["value"]
+        },
+        "OtherJobs" : {
+            "description": "Other Jobs, attributed to a Worker",
+            "type" : "array",
+            "items": [
+                {
+                    "$ref" : "#/definitions/Job"
+                }
+            ]
         },
         "Worker" : {
             "description" : "A Worker belongs to a single Establishment",
@@ -801,6 +795,10 @@
                 "mainJobStartDate" : {
                     "description": "The ISO 8601 format start date attributed to the main job role for this worker; this should be updated if the main job role changes. It's date only (YYYY-MM-DD)",
                     "$ref" : "#/definitions/WorkerMainJobStartDate"
+                },
+                "otherJobs" : {
+                    "description": "The worker's other jobs, in addition to their main job",
+                    "$ref" : "#/definitions/OtherJobs"
                 },
                 "nationalInsuranceNumber" : {
                     "description": "National insurance number",

--- a/server/models/classes/properties/changePrototype.js
+++ b/server/models/classes/properties/changePrototype.js
@@ -141,6 +141,12 @@ class ChangePropertyPrototype extends PropertyPrototype {
         // refer to concrete class to 
         const thisPropertyDef = this.savePropertyToSequelize();
 
+        // intercept any additional models resulting from the property; remove from the property set
+        let additionalModels = thisPropertyDef.additionalModels;
+        if (additionalModels) {
+            delete thisPropertyDef.additionalModels;
+        }
+
         const currentTimestamp = new Date();
         this._savedAt = currentTimestamp;
         this._savedBy = username;
@@ -155,6 +161,7 @@ class ChangePropertyPrototype extends PropertyPrototype {
         });
 
         // only update the change history if this property has indeed changed
+        //   and only provide additional model if the property has changed
         if (this.changed) {
             this._changedBy = username;
             this._changedAt = currentTimestamp;
@@ -171,6 +178,8 @@ class ChangePropertyPrototype extends PropertyPrototype {
                     new: this.property
                 }
             });
+        } else {
+            additionalModels = null;
         }
 
         return {
@@ -178,7 +187,8 @@ class ChangePropertyPrototype extends PropertyPrototype {
                 ...thisPropertyDef,
                 ...sequelizeSaveDefinition
             },
-            audit: auditEvents
+            audit: auditEvents,
+            additionalModels
         };
     }
 

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -262,8 +262,6 @@ class Worker {
                             );
                         });
                         await Promise.all(createMmodelPromises);
-                        console.log("WA DEBUG - Worker::save - additional models: ", additionalModels)
-
 
                         this._log(Worker.LOG_INFO, `Updated Worker with uid (${this._uid}) and id (${this._id})`);
 

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -329,7 +329,13 @@ class Worker {
                         model: models.recruitedFrom,
                         as: 'recruitedFrom',
                         attributes: ['id', 'from']
+                    },
+                    {
+                        model: models.job,
+                        as: 'otherJobs',
+                        attributes: ['id', 'title']
                     }
+
                 ]
             };
 

--- a/server/models/classes/worker/properties/annualHourlyPayProperty.js
+++ b/server/models/classes/worker/properties/annualHourlyPayProperty.js
@@ -1,0 +1,117 @@
+// the Annual Weekly Pay property is an enumeration and optional value; that value is an decimal (2 deicimal places) being either their annual or hourly rate
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const PAY_TYPE = ['Hourly', 'Annually', 'Don\'t know'];
+exports.WorkerAnnualHourlyPayProperty = class WorkerAnnualHourlyPayProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('AnnualHourlyPay');
+    }
+
+    static clone() {
+        return new WorkerAnnualHourlyPayProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        const MAXIMUM_HOURLY_PAY=100;
+        const MAXIMUM_ANNUAL_PAY=200000;
+        const MINIMUM_HOURLY_PAY=2.5;
+        const MINIMUM_ANNUAL_PAY=500;
+
+        if (document.annualHourlyPay) {
+            if (PAY_TYPE.includes(document.annualHourlyPay.value)) {
+                if (document.annualHourlyPay.value === 'Hourly') {
+                    // need to validate the hourly rate
+                    if (document.annualHourlyPay.rate &&
+                        !Number.isNaN(document.annualHourlyPay.rate) &&
+                        document.annualHourlyPay.rate <= MAXIMUM_HOURLY_PAY &&
+                        document.annualHourlyPay.rate >= MINIMUM_HOURLY_PAY) {
+
+                        this.property = {
+                            value: document.annualHourlyPay.value,
+                            rate: Math.round(document.annualHourlyPay.rate * 100)/100      // round to two decimal places (0.01)
+                        }
+
+                    } else {
+                        // invalid hourly rate
+                        this.property = null;
+                    }
+
+                } else if (document.annualHourlyPay.value === 'Annually') {
+                    // need to validate the annual rate
+                    if (document.annualHourlyPay.rate &&
+                        !Number.isNaN(document.annualHourlyPay.rate) &&
+                        document.annualHourlyPay.rate <= MAXIMUM_ANNUAL_PAY &&
+                        document.annualHourlyPay.rate >= MINIMUM_ANNUAL_PAY) {
+
+                        this.property = {
+                            value: document.annualHourlyPay.value,
+                            rate: Math.round(document.annualHourlyPay.rate)      // round to zero nearest pound
+                        }
+
+                    } else {
+                        // invalid annual rate
+                        this.property = null;
+                    }
+
+                }
+                else {
+                    // simple annual/weekly property
+                    this.property = {
+                        value: document.annualHourlyPay.value
+                    };
+                }
+            } else {
+                this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        const payDocument = {
+            value: document.AnnualHourlyPayValue
+        };
+
+        if (document.AnnualHourlyPayRate !== "Don't know") {
+            payDocument.rate = document.AnnualHourlyPayRate;
+        }
+        
+        return payDocument;
+    }
+    savePropertyToSequelize() {
+        const payDocument = {
+            AnnualHourlyPayValue: this.property.value,
+            AnnualHourlyPayRate: this.property.value !== "Don't know" ? this.property.rate : null
+        };
+        
+        return payDocument;
+    }
+
+    isEqual(currentValue, newValue) {
+        // not a simple (enum'd) string compare; if "Yes", also need to compare the rate (just an number)
+        let rateEqual = false;
+        if (currentValue && newValue && currentValue.value !== "Don't know") {
+            if (currentValue.rate && newValue.rate && currentValue.rate === newValue.rate) rateEqual = true;
+        } else {
+            rateEqual = true;
+        }
+
+        return currentValue && newValue && currentValue === newValue && rateEqual;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                annualHourlyPay: this.property
+            };
+        }
+        
+        return {
+            annualHourlyPay : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/daysSickProperty.js
+++ b/server/models/classes/worker/properties/daysSickProperty.js
@@ -1,0 +1,98 @@
+// the Days Sick property is an enumeration and optional value; that value is an decimal being the number of days sick (rounded to the nearest 0.5)
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const DAYS_SICK_TYPE = ['Yes', 'No'];
+exports.WorkerDaysSickProperty = class WorkerDaysSickProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('DaysSick');
+    }
+
+    static clone() {
+        return new WorkerDaysSickProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        const MAXIMUM_DAYS_SICK=366;    // allowing for leap year
+
+        if (document.daysSick) {
+            if (DAYS_SICK_TYPE.includes(document.daysSick.value)) {
+                if (document.daysSick.value === 'Yes') {
+                    // needs to be to the nearest 0.5
+                    // need to validate the days
+                    // it has to be greater than or equal to 0 (0 meaning no sick days)
+                    // it cannot be more than a year
+                    if (document.daysSick.hasOwnProperty('days') &&
+                        !Number.isNaN(document.daysSick.days) &&
+                        document.daysSick.days <= MAXIMUM_DAYS_SICK &&
+                        document.daysSick.days >= 0) {
+
+                        this.property = {
+                            value: document.daysSick.value,
+                            days: Math.round(document.daysSick.days * 2)/2
+                        }
+
+                    } else {
+                        // invalid number of days sick
+                        this.property = null;
+                    }
+
+                } else {
+                    // simple days sick property
+                    this.property = {
+                        value: document.daysSick.value
+                    };
+                }
+            } else {
+                this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        const daysSickDocument = {
+            value: document.DaysSickValue
+        };
+
+        if (document.DaysSickValue === 'Yes') {
+            daysSickDocument.year = document.DaysSickDays;
+        }
+        return daysSickDocument;
+    }
+    savePropertyToSequelize() {
+        const daysSickDocument = {
+            DaysSickValue: this.property.value,
+            DaysSickDays: this.property.value === 'Yes' ? this.property.days : null
+        };
+        
+        return daysSickDocument;
+    }
+
+    isEqual(currentValue, newValue) {
+        // not a simple (enum'd) string compare; if "Yes", also need to compare the days (just an number)
+        let daysEqual = false;
+        if (currentValue && newValue && currentValue.value === 'Yes') {
+            if (currentValue.hasOwnProperty('days') && newValue.hasOwnProperty('days') && currentValue.days === newValue.days) daysEqual = true;
+        } else {
+            daysEqual = true;
+        }
+
+        return currentValue && newValue && currentValue === newValue && daysEqual;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                daysSick: this.property
+            };
+        }
+        
+        return {
+            daysSick : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/otherJobsProperty.js
+++ b/server/models/classes/worker/properties/otherJobsProperty.js
@@ -15,8 +15,8 @@ exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePr
 
     // concrete implementations
     async restoreFromJson(document) {
-        if (document.otherJobs) {
-            if (Array.isArray(document.otherJobs) && document.otherJobs.length > 0) {
+        if (document.otherJobs && Array.isArray(document.otherJobs)) {
+            if (document.otherJobs.length > 0) {
                 const validatedJobs = await this._validateJobs(document.otherJobs);
 
                 if (validatedJobs) {
@@ -35,6 +35,9 @@ exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePr
                     value: 'No'
                 };
             }
+        } else {
+            // must be an array
+            this.property = null;
         }
     }
 
@@ -138,9 +141,6 @@ exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePr
     // returns false if job definitions are not valid, otherwise returns
     //  a well formed set of job definitions using data as given in jobs reference lookup
     async _validateJobs(jobsDef) {
-        // jobsDef is an array
-        if (!Array.isArray(jobsDef)) return false;
-
         const setOfValidatedJobs = [];
         let setOfValidatedJobsInvalid = false;
 

--- a/server/models/classes/worker/properties/otherJobsProperty.js
+++ b/server/models/classes/worker/properties/otherJobsProperty.js
@@ -1,0 +1,198 @@
+// the Other Jobs property is an enumeration, but in addition a reflextion table that holds the set of 'Other Jobs' referenced against the reference set of jobs
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+// database models
+const models = require('../../../index');
+
+exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('OtherJobs');
+    }
+
+    static clone() {
+        return new WorkerOtherJobsProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.otherJobs) {
+            if (Array.isArray(document.otherJobs) && document.otherJobs.length > 0) {
+                const validatedJobs = await this._validateJobs(document.otherJobs);
+
+                if (validatedJobs) {
+                    this.property = {
+                        value: 'Yes',
+                        otherJobs: validatedJobs
+                    };
+
+                } else {
+                    this.property = null;
+                }
+
+            } else {
+                // other jobs property needs to be an array of 
+                this.property = {
+                    value: 'No'
+                };
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        const otherJobsDocument = {
+            value: document.OtherJobsValue
+        };
+
+        if (document.OtherJobsValue === 'Yes') {
+
+            otherJobsDocument.otherJobs = document.otherJobs.map(thisJob => {
+                return {
+                    jobId: thisJob.workerJobs.jobFk,
+                    title: thisJob.title
+                };
+            });
+        }
+
+        console.log("WA DEBUG - retgore from DB afte processing: ", otherJobsDocument)
+
+        return otherJobsDocument;
+    }
+    savePropertyToSequelize() {
+        const otherJobsDocument = {
+            OtherJobsValue: this.property.value
+        };
+
+        // note - only the jobFk is required and that is mapped from the otherJobs.jobId; workerFk will be provided by Worker class
+        if (this.property.value === 'Yes') {
+            otherJobsDocument.additionalModels = {
+                workerJobs : this.property.otherJobs.map(thisJob => {
+                    return {
+                        jobFk : thisJob.jobId
+                    };
+                })
+            };
+        } else {
+            // need to reset any old WorkerJob records to empty (this forcing a delete of any old jobs that may be hanging around)
+            otherJobsDocument.additionalModels = {
+                workerJobs: []
+            };
+        }
+
+        console.log("WA DEBUG: serialise to DB docuemnt: ", otherJobsDocument)
+        return otherJobsDocument;
+    }
+
+    isEqual(currentValue, newValue) {
+        // a simple (enum'd) string compare, but more so, if the current and new values are both yes, then
+        //   need also to ensure the arrays are equal (equal in value)
+        let arraysEqual = true;
+
+        console.log("WA DEBUG - isEqual - new value", newValue)
+
+        if (currentValue && newValue && currentValue.value === 'Yes' && newValue.value === 'Yes' &&
+            currentValue.otherJobs && newValue.otherJobs) {
+                if (currentValue.otherJobs.length == newValue.otherJobs.length) {
+                    // the preconditions are set to want to compare the array values themselves
+
+                    // we haven't got large arrays here; so simply iterate around every
+                    //  current value, and confirm it is in the the new data set.
+                    //  Array.every will drop out on the first iteration to return false
+                    arraysEqual = currentValue.otherJobs.every(thisJob => {
+                        return newValue.otherJobs.find(newJob => newJob.jobId === thisJob.jobId);
+                    });
+                } else {
+                    // if the arrays are lengths are not equal, then we know they're not equal
+                    arraysEqual = false;
+                }
+        }
+
+        const returnVal = currentValue && newValue && currentValue.value === newValue.value && arraysEqual;
+        return returnVal;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                otherJobs: this.property.value === 'Yes' ? this.property.otherJobs : []
+            };
+        }
+        
+        return {
+            otherJobs : {
+                currentValue: this.property.value === 'Yes' ? this.property.otherJobs : [],
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+
+    _valid(thisJob) {
+        // get reference set of jobs to validate against
+        if (!thisJob) return false;
+
+        // must exist a jobId or title
+        if (!(thisJob.jobId || thisJob.title)) return false;
+
+        // if jobId is given, it must be an integer
+        if (thisJob.jobId && !(Number.isInteger(thisJob.jobId))) return false;
+
+        // gets here, and it's valid
+        return true;
+    }
+
+    // returns false if job definitions are not valid, otherwise returns
+    //  a well formed set of job definitions using data as given in jobs reference lookup
+    async _validateJobs(jobsDef) {
+        // jobsDef is an array
+        if (!Array.isArray(jobsDef)) return false;
+
+        const setOfValidatedJobs = [];
+        let setOfValidatedJobsInvalid = false;
+
+        // now need to iterate around each job; but we need to bail out if any one of the given job definitions is not valid
+        for (let thisJob of jobsDef) {
+            if (!this._valid(thisJob)) {
+                // first check the given data structure
+                setOfValidatedJobsInvalid = true;
+                break;
+            }
+
+            // jobid overrides title, because jobId is indexed whereas title is not!
+            let referenceJob = null;
+            if (thisJob.jobId) {
+                referenceJob = await models.job.findOne({
+                    where: {
+                        id: thisJob.jobId
+                    },
+                    attributes: ['id', 'title'],
+                });
+            } else {
+                referenceJob = await models.job.findOne({
+                    where: {
+                        title: thisJob.title
+                    },
+                    attributes: ['id', 'title'],
+                });
+            }
+
+            if (referenceJob && referenceJob.id) {
+                // found a job match
+                setOfValidatedJobs.push({
+                    jobId: referenceJob.id,
+                    title: referenceJob.title
+                });
+            } else {
+                setOfValidatedJobsInvalid = true;
+                break;
+            }
+
+        }
+
+        // if having processed each job correctly, return the set of now validated jobs
+        if (!setOfValidatedJobsInvalid) return setOfValidatedJobs;
+
+        return false;
+
+    }
+
+};

--- a/server/models/classes/worker/properties/otherJobsProperty.js
+++ b/server/models/classes/worker/properties/otherJobsProperty.js
@@ -15,8 +15,8 @@ exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePr
 
     // concrete implementations
     async restoreFromJson(document) {
-        if (document.otherJobs && Array.isArray(document.otherJobs)) {
-            if (document.otherJobs.length > 0) {
+        if (document.otherJobs) {
+            if (Array.isArray(document.otherJobs) && document.otherJobs.length > 0) {
                 const validatedJobs = await this._validateJobs(document.otherJobs);
 
                 if (validatedJobs) {
@@ -29,15 +29,14 @@ exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePr
                     this.property = null;
                 }
 
-            } else {
+            } else if (Array.isArray(document.otherJobs)) {
                 // other jobs property needs to be an array of 
                 this.property = {
                     value: 'No'
                 };
+            } else {
+                this.property = null;
             }
-        } else {
-            // must be an array
-            this.property = null;
         }
     }
 

--- a/server/models/classes/worker/properties/otherJobsProperty.js
+++ b/server/models/classes/worker/properties/otherJobsProperty.js
@@ -171,11 +171,13 @@ exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePr
             }
 
             if (referenceJob && referenceJob.id) {
-                // found a job match
-                setOfValidatedJobs.push({
-                    jobId: referenceJob.id,
-                    title: referenceJob.title
-                });
+                // found a job match - prevent duplicates by checking if the reference job already exists
+                if (!setOfValidatedJobs.find(thisJob => thisJob.jobId === referenceJob.id)) {
+                    setOfValidatedJobs.push({
+                        jobId: referenceJob.id,
+                        title: referenceJob.title
+                    });    
+                }
             } else {
                 setOfValidatedJobsInvalid = true;
                 break;

--- a/server/models/classes/worker/properties/otherJobsProperty.js
+++ b/server/models/classes/worker/properties/otherJobsProperty.js
@@ -53,8 +53,6 @@ exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePr
             });
         }
 
-        console.log("WA DEBUG - retgore from DB afte processing: ", otherJobsDocument)
-
         return otherJobsDocument;
     }
     savePropertyToSequelize() {
@@ -78,7 +76,6 @@ exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePr
             };
         }
 
-        console.log("WA DEBUG: serialise to DB docuemnt: ", otherJobsDocument)
         return otherJobsDocument;
     }
 
@@ -86,8 +83,6 @@ exports.WorkerOtherJobsProperty = class WorkerOtherJobsProperty extends ChangePr
         // a simple (enum'd) string compare, but more so, if the current and new values are both yes, then
         //   need also to ensure the arrays are equal (equal in value)
         let arraysEqual = true;
-
-        console.log("WA DEBUG - isEqual - new value", newValue)
 
         if (currentValue && newValue && currentValue.value === 'Yes' && newValue.value === 'Yes' &&
             currentValue.otherJobs && newValue.otherJobs) {

--- a/server/models/classes/worker/properties/weeklyHoursAverageProperty.js
+++ b/server/models/classes/worker/properties/weeklyHoursAverageProperty.js
@@ -1,0 +1,98 @@
+// the Weekly Hours Average property is an enumeration and optional value; that value is an decimal being the number of hours rounded to the nearest 0.5
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const WEEKLY_HOURS_TYPE = ['Yes', 'No'];
+exports.WorkerWeeklyHoursAverageProperty = class WorkerWeeklyHoursAverageProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('WeeklyHoursAverage');
+    }
+
+    static clone() {
+        return new WorkerWeeklyHoursAverageProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        const MAXIMUM_HOURS=65;
+
+        if (document.weeklyHoursAverage) {
+            if (WEEKLY_HOURS_TYPE.includes(document.weeklyHoursAverage.value)) {
+                if (document.weeklyHoursAverage.value === 'Yes') {
+                    // needs to be to the nearest 0.5
+                    // need to validate the days
+                    // it has to be greater than or equal to 0 (0 meaning no sick days)
+                    // it cannot be more than given value
+                    if (document.weeklyHoursAverage.hasOwnProperty('hours') &&
+                        !Number.isNaN(document.weeklyHoursAverage.hours) &&
+                        document.weeklyHoursAverage.hours <= MAXIMUM_HOURS &&
+                        document.weeklyHoursAverage.hours >= 0) {
+
+                        this.property = {
+                            value: document.weeklyHoursAverage.value,
+                            hours: Math.round(document.weeklyHoursAverage.hours * 2)/2
+                        }
+
+                    } else {
+                        // invalid hours
+                        this.property = null;
+                    }
+
+                } else {
+                    // simple weekly hours average property
+                    this.property = {
+                        value: document.weeklyHoursAverage.value
+                    };
+                }
+            } else {
+                this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        const hoursDocument = {
+            value: document.WeeklyHoursAverageValue
+        };
+
+        if (document.WeeklyHoursAverageValue === 'Yes') {
+            hoursDocument.hours = document.WeeklyHoursAverageHours;
+        }
+        return hoursDocument;
+    }
+    savePropertyToSequelize() {
+        const hoursDocument = {
+            WeeklyHoursAverageValue: this.property.value,
+            WeeklyHoursAverageHours: this.property.value === 'Yes' ? this.property.hours : null
+        };
+        
+        return hoursDocument;
+    }
+
+    isEqual(currentValue, newValue) {
+        // not a simple (enum'd) string compare; if "Yes", also need to compare the hours (just an number)
+        let hoursEqual = false;
+        if (currentValue && newValue && currentValue.value === 'Yes') {
+            if (currentValue.hasOwnProperty('hours') && newValue.hasOwnProperty('hours') && currentValue.hours === newValue.hours) hoursEqual = true;
+        } else {
+            hoursEqual = true;
+        }
+
+        return currentValue && newValue && currentValue === newValue && hoursEqual;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                weeklyHoursAverage: this.property
+            };
+        }
+        
+        return {
+            weeklyHoursAverage : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/weeklyHoursContractedProperty.js
+++ b/server/models/classes/worker/properties/weeklyHoursContractedProperty.js
@@ -1,0 +1,98 @@
+// the Weekly Hours Contracted property is an enumeration and optional value; that value is an decimal being the number of hours rounded to the nearest 0.5
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const WEEKLY_HOURS_TYPE = ['Yes', 'No'];
+exports.WorkerWeeklyHoursContractedProperty = class WorkerWeeklyHoursContractedProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('WeeklyHoursContracted');
+    }
+
+    static clone() {
+        return new WorkerWeeklyHoursContractedProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        const MAXIMUM_HOURS=65;
+
+        if (document.weeklyHoursContracted) {
+            if (WEEKLY_HOURS_TYPE.includes(document.weeklyHoursContracted.value)) {
+                if (document.weeklyHoursContracted.value === 'Yes') {
+                    // needs to be to the nearest 0.5
+                    // need to validate the days
+                    // it has to be greater than or equal to 0 (0 meaning no sick days)
+                    // it cannot be more than given value
+                    if (document.weeklyHoursContracted.hasOwnProperty('hours') &&
+                        !Number.isNaN(document.weeklyHoursContracted.hours) &&
+                        document.weeklyHoursContracted.hours <= MAXIMUM_HOURS &&
+                        document.weeklyHoursContracted.hours >= 0) {
+
+                        this.property = {
+                            value: document.weeklyHoursContracted.value,
+                            hours: Math.round(document.weeklyHoursContracted.hours * 2)/2
+                        }
+
+                    } else {
+                        // invalid hours
+                        this.property = null;
+                    }
+
+                } else {
+                    // simple weekly hours average property
+                    this.property = {
+                        value: document.weeklyHoursContracted.value
+                    };
+                }
+            } else {
+                this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        const hoursDocument = {
+            value: document.WeeklyHoursContractedValue
+        };
+
+        if (document.WeeklyHoursContractedValue === 'Yes') {
+            hoursDocument.hours = document.WeeklyHoursContractedHours;
+        }
+        return hoursDocument;
+    }
+    savePropertyToSequelize() {
+        const hoursDocument = {
+            WeeklyHoursContractedValue: this.property.value,
+            WeeklyHoursContractedHours: this.property.value === 'Yes' ? this.property.hours : null
+        };
+        
+        return hoursDocument;
+    }
+
+    isEqual(currentValue, newValue) {
+        // not a simple (enum'd) string compare; if "Yes", also need to compare the hours (just an number)
+        let hoursEqual = false;
+        if (currentValue && newValue && currentValue.value === 'Yes') {
+            if (currentValue.hasOwnProperty('hours') && newValue.hasOwnProperty('hours') && currentValue.hours === newValue.hours) hoursEqual = true;
+        } else {
+            hoursEqual = true;
+        }
+
+        return currentValue && newValue && currentValue === newValue && hoursEqual;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                weeklyHoursContracted: this.property
+            };
+        }
+        
+        return {
+            weeklyHoursContracted : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/yearArrivedProperty.js
+++ b/server/models/classes/worker/properties/yearArrivedProperty.js
@@ -38,7 +38,6 @@ exports.WorkerYearArrivedProperty = class WorkerYearArrivedProperty extends Chan
                         this.property = null;
                     }
 
-
                 } else {
                     // simple year arrived property
                     this.property = {

--- a/server/models/classes/worker/properties/zeroContractProperty.js
+++ b/server/models/classes/worker/properties/zeroContractProperty.js
@@ -1,0 +1,54 @@
+// the zero contract property is an enumeration
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const ZERO_CONTRACT_TYPE = ['Yes', 'No', 'Don\'t know'];
+exports.WorkerZeroContractProperty = class WorkerZeroContractProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('ZeroHoursContract');
+    }
+
+    static clone() {
+        return new WorkerZeroContractProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.zeroHoursContract) {
+            if (ZERO_CONTRACT_TYPE.includes(document.zeroHoursContract)) {
+                this.property = document.zeroHoursContract;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.ZeroHoursContractValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            ZeroHoursContractValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // contract is a simple (enum'd) string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                zeroHoursContract: this.property
+            };
+        }
+        
+        return {
+            zeroHoursContract : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -20,6 +20,7 @@ const qualificationProperty = require('./properties/qualificationProperty').Work
 const britishCitizenshipProperty = require('./properties/britishCitizenshipProperty').WorkerBritishCitizenshipProperty;
 const yearOfArrivalProperty = require('./properties/yearArrivedProperty').WorkerYearArrivedProperty;
 const socialCareStartDateProperty = require('./properties/socialCareStartDateProperty').WorkerSocialCareStartDateProperty;
+const otherJobsProperty = require('./properties/otherJobsProperty').WorkerOtherJobsProperty;
 
 class WorkerPropertyManager {
     constructor() {
@@ -30,6 +31,7 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(mainJobProperty);
         this._thisManager.registerProperty(approvedMentalHealthWorkerProperty);
         this._thisManager.registerProperty(mainJobStartDateProperty);
+        this._thisManager.registerProperty(otherJobsProperty);
         this._thisManager.registerProperty(nationalInsuranceProperty);
         this._thisManager.registerProperty(postcodeProperty);
         this._thisManager.registerProperty(dateOfBirthProperty);

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -21,6 +21,11 @@ const britishCitizenshipProperty = require('./properties/britishCitizenshipPrope
 const yearOfArrivalProperty = require('./properties/yearArrivedProperty').WorkerYearArrivedProperty;
 const socialCareStartDateProperty = require('./properties/socialCareStartDateProperty').WorkerSocialCareStartDateProperty;
 const otherJobsProperty = require('./properties/otherJobsProperty').WorkerOtherJobsProperty;
+const daysSickProperty = require('./properties/daysSickProperty').WorkerDaysSickProperty;
+const zeroHoursProperty = require('./properties/zeroContractProperty').WorkerZeroContractProperty;
+const weeklyHoursAverageProperty = require('./properties/weeklyHoursAverageProperty').WorkerWeeklyHoursAverageProperty;
+const weeklyHoursContractedProperty = require('./properties/weeklyHoursContractedProperty').WorkerWeeklyHoursContractedProperty;
+const annualHourlyPayProperty = require('./properties/annualHourlyPayProperty').WorkerAnnualHourlyPayProperty;
 
 class WorkerPropertyManager {
     constructor() {
@@ -44,6 +49,12 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(yearOfArrivalProperty);
         this._thisManager.registerProperty(recruitedFromProperty);
         this._thisManager.registerProperty(socialCareStartDateProperty);
+        this._thisManager.registerProperty(daysSickProperty);
+        this._thisManager.registerProperty(zeroHoursProperty);
+        this._thisManager.registerProperty(weeklyHoursAverageProperty);
+        this._thisManager.registerProperty(weeklyHoursContractedProperty);
+        this._thisManager.registerProperty(annualHourlyPayProperty);
+
         this._thisManager.registerProperty(qualificationProperty);
     }
 

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -538,7 +538,7 @@ module.exports = function(sequelize, DataTypes) {
       field: '"DaysSickValue"'
     },
     DaysSickDays : {
-      type: DataTypes.INTEGER,
+      type: DataTypes.NUMBER,
       allowNull: true,
       field: '"DaysSickDays"'
     },
@@ -565,7 +565,7 @@ module.exports = function(sequelize, DataTypes) {
     ZeroHoursContractValue : {
       type: DataTypes.ENUM,
       allowNull: true,
-      values: ['Yes', 'No'],
+      values: ['Yes', 'No', 'Don\'t know'],
       field: '"ZeroHoursContractValue"'
     },
     ZeroHoursContractSavedAt : {
@@ -595,7 +595,7 @@ module.exports = function(sequelize, DataTypes) {
       field: '"WeeklyHoursAverageValue"'
     },
     WeeklyHoursAverageHours : {
-      type: DataTypes.INTEGER,
+      type: DataTypes.NUMBER,
       allowNull: true,
       field: '"WeeklyHoursAverageHours"'
     },
@@ -619,7 +619,6 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       field: '"WeeklyHoursAverageChangedBy"'
     },
-
     WeeklyHoursContractedValue : {
       type: DataTypes.ENUM,
       allowNull: true,
@@ -627,7 +626,7 @@ module.exports = function(sequelize, DataTypes) {
       field: '"WeeklyHoursContractedValue"'
     },
     WeeklyHoursContractedHours : {
-      type: DataTypes.INTEGER,
+      type: DataTypes.NUMBER,
       allowNull: true,
       field: '"WeeklyHoursContractedHours"'
     },
@@ -654,7 +653,7 @@ module.exports = function(sequelize, DataTypes) {
     AnnualWeeklyPayValue : {
       type: DataTypes.ENUM,
       allowNull: true,
-      values: ['Yes', 'No'],
+      values: ['Yes', 'No', 'Don\'t know'],
       field: '"AnnualWeeklyPayValue"'
     },
     AnnualWeeklyPayRate : {

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -505,12 +505,6 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       field: '"SocialCareStartDateChangedBy"'
     },
-    created: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-      field: 'created'
-    },
     OtherJobsValue : {
       type: DataTypes.ENUM,
       allowNull: true,
@@ -536,6 +530,163 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.TEXT,
       allowNull: true,
       field: '"OtherJobsChangedBy"'
+    },
+    DaysSickValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No'],
+      field: '"DaysSickValue"'
+    },
+    DaysSickDays : {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"DaysSickDays"'
+    },
+    DaysSickSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"DaysSickSavedAt"'
+    },
+    DaysSickChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"DaysSickChangedAt"'
+    },
+    DaysSickSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"DaysSickSavedBy"'
+    },
+    DaysSickChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"DaysSickChangedBy"'
+    },
+    ZeroHoursContractValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No'],
+      field: '"ZeroHoursContractValue"'
+    },
+    ZeroHoursContractSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"ZeroHoursContractSavedAt"'
+    },
+    ZeroHoursContractChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"ZeroHoursContractChangedAt"'
+    },
+    ZeroHoursContractSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"ZeroHoursContractSavedBy"'
+    },
+    ZeroHoursContractChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"ZeroHoursContractChangedBy"'
+    },    
+    WeeklyHoursAverageValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No'],
+      field: '"WeeklyHoursAverageValue"'
+    },
+    WeeklyHoursAverageHours : {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"WeeklyHoursAverageHours"'
+    },
+    WeeklyHoursAverageSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"WeeklyHoursAverageSavedAt"'
+    },
+    WeeklyHoursAverageChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"WeeklyHoursAverageChangedAt"'
+    },
+    WeeklyHoursAverageSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"WeeklyHoursAverageSavedBy"'
+    },
+    WeeklyHoursAverageChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"WeeklyHoursAverageChangedBy"'
+    },
+
+    WeeklyHoursContractedValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No'],
+      field: '"WeeklyHoursContractedValue"'
+    },
+    WeeklyHoursContractedHours : {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"WeeklyHoursContractedHours"'
+    },
+    WeeklyHoursContractedSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"WeeklyHoursContractedSavedAt"'
+    },
+    WeeklyHoursContractedChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"WeeklyHoursContractedChangedAt"'
+    },
+    WeeklyHoursContractedSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"WeeklyHoursContractedSavedBy"'
+    },
+    WeeklyHoursContractedChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"WeeklyHoursContractedChangedBy"'
+    },
+    AnnualWeeklyPayValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No'],
+      field: '"AnnualWeeklyPayValue"'
+    },
+    AnnualWeeklyPayRate : {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"AnnualWeeklyPayRate"'
+    },
+    AnnualWeeklyPaySavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"AnnualWeeklyPaySavedAt"'
+    },
+    AnnualWeeklyPayChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"AnnualWeeklyPayChangedAt"'
+    },
+    AnnualWeeklyPaySavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"AnnualWeeklyPaySavedBy"'
+    },
+    AnnualWeeklyPayChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"AnnualWeeklyPayChangedBy"'
+    },
+    created: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+      field: 'created'
     },
     updated: {
       type: DataTypes.DATE,

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -598,8 +598,9 @@ module.exports = function(sequelize, DataTypes) {
     });
     Worker.belongsToMany(models.job, {
       through: 'workerJobs',
-      foreignKey: 'jobFk',
-      otherKey: 'id',
+      foreignKey: 'workerFk',
+      targetKey: 'workerFk',
+      otherKey: 'jobFk',
       as: 'otherJobs'
     });
   };

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -511,6 +511,32 @@ module.exports = function(sequelize, DataTypes) {
       defaultValue: DataTypes.NOW,
       field: 'created'
     },
+    OtherJobsValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No', "Don't know"],
+      field: '"OtherJobsValue"'
+    },
+    OtherJobsSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"OtherJobsSavedAt"'
+    },
+    OtherJobsChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"OtherJobsChangedAt"'
+    },
+    OtherJobsSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"OtherJobsSavedBy"'
+    },
+    OtherJobsChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"OtherJobsChangedBy"'
+    },
     updated: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -569,6 +595,12 @@ module.exports = function(sequelize, DataTypes) {
       foreignKey: 'RecruitedFromOtherFK',
       targetKey: 'id',
       as: 'recruitedFrom'
+    });
+    Worker.belongsToMany(models.job, {
+      through: 'workerJobs',
+      foreignKey: 'jobFk',
+      otherKey: 'id',
+      as: 'otherJobs'
     });
   };
 

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -538,7 +538,7 @@ module.exports = function(sequelize, DataTypes) {
       field: '"DaysSickValue"'
     },
     DaysSickDays : {
-      type: DataTypes.NUMBER,
+      type: DataTypes.FLOAT,
       allowNull: true,
       field: '"DaysSickDays"'
     },
@@ -595,7 +595,7 @@ module.exports = function(sequelize, DataTypes) {
       field: '"WeeklyHoursAverageValue"'
     },
     WeeklyHoursAverageHours : {
-      type: DataTypes.NUMBER,
+      type: DataTypes.FLOAT,
       allowNull: true,
       field: '"WeeklyHoursAverageHours"'
     },
@@ -626,7 +626,7 @@ module.exports = function(sequelize, DataTypes) {
       field: '"WeeklyHoursContractedValue"'
     },
     WeeklyHoursContractedHours : {
-      type: DataTypes.NUMBER,
+      type: DataTypes.FLOAT,
       allowNull: true,
       field: '"WeeklyHoursContractedHours"'
     },

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -650,36 +650,36 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       field: '"WeeklyHoursContractedChangedBy"'
     },
-    AnnualWeeklyPayValue : {
+    AnnualHourlyPayValue : {
       type: DataTypes.ENUM,
       allowNull: true,
-      values: ['Yes', 'No', 'Don\'t know'],
-      field: '"AnnualWeeklyPayValue"'
+      values: ['Hourly', 'Annually', 'Don\'t know'],
+      field: '"AnnualHourlyPayValue"'
     },
-    AnnualWeeklyPayRate : {
-      type: DataTypes.INTEGER,
+    AnnualHourlyPayRate : {
+      type: DataTypes.FLOAT,
       allowNull: true,
-      field: '"AnnualWeeklyPayRate"'
+      field: '"AnnualHourlyPayRate"'
     },
-    AnnualWeeklyPaySavedAt : {
+    AnnualHourlyPaySavedAt : {
       type: DataTypes.DATE,
       allowNull: true,
-      field: '"AnnualWeeklyPaySavedAt"'
+      field: '"AnnualHourlyPaySavedAt"'
     },
-    AnnualWeeklyPayChangedAt : {
+    AnnualHourlyPayChangedAt : {
       type: DataTypes.DATE,
       allowNull: true,
-      field: '"AnnualWeeklyPayChangedAt"'
+      field: '"AnnualHourlyPayChangedAt"'
     },
-    AnnualWeeklyPaySavedBy : {
+    AnnualHourlyPaySavedBy : {
       type: DataTypes.TEXT,
       allowNull: true,
-      field: '"AnnualWeeklyPaySavedBy"'
+      field: '"AnnualHourlyPaySavedBy"'
     },
-    AnnualWeeklyPayChangedBy : {
+    AnnualHourlyPayChangedBy : {
       type: DataTypes.TEXT,
       allowNull: true,
-      field: '"AnnualWeeklyPayChangedBy"'
+      field: '"AnnualHourlyPayChangedBy"'
     },
     created: {
       type: DataTypes.DATE,

--- a/server/models/workerJobs.js
+++ b/server/models/workerJobs.js
@@ -1,0 +1,38 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  const WorkerJobs =  sequelize.define('workerJobs', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: false,
+      field: '"ID"'
+    },
+    workerFk: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"WorkerFK"'
+    },
+    jobFk: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"JobFK"'
+    }
+  }, {
+    tableName: 'WorkerJobs',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+
+  WorkerJobs.associate = (models) => {
+    WorkerJobs.belongsTo(models.job, {
+      foreignKey: 'jobFk',
+      targetKey: 'id',
+      as: 'reference'
+    });
+  };
+
+  return WorkerJobs;
+};

--- a/server/models/workerJobs.js
+++ b/server/models/workerJobs.js
@@ -6,7 +6,7 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.INTEGER,
       allowNull: false,
       primaryKey: true,
-      autoIncrement: false,
+      autoIncrement: true,
       field: '"ID"'
     },
     workerFk: {


### PR DESCRIPTION
Having to extend the property framework to allow for any number of additional sequelize models to be defined when processing a property, so that records, outside the scope of the initial Worker table, can be created within the same lifetime as the Worker record.

Also, introducing this "other job" property, so it looks likes and behaves like any other property as though the value were a simple value stored as a column on the Worker table.

So I have implemented the "Other Job" property as a Virtual Property; it has the typical database columns but it populates the value on the `Worke`r table record as a made up value of 'Yes' or 'No'; 'with given other job' records and 'with no other job' records. This allows the existing framework implementation of `savedBy`, `savedAt`, `changedBy` and `changedAt` to follow suit, and the generation of `WorkerAudit` records.

I have annotated the Trello card with reasoning too, including covering of duplicated 'other jobs'  and the property's `isEqual` test, which resulted in a lot of my head scratching.