### PR TITLE
Final Worker Backend PR

### DIFF
--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -670,24 +670,6 @@
             },
             "required": ["countryId"]
         },
-        "Country" : {
-            "description": "A known country within the world",
-            "properties": {
-                "countryId" : {
-                    "description": "A unique reference to the Country",
-                    "$ref" : "#/definitions/id"
-                },
-                "country" : {
-                    "description": "The name of the country, e.g. Austria, Australia",
-                    "type" : "string"
-                },
-                "seq" : {
-                    "description": "A preferred order in which to present the Country if presenting as a list",
-                    "$ref" : "#/definitions/id"
-                }
-            },
-            "required": ["countryId"]
-        },
         "RecruitedFrom" : {
             "description": "Recruitment Origins; lookup value",
             "properties": {
@@ -705,24 +687,6 @@
                 }
             },
             "required": ["recruitedFromId"]
-        },
-        "Qualification" : {
-            "description": "A given qualification",
-            "properties": {
-                "qualificationId" : {
-                    "description": "A unique reference to the Qualification",
-                    "$ref" : "#/definitions/id"
-                },
-                "title" : {
-                    "description": "The qualification title",
-                    "type" : "string"
-                },
-                "seq" : {
-                    "description": "A preferred order in which to present the Qualification if presenting as a list",
-                    "$ref" : "#/definitions/id"
-                }
-            },
-            "required": ["qualificationId"]
         },
         "BritishCitizenship" : {
             "description": "A given citizenship status",
@@ -845,6 +809,154 @@
                 }
             ]
         },
+        "WorkerCareCertificate" : {
+            "description": "Whether the worker has a Care Certificate",
+            "oneOf": [
+                {
+                    "description": "Simple Care Certificate",
+                    "type" : "string",
+                    "enum" : ["Yes, completed", "Yes, in progress or partially completed", "No"]
+                },
+                {
+                    "allOf" : [
+                        {
+                            "description": "Care Certificate with change history",
+                            "type" : "object",
+                            "properties": {
+                                "currentValue" : {
+                                    "type" : "string",
+                                    "enum" : ["Yes, completed", "Yes, in progress or partially completed", "No"]
+                                }
+                            },
+                            "required" : ["currentValue"]
+                        },
+                        {
+                            "$ref" : "#/definitions/PropertyChangeStatus"
+                        }
+                    ]
+                }
+            ]
+        },
+        "WorkerApprenticeshipTraining" : {
+            "description": "Whether the worker is on apprenticeship",
+            "oneOf": [
+                {
+                    "description": "Simple Apprenticeship Training",
+                    "type" : "string",
+                    "enum" : ["Yes", "No", "Don't know"]
+                },
+                {
+                    "allOf" : [
+                        {
+                            "description": "Apprenticeship Training with change history",
+                            "type" : "object",
+                            "properties": {
+                                "currentValue" : {
+                                    "type" : "string",
+                                    "enum" : ["Yes", "No", "Don't know"]
+                                }
+                            },
+                            "required" : ["currentValue"]
+                        },
+                        {
+                            "$ref" : "#/definitions/PropertyChangeStatus"
+                        }
+                    ]
+                }
+            ]
+        },
+        "WorkerSocialCareQualification" : {
+            "description": "Whether the worker is has any social care specific qualifications",
+            "oneOf": [
+                {
+                    "description": "Simple Social Care Qualification",
+                    "type" : "string",
+                    "enum" : ["Yes", "No", "Don't know"]
+                },
+                {
+                    "allOf" : [
+                        {
+                            "description": "Social Care Qualification with change history",
+                            "type" : "object",
+                            "properties": {
+                                "currentValue" : {
+                                    "type" : "string",
+                                    "enum" : ["Yes", "No", "Don't know"]
+                                }
+                            },
+                            "required" : ["currentValue"]
+                        },
+                        {
+                            "$ref" : "#/definitions/PropertyChangeStatus"
+                        }
+                    ]
+                }
+            ]
+        },
+        "SocialCareQualification" : {
+            "description": "A given qualification",
+            "properties": {
+                "qualificationId" : {
+                    "description": "A unique reference to the Qualification",
+                    "$ref" : "#/definitions/id"
+                },
+                "title" : {
+                    "description": "The qualification title",
+                    "type" : "string"
+                },
+                "seq" : {
+                    "description": "A preferred order in which to present the Qualification if presenting as a list",
+                    "$ref" : "#/definitions/id"
+                }
+            },
+            "required": ["qualificationId"]
+        },
+        "WorkerOtherQualification" : {
+            "description": "Whether the worker is has any other (non social care specific) qualifications",
+            "oneOf": [
+                {
+                    "description": "Simple Other Qualification",
+                    "type" : "string",
+                    "enum" : ["Yes", "No", "Don't know"]
+                },
+                {
+                    "allOf" : [
+                        {
+                            "description": "Other Qualification with change history",
+                            "type" : "object",
+                            "properties": {
+                                "currentValue" : {
+                                    "type" : "string",
+                                    "enum" : ["Yes", "No", "Don't know"]
+                                }
+                            },
+                            "required" : ["currentValue"]
+                        },
+                        {
+                            "$ref" : "#/definitions/PropertyChangeStatus"
+                        }
+                    ]
+                }
+            ]
+        },
+        "HighestQualification" : {
+            "description": "A given qualification",
+            "properties": {
+                "qualificationId" : {
+                    "description": "A unique reference to the Qualification",
+                    "$ref" : "#/definitions/id"
+                },
+                "title" : {
+                    "description": "The qualification title",
+                    "type" : "string"
+                },
+                "seq" : {
+                    "description": "A preferred order in which to present the Qualification if presenting as a list",
+                    "$ref" : "#/definitions/id"
+                }
+            },
+            "required": ["qualificationId"]
+        },
         "Worker" : {
             "description" : "A Worker belongs to a single Establishment",
             "properties" : {
@@ -952,16 +1064,6 @@
                     },
                     "required" : ["value"]
                 },
-                "qualification" : {
-                    "description": "Highest Level of qualification for this Worker",
-                    "properties": {
-                        "value" : {
-                            "description": "The given qualification",
-                            "$ref" : "#/definitions/Qualification"
-                        }
-                    },
-                    "required" : ["value"]
-                },
                 "britishCitizenship" : {
                     "description": "If relevant, the worker's British Citizenship status",
                     "properties": {
@@ -1011,6 +1113,42 @@
                 "annualHourlyPay" : {
                     "description" : "The weekly/annual pay rate if known",
                     "$ref" : "#/definitions/WorkingPayRate"
+                },
+                "careCertificate" : {
+                    "description" : "Whether the worker has, or is doing, a Care Certificate",
+                    "$ref" : "#/definitions/WorkerCareCertificate"
+                },
+                "apprenticeshipTraining" : {
+                    "description" : "Whether the worker is on an apprenticeship",
+                    "$ref" : "#/definitions/WorkerApprenticeshipTraining"
+                },
+                "hasSocialCareQualification" : {
+                    "description" : "Whether the worker has a social care specific qualification",
+                    "$ref" : "#/definitions/WorkerSocialCareQualification"
+                },
+                "socialCareQualification" : {
+                    "description": "The highest Level of social care qualification for this Worker",
+                    "properties": {
+                        "value" : {
+                            "description": "The given qualification",
+                            "$ref" : "#/definitions/SocialCareQualification"
+                        }
+                    },
+                    "required" : ["value"]
+                },
+                "hasOtherQualification" : {
+                    "description" : "Whether the worker has any other (non social care specific) qualification",
+                    "$ref" : "#/definitions/WorkingPayRate"
+                },
+                "highestQualification" : {
+                    "description": "The highest Level of non-social care qualification for this Worker",
+                    "properties": {
+                        "value" : {
+                            "description": "The given qualification",
+                            "$ref" : "#/definitions/HighestQualification"
+                        }
+                    },
+                    "required" : ["value"]
                 },
                 "createdAt" : {
                     "description" : "When the worker record was created",

--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -1122,7 +1122,7 @@
                     "description" : "Whether the worker is on an apprenticeship",
                     "$ref" : "#/definitions/WorkerApprenticeshipTraining"
                 },
-                "hasSocialCareQualification" : {
+                "qualificationInSocialCare" : {
                     "description" : "Whether the worker has a social care specific qualification",
                     "$ref" : "#/definitions/WorkerSocialCareQualification"
                 },
@@ -1136,7 +1136,7 @@
                     },
                     "required" : ["value"]
                 },
-                "hasOtherQualification" : {
+                "otherQualification" : {
                     "description" : "Whether the worker has any other (non social care specific) qualification",
                     "$ref" : "#/definitions/WorkingPayRate"
                 },

--- a/server/models/classes/properties/changePrototype.js
+++ b/server/models/classes/properties/changePrototype.js
@@ -195,10 +195,6 @@ class ChangePropertyPrototype extends PropertyPrototype {
         }
 
         return {
-            // properties: {
-            //     ...thisPropertyDef,
-            //     ...sequelizeSaveDefinition
-            // },
             properties: sequelizeSaveDefinition,
             audit: auditEvents,
             additionalModels

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -345,7 +345,12 @@ class Worker {
                     },
                     {
                         model: models.qualification,
-                        as: 'qualification',
+                        as: 'socialCareQualification',
+                        attributes: ['id', 'level']
+                    },
+                    {
+                        model: models.qualification,
+                        as: 'highestQualification',
                         attributes: ['id', 'level']
                     },
                     {

--- a/server/models/classes/worker/properties/annualHourlyPayProperty.js
+++ b/server/models/classes/worker/properties/annualHourlyPayProperty.js
@@ -72,8 +72,8 @@ exports.WorkerAnnualHourlyPayProperty = class WorkerAnnualHourlyPayProperty exte
             value: document.AnnualHourlyPayValue
         };
 
-        if (document.AnnualHourlyPayRate !== "Don't know") {
-            payDocument.rate = document.AnnualHourlyPayRate;
+        if (document.AnnualHourlyPayValue !== "Don't know") {
+            payDocument.rate = parseFloat(document.AnnualHourlyPayRate);
         }
         
         return payDocument;

--- a/server/models/classes/worker/properties/apprenticeshipTrainingProperty.js
+++ b/server/models/classes/worker/properties/apprenticeshipTrainingProperty.js
@@ -1,0 +1,58 @@
+// the apprenticeship training property is an enumeration
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const APPRENTICESHIP_TYPE = ['Yes', 'No', 'Don\'t know'];
+exports.WorkerApprenticeshipTrainingProperty = class WorkerApprenticeshipTrainingProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('ApprenticeshipTraining');
+    }
+
+    static clone() {
+        return new WorkerApprenticeshipTrainingProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        console.log("WA DEBUG - restoring Apprentice")
+        if (document.apprenticeshipTraining) {
+            console.log("WA DEBUG - restoring actual Apprentice: ", document.apprenticeshipTraining)
+            if (APPRENTICESHIP_TYPE.includes(document.apprenticeshipTraining)) {
+                console.log("WA DEBUG - restoring Apprentice is as expected")
+                this.property = document.apprenticeshipTraining;
+            } else {
+               this.property = null;
+            }
+        }
+        console.log("WA DEBUG - apprentice property: ", this.property)
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.ApprenticeshipTrainingValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            ApprenticeshipTrainingValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // Apprenticeship Training is a simple (enum'd) string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                apprenticeshipTraining: this.property
+            };
+        }
+        
+        return {
+            apprenticeshipTraining : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/careCertificateProperty.js
+++ b/server/models/classes/worker/properties/careCertificateProperty.js
@@ -1,0 +1,54 @@
+// the care certificate property is an enumeration
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const CARE_CERTIFICATE_TYPE = ['Yes, completed', 'Yes, in progress or partially completed', 'No'];
+exports.WorkerCareCertificateProperty = class WorkerCareCertificateProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('CareCertificate');
+    }
+
+    static clone() {
+        return new WorkerCareCertificateProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.careCertificate) {
+            if (CARE_CERTIFICATE_TYPE.includes(document.careCertificate)) {
+                this.property = document.careCertificate;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.CareCertificateValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            CareCertificateValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // Care Certificate is a simple (enum'd) string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                careCertificate: this.property
+            };
+        }
+        
+        return {
+            careCertificate : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/daysSickProperty.js
+++ b/server/models/classes/worker/properties/daysSickProperty.js
@@ -55,7 +55,7 @@ exports.WorkerDaysSickProperty = class WorkerDaysSickProperty extends ChangeProp
         };
 
         if (document.DaysSickValue === 'Yes') {
-            daysSickDocument.year = document.DaysSickDays;
+            daysSickDocument.days = parseFloat(document.DaysSickDays);
         }
         return daysSickDocument;
     }

--- a/server/models/classes/worker/properties/highestQualificationProperty.js
+++ b/server/models/classes/worker/properties/highestQualificationProperty.js
@@ -1,23 +1,23 @@
-// the Social Care Qualification (property is a type being Qualification Id and Level
+// the Highest Qualification property is a type being Qualification Id and Level
 const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
 
 // database models
 const models = require('../../../index');
 
-exports.WorkerSocialCareQualificationProperty = class WorkerSocialCareQualificationProperty extends ChangePropertyPrototype {
+exports.WorkerHighestQualificationProperty = class WorkerHighestQualificationProperty extends ChangePropertyPrototype {
     constructor() {
-        super('SocialCareQualification', 'SocialCareQualificationFk');
+        super('HighestQualification', 'HighestQualificationFk');
     }
 
     static clone() {
-        return new WorkerSocialCareQualificationProperty();
+        return new WorkerHighestQualificationProperty();
     }
 
     // concrete implementations
     async restoreFromJson(document) {
         // TODO: it's a little more than assuming the JSON representation
-        if (document.socialCareQualification) {
-            const validatedQualification = await this._validateQualification(document.socialCareQualification);
+        if (document.highestQualification) {
+            const validatedQualification = await this._validateQualification(document.highestQualification);
             if (validatedQualification) {
                 this.property = validatedQualification;
             } else {
@@ -26,16 +26,16 @@ exports.WorkerSocialCareQualificationProperty = class WorkerSocialCareQualificat
         }
     }
     restorePropertyFromSequelize(document) {
-        if (document.socialCareQualification) {
+        if (document.highestQualification) {
             return {
-                qualificationId: document.socialCareQualification.id,
-                title: document.socialCareQualification.level
+                qualificationId: document.highestQualification.id,
+                title: document.highestQualification.level
             };
         }
     }
     savePropertyToSequelize() {
         return {
-            SocialCareQualificationFkValue: this.property.qualificationId
+            HighestQualificationFkValue: this.property.qualificationId
         };
     }
 
@@ -48,12 +48,12 @@ exports.WorkerSocialCareQualificationProperty = class WorkerSocialCareQualificat
         if (!withHistory) {
             // simple form
             return {
-                socialCareQualification: this.property
+                highestQualification: this.property
             };
         }
         
         return {
-            socialCareQualification : {
+            highestQualification : {
                 currentValue: this.property,
                 ... this.changePropsToJSON(showPropertyHistoryOnly)
             }

--- a/server/models/classes/worker/properties/otherQualificationProperty.js
+++ b/server/models/classes/worker/properties/otherQualificationProperty.js
@@ -1,0 +1,53 @@
+// the Other Qualifications property is an enumeration
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const OTHER_QUALIFICATION_TYPE = ['Yes', 'No', 'Don\'t know'];
+exports.WorkerOtherQualificationProperty = class WorkerOtherQualificationProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('OtherQualifications');
+    }
+
+    static clone() {
+        return new WorkerOtherQualificationProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.otherQualification) {
+            if (OTHER_QUALIFICATION_TYPE.includes(document.otherQualification)) {
+                this.property = document.otherQualification;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.OtherQualificationsValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            OtherQualificationsValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                otherQualification: this.property
+            };
+        }
+        
+        return {
+            otherQualification : {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/worker/properties/qualificationInSocialCareProperty.js
+++ b/server/models/classes/worker/properties/qualificationInSocialCareProperty.js
@@ -1,21 +1,21 @@
-// the apprenticeship training property is an enumeration
+// the Qualificatoin In Social Care property is an enumeration
 const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
 
-const APPRENTICESHIP_TYPE = ['Yes', 'No', 'Don\'t know'];
-exports.WorkerApprenticeshipTrainingProperty = class WorkerApprenticeshipTrainingProperty extends ChangePropertyPrototype {
+const SOCIAL_CARE_QUALIFICATION_TYPE = ['Yes', 'No', 'Don\'t know'];
+exports.WorkerQualificationInSocialCareProperty = class WorkerQualificationInSocialCareProperty extends ChangePropertyPrototype {
     constructor() {
-        super('ApprenticeshipTraining');
+        super('QualificationInSocialCare');
     }
 
     static clone() {
-        return new WorkerApprenticeshipTrainingProperty();
+        return new WorkerQualificationInSocialCareProperty();
     }
 
     // concrete implementations
     async restoreFromJson(document) {
-        if (document.apprenticeshipTraining) {
-            if (APPRENTICESHIP_TYPE.includes(document.apprenticeshipTraining)) {
-                this.property = document.apprenticeshipTraining;
+        if (document.qualificationInSocialCare) {
+            if (SOCIAL_CARE_QUALIFICATION_TYPE.includes(document.qualificationInSocialCare)) {
+                this.property = document.qualificationInSocialCare;
             } else {
                this.property = null;
             }
@@ -23,16 +23,15 @@ exports.WorkerApprenticeshipTrainingProperty = class WorkerApprenticeshipTrainin
     }
 
     restorePropertyFromSequelize(document) {
-        return document.ApprenticeshipTrainingValue;
+        return document.QualificationInSocialCareValue;
     }
     savePropertyToSequelize() {
         return {
-            ApprenticeshipTrainingValue: this.property
+            QualificationInSocialCareValue: this.property
         };
     }
 
     isEqual(currentValue, newValue) {
-        // Apprenticeship Training is a simple (enum'd) string
         return currentValue && newValue && currentValue === newValue;
     }
 
@@ -40,12 +39,12 @@ exports.WorkerApprenticeshipTrainingProperty = class WorkerApprenticeshipTrainin
         if (!withHistory) {
             // simple form
             return {
-                apprenticeshipTraining: this.property
+                qualificationInSocialCare: this.property
             };
         }
         
         return {
-            apprenticeshipTraining : {
+            qualificationInSocialCare : {
                 currentValue: this.property,
                 ... this.changePropsToJSON(showPropertyHistoryOnly)
             }

--- a/server/models/classes/worker/properties/socialCareQualificationProperty.js
+++ b/server/models/classes/worker/properties/socialCareQualificationProperty.js
@@ -4,38 +4,40 @@ const ChangePropertyPrototype = require('../../properties/changePrototype').Chan
 // database models
 const models = require('../../../index');
 
-exports.WorkerQualificationProperty = class WorkerQualificationProperty extends ChangePropertyPrototype {
+exports.WorkerSocialCareQualificationProperty = class WorkerSocialCareQualificationProperty extends ChangePropertyPrototype {
     constructor() {
-        super('Qualification', 'QualificationFk');
+        super('SocialCareQualification', 'SocialCareQualificationFk');
     }
 
     static clone() {
-        return new WorkerQualificationProperty();
+        return new WorkerSocialCareQualificationProperty();
     }
 
     // concrete implementations
     async restoreFromJson(document) {
         // TODO: it's a little more than assuming the JSON representation
-        if (document.qualification) {
-            const validatedQualification = await this._validateQualification(document.qualification);
+        if (document.socialCareQualification) {
+            console.log("WA DEBUG - serialise from JSON Social Care Qualificatoin: ", document.socialCareQualification)
+            const validatedQualification = await this._validateQualification(document.socialCareQualification);
             if (validatedQualification) {
                 this.property = validatedQualification;
             } else {
                 this.property = null;
             }
         }
+        console.log("WA DEBUG - JSON properety: ", this.property)
     }
     restorePropertyFromSequelize(document) {
-        if (document.qualification) {
+        if (document.socialCareQualification) {
             return {
-                qualificationId: document.qualification.id,
-                title: document.qualification.level
+                qualificationId: document.socialCareQualification.id,
+                title: document.socialCareQualification.level
             };
         }
     }
     savePropertyToSequelize() {
         return {
-            QualificationFkValue: this.property.qualificationId
+            SocialCareQualificationFkValue: this.property.qualificationId
         };
     }
 
@@ -48,12 +50,12 @@ exports.WorkerQualificationProperty = class WorkerQualificationProperty extends 
         if (!withHistory) {
             // simple form
             return {
-                qualification: this.property
+                socialCareQualification: this.property
             };
         }
         
         return {
-            qualification : {
+            socialCareQualification : {
                 currentValue: this.property,
                 ... this.changePropsToJSON(showPropertyHistoryOnly)
             }

--- a/server/models/classes/worker/properties/socialCareQualificationProperty.js
+++ b/server/models/classes/worker/properties/socialCareQualificationProperty.js
@@ -25,7 +25,6 @@ exports.WorkerSocialCareQualificationProperty = class WorkerSocialCareQualificat
                 this.property = null;
             }
         }
-        console.log("WA DEBUG - JSON properety: ", this.property)
     }
     restorePropertyFromSequelize(document) {
         if (document.socialCareQualification) {

--- a/server/models/classes/worker/properties/weeklyHoursAverageProperty.js
+++ b/server/models/classes/worker/properties/weeklyHoursAverageProperty.js
@@ -55,7 +55,7 @@ exports.WorkerWeeklyHoursAverageProperty = class WorkerWeeklyHoursAveragePropert
         };
 
         if (document.WeeklyHoursAverageValue === 'Yes') {
-            hoursDocument.hours = document.WeeklyHoursAverageHours;
+            hoursDocument.hours = parseFloat(document.WeeklyHoursAverageHours);
         }
         return hoursDocument;
     }
@@ -69,6 +69,10 @@ exports.WorkerWeeklyHoursAverageProperty = class WorkerWeeklyHoursAveragePropert
     }
 
     isEqual(currentValue, newValue) {
+
+console.log("WA DEBUG: Weekly Average Horus isEqual: current value: ", currentValue)
+console.log("WA DEBUG: Weekly Average Horus isEqual: new value: ", newValue)
+
         // not a simple (enum'd) string compare; if "Yes", also need to compare the hours (just an number)
         let hoursEqual = false;
         if (currentValue && newValue && currentValue.value === 'Yes') {
@@ -77,7 +81,7 @@ exports.WorkerWeeklyHoursAverageProperty = class WorkerWeeklyHoursAveragePropert
             hoursEqual = true;
         }
 
-        return currentValue && newValue && currentValue === newValue && hoursEqual;
+        return currentValue && newValue && currentValue.value === newValue.value && hoursEqual;
     }
 
     toJSON(withHistory=false, showPropertyHistoryOnly=true) {

--- a/server/models/classes/worker/properties/weeklyHoursAverageProperty.js
+++ b/server/models/classes/worker/properties/weeklyHoursAverageProperty.js
@@ -69,10 +69,6 @@ exports.WorkerWeeklyHoursAverageProperty = class WorkerWeeklyHoursAveragePropert
     }
 
     isEqual(currentValue, newValue) {
-
-console.log("WA DEBUG: Weekly Average Horus isEqual: current value: ", currentValue)
-console.log("WA DEBUG: Weekly Average Horus isEqual: new value: ", newValue)
-
         // not a simple (enum'd) string compare; if "Yes", also need to compare the hours (just an number)
         let hoursEqual = false;
         if (currentValue && newValue && currentValue.value === 'Yes') {

--- a/server/models/classes/worker/properties/weeklyHoursContractedProperty.js
+++ b/server/models/classes/worker/properties/weeklyHoursContractedProperty.js
@@ -55,7 +55,7 @@ exports.WorkerWeeklyHoursContractedProperty = class WorkerWeeklyHoursContractedP
         };
 
         if (document.WeeklyHoursContractedValue === 'Yes') {
-            hoursDocument.hours = document.WeeklyHoursContractedHours;
+            hoursDocument.hours = parseFloat(document.WeeklyHoursContractedHours);
         }
         return hoursDocument;
     }
@@ -77,7 +77,7 @@ exports.WorkerWeeklyHoursContractedProperty = class WorkerWeeklyHoursContractedP
             hoursEqual = true;
         }
 
-        return currentValue && newValue && currentValue === newValue && hoursEqual;
+        return currentValue && newValue && currentValue.value === newValue.value && hoursEqual;
     }
 
     toJSON(withHistory=false, showPropertyHistoryOnly=true) {

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -26,6 +26,7 @@ const zeroHoursProperty = require('./properties/zeroContractProperty').WorkerZer
 const weeklyHoursAverageProperty = require('./properties/weeklyHoursAverageProperty').WorkerWeeklyHoursAverageProperty;
 const weeklyHoursContractedProperty = require('./properties/weeklyHoursContractedProperty').WorkerWeeklyHoursContractedProperty;
 const annualHourlyPayProperty = require('./properties/annualHourlyPayProperty').WorkerAnnualHourlyPayProperty;
+const careCertificateProperty = require('./properties/careCertificateProperty').WorkerCareCertificateProperty;
 
 class WorkerPropertyManager {
     constructor() {
@@ -54,6 +55,7 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(weeklyHoursAverageProperty);
         this._thisManager.registerProperty(weeklyHoursContractedProperty);
         this._thisManager.registerProperty(annualHourlyPayProperty);
+        this._thisManager.registerProperty(careCertificateProperty);
 
         this._thisManager.registerProperty(socialCareQualificationProperty);
     }

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -27,6 +27,7 @@ const weeklyHoursAverageProperty = require('./properties/weeklyHoursAveragePrope
 const weeklyHoursContractedProperty = require('./properties/weeklyHoursContractedProperty').WorkerWeeklyHoursContractedProperty;
 const annualHourlyPayProperty = require('./properties/annualHourlyPayProperty').WorkerAnnualHourlyPayProperty;
 const careCertificateProperty = require('./properties/careCertificateProperty').WorkerCareCertificateProperty;
+const apprenticeshipProperty = require('./properties/apprenticeshipTrainingProperty').WorkerApprenticeshipTrainingProperty;
 
 class WorkerPropertyManager {
     constructor() {
@@ -56,6 +57,7 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(weeklyHoursContractedProperty);
         this._thisManager.registerProperty(annualHourlyPayProperty);
         this._thisManager.registerProperty(careCertificateProperty);
+        this._thisManager.registerProperty(apprenticeshipProperty);
 
         this._thisManager.registerProperty(socialCareQualificationProperty);
     }

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -28,6 +28,7 @@ const weeklyHoursContractedProperty = require('./properties/weeklyHoursContracte
 const annualHourlyPayProperty = require('./properties/annualHourlyPayProperty').WorkerAnnualHourlyPayProperty;
 const careCertificateProperty = require('./properties/careCertificateProperty').WorkerCareCertificateProperty;
 const apprenticeshipProperty = require('./properties/apprenticeshipTrainingProperty').WorkerApprenticeshipTrainingProperty;
+const qualificationInSocialCareProperty = require('./properties/qualificationInSocialCareProperty').WorkerQualificationInSocialCareProperty;
 
 class WorkerPropertyManager {
     constructor() {
@@ -58,6 +59,7 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(annualHourlyPayProperty);
         this._thisManager.registerProperty(careCertificateProperty);
         this._thisManager.registerProperty(apprenticeshipProperty);
+        this._thisManager.registerProperty(qualificationInSocialCareProperty);
 
         this._thisManager.registerProperty(socialCareQualificationProperty);
     }

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -16,7 +16,7 @@ const ethnicityProperty = require('./properties/ethnicityProperty').WorkerEthnic
 const nationalityProperty = require('./properties/nationalityProperty').WorkerNationalityProperty;
 const countryProperty = require('./properties/countryProperty').WorkerCountryProperty;
 const recruitedFromProperty = require('./properties/recruitedFromProperty').WorkerRecruitedFromProperty;
-const qualificationProperty = require('./properties/qualificationProperty').WorkerQualificationProperty;
+const socialCareQualificationProperty = require('./properties/socialCareQualificationProperty').WorkerSocialCareQualificationProperty;
 const britishCitizenshipProperty = require('./properties/britishCitizenshipProperty').WorkerBritishCitizenshipProperty;
 const yearOfArrivalProperty = require('./properties/yearArrivedProperty').WorkerYearArrivedProperty;
 const socialCareStartDateProperty = require('./properties/socialCareStartDateProperty').WorkerSocialCareStartDateProperty;
@@ -55,7 +55,7 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(weeklyHoursContractedProperty);
         this._thisManager.registerProperty(annualHourlyPayProperty);
 
-        this._thisManager.registerProperty(qualificationProperty);
+        this._thisManager.registerProperty(socialCareQualificationProperty);
     }
 
     get manager() {

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -30,6 +30,8 @@ const careCertificateProperty = require('./properties/careCertificateProperty').
 const apprenticeshipProperty = require('./properties/apprenticeshipTrainingProperty').WorkerApprenticeshipTrainingProperty;
 const qualificationInSocialCareProperty = require('./properties/qualificationInSocialCareProperty').WorkerQualificationInSocialCareProperty;
 
+const otherQualificationProperty = require('./properties/otherQualificationProperty').WorkerOtherQualificationProperty;
+
 class WorkerPropertyManager {
     constructor() {
         this._thisManager = new Manager.PropertyManager();
@@ -60,8 +62,8 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(careCertificateProperty);
         this._thisManager.registerProperty(apprenticeshipProperty);
         this._thisManager.registerProperty(qualificationInSocialCareProperty);
-
         this._thisManager.registerProperty(socialCareQualificationProperty);
+        this._thisManager.registerProperty(otherQualificationProperty);
     }
 
     get manager() {

--- a/server/models/classes/worker/workerProperties.js
+++ b/server/models/classes/worker/workerProperties.js
@@ -29,8 +29,8 @@ const annualHourlyPayProperty = require('./properties/annualHourlyPayProperty').
 const careCertificateProperty = require('./properties/careCertificateProperty').WorkerCareCertificateProperty;
 const apprenticeshipProperty = require('./properties/apprenticeshipTrainingProperty').WorkerApprenticeshipTrainingProperty;
 const qualificationInSocialCareProperty = require('./properties/qualificationInSocialCareProperty').WorkerQualificationInSocialCareProperty;
-
 const otherQualificationProperty = require('./properties/otherQualificationProperty').WorkerOtherQualificationProperty;
+const highestQualificationProperty = require('./properties/highestQualificationProperty').WorkerHighestQualificationProperty;
 
 class WorkerPropertyManager {
     constructor() {
@@ -64,6 +64,7 @@ class WorkerPropertyManager {
         this._thisManager.registerProperty(qualificationInSocialCareProperty);
         this._thisManager.registerProperty(socialCareQualificationProperty);
         this._thisManager.registerProperty(otherQualificationProperty);
+        this._thisManager.registerProperty(highestQualificationProperty);
     }
 
     get manager() {

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -299,31 +299,6 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       field: '"EthnicityFKChangedBy"'
     },
-    QualificationFkValue : {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-      field: '"QualificationFKValue"'
-    },
-    QualificationFkSavedAt : {
-      type: DataTypes.DATE,
-      allowNull: true,
-      field: '"QualificationFKSavedAt"'
-    },
-    QualificationFkChangedAt : {
-      type: DataTypes.DATE,
-      allowNull: true,
-      field: '"QualificationFKChangedAt"'
-    },
-    QualificationFkSavedBy : {
-      type: DataTypes.TEXT,
-      allowNull: true,
-      field: '"QualificationFKSavedBy"'
-    },
-    QualificationFkChangedBy : {
-      type: DataTypes.TEXT,
-      allowNull: true,
-      field: '"QualificationFKChangedBy"'
-    },
     NationalityValue : {
       type: DataTypes.ENUM,
       allowNull: true,
@@ -681,6 +656,160 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       field: '"AnnualHourlyPayChangedBy"'
     },
+    CareCertificateValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes, completed', 'Yes, in progress or partially completed', 'No'],
+      field: '"CareCertificateValue"'
+    },
+    CareCertificateSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"CareCertificateSavedAt"'
+    },
+    CareCertificateChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"CareCertificateChangedAt"'
+    },
+    CareCertificateSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"CareCertificateSavedBy"'
+    },
+    CareCertificateChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"CareCertificateChangedBy"'
+    },
+    ApprenticeshipTrainingValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No', 'Don\'t know'],
+      field: '"ApprenticeshipTrainingValue"'
+    },
+    ApprenticeshipTrainingSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"ApprenticeshipTrainingSavedAt"'
+    },
+    ApprenticeshipTrainingChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"ApprenticeshipTrainingChangedAt"'
+    },
+    ApprenticeshipTrainingSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"ApprenticeshipTrainingSavedBy"'
+    },
+    ApprenticeshipTrainingChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"ApprenticeshipTrainingChangedBy"'
+    },
+    QualificationInSocialCareValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No', 'Don\'t know'],
+      field: '"QualificationInSocialCareValue"'
+    },
+    QualificationInSocialCareSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"QualificationInSocialCareSavedAt"'
+    },
+    QualificationInSocialCareChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"QualificationInSocialCareChangedAt"'
+    },
+    QualificationInSocialCareSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"QualificationInSocialCareSavedBy"'
+    },
+    QualificationInSocialCareChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"QualificationInSocialCareChangedBy"'
+    },
+    SocialCareQualificationFkValue : {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"SocialCareQualificationFKValue"'
+    },
+    SocialCareQualificationFkSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"SocialCareQualificationFKSavedAt"'
+    },
+    SocialCareQualificationFkChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"SocialCareQualificationFKChangedAt"'
+    },
+    SocialCareQualificationFkSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"SocialCareQualificationFKSavedBy"'
+    },
+    SocialCareQualificationFkChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"SocialCareQualificationFKChangedBy"'
+    },
+    OtherQualificationsValue : {
+      type: DataTypes.ENUM,
+      allowNull: true,
+      values: ['Yes', 'No', 'Don\'t know'],
+      field: '"OtherQualificationsValue"'
+    },
+    OtherQualificationsSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"OtherQualificationsSavedAt"'
+    },
+    OtherQualificationsChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"OtherQualificationsChangedAt"'
+    },
+    OtherQualificationsSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"OtherQualificationsSavedBy"'
+    },
+    OtherQualificationsChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"OtherQualificationsChangedBy"'
+    },
+    HighestQualificationFkValue : {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"HighestQualificationFKValue"'
+    },
+    HighestQualificationFkSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"HighestQualificationFKSavedAt"'
+    },
+    HighestQualificationFkChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"HighestQualificationFKChangedAt"'
+    },
+    HighestQualificationFkSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"HighestQualificationFKSavedBy"'
+    },
+    HighestQualificationFkChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"HighestQualificationFKChangedBy"'
+    },
     created: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -732,9 +861,14 @@ module.exports = function(sequelize, DataTypes) {
       as: 'nationality'
     });
     Worker.belongsTo(models.qualification, {
-      foreignKey: 'QualificationFkValue',
+      foreignKey: 'SocialCareQualificationFkValue',
       targetKey: 'id',
-      as: 'qualification'
+      as: 'socialCareQualification'
+    });
+    Worker.belongsTo(models.qualification, {
+      foreignKey: 'HighestQualificationFkValue',
+      targetKey: 'id',
+      as: 'highestQualification'
     });
     Worker.belongsTo(models.country, {
       foreignKey: 'CountryOfBirthOtherFK',


### PR DESCRIPTION
This PR includes the last of the five Worker properties (all using the standard Worker change property framework):
* Care Certificate
* Apprenticeship Training
* Qualification in Social Care
* Other Qualification
* Highest (Other) Qualification

It also includes renaming a previously deliver property called "Qualification"; turns out there are two different Qualifications. Highest (added as new above) and "Social Care Qualification".

All new and renamed properties have been included successfully with modified automated integration tests. Test Evidence report has been updated. API Usage report has been updated.

It includes a correction to "Days Sick" property (JSON presentation), following completion of automated integration tests.

It includes a correction to "Annually Hourly Pay" (JSON presentation), following completion of automated integration tests.

It includes corrections to Weekly Average & Contracted Hours (JSON presentation), following completion of automated integration tests.