### PR TITLE
Revised default uninitialised job role for None and Don't know options.

### DIFF
--- a/src/app/features/leavers/leavers.component.ts
+++ b/src/app/features/leavers/leavers.component.ts
@@ -127,14 +127,21 @@ export class LeaversComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.establishmentService.getLeavers().subscribe(leavers => {
         if (leavers === 'None') {
+          // Even if "None" option, want a single job role shown
+          recordsControl.push(this.createRecordItem())
+          
           this.form.patchValue({noRecordsReason: 'no-new'}, { emitEvent: true })
         } else if (leavers === 'Don\'t know') {
+          // Even if "Don'#t know" option on restore, want a single job role shown
+          recordsControl.push(this.createRecordItem())
+          
           this.form.patchValue({noRecordsReason: 'dont-know'}, { emitEvent: true })
         }
         else if (Array.isArray(leavers) && leavers.length) {
           leavers.forEach(v => recordsControl.push(this.createRecordItem(v.jobId.toString(), v.total)))
         } else {
-          leavers.push(this.createRecordItem())
+          // If no options and no leavers (the value has never been set) - just the default (select job) drop down
+          recordsControl.push(this.createRecordItem())
         }
       })
     )

--- a/src/app/features/starters/starters.component.ts
+++ b/src/app/features/starters/starters.component.ts
@@ -124,19 +124,25 @@ export class StartersComponent implements OnInit, OnDestroy {
     })
 
     const recordsControl = <FormArray> this.form.controls.recordsControl
-    const noVacanciesReasonControl = this.form.controls.noVacanciesReason
 
     this.subscriptions.push(
       this.establishmentService.getStarters().subscribe(starters => {
         if (starters === 'None') {
+          // Even if "None" option on restore, want a single job role shown
+          recordsControl.push(this.createRecordItem())
+          
           this.form.patchValue({noRecordsReason: 'no-new'}, { emitEvent: true })
         } else if (starters === 'Don\'t know') {
+          // Even if "Don't know" option on restore, want a single job role shown
+          recordsControl.push(this.createRecordItem())
+          
           this.form.patchValue({noRecordsReason: 'dont-know'}, { emitEvent: true })
         }
         else if (Array.isArray(starters) && starters.length) {
           starters.forEach(v => recordsControl.push(this.createRecordItem(v.jobId.toString(), v.total)))
         } else {
-          starters.push(this.createRecordItem())
+          // If no options and no starters (the value has never been set) - just the default (select job) drop down
+          recordsControl.push(this.createRecordItem())
         }
       })
     )

--- a/src/app/features/vacancies/vacancies.component.ts
+++ b/src/app/features/vacancies/vacancies.component.ts
@@ -139,18 +139,24 @@ export class VacanciesComponent implements OnInit, OnDestroy {
     })
 
     const vacancyControl = <FormArray> this.vacanciesForm.controls.vacancyControl
-    const noVacanciesReasonControl = this.vacanciesForm.controls.noVacanciesReason
 
     this.subscriptions.push(
       this.establishmentService.getVacancies().subscribe(vacancies => {
         if (vacancies === 'None') {
+          // Even if "None" option on restore, want a single job role shown
+          vacancyControl.push(this.createVacancyControlItem())
+          
           this.vacanciesForm.patchValue({noVacanciesReason: 'no-staff'}, { emitEvent: true })
         } else if (vacancies === 'Don\'t know') {
+          // Even if "Don't know" option on restore, want a single job role shown
+          vacancyControl.push(this.createVacancyControlItem())
+
           this.vacanciesForm.patchValue({noVacanciesReason: 'dont-know'}, { emitEvent: true })
         }
         else if (Array.isArray(vacancies) && vacancies.length) {
           vacancies.forEach(v => vacancyControl.push(this.createVacancyControlItem(v.jobId.toString(), v.total)))
         } else {
+          // If no options and no vacancies (the value has never been set) - just the default (select job) drop down
           vacancyControl.push(this.createVacancyControlItem())
         }
       })


### PR DESCRIPTION
This follows feedback from Ann on testing https://trello.com/c/d4uwAajW yesterday.

Even when the user had previously selected "none" or "don't know" options, we still need to display a single job role with "Select job title" option shown.

This also fixed a bug I had introduced on starters and leavers default view (the else clause using the wrong control to set).

I've taken the opporutnity to remove unused variable in vacancies and starters (`noVacanciesReasonControl`).