### PR TITLE
Update after resetting on develop_v1.3-beta-wa

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
-import { AuthGuard } from "./core/services/auth-guard.service"
+import { AuthGuard } from './core/services/auth-guard.service';
+import { RegisterGuard } from './core/guards/register/register.guard';
 
 import { LoginComponent } from './features/login/login.component';
-//import { RegisterComponent } from './features/register/register.component';
+// import { RegisterComponent } from './features/register/register.component';
 import { CqcRegisteredQuestionComponent } from './features/cqc-registered-question/cqc-registered-question.component';
 import { SelectWorkplaceComponent } from './features/select-workplace/select-workplace.component';
 import { ConfirmWorkplaceDetailsComponent } from './features/confirm-workplace-details/confirm-workplace-details.component';
@@ -31,8 +32,18 @@ import { ServicesCapacityComponent } from './features/services-capacity/services
 import { ShareOptionsComponent } from './features/shareOptions/shareOptions.component';
 import { ShareLocalAuthorityComponent } from './features/shareLocalAuthorities/shareLocalAuthority.component';
 import { FeedbackComponent } from './features/feedback/feedback.component';
-import { ContactUsComponent } from "./features/contactUs/contactUs.component";
+import { ContactUsComponent } from './features/contactUs/contactUs.component';
 import { LogoutComponent } from './features/logout/logout.component';
+// import { CreateStaffRecordComponent } from './features/workers/create-staff-record/create-staff-record.component';
+// import { MentalHealthComponent } from './features/workers/mental-health/mental-health.component';
+// import { MainJobStartDateComponent } from './features/workers/main-job-start-date/main-job-start-date.component';
+// import { NationalInsuranceNumberComponent } from './features/workers/national-insurance-number/national-insurance-number.component';
+// import { OtherJobRolesComponent } from './features/workers/other-job-roles/other-job-roles.component';
+// import { DateOfBirthComponent } from './features/workers/date-of-birth/date-of-birth.component';
+// import { HomePostcodeComponent } from './features/workers/home-postcode/home-postcode.component';
+// import { GenderComponent } from './features/workers/gender/gender.component';
+// import { DisabilityComponent } from './features/workers/disability/disability.component';
+// import { EthnicityComponent } from './features/workers/ethnicity/ethnicity.component';
 import { TermsConditionsComponent } from './shared/terms-conditions/terms-conditions.component';
 
 const routes: Routes = [
@@ -41,52 +52,62 @@ const routes: Routes = [
     component: LoginComponent
   },
   {
-    path: 'registered-question',
-    component: CqcRegisteredQuestionComponent,
-  },
-  {
     path: 'sign-out',
     component: LogoutComponent
   },
   {
+    path: 'registered-question',
+    component: CqcRegisteredQuestionComponent,
+  },
+  {
     path: 'select-workplace',
-    component: SelectWorkplaceComponent
+    component: SelectWorkplaceComponent,
+    canActivate: [RegisterGuard],
   },
   {
     path: 'confirm-workplace-details',
-    component: ConfirmWorkplaceDetailsComponent
-  },
-  {
-    path: 'select-workplace-address',
-    component: SelectWorkplaceAddressComponent
+    component: ConfirmWorkplaceDetailsComponent,
+    canActivate: [RegisterGuard],
   },
   {
     path: 'user-details',
-    component: UserDetailsComponent
+    component: UserDetailsComponent,
+    canActivate: [RegisterGuard],
   },
   {
     path: 'create-username',
-    component: CreateUsernameComponent
+    component: CreateUsernameComponent,
+    canActivate: [RegisterGuard],
   },
   {
     path: 'security-question',
-    component: SecurityQuestionComponent
+    component: SecurityQuestionComponent,
+    canActivate: [RegisterGuard],
   },
   {
     path: 'confirm-account-details',
-    component: ConfirmAccountDetailsComponent
+    component: ConfirmAccountDetailsComponent,
+    canActivate: [RegisterGuard],
   },
   {
     path: 'registration-complete',
-    component: RegistrationCompleteComponent
+    component: RegistrationCompleteComponent,
+    canActivate: [RegisterGuard],
+  },
+  {
+    path: 'select-workplace-address',
+    component: SelectWorkplaceAddressComponent,
+    canActivate: [RegisterGuard],
   },
   {
     path: 'enter-workplace-address',
-    component: EnterWorkplaceAddressComponent
+    component: EnterWorkplaceAddressComponent,
+    canActivate: [RegisterGuard],
   },
   {
     path: 'select-main-service',
-    component: SelectMainServiceComponent
+    component: SelectMainServiceComponent,
+    canActivate: [RegisterGuard],
   },
   {
     path: 'continue-creating-account',
@@ -182,15 +203,76 @@ const routes: Routes = [
     path: 'terms-and-conditions',
     component: TermsConditionsComponent
   },
+  // {
+  //   path: 'worker',
+  //   canActivateChild: [AuthGuard],
+  //   children: [
+  //     {
+  //       path: 'edit-staff-record/:id',
+  //       component: CreateStaffRecordComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'create-staff-record',
+  //       component: CreateStaffRecordComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'mental-health/:id',
+  //       component: MentalHealthComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'main-job-start-date/:id',
+  //       component: MainJobStartDateComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'other-job-roles/:id',
+  //       component: OtherJobRolesComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'national-insurance-number/:id',
+  //       component: NationalInsuranceNumberComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'date-of-birth/:id',
+  //       component: DateOfBirthComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'home-postcode/:id',
+  //       component: HomePostcodeComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'gender/:id',
+  //       component: GenderComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'disability/:id',
+  //       component: DisabilityComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //     {
+  //       path: 'ethnicity/:id',
+  //       component: EthnicityComponent,
+  //       canLoad: [AuthGuard]
+  //     },
+  //   ]
+  // },
   {
-    path: "",
-    redirectTo: "/welcome",
-    pathMatch: "full"
+    path: '',
+    redirectTo: '/welcome',
+    pathMatch: 'full'
   },
   {
-    path: "**",
-    redirectTo: "/welcome"
-  }
+    path: '**',
+    redirectTo: '/welcome'
+  },
 ];
 
 @NgModule({

--- a/src/app/core/guards/register/register.guard.spec.ts
+++ b/src/app/core/guards/register/register.guard.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+
+import { RegisterGuard } from './register.guard';
+
+describe('RegisterGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RegisterGuard]
+    });
+  });
+
+  it('should ...', inject([RegisterGuard], (guard: RegisterGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/src/app/core/guards/register/register.guard.ts
+++ b/src/app/core/guards/register/register.guard.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+
+import { RegistrationService } from '../../services/registration.service';
+import { RegistrationModel } from '../../../core/model/registration.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RegisterGuard implements CanActivate {
+  registration: RegistrationModel;
+
+  constructor(private _registrationService: RegistrationService, private router: Router) {}
+
+  canActivate() {
+    this._registrationService.registration$.subscribe(registration => this.registration = registration);
+
+    if (this.registration.locationdata[0].isRegulated !== null) {
+      return true;
+    }
+
+    this.router.navigate(['/registered-question']);
+    return false;
+  }
+}

--- a/src/app/core/services/registration.service.ts
+++ b/src/app/core/services/registration.service.ts
@@ -19,36 +19,35 @@ const initialRegistration: RegistrationModel = {
     route: []
   },
   locationdata: [{
-    addressLine1: '14 Shepherd\'s Court',
-    addressLine2: '111 High Street',
-    county: 'Berkshire',
-    locationId: '1-1000270393',
-    locationName: 'Red Kite Home Care',
-    mainService: 'Homecare agencies',
-    postalCode: 'SL1 7JZ',
-    townCity: 'Slough',
-    isRegulated: true,
+    addressLine1: '',
+    addressLine2: '',
+    county: '',
+    locationId: '',
+    locationName: '',
+    mainService: '',
+    postalCode: '',
+    townCity: '',
+    isRegulated: null,
     user: {
-      fullname: 'Mike Wazowski',
-      jobTitle: 'Scaring assistant',
-      emailAddress: 'mike.wazowski@monsters.inc',
-      contactNumber: '07828732666',
-      username: 'cyclops',
-      password: 'password1',
-      securityQuestion: 'Who is my partner',
-      securityAnswer: 'James P.Sulivan'
+      fullname: '',
+      jobTitle: '',
+      emailAddress: '',
+      contactNumber: '',
+      username: '',
+      password: '',
+      securityQuestion: '',
+      securityAnswer: ''
     }
   }],
   postcodedata: [{
     locationName: '',
-    addressLine1: '14 Shepherd\'s Court',
-    addressLine2: '111 High Street',
-    townCity: 'Slough',
-    county: 'Berkshire',
-    postalCode: 'SL1 7JZ'
+    addressLine1: '',
+    addressLine2: '',
+    townCity: '',
+    county: '',
+    postalCode: ''
   }]
 };
-
 
 @Injectable({
   providedIn: 'root'
@@ -110,19 +109,6 @@ export class RegistrationService {
       .pipe(
         catchError(err => this.handleHttpError(err))
       );
-    // .subscribe(
-    //   (data: RegistrationModel) => {
-    //     this.updateState(data);
-
-    //     // this.router.navigate(['/select-workplace-address']);
-
-    //   },
-    //   (err: any) => console.log(err),
-    //   () => {
-    //     console.log('Updated locations by postcode complete');
-    //     console.log(this._registration$);
-    //   }
-    // );
   }
 
   getMainServices(id: boolean) {

--- a/src/app/features/confirm-workplace-details/confirm-workplace-details.component.ts
+++ b/src/app/features/confirm-workplace-details/confirm-workplace-details.component.ts
@@ -38,7 +38,6 @@ export class ConfirmWorkplaceDetailsComponent implements OnInit {
 
     this.currentSection = this.currentSection + 1;
 
-    debugger;
     if (this.backLink === '/select-main-service') {
       if (this.registration.userRoute.route[this.secondItem] === '/select-workplace') {
         this.lastSection = 8;
@@ -50,21 +49,6 @@ export class ConfirmWorkplaceDetailsComponent implements OnInit {
         this.lastSection = 7;
       }
     }
-    // if (this.backLink === '/select-workplace') {
-    //   this.lastSection = 8;
-    // }
-
-    // if ((this.prevPage === 'registered-question') && (this.currentSection === 2)) {
-    //   //this.currentSection = '2';
-    //   this.lastSection = 7;
-    // }
-    // else if ((this.prevPage === 'select-workplace') && (this.currentSection === 3)) {
-    //   //this.currentSection = '3';
-    //   this.lastSection = 7;
-    // }
-    // else if ((this.prevPage === 'select-main-service') && (this.currentSection === 4)) {
-    //   this.lastSection = 8;
-    // }
   }
 
   isRegulatedCheck(id: any) {
@@ -79,65 +63,52 @@ export class ConfirmWorkplaceDetailsComponent implements OnInit {
   }
 
   save() {
-    //this._registrationService.getLocationByLocationId(this.selectedAddressId);
-    //const isRegulatedAddress = [this.registration[0].locationdata[0].locationId];
+
     this.isRegulatedCheck(this.registration);
 
-    //console.log(isRegulatedAddress);
-    //this.registration.locationdata[0].prevPage = 'confirm-workplace-details';
-    //this.registration.locationdata[0].currentPage = this.currentSection;
     this.updateSectionNumbers(this.registration);
 
     this._registrationService.updateState(this.registration);
 
-    //this._registrationService.routingCheck(this.registration);
     this.router.navigate(['/user-details']);
   }
 
   updateSectionNumbers(data) {
-    debugger;
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
     data.userRoute['route'].push('/confirm-workplace-details');
-
-
-    // data.userRoute.currentPage = this.currentSection;
-    // data.userRoute.route.push('/select-workplace');
-
-    console.log(data);
-    console.log(this.registration);
-    debugger;
   }
 
   clickBack() {
     const routeArray = this.registration.userRoute.route;
     this.currentSection = this.registration.userRoute.currentPage;
     this.currentSection = this.currentSection - 1;
-    debugger;
-    this.registration.userRoute.route.splice(-1);
-    debugger;
 
-    //this.updateSectionNumbers(this.registration);
-    //this.registration.userRoute = this.registration.userRoute;
+    this.registration.userRoute.route.splice(-1);
+
     this.registration.userRoute.currentPage = this.currentSection;
-    //this.registration.userRoute['route'] = this.registration.userRoute['route'];
-    debugger;
+
     this._registrationService.updateState(this.registration);
 
-    debugger;
     this.router.navigate([this.backLink]);
+  }
+
+  setRegulatedCheckFalse(data) {
+    // clear default location data
+    data.locationdata = [{}];
+    data.locationdata[0]['isRegulated'] = false;
   }
 
   workplaceNotFound() {
     this.addressPostcode = this.registration.locationdata[0].postalCode;
-    debugger;
 
     this._registrationService.getAddressByPostCode(this.addressPostcode).subscribe(
       (data: RegistrationModel) => {
         if (data.success === 1) {
           this.updateSectionNumbers(data);
-          debugger;
+          this.setRegulatedCheckFalse(data);
+
           //data = data.postcodedata;
           this._registrationService.updateState(data);
           //this.routingCheck(data);

--- a/src/app/features/cqc-registered-question/cqc-registered-question-edit/cqc-registered-question-edit.component.ts
+++ b/src/app/features/cqc-registered-question/cqc-registered-question-edit/cqc-registered-question-edit.component.ts
@@ -37,6 +37,10 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
   cqclocationApiError: string;
   nonCqcPostcodeApiError: string;
 
+  currentSection: number;
+  lastSection: number;
+  backLink: string;
+
   private cqcRegPostcodeMessages = {
     maxlength: 'Your postcode must be no longer than 8 characters.',
     bothHaveContent: 'Both have content.',
@@ -141,17 +145,6 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
             //this.submittedCqcRegLocationId = false;
             this.setCqcRegisteredLocationIdMessage(this.cqcRegisteredLocationId);
           }
-          // else if (this.cqcRegisteredPostcode.errors) {
-          //   this.isSubmitted = true;
-          //   this.submittedCqcRegPostcode = true;
-          //   this.submittedCqcRegLocationId = true;
-          // }
-          // if (!this.cqcRegisteredPostcode.errors && !this.cqcRegisteredLocationId.errors) {
-          //   this.isSubmitted = true;
-          //   this.submittedCqcRegPostcode = true;
-          //   this.submittedCqcRegLocationId = true;
-          // }
-
         }
         else {
           this.isSubmitted = false;
@@ -171,6 +164,8 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
     // -- END -- Validation check watchers
 
     this._registrationService.registration$.subscribe(registration => this.registration = registration);
+
+    this.setSectionNumbers();
   }
 
   // -- START -- Set validation handlers
@@ -182,14 +177,6 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
         key => this.cqcRegPostcodeMessage += this.cqcRegPostcodeMessages[key]).join(' ');
     }
     else {
-      // if (this.cqcRegisteredLocationId.errors) {
-      //   this.isSubmitted = false;
-      // }
-      // else if (!this.cqcRegisteredPostcode.errors) {
-      //   // this.isSubmitted = true;
-      //   // this.submittedCqcRegPostcode = true;
-      //   // this.submittedCqcRegLocationId = true;
-      // }
       if (this.isSubmitted && !this.cqcRegisteredLocationId.errors) {
         this.save();
       }
@@ -204,15 +191,6 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
         key => this.cqcRegLocationIdMessage += this.cqcRegLocationIdMessages[key]).join('<br />');
     }
     else {
-      // if (this.cqcRegisteredPostcode.errors) {
-      //   this.isSubmitted = false;
-      // }
-      // else if (!this.cqcRegisteredLocationId.errors) {
-      //   debugger;
-      //   // this.isSubmitted = true;
-      //   // this.submittedCqcRegPostcode = true;
-      //   // this.submittedCqcRegLocationId = true;
-      // }
       if (this.isSubmitted && !this.cqcRegisteredPostcode.errors) {
         this.save();
       }
@@ -238,16 +216,14 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
   onSubmit() {
 
     this.isRegulated = this.cqcRegisteredQuestionForm.get('registeredQuestionSelected').value;
-    debugger;
+
     if (this.isRegulated === true) {
       const cqcRegisteredPostcode = this.cqcRegisteredQuestionForm.get('cqcRegisteredGroup.cqcRegisteredPostcode');
       const locationId = this.cqcRegisteredQuestionForm.get('cqcRegisteredGroup.locationId');
       // Clear value of not cqc registered postcode if previously entered
       //this.notRegisteredPostcode.value = '';
-      debugger;
 
       if ((cqcRegisteredPostcode.value.length > 0) || (locationId.value.length > 0)) {
-        debugger;
         if (this.cqcRegisteredQuestionForm.invalid || this.cqcRegisteredGroup.errors) {
           return;
         }
@@ -269,48 +245,8 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
       }
     }
   }
-        // if (this.cqcRegisteredPostcode.errors) {
-        //   debugger;
-        //   this.isSubmitted = true;
-        //   this.submittedCqcRegPostcode = false;
-        // }
-        // else {
-        //   debugger;
-        //   this.isSubmitted = true;
-        //   this.submittedCqcRegPostcode = true;
-        //   this.save();
-        // }
-      //}
-      // if (locationId.value.length > 0) {
-      //   debugger;
-      //   if (this.cqcRegisteredLocationId.errors) {
-      //     debugger;
-      //     this.isSubmitted = true;
-      //     this.submittedCqcRegLocationId = false;
-      //   }
-      //   else {
-      //     debugger;
-      //     this.isSubmitted = true;
-      //     this.submittedCqcRegLocationId = true;
-      //     this.save();
-      //   }
-      // }
-
-      // if (!locationId.value && !cqcRegisteredPostcode.value)  {
-      //   cqcRegisteredPostcode.setValidators([Validators.required, Validators.maxLength(8)]);
-      //   locationId.setValidators([Validators.required, Validators.maxLength(50)]);
-      //   cqcRegisteredPostcode.updateValueAndValidity();
-      //   locationId.updateValueAndValidity();
-      // }
-    //}
-    // else if (isRegulated === 'false') {
-    //   debugger;
-    //   this.save();
-    // }
-
 
   save() {
-
     const cqcRegisteredPostcodeValue = this.cqcRegisteredQuestionForm.get('cqcRegisteredGroup.cqcRegisteredPostcode').value;
     const locationIdValue = this.cqcRegisteredQuestionForm.get('cqcRegisteredGroup.locationId').value;
     const notRegisteredPostcodeValue = this.cqcRegisteredQuestionForm.get('notRegisteredPostcode').value;
@@ -320,17 +256,14 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
         (data: RegistrationModel) => {
           if (data.success === 1) {
 
-            this.setSectionNumbers(data);
+            this.updateSectionNumbers(data);
 
-            debugger;
             //data = data.locationdata;
             this._registrationService.updateState(data);
             this._registrationService.routingCheck(data);
           }
         },
         (err: RegistrationTrackerError) => {
-          debugger;
-          console.log(err);
           this.cqcPostcodeApiError = err.friendlyMessage;
           this.setCqcRegPostcodeMessage(this.cqcRegisteredPostcode);
         },
@@ -344,17 +277,14 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
         (data: RegistrationModel) => {
           if (data.success === 1) {
 
-            this.setSectionNumbers(data);
+            this.updateSectionNumbers(data);
 
-            debugger;
             //data = data.locationdata;
             this._registrationService.updateState(data);
             this._registrationService.routingCheck(data);
           }
         },
         (err: RegistrationTrackerError) => {
-          debugger;
-          console.log(err);
           this.cqclocationApiError = err.friendlyMessage;
           this.setCqcRegPostcodeMessage(this.cqcRegisteredPostcode);
         },
@@ -368,17 +298,16 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
         (data: RegistrationModel) => {
           if (data.success === 1) {
 
-            this.setSectionNumbers(data);
+            this.updateSectionNumbers(data);
+            this.setRegulatedCheckFalse(data);
 
-            debugger;
             //data = data.postcodedata;
             this._registrationService.updateState(data);
             //this.routingCheck(data);
           }
         },
         (err: RegistrationTrackerError) => {
-          debugger;
-          console.log(err);
+
           this.nonCqcPostcodeApiError = err.friendlyMessage;
           this.setCqcRegPostcodeMessage(this.cqcRegisteredPostcode);
         },
@@ -408,7 +337,6 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
 
   // Routing check
   routingCheck(data) {
-    debugger;
     if (data.length > 1) {
       this.router.navigate(['/select-workplace']);
     } else {
@@ -422,16 +350,33 @@ export class CqcRegisteredQuestionEditComponent implements OnInit {
     }
   }
 
-  setSectionNumbers(data) {
+  setSectionNumbers() {
+    this.currentSection = 0;
+    this.backLink = '/login';
 
-    data['userRoute'] = this.registration.userRoute;
-    data.userRoute['currentPage'] = this.registration.userRoute['currentPage'] = 1;
-    data.userRoute['route'] = this.registration.userRoute['route'];
-    data.userRoute['route'].push('/registered-question');
+    this.currentSection = this.currentSection + 1;
+    this.lastSection = 8;
+  }
 
-    console.log(data);
-    console.log(this.registration);
-    debugger;
+  updateSectionNumbers(data) {
+    if (this.registration.userRoute) {
+      data['userRoute'] = this.registration.userRoute;
+      data.userRoute['currentPage'] = this.registration.userRoute['currentPage'];
+      data.userRoute['route'] = this.registration.userRoute['route'];
+      data.userRoute['route'].push('/registered-question');
+    }
+    else {
+      data['userRoute'] = {};
+      data.userRoute['currentPage'] = this.currentSection;
+      data.userRoute['route'] = [];
+      data.userRoute['route'].push('/registered-question');
+    }
+  }
+
+  setRegulatedCheckFalse(reg) {
+    // clear default location data
+    reg.locationdata = [{}];
+    reg.locationdata[0]['isRegulated'] = false;
   }
 }
 

--- a/src/app/features/create-username/create-username.component.ts
+++ b/src/app/features/create-username/create-username.component.ts
@@ -92,7 +92,6 @@ export class CreateUsernameComponent implements OnInit {
     });
 
     this._registrationService.registration$.subscribe(registration => this.registration = registration);
-    //console.log(this.registration);
 
     // Create username watcher
     this.getCreateUsernameInput.valueChanges.pipe(
@@ -147,27 +146,13 @@ export class CreateUsernameComponent implements OnInit {
 
   checkUsernameDuplicate(value) {
 
-    //const username = this.getCreateUsernameInput();
-    debugger;
     this._registrationService.getUsernameDuplicate(value)
-    // .subscribe(
-    //   res => {
-    //     // console.log(res)
-    //     debugger;
-    //     if (res.status === '1') {
-    //       debugger;
-    //       this.usernameApiError = res.message;
-    //       //this.setCreateUsernameMessage(this.getCreateUsernameInput);
-    //     }
-    //   }
-    // );
     .subscribe(
       (data: RegistrationModel) => {
         if (data['status'] === '1') {
 
           this.usernameApiError = data.message;
 
-          debugger;
           this.setCreateUsernameMessage(this.getCreateUsernameInput);
 
         }
@@ -176,7 +161,6 @@ export class CreateUsernameComponent implements OnInit {
         }
       },
       (err: RegistrationTrackerError) => {
-        debugger;
         console.log(err);
         this.usernameApiError = err.message;
         this.setCreateUsernameMessage(this.getCreateUsernameInput);
@@ -194,9 +178,8 @@ export class CreateUsernameComponent implements OnInit {
 
     this.currentSection = this.currentSection + 1;
 
-    debugger;
     if (this.backLink === '/user-details') {
-      debugger;
+
       if (this.registration.userRoute.route[this.secondItem] === '/select-workplace') {
         this.lastSection = 8;
       }
@@ -217,7 +200,6 @@ export class CreateUsernameComponent implements OnInit {
         key => this.usernameMessage += this.usernameMessages[key]).join(' ');
     }
 
-    //this.submittedUsername = false;
   }
 
   setPasswordMessage(c: AbstractControl): void {
@@ -228,7 +210,6 @@ export class CreateUsernameComponent implements OnInit {
         key => this.passwordMessage += this.passwordMessages[key]).join(' ');
     }
 
-    //this.submittedPassword = false;
   }
 
   setConfirmPasswordMessage(c: AbstractControl): void {
@@ -244,7 +225,6 @@ export class CreateUsernameComponent implements OnInit {
       }
     }
 
-    //this.submittedConfirmPassword = false;
   }
 
   changeDetails(): void {
@@ -274,10 +254,6 @@ export class CreateUsernameComponent implements OnInit {
     // stop here if form is invalid
     if (this.createUserNamePasswordForm.invalid || this.usernameApiError) {
 
-      //this.isSubmitted = false;
-      //this.submittedUsername = false;
-      //this.submittedPassword = false;
-      //this.submittedConfirmPassword = false;
       return;
     }
     else {
@@ -289,7 +265,6 @@ export class CreateUsernameComponent implements OnInit {
 
     const createUsernameValue = this.createUserNamePasswordForm.get('createUsernameInput').value;
     const createPasswordValue = this.createUserNamePasswordForm.get('passwordGroup.createPasswordInput').value;
-    //let confirmPasswordValue = this.createUserNamePasswordForm.get('confirmPasswordInput').value;
 
     if (this.registration.hasOwnProperty('detailsChanged') && this.registration.detailsChanged === true) {
       // Get updated form results
@@ -318,66 +293,31 @@ export class CreateUsernameComponent implements OnInit {
 
     this._registrationService.updateState(this.registration);
 
-    //this._registrationService.routingCheck(this.registration);
-
     if (this.registration.hasOwnProperty('detailsChanged') && this.registration.detailsChanged === true) {
       this.router.navigate(['/confirm-account-details']);
     }
     else {
       this.router.navigate(['/security-question']);
     }
-
-
-    //routerLink = "/security-question"
   }
 
   updateSectionNumbers(data) {
-    debugger;
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
     data.userRoute['route'].push('/create-username');
-
-    // data.userRoute.currentPage = this.currentSection;
-    // data.userRoute.route.push('/select-workplace');
-
-    console.log(data);
-    console.log(this.registration);
-    debugger;
   }
 
   clickBack() {
     const routeArray = this.registration.userRoute.route;
     this.currentSection = this.registration.userRoute.currentPage;
     this.currentSection = this.currentSection - 1;
-    debugger;
     this.registration.userRoute.route.splice(-1);
-    debugger;
 
-    //this.updateSectionNumbers(this.registration);
-    //this.registration.userRoute = this.registration.userRoute;
     this.registration.userRoute.currentPage = this.currentSection;
-    //this.registration.userRoute['route'] = this.registration.userRoute['route'];
-    debugger;
+
     this._registrationService.updateState(this.registration);
 
-    debugger;
     this.router.navigate([this.backLink]);
   }
 }
-
-// Check for content in both CQC registered input fields
-// function matchInputValues(c: AbstractControl): { [key: string]: boolean } | null {
-//   const passwordControl = c.get('createPasswordInput');
-//   const confirmPasswordControl = c.get('confirmPasswordInput');
-
-//   if (confirmPasswordControl.pristine) {
-//     return null;
-//   }
-
-//   if (passwordControl.value === confirmPasswordControl.value) {
-//     return null;
-//   }
-
-//   return { 'notMatched': true };
-// }

--- a/src/app/features/enter-workplace-address/enter-workplace-address.component.ts
+++ b/src/app/features/enter-workplace-address/enter-workplace-address.component.ts
@@ -202,14 +202,6 @@ export class EnterWorkplaceAddressComponent implements OnInit {
     this.setSectionNumbers();
   }
 
-  setSectionNumbers() {
-    this.currentSection = this.registration.userRoute.currentPage;
-    this.backLink = this.registration.userRoute.route[this.currentSection - 1];
-
-    this.currentSection = this.currentSection + 1;
-    this.lastSection = 8;
-  }
-
   // -- START -- Set validation handlers
   setPostcodeMessage(c: AbstractControl): void {
     this.postcodeMessage = '';
@@ -321,16 +313,12 @@ export class EnterWorkplaceAddressComponent implements OnInit {
 
     // this._registrationService.registration$.subscribe(registration => this.registration = registration);
 
-    console.log(this.registration);
-
     this.registration.locationdata[0]['postalCode'] = postcodeValue;
     this.registration.locationdata[0]['addressLine1'] = address1Value;
     this.registration.locationdata[0]['addressLine2'] = address2Value;
     this.registration.locationdata[0]['townCity'] = townCityValue;
     this.registration.locationdata[0]['county'] = countyValue;
     this.registration.locationdata[0]['locationName'] = wpNameValue;
-
-    console.log(this.registration.locationdata.length);
 
     const updateRegistration = this.registration.locationdata[0];
 
@@ -342,20 +330,19 @@ export class EnterWorkplaceAddressComponent implements OnInit {
 
   }
 
+  setSectionNumbers() {
+    this.currentSection = this.registration.userRoute.currentPage;
+    this.backLink = this.registration.userRoute.route[this.currentSection - 1];
+
+    this.currentSection = this.currentSection + 1;
+    this.lastSection = 8;
+  }
+
   updateSectionNumbers(data) {
-    debugger;
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
     data.userRoute['route'].push('/enter-workplace-address');
-
-
-    // data.userRoute.currentPage = this.currentSection;
-    // data.userRoute.route.push('/select-workplace');
-
-    console.log(data);
-    console.log(this.registration);
-    debugger;
   }
 
 }

--- a/src/app/features/select-main-service/select-main-service.component.ts
+++ b/src/app/features/select-main-service/select-main-service.component.ts
@@ -42,6 +42,8 @@ export class SelectMainServiceComponent implements OnInit {
 
     this._registrationService.registration$.subscribe(registration => this.registration = registration);
 
+    this.setSectionNumbers();
+
     // Get main services
     this.getMainServices();
 
@@ -51,31 +53,7 @@ export class SelectMainServiceComponent implements OnInit {
     );
 
     this.isInvalid = false;
-    this.setSectionNumbers();
-  }
 
-  setSectionNumbers() {
-    this.currentSection = this.registration.userRoute.currentPage;
-    this.backLink = this.registration.userRoute.route[this.currentSection - 1];
-
-    this.currentSection = this.currentSection + 1;
-    if (this.backLink === '/registered-question') {
-      this.lastSection = 7;
-    }
-    else if (this.backLink === '/select-workplace') {
-      this.lastSection = 8;
-    }
-    else if (this.backLink === '/enter-workplace-address') {
-      this.lastSection = 9;
-    }
-    else if (this.backLink === '/confirm-workplace-details') {
-      if (this.registration.userRoute[1].route === '/select-workplace') {
-        this.lastSection = 8;
-      }
-      else {
-        this.lastSection = 7;
-      }
-    }
   }
 
   clickBack() {
@@ -84,7 +62,7 @@ export class SelectMainServiceComponent implements OnInit {
     this.currentSection = this.currentSection - 1;
     this.registration.userRoute.route.splice(-1);
 
-    //this.updateSectionNumbers(this.registration);
+    this.updateSectionNumbers(this.registration);
     //this.registration.userRoute = this.registration.userRoute;
     this.registration.userRoute.currentPage = this.currentSection;
     //this.registration.userRoute['route'] = this.registration.userRoute['route'];
@@ -138,18 +116,35 @@ export class SelectMainServiceComponent implements OnInit {
 
   }
 
+  setSectionNumbers() {
+    this.currentSection = this.registration.userRoute.currentPage;
+    this.backLink = this.registration.userRoute.route[this.currentSection - 1];
+    this.currentSection = this.currentSection + 1;
+
+    if (this.backLink === '/registered-question') {
+      this.lastSection = 7;
+    }
+    else if (this.backLink === '/select-workplace') {
+      this.lastSection = 8;
+    }
+    else if (this.backLink === '/enter-workplace-address') {
+      this.lastSection = 9;
+    }
+    else if (this.backLink === '/confirm-workplace-details') {
+      if (this.registration.userRoute[1].route === '/select-workplace') {
+        this.lastSection = 8;
+      }
+      else {
+        this.lastSection = 7;
+      }
+    }
+  }
+
   updateSectionNumbers(data) {
     data['userRoute'] = this.registration.userRoute;
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
     data.userRoute['route'].push('/select-main-service');
-
-
-    // data.userRoute.currentPage = this.currentSection;
-    // data.userRoute.route.push('/select-workplace');
-
-    console.log(data);
-    console.log(this.registration);
   }
 
 }

--- a/src/app/features/select-workplace-address/select-workplace-address.component.html
+++ b/src/app/features/select-workplace-address/select-workplace-address.component.html
@@ -17,18 +17,32 @@
     <div class="form-group mb-5">
       <div class="col-12 col-md-7 p-0">
 
-        <div class="field-group">
-          <div class="row m-0" *ngIf="editPostcode">
-            <input placeholder="" type="text" id="postcode" class="form-control col-md-4 d-inline-block pl-3 mb-5" formControlName="postcodeInput" />
+        <div class="field-group updatePostcode" [ngClass]="{'is-invalid': postcodeApiError }">
+
+          <span class="invalid-feedback">
+            <span class="main-body-text mb-2" *ngIf="postcodeApiError">
+              Invalid Postcode
+            </span>
+          </span>
+
+          <div class="row ml-0 mb-5" *ngIf="editPostcode">
+            <input placeholder="" type="text" id="postcode" class="form-control col-md-4 d-inline-block" formControlName="postcodeInput" />
             <button class="btn btn-secondary d-inline-block align-top ml-4" (click)="updatePostcode()">Update</button>
           </div>
-          <div class="row" *ngIf="!editPostcode">
-            <div class="main-body-text-bold col-5 col-sm-3 pb-5">{{ registration.postcodedata[0].postalCode }}</div>
-            <div class="main-body-text col-5 col-sm-3 pb-5 pl-0"><span class="text-link" title="Edit postcode" (click)="postcodeChange()">Change</span></div>
+          <div class="row mb-5" *ngIf="!editPostcode">
+            <div class="main-body-text-bold col-5 col-sm-3">{{ postcodeValue }}</div>
+            <div class="main-body-text col-5 col-sm-3 pl-0"><span class="text-link" title="Edit postcode" (click)="postcodeChange()">Change</span></div>
           </div>
         </div>
 
-        <div class="field-group">
+        <div class="field-group" [ngClass]="{'is-invalid': selectAddressMessage, 'd-none': postcodeApiError }">
+
+          <span class="invalid-feedback">
+            <span class="main-body-text mb-2" *ngIf="selectAddressMessage">
+              Select your address
+            </span>
+          </span>
+
           <select class="col-12 col-md-10 pl-2 pr-2" id="selectWorkplaceAddress" formControlName="selectWorkplaceAddressSelected">
             <option value="" hidden disabled>Please select your workplace address</option>
             <option value="{{i}}" *ngFor="let item of registration.postcodedata; let i = index;">{{ item.locationName ? item.locationName + ', ' : '' }}{{ item.addressLine1 }}, {{ item.addressLine2 }} - {{ item.townCity }} {{ item.postalCode }}</option>

--- a/src/app/features/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/select-workplace-address/select-workplace-address.component.ts
@@ -17,22 +17,25 @@ export class SelectWorkplaceAddressComponent implements OnInit {
   registration: RegistrationModel;
   selectedAddress: string;
   editPostcode: boolean;
+  postcodeValue: string;
   locationdata = [];
 
   cqcPostcodeApiError: string;
   cqclocationApiError: string;
-  nonCqcPostcodeApiError: string;
+  postcodeApiError: boolean;
+  selectAddressMessage: boolean;
 
   currentSection: number;
   lastSection: number;
   backLink: string;
 
-  // Set up Validation messages
-  addressSelected: boolean;
 
   constructor(private _registrationService: RegistrationService, private router: Router, private fb: FormBuilder) { }
 
   ngOnInit() {
+    this.selectAddressMessage = false;
+    this.postcodeApiError = false;
+
     this.selectWorkplaceAddressForm = this.fb.group({
       selectWorkplaceAddressSelected: ['', [Validators.required]],
       postcodeInput: ['', Validators.maxLength(8)]
@@ -47,21 +50,73 @@ export class SelectWorkplaceAddressComponent implements OnInit {
     );
 
     this._registrationService.registration$.subscribe(registration => this.registration = registration);
-
     this.editPostcode = false;
+
 
     this.setSectionNumbers();
 
+    // Check if postcode already exists on load
+    this.checkExistingPostcode(this.registration);
+
     // set not registered
     this.setRegulatedCheckFalse(this.registration);
-
-    this.addressSelected = true;
   }
 
-  setRegulatedCheckFalse(reg) {
+  setRegulatedCheckFalse(data) {
     // clear default location data
-    reg.locationdata = [{}];
-    reg.locationdata[0]['isRegulated'] = false;
+    data.locationdata = [{}];
+    data.locationdata[0]['isRegulated'] = false;
+  }
+
+  checkExistingPostcode(data) {
+
+    if (data.locationdata[0].postalCode) {
+      this.postcodeValue = data.locationdata[0].postalCode;
+    }
+    else if (data.postcodedata[0].postalCode) {
+      this.postcodeValue = data.postcodedata[0].postalCode;
+    }
+
+    if ((data.locationdata.length <= 1) && data.locationdata[0].postalCode) {
+      const existingPostcode = data.locationdata[0].postalCode;
+      this.updatePostcode(existingPostcode);
+    }
+  }
+
+  selectWorkplaceAddressChanged(value: string): void {
+    this.selectedAddress = this.registration.postcodedata[value];
+    this.selectAddressMessage = false;
+  }
+
+  save() {
+
+    if (!this.selectedAddress) {
+      this.selectAddressMessage = true;
+    }
+    else {
+
+      const locationdata = [this.selectedAddress];
+
+      const postcodeObj = {
+        locationdata
+      };
+
+      postcodeObj.locationdata[0]['isRegulated'] = false;
+
+      this.updateSectionNumbers(postcodeObj);
+
+      this._registrationService.updateState(postcodeObj);
+
+      if (this.registration.locationdata[0].locationName === '') {
+
+        this.router.navigate(['/enter-workplace-address']);
+      }
+      else {
+        this.router.navigate(['/select-main-service']);
+      }
+
+    }
+
   }
 
   setSectionNumbers() {
@@ -72,76 +127,42 @@ export class SelectWorkplaceAddressComponent implements OnInit {
     this.lastSection = 8;
   }
 
-  selectWorkplaceAddressChanged(value: string): void {
-    this.selectedAddress = this.registration.postcodedata[value];
-  }
-
-  save() {
-    const locationdata = [this.selectedAddress];
-
-    const postcodeObj = { locationdata };
-
-    if (!locationdata[0]) {
-      this.addressSelected = false;
-    }
-    else {
-      this.addressSelected = true;
-
-      this.locationdata.push(postcodeObj);
-
-      this.updateSectionNumbers(this.locationdata[0]);
-
-      this._registrationService.updateState(this.locationdata[0]);
-
-      if (this.registration.locationdata[0].locationName === '') {
-
-        this.router.navigate(['/enter-workplace-address']);
-      }
-      else {
-        this.router.navigate(['/select-main-service']);
-      }
-    }
-
-  }
-
   updateSectionNumbers(data) {
-    data['userRoute'] = this.registration.userRoute || {}
+    data['userRoute'] = this.registration.userRoute || {};
     data.userRoute['currentPage'] = this.currentSection;
-    data.userRoute['route'] = (this.registration.userRoute && this.registration.userRoute['route']) || []
+    data.userRoute['route'] = (this.registration.userRoute && this.registration.userRoute['route']) || [];
     data.userRoute['route'].push('/select-workplace-address');
-
-
-    // data.userRoute.currentPage = this.currentSection;
-    // data.userRoute.route.push('/select-workplace');
-
-    console.log(data);
-    console.log(this.registration);
   }
 
   postcodeChange() {
     this.editPostcode = true;
   }
 
-  updatePostcode() {
-    const postcodeValue = this.selectWorkplaceAddressForm.get('postcodeInput').value;
+  updatePostcode(existingPostcode) {
+    if (!existingPostcode) {
+      this.postcodeValue = this.selectWorkplaceAddressForm.get('postcodeInput').value;
+    }
+    else {
+      this.postcodeValue = existingPostcode;
+    }
 
-    this._registrationService.getUpdatedAddressByPostCode(postcodeValue)
+    this._registrationService.getUpdatedAddressByPostCode(this.postcodeValue)
       .subscribe(
         (data: RegistrationModel) => {
+          this.setRegulatedCheckFalse(data);
           this._registrationService.updateState(data);
-
-          // this.router.navigate(['/select-workplace-address']);
-
         },
-        (err: any) => console.log(err),
+        (err: any) => {
+          //this.nonCqcPostcodeApiError = err.friendlyMessage;
+          this.postcodeApiError = true;
+        },
         () => {
           console.log('Updated locations by postcode complete');
-          console.log(this._registrationService);
+          this.postcodeApiError = false;
         }
       );
 
     this.editPostcode = false;
-    //console.log(this.registration);
   }
 
 }

--- a/src/app/features/select-workplace/select-workplace.component.ts
+++ b/src/app/features/select-workplace/select-workplace.component.ts
@@ -122,13 +122,12 @@ export class SelectWorkplaceComponent implements OnInit, OnDestroy {
     data.userRoute['currentPage'] = this.currentSection;
     data.userRoute['route'] = this.registration.userRoute['route'];
     data.userRoute['route'].push('/select-workplace');
+  }
 
-
-    // data.userRoute.currentPage = this.currentSection;
-    // data.userRoute.route.push('/select-workplace');
-
-    console.log(data);
-    console.log(this.registration);
+  setRegulatedCheckFalse(data) {
+    // clear default location data
+    data.locationdata = [{}];
+    data.locationdata[0]['isRegulated'] = false;
   }
 
   workplaceNotFound() {
@@ -138,22 +137,13 @@ export class SelectWorkplaceComponent implements OnInit, OnDestroy {
       (data: RegistrationModel) => {
         if (data.success === 1) {
           this.updateSectionNumbers(data);
+          this.setRegulatedCheckFalse(data);
           //data = data.postcodedata;
           this._registrationService.updateState(data);
           //this.routingCheck(data);
           this.router.navigate(["/select-workplace-address"])
         }
       }
-      // ,
-      // (err: RegistrationTrackerError) => {
-      //   console.log(err);
-      //   this.nonCqcPostcodeApiError = err.friendlyMessage;
-      //   //this.setCqcRegPostcodeMessage(this.cqcRegisteredPostcode);
-      // },
-      // () => {
-      //   console.log('Get location by postcode complete');
-      //   this.router.navigate(['/select-workplace-address']);
-      // }
     );
   }
 

--- a/src/app/features/user-details/user-details.component.ts
+++ b/src/app/features/user-details/user-details.component.ts
@@ -93,7 +93,7 @@ export class UserDetailsComponent implements OnInit {
       userEmailInput: ['', [Validators.required, Validators.email, Validators.maxLength(120)]],
       userPhoneInput: ['', [Validators.required, Validators.pattern('^[0-9 x(?=ext 0-9+)]{8,50}$')]],
 
-      
+
     });
 
     this._registrationService.registration$.subscribe(registration => this.registration = registration);


### PR DESCRIPTION
So in completing this task I had to fix a few other things also. Here is what has been done:

* Created registration guard for all registration pages, if you go to them directly you will be kicked back to 'registered-question'.
* Cleared down default values to empty strings and null values.
* Fix validation and error checks on 'select-workplace-address'. Also if the postcode changed on this page it will hide the dropdown until the 'invalid postcode' error has been fixed.
* Have added functionality to each entry of the 'select-workplace-address' page to reset the 'isRegulated' to false.
* Also due to apparent fixes made by other developers I had to update those fixes and then also fix the knock on effects of them not checking and testing the actual impact of their changes across multiple pages.
* Update back button functionality across registration, but will need to be have a full service created later.

I have tested it as best I can but after merging I noticed there were some issues caused by that. I hope I have been able to fix all of those, but if you spot any give me a shout and im happy to re-fix :)