### PR TITLE
Social Care Start Date & Year of entry - lower boundary (100 years) now inclusive

### DIFF
--- a/server/models/classes/worker/properties/socialCareStartDateProperty.js
+++ b/server/models/classes/worker/properties/socialCareStartDateProperty.js
@@ -28,7 +28,7 @@ exports.WorkerSocialCareStartDateProperty = class WorkerSocialCareStartDatePrope
                     if (document.socialCareStartDate.year &&
                         Number.isInteger(document.socialCareStartDate.year) &&
                         document.socialCareStartDate.year <= thisYear &&
-                        document.socialCareStartDate.year > (thisYear - MAXIMUM_AGE)) {
+                        document.socialCareStartDate.year >= (thisYear - MAXIMUM_AGE)) {
                         
                         this.property = {
                             value: document.socialCareStartDate.value,

--- a/server/models/classes/worker/properties/yearArrivedProperty.js
+++ b/server/models/classes/worker/properties/yearArrivedProperty.js
@@ -26,7 +26,7 @@ exports.WorkerYearArrivedProperty = class WorkerYearArrivedProperty extends Chan
                     if (document.yearArrived.year &&
                         Number.isInteger(document.yearArrived.year) &&
                         document.yearArrived.year <= thisYear &&
-                        document.yearArrived.year > (thisYear - MAXIMUM_AGE)) {
+                        document.yearArrived.year >= (thisYear - MAXIMUM_AGE)) {
                         
                         this.property = {
                             value: document.yearArrived.value,


### PR DESCRIPTION
Revising the year of entry lower bound to be inclusive, this matching the UI.

The same logic is used for start date in social care; for consistency, updated that too.