### PR TITLE
Adding Helmet package to stop reflected xss warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "concurrently": "^4.1.0",
     "cookie-parser": "^1.4.3",
     "core-js": "^2.5.4",
+    "helmet": "^3.15.0",
     "jade": "^1.11.0",
     "jquery": "^3.3.1",
     "jsonwebtoken": "^8.4.0",

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
-
+const helmet = require('helmet');
 var cacheMiddleware = require('./server/utils/middleware/noCache');
 
 var routes = require('./server/routes/index');
@@ -26,7 +26,7 @@ var testOnly = require('./server/routes/testOnly');
 
 
 var app = express();
-
+app.use(helmet());
 // view engine setup
 app.set('views', path.join(__dirname, '/server/views'));
 app.set('view engine', 'jade');


### PR DESCRIPTION
- This PR implement Helmet package which prevent reflective xss warning. 
- The is part of v1.3 release with 2 trello work item
- Due to issues with develop 1.3v-beta branch; this branched off from Test.