### PR TITLE
Correcting the hourly pay upper boundary limit both frontend and backend

### DIFF
--- a/server/models/classes/worker/properties/annualHourlyPayProperty.js
+++ b/server/models/classes/worker/properties/annualHourlyPayProperty.js
@@ -13,7 +13,7 @@ exports.WorkerAnnualHourlyPayProperty = class WorkerAnnualHourlyPayProperty exte
 
     // concrete implementations
     async restoreFromJson(document) {
-        const MAXIMUM_HOURLY_PAY=100;
+        const MAXIMUM_HOURLY_PAY=200;
         const MAXIMUM_ANNUAL_PAY=200000;
         const MINIMUM_HOURLY_PAY=2.5;
         const MINIMUM_ANNUAL_PAY=500;

--- a/src/app/features/workers/salary/salary.component.ts
+++ b/src/app/features/workers/salary/salary.component.ts
@@ -35,7 +35,7 @@ export class SalaryComponent implements OnInit, OnDestroy {
       rate.reset();
 
       if (val === 'Hourly') {
-        rate.setValidators([Validators.min(2.5), Validators.max(100), Validators.required]);
+        rate.setValidators([Validators.min(2.5), Validators.max(200), Validators.required]);
       } else if (val === 'Annually') {
         rate.setValidators([Validators.min(500), Validators.max(200000), Validators.required]);
       }


### PR DESCRIPTION
Following test review, the upper boundary for hourly pay should be £200 not £100. Frontend and backend updates here.

Trello card (https://trello.com/c/el8TER0J) has evidence screenshots for frontend and backend showing 200 now successful.

Thanks