### PR TITLE
Refactoring helmet and introducing xss-clean and express-santizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "concurrently": "^4.1.0",
     "cookie-parser": "^1.4.3",
     "core-js": "^2.5.4",
+    "express-sanitizer": "^1.0.5",
     "helmet": "^3.15.0",
     "jade": "^1.11.0",
     "jquery": "^3.3.1",
@@ -48,6 +49,7 @@
     "sequelize": "^4.41.2",
     "serve-favicon": "^2.5.0",
     "uuid": "^3.3.2",
+    "xss-clean": "^0.1.1",
     "zone.js": "~0.8.26"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -104,9 +104,6 @@ app.use('/api/test', sanitizer());       // used as demonstration on test routes
 
 
 app.use(cookieParser());
-
-
-
 app.use(express.static(path.join(__dirname, 'dist')));
 
 // open/reference endpoints

--- a/server.js
+++ b/server.js
@@ -4,9 +4,15 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
-const helmet = require('helmet');
+
+// caching middleware - ref and transactional
 var cacheMiddleware = require('./server/utils/middleware/noCache');
 var refCacheMiddleware = require('./server/utils/middleware/refCache');
+
+// security libraries
+var helmet = require('helmet');
+var xssClean = require('xss-clean');
+var sanitizer = require('express-sanitizer');
 
 var routes = require('./server/routes/index');
 var locations = require('./server/routes/locations');
@@ -31,7 +37,52 @@ var testOnly = require('./server/routes/testOnly');
 
 
 var app = express();
-app.use(helmet());
+
+/*  
+ * security - incorproate helmet & xss-clean (de facto/good practice headers) across all endpoints
+ */
+
+// exclude middleware for given API path - used to exclude xss-clean to be able to demonstrate express-sanitizer on /api/test
+var unless = function(root, path, middleware) {
+    return function(req, res, next) {
+        const rootRegex = new RegExp('^' + root);
+        const excludePathRegex = new RegExp('^' + root + '/' + path);
+
+        // first, if the exclude root, simply move on
+        if (excludePathRegex.test(req.path)) {
+            return next();
+        } else if (rootRegex.test(req.path)) {
+            // matches on the root path, and is not excluded
+            return middleware(req, res, next);
+        } else {
+            // doesn't match the root path, so move on
+            return next();
+        }
+    };
+};
+
+// disable Helmet's caching - because we control that directly - cahcing is not enabled by default; but explicitly disabling it here
+// set frame policy to deny
+// only use on '/api' endpoint, because these changes may otherwise impact on the UI.
+app.use('/api', helmet({
+    noCache: false,
+    frameguard: {
+        action: 'deny'
+    },
+    contentSecurityPolicy : {
+        directives: {
+            defaultSrc: ["'self'"]
+        }
+    }
+}));
+
+// encodes all URL parameters
+app.use(unless('/api', 'test', xssClean()));
+
+/*  
+ * end security
+ */
+
 // view engine setup
 app.set('views', path.join(__dirname, '/server/views'));
 app.set('view engine', 'jade');
@@ -40,7 +91,22 @@ app.use(favicon(path.join(__dirname, 'dist/favicon.ico')));
 app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
+
+/*  
+ * security - removes unwanted HTML from data
+ */
+
+app.use('/api/test', sanitizer());       // used as demonstration on test routes only
+
+/*  
+ * end security
+ */
+
+
 app.use(cookieParser());
+
+
+
 app.use(express.static(path.join(__dirname, 'dist')));
 
 // open/reference endpoints

--- a/server/routes/testOnly/location.js
+++ b/server/routes/testOnly/location.js
@@ -5,7 +5,11 @@ const models = require('../../models');
 // returns a random set of addresses from the location dataset
 //  if passing the limit parameter can vary the set size (defaults to 100)
 router.route('/random').get(async (req, res) => {
-  const setSize = req.query.limit ? req.query.limit : 10;
+  console.log("WA DEBUG - req param: ", req.query.limit)
+  console.log("WA DEBUG - sanitised req param: ", req.sanitize(req.query.limit))
+
+
+  const setSize = req.sanitize(req.query.limit) ? req.sanitize(req.query.limit) : 10;
 
   try {
     let results = await models.location.findAll({

--- a/server/routes/testOnly/postcode.js
+++ b/server/routes/testOnly/postcode.js
@@ -5,7 +5,7 @@ const models = require('../../models');
 // returns a random set of addresses from the postcode dataset
 //  if passing the limit parameter can vary the set size (defaults to 100)
 router.route('/random').get(async (req, res) => {
-  const setSize = req.query.limit ? req.query.limit : 100;
+  const setSize = req.sanitize(req.query.limit) ? req.sanitize(req.query.limit) : 100;
 
   try {
     let results = await models.pcodedata.findAll({


### PR DESCRIPTION
Hi Nasir

To complete on the outstanding helmet Trello card code review (https://trello.com/c/0395dNwz), I've created a new branch from the stabalised `develop` branch, and I've manually brought in the explicit configuration of helmet which includes CSP, brought in `xss-clean`, and `express-sanitizer`, both used in my last demonstration to remove all but two warnings from contrast.

I've added that last contrast log that demonstrated this to the trello card.

I've tidied up the middleware paths, including allowing for exclusion of `xss-clean` on the test only route, allowing the demonstration of sanitizer on test only routes.

Ready for your review and approval, then we can close out the work done during evaluation of contrast.