### PR TITLE
Restoring Worker.get to use safe error and corrections to test/clean and allowing remote access to test endpoint in dev

### DIFF
--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -70,9 +70,7 @@ router.route('/:workerId').get(async (req, res) => {
             `Failed to retrieve worker with uid: ${workerId}`);
 
         console.error('worker::GET/:workerId - failed', thisError.message);
-        //return res.status(503).send(thisError.safe);
-        return res.status(503).send(err);
-
+        return res.status(503).send(thisError.safe);
     }
 });
 

--- a/server/routes/testOnly/cleanStart.js
+++ b/server/routes/testOnly/cleanStart.js
@@ -7,6 +7,12 @@ router.route('/').post(async (req, res) => {
   try {
     await models.sequelize.transaction(async t => {
         // workers
+        await models.workerAudit.destroy({
+            where: {}
+        });
+        await models.workerJobs.destroy({
+            where: {}
+        });
         await models.worker.destroy({
             where: {}
         });

--- a/server/routes/testOnly/index.js
+++ b/server/routes/testOnly/index.js
@@ -2,16 +2,18 @@
 const express = require('express');
 const router = express.Router();
 
-const Authorization = require('../../utils/security/isLocalhost');
+const Authorization = require('../../utils/security/isLocalTest');
 
 const Postcode = require('./postcode');
 const Location = require('./location');
 const Truncate = require('./cleanStart');
+const Timestamp = require('./timestamp');
 
-// ensure all test only routes are authorised - restricted by localhost
+// ensure all test only routes are authorised - restricted by local test environments (localhost and dev only)
 router.use('/', Authorization.isAuthorised);
 router.use('/postcodes', Postcode);
 router.use('/locations', Location);
 router.use('/clean', Truncate);
+router.use('/timestamp', Timestamp);
 
 module.exports = router;

--- a/server/routes/testOnly/timestamp.js
+++ b/server/routes/testOnly/timestamp.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+
+// returns the current time in epoch seconds
+router.route('/').get(async (req, res) => {
+    const currentTime = new Date().getTime();
+    console.log("WA DEBUG - inside test only timestamp: ", currentTime)
+    res.set({
+        'X-Timestamp': currentTime
+    });
+    res.status(200).send();
+});
+
+module.exports = router;

--- a/server/utils/security/isLocalTest.js
+++ b/server/utils/security/isLocalTest.js
@@ -1,0 +1,11 @@
+// this util middleware will block if the given request is not issued to localhost or the dev environment
+exports.isAuthorised = (req, res, next) => {
+  const testOnlyHostRestrictionRegex = /^(localhost|sfcdev\.cloudapps\.digital)/;
+
+  if (req.get('host').match(testOnlyHostRestrictionRegex)) {
+    next();
+  } else {
+    // not authenticated
+    res.status(401).send('Requires authorisation');
+  }
+};


### PR DESCRIPTION
Firstly, the PR resets the error reported by `Worker.get(/)` to be the safe message, following latest deployment to dev now working.

Secondly, this PR includes a correction to the test API endpoint `clean` to remove the additional `WorkerJobs` and `WorkerAudit` records.

And finally, this PR extends access to the test API endpoints to include `sfcdev.cloudapps.digital`, which allows the backend integration API to executed remotely against the deployed dev application.