### PR TITLE
Change user details

### DIFF
--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -31,6 +31,38 @@
             "minLength" : 3,
             "maxLength": 120
         },
+        "Email" : {
+            "description" : "Optional email for the feedback",
+            "type" : "string",
+            "minLength" : 3,
+            "maxLength" : 120,
+            "pattern" : "^(([^<>()\[\]\\.,;:\s@\"]+(\.[^<>()\[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$"
+        },
+        "JobTitle" : {
+            "description" : "Job Title",
+            "type" : "string",
+            "minLength" : 3,
+            "maxLength" : 120
+        },
+        "SecurityQuestion" : {
+            "description" : "Security Question",
+            "type" : "string",
+            "minLength" : 3,
+            "maxLength" : 255
+        },
+        "SecurityQuestionAnswer" : {
+            "description" : "Security Question's Answer",
+            "type" : "string",
+            "minLength" : 3,
+            "maxLength" : 255
+        },
+        "Phone" : {
+            "description" : "Optional email for the feedback",
+            "type" : "string",
+            "minLength" : 3,
+            "maxLength" : 120,
+            "pattern" : "^[0-9 x(?=ext 0-9+)]{8,50}$"
+        },
         "Address" : {
             "description" : "Concatenated address - excluding postcode",
             "type" : "string",
@@ -1247,6 +1279,251 @@
             "required" : ["id", "name"]
         }
     },
+    "UsersType": {
+        "description" : "A users' short definition",
+        "type" : "object",
+        "properties" : {
+            "uid" : {
+                "$ref" : "#/definitions/Uid"
+            },
+            "fullname" : {
+                "$ref" : "#/definitions/Fullname"
+            },
+            "email": {
+                "$ref" : "#/definitions/Email"
+            },
+            "username" : {
+                "$ref" : "#/definitions/Username"
+            },
+            "createdAt" : {
+                "description" : "When the worker record was created",
+                "type" : "date-time"
+            },
+            "updatedAt" : {
+                "description": "When the worker record was last updated",
+                "type" : "date-time"
+            },
+            "updatedBy" : {
+                "description" : "The username of the last person to update the Worker",
+                "type" : "string"
+            }
+        },
+        "required": ["uid", "fullname", "email", "username", "created", "updated", "updatedBy"]
+    },
+    "Users" : {
+        "description" : "A list of establishment's users, ordered by updated descending",
+        "type" : "array",
+        "properties" : {
+            "users" : {
+                "type" : "array",
+                "items" : [
+                    {
+                        "$ref" : "#/definitions/UsersType"
+                    }
+                ]
+            }
+        },
+        "required" : ["users"]
+    },
+    "UserFullname" : {
+        "description": "The user's fullname",
+        "oneOf": [
+            {
+                "description": "Simple fullname",
+                "$ref" : "#/definitions/Fullname"
+            },
+            {
+                "allOf" : [
+                    {
+                        "description": "Fullname with change history",
+                        "type" : "object",
+                        "properties": {
+                            "currentValue" : {
+                                "$ref" : "#/definitions/Fullname"
+                            }
+                        },
+                        "required" : ["currentValue"]
+                    },
+                    {
+                        "$ref" : "#/definitions/PropertyChangeStatus"
+                    }
+                ]
+            }
+        ]
+    },
+    "UserEmail" : {
+        "description": "The user's email",
+        "oneOf": [
+            {
+                "description": "Simple email",
+                "$ref" : "#/definitions/Email"
+            },
+            {
+                "allOf" : [
+                    {
+                        "description": "Email with change history",
+                        "type" : "object",
+                        "properties": {
+                            "currentValue" : {
+                                "$ref" : "#/definitions/Email"
+                            }
+                        },
+                        "required" : ["currentValue"]
+                    },
+                    {
+                        "$ref" : "#/definitions/PropertyChangeStatus"
+                    }
+                ]
+            }
+        ]
+    },
+    "UserJobTitle" : {
+        "description": "The user's job title",
+        "oneOf": [
+            {
+                "description": "Simple job title",
+                "$ref" : "#/definitions/Fullname"
+            },
+            {
+                "allOf" : [
+                    {
+                        "description": "Job Title with change history",
+                        "type" : "object",
+                        "properties": {
+                            "currentValue" : {
+                                "$ref" : "#/definitions/Fullname"
+                            }
+                        },
+                        "required" : ["currentValue"]
+                    },
+                    {
+                        "$ref" : "#/definitions/PropertyChangeStatus"
+                    }
+                ]
+            }
+        ]
+    },
+    "UserPhone" : {
+        "description": "The user's phone number",
+        "oneOf": [
+            {
+                "description": "Simple phone",
+                "$ref" : "#/definitions/Phone"
+            },
+            {
+                "allOf" : [
+                    {
+                        "description": "Phone with change history",
+                        "type" : "object",
+                        "properties": {
+                            "currentValue" : {
+                                "$ref" : "#/definitions/Phone"
+                            }
+                        },
+                        "required" : ["currentValue"]
+                    },
+                    {
+                        "$ref" : "#/definitions/PropertyChangeStatus"
+                    }
+                ]
+            }
+        ]
+    },
+    "UserSecurityQuestion" : {
+        "description": "The user's secutity question",
+        "oneOf": [
+            {
+                "description": "Simple Security Question",
+                "$ref" : "#/definitions/SecurityQuestion"
+            },
+            {
+                "allOf" : [
+                    {
+                        "description": "Security Question with change history",
+                        "type" : "object",
+                        "properties": {
+                            "currentValue" : {
+                                "$ref" : "#/definitions/SecurityQuestion"
+                            }
+                        },
+                        "required" : ["currentValue"]
+                    },
+                    {
+                        "$ref" : "#/definitions/PropertyChangeStatus"
+                    }
+                ]
+            }
+        ]
+    },
+    "UserSecurityQuestionAnswer" : {
+        "description": "The user's secutity question answer",
+        "oneOf": [
+            {
+                "description": "Simple Security Question Answer",
+                "$ref" : "#/definitions/SecurityQuestionAnswer"
+            },
+            {
+                "allOf" : [
+                    {
+                        "description": "Security Question Answer with change history",
+                        "type" : "object",
+                        "properties": {
+                            "currentValue" : {
+                                "$ref" : "#/definitions/SecurityQuestionAnswer"
+                            }
+                        },
+                        "required" : ["currentValue"]
+                    },
+                    {
+                        "$ref" : "#/definitions/PropertyChangeStatus"
+                    }
+                ]
+            }
+        ]
+    },
+    "User" : {
+        "description" : "A user definition with/without change history",
+        "type" : "object",
+        "properties" : {
+            "uid" : {
+                "$ref" : "#/definitions/Uid"
+            },
+            "username" : {
+                "$ref" : "#/definitions/Username"
+            },
+            "fullname" : {
+                "$ref" : "#/definitions/UserFullname"
+            },
+            "email": {
+                "$ref" : "#/definitions/UserEmail"
+            },
+            "phone": {
+                "$ref" : "#/definitions/UserPhone"
+            },
+            "jobTitle": {
+                "$ref" : "#/definitions/UserJobTitle"
+            },
+            "securityQuestion": {
+                "$ref" : "#/definitions/UserSecurityQuestion"
+            },
+            "securityQuestionAnswer": {
+                "$ref" : "#/definitions/UserSecurityQuestionAnswer"
+            },
+            "createdAt" : {
+                "description" : "When the worker record was created",
+                "type" : "date-time"
+            },
+            "updatedAt" : {
+                "description": "When the worker record was last updated",
+                "type" : "date-time"
+            },
+            "updatedBy" : {
+                "description" : "The username of the last person to update the Worker",
+                "type" : "string"
+            }
+        },
+        "required": ["uid", "fullname", "created", "updated", "updatedBy"]
+    },
     "Feedback" : {
         "description" : "For capturing user feedback",
         "properties" : {
@@ -1267,17 +1544,10 @@
                 "maxLength" : 500
             },
             "name" : {
-                "description" : "Optional name for the feedback",
-                "type" : "string",
-                "minLength" : 3,
-                "maxLength" : 120
+                "$ref" : "#/definitions/Fullname"
             },
             "email" : {
-                "description" : "Optional email for the feedback",
-                "type" : "string",
-                "minLength" : 3,
-                "maxLength" : 120,
-                "pattern" : "^(([^<>()\[\]\\.,;:\s@\"]+(\.[^<>()\[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$"
+                "$ref" : "#/definitions/Email"
             }
         },
         "required" : ["whenDoing", "tellUs"]

--- a/server/models/classes/properties/manager.js
+++ b/server/models/classes/properties/manager.js
@@ -191,12 +191,9 @@ class PropertyManager {
         let thisJsonObject = {};
         const allProperties = Object.keys(this._properties);
 
-        console.log("Manager toJSON - modified only: ", modifiedPropertiesOnly)
-
         allProperties.forEach(thisPropertyName => {
             const thisProperty = this._properties[thisPropertyName];
             if (thisProperty.property && (!modifiedPropertiesOnly || (modifiedPropertiesOnly && thisProperty.modified))) {
-                console.log("WA DEBUG - is modified: ", thisPropertyName, modifiedPropertiesOnly, thisProperty.modified)
                 thisJsonObject = {
                     ...thisJsonObject,
                     ...thisProperty.toJSON(withHistory, showPropertyHistoryOnly)

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -390,8 +390,6 @@ class User {
                 ];
             }
 
-            console.log("WA DEBUG: fetch with history: ", fetchQuery)
-
             const fetchResults = await models.user.findOne(fetchQuery);
             if (fetchResults && fetchResults.id && Number.isInteger(fetchResults.id)) {
                 // update self - don't use setters because they modify the change state
@@ -470,7 +468,7 @@ class User {
     //  or updated only)
     formatWorkerHistoryEvents(auditEvents) {
         if (auditEvents) {
-            return auditEvents.filter(thisEvent => ['created', 'updated'].includes(thisEvent.type))
+            return auditEvents.filter(thisEvent => ['created', 'updated', 'loginSuccess', 'loginFailed', 'loginWhileLocked', 'passwdReset'].includes(thisEvent.type))
                                .map(thisEvent => {
                                     return {
                                         when: thisEvent.when,

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -259,7 +259,7 @@ class User {
 
                         this._updated = updatedRecord.updated;
                         this._updatedBy = savedBy;
-                        this._id = updatedRecord.ID;
+                        this._id = updatedRecord.RegistrationID;
 
                         const allAuditEvents = [{
                             userFk: this._id,
@@ -394,6 +394,7 @@ class User {
             if (fetchResults && fetchResults.id && Number.isInteger(fetchResults.id)) {
                 // update self - don't use setters because they modify the change state
                 this._isNew = false;
+                this._id = fetchResults.id;
                 this._uid = fetchResults.uid;
                 this._created = fetchResults.created;
                 this._updated = fetchResults.updated;

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -541,6 +541,7 @@ class User {
         } else {
             return {
                 uid:  this.uid,
+                username: this.username,
                 created: this.created.toJSON(),
                 updated: this.updated.toJSON(),
                 updatedBy: this.updatedBy,

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -23,6 +23,7 @@ class User {
         this._establishmentId = establishmentId;           // NOTE - a User has a direct link to an Establishment; this is likely to change with parent/sub
         this._id = null;
         this._uid = null;
+        this._username = null;
         this._created = null;
         this._updated = null;
         this._updatedBy = null;
@@ -74,6 +75,9 @@ class User {
     //
     get uid() {
         return this._uid;
+    }
+    get username() {
+        return this._username;
     }
     get fullname() {
         const prop = this._properties.get('Fullname');
@@ -396,6 +400,7 @@ class User {
                 this._isNew = false;
                 this._id = fetchResults.id;
                 this._uid = fetchResults.uid;
+                this._username = fetchResults.login.username;
                 this._created = fetchResults.created;
                 this._updated = fetchResults.updated;
                 this._updatedBy = fetchResults.updatedBy;
@@ -512,7 +517,8 @@ class User {
 
             // add worker default properties
             const myDefaultJSON = {
-                uid:  this.uid
+                uid:  this.uid,
+                username: this.username,
             };
 
             myDefaultJSON.created = this.created.toJSON();

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -415,15 +415,15 @@ class User {
         const allUsers = [];
         const fetchResults = await models.user.findAll({
             where: {
-                establishmentFk: establishmentId
+                establishmentId: establishmentId
             },
             include: [
                 {
-                    model: models.user,
+                    model: models.login,
                     attributes: ['username']
                   }
             ],
-            attributes: ['id', 'FullNameValue', 'EmailValue'],
+            attributes: ['id', 'FullNameValue', 'EmailValue', 'created', 'updated', 'updatedBy'],
             order: [
                 ['updated', 'DESC']
             ]           
@@ -431,14 +431,15 @@ class User {
 
         if (fetchResults) {
             fetchResults.forEach(thisUser => {
+                console.log("WA DEBUG - this user: ", thisUser)
                 allUsers.push({
                     uid: thisUser.id,
                     fullname: thisUser.FullNameValue,
                     email: thisUser.EmailValue,
                     username: thisUser.login && thisUser.login.username ? thisUser.login.username : null,
-                    created:  thisWorker.created.toJSON(),
-                    updated: thisWorker.updated.toJSON(),
-                    updatedBy: thisWorker.updatedBy
+                    created:  thisUser.created.toJSON(),
+                    updated: thisUser.updated.toJSON(),
+                    updatedBy: thisUser.updatedBy
                 })
             });
         }
@@ -591,7 +592,7 @@ class User {
 
 };
 
-module.exports.Worker = Worker;
+module.exports.User = User;
 
 // sub types
-module.exports.WorkerExceptions = WorkerExceptions;
+module.exports.UserExceptions = UserExceptions;

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -1,0 +1,597 @@
+/*
+ * user.js
+ *
+ * The encapsulation of a User, including all properties, all specific validation (not API, but object validation),
+ * saving & restoring of data to database (via sequelize model), construction and deletion.
+ * 
+ * Also includes representation as JSON, in one or more presentations.
+ */
+
+// database models
+const models = require('../index');
+
+const UserExceptions = require('./user/userExceptions');
+
+// User properties
+const UserProperties = require('./user/userProperties').UserPropertyManager;
+const JSON_DOCUMENT_TYPE = require('./user/userProperties').JSON_DOCUMENT;
+const SEQUELIZE_DOCUMENT_TYPE = require('./user/userProperties').SEQUELIZE_DOCUMENT;
+
+class User {
+    constructor() {
+        this._establishmentId = establishmentId;           // NOTE - a User has a direct link to an Establishment; this is likely to change with parent/sub
+        this._id = null;
+        this._created = null;
+        this._updated = null;
+        this._updatedBy = null;
+        this._auditEvents = null;
+
+        // abstracted properties
+        const thisUserManager = new UserProperties();
+        this._properties =thisUserManager.manager;
+
+        // change properties
+        this._isNew = false;
+        Question
+        // default logging level - errors only
+        // TODO: INFO logging on User; change to LOG_ERROR only
+        this._logLevel = User.LOG_INFO;
+    }
+
+    // returns true if valid establishment id
+    get _isEstablishmentIdValid() {
+        if ((this._establishmentId &&
+                Number.isInteger(this._establishmentId) &&
+                this._establishmentId > 0)
+            ) {
+                return true;
+            } else {
+                return false;
+            }
+    }
+
+    // private logging
+    static get LOG_ERROR() { return 100; }
+    static get LOG_WARN() { return 200; }
+    static get LOG_INFO() { return 300; }
+    static get LOG_TRACE() { return 400; }
+    static get LOG_DEBUG() { return 500; }
+
+    set logLevel(logLevel) {
+        this._logLevel = logLevel;
+    }
+
+    _log(level, msg) {
+        if (this._logLevel >= level) {
+            console.log(`TODO: (${level}) - User class: `, msg);
+        }
+    }
+
+    //
+    // attributes
+    //
+    get fullname() {
+        const prop = this._properties.get('Fullname');
+        return prop ? prop.property : null;
+    };
+    get jobTitle() {
+        const prop = this._properties.get('JobTitle');
+        return prop ? prop.property : null;
+    };
+    get email() {
+        const prop = this._properties.get('Email');
+        return prop ? prop.property : null;
+    };
+    get phone() {
+        const prop = this._properties.get('Phone');
+        return prop ? prop.property : null;
+    };
+    get securityQuestion() {
+        const prop = this._properties.get('SecurityQuestion');
+        return prop ? prop.property : null;
+    };
+    get securityAnswer() {
+        const prop = this._properties.get('SecurityQuestionAnswer');
+        return prop ? prop.property : null;
+    };
+    get created() {
+        return this._created;
+    }
+    get updated() {
+        return this._updated;
+    }
+    get updatedBy() {
+        return this._updatedBy;
+    }
+
+    // used by save to initialise a new User; returns true if having initialised this user
+    _initialise() {
+        if (this._id === null) {
+            this._isNew = true;
+            
+            if (!this._isEstablishmentIdValid)
+                throw new UserExceptions.UserSaveException(null,
+                                                           this._id,
+                                                           this.fullname,
+                                                           `Unexpected Establishment Id (${this._establishmentId})`,
+                                                           'Unknown Establishment');
+
+
+            // note, do not initialise the id as this will be returned by database
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // takes the given JSON document and creates a User's set of extendable properties
+    // Returns true if the resulting User is valid; otherwise false
+    async load(document) {
+        try {
+            await this._properties.restore(document, JSON_DOCUMENT_TYPE);
+        } catch (err) {
+            this._log(User.LOG_ERROR, `User::load - failed: ${err}`);
+            throw new UserExceptions.UserJsonException(
+                err,
+                null,
+                'Failed to load User from JSON');
+        }
+        return this.isValid();
+    }
+
+    // returns true if User is valid, otherwise false
+    isValid() {
+        // the property manager returns a list of all properties that are invalid; or true
+        const thisUserIsValid = this._properties.isValid;
+        if (thisUserIsValid === true) {
+            return true;
+        } else {
+            this._log(User.LOG_ERROR, `User invalid properties: ${thisUserIsValid.toString()}`);
+            return false;
+        }
+    }
+
+    // saves the User to DB. Returns true if saved; false is not.
+    // Throws "UserSaveException" on error
+    async save(savedBy) {
+        let mustSave = this._initialise();
+
+        if (mustSave && this._isNew) {
+            // create new User
+            try {
+                const creationDocument = {
+                    establishmentId: this._establishmentId,
+                    updatedBy: savedBy,
+                    attributes: ['id', 'created', 'updated'],
+                };
+
+                // need to create the User record and the User Audit event
+                //  in one transaction
+                await models.sequelize.transaction(async t => {
+                    // now append the extendable properties.
+                    // Note - although the POST (create) has a default
+                    //   set of mandatory properties, there is no reason
+                    //   why we cannot create a User record with more properties
+                    const modifedCreationDocument = this._properties.save(savedBy, creationDocument);
+
+                    // check all mandatory parameters have been provided
+                    if (!this.hasMandatoryProperties) {
+                        throw new UserExceptions.UserSaveException(null, this.fullname, 'Missing Mandatory properties', null);
+                    }
+
+                    // now save the document
+                    let creation = await models.user.create(modifedCreationDocument, {transaction: t});
+
+                    const sanitisedResults = creation.get({plain: true});
+
+                    this._id = sanitisedResults.ID;
+                    this._created = sanitisedResults.created;
+                    this._updated = sanitisedResults.updated;
+                    this._updatedBy = savedBy;
+                    this._isNew = false;
+
+                    // having the usser we can now create the audit record; injecting the userFk
+                    const allAuditEvents = [{
+                        userFk: this._id,
+                        username: savedBy,
+                        type: 'created'}].concat(this._properties.auditEvents.map(thisEvent => {
+                            return {
+                                ...thisEvent,
+                                userFk: this._id
+                            };
+                        }));
+                    await models.userAudit.bulkCreate(allAuditEvents, {transaction: t});
+
+                    this._log(User.LOG_INFO, `Created User with fullname (${this.fullname}) and id (${this._id})`);
+                });
+                
+            } catch (err) {
+                throw new UserExceptions.UserSaveException(null, this.fullname, err, null);
+            }
+        } else {
+            // we are updating an existing User
+            try {
+                const updatedTimestamp = new Date();
+
+                // need to update the existing User record and add an
+                //  updated audit event within a single transaction
+                await models.sequelize.transaction(async t => {
+                    // now append the extendable properties
+                    const modifedUpdateDocument = this._properties.save(savedBy, {});
+
+                    const updateDocument = {
+                        ...modifedUpdateDocument,
+                        updated: updatedTimestamp,
+                        updatedBy: savedBy
+                    };
+
+                    // now save the document
+                    let [updatedRecordCount, updatedRows] =
+                        await models.user.update(updateDocument,
+                                                 {
+                                                    returning: true,
+                                                    where: {
+                                                        id: this.id
+                                                    },
+                                                    attributes: ['id', 'updated'],
+                                                    transaction: t,
+                                                 }
+                                                );
+
+                    if (updatedRecordCount === 1) {
+                        const updatedRecord = updatedRows[0].get({plain: true});
+
+                        this._updated = updatedRecord.updated;
+                        this._updatedBy = savedBy;
+                        this._id = updatedRecord.ID;
+
+                        const allAuditEvents = [{
+                            userFk: this._id,
+                            username: savedBy,
+                            type: 'updated'}].concat(this._properties.auditEvents.map(thisEvent => {
+                                return {
+                                    ...thisEvent,
+                                    userFk: this._id
+                                };
+                            }));
+                            // having updated the record, create the audit event
+                        await models.userAudit.bulkCreate(allAuditEvents, {transaction: t});
+
+                        // now - work through any additional models having processed all properties (first delete and then re-create)
+                        const additionalModels = this._properties.additionalModels;
+                        const additionalModelsByname = Object.keys(additionalModels);
+                        const deleteModelPromises = [];
+                        additionalModelsByname.forEach(async thisModelByName => {
+                            deleteModelPromises.push(
+                                models[thisModelByName].destroy({
+                                    where: {
+                                        userFk: this._id
+                                    }
+                                  })
+                            );
+                        });
+                        await Promise.all(deleteModelPromises);
+                        const createModelPromises = [];
+                        additionalModelsByname.forEach(async thisModelByName => {
+                            const thisModelData = additionalModels[thisModelByName];
+                            createModelPromises.push(
+                                models[thisModelByName].bulkCreate(thisModelData.map(thisRecord => {
+                                    return {
+                                        ...thisRecord,
+                                        userFk: this._id
+                                    };
+                                }))
+                            );
+                        });
+                        await Promise.all(createModelPromises);
+
+                        this._log(User.LOG_INFO, `Updated User with id (${this._id}) and name (${this.fullname})`);
+
+                    } else {
+                        throw new UserExceptions.UserSaveException(null, this.fullname, err, `Failed to update resulting user record with id: ${this._id}`);
+                    }
+
+                });
+                
+            } catch (err) {
+                throw new UserExceptions.UserSaveException(null, this.fullname, err, `Failed to update user record with id: ${this._id}`);
+            }
+
+        }
+
+        return mustSave;
+    };
+
+    // loads the User (with given id or username) from DB, but only if it belongs to the given Establishment
+    // returns true on success; false if no User
+    // Can throw WorkerRestoreException exception.
+    async restore(uid, username, showHistory=false) {
+        if (!uid && !username) {
+            throw new UserExceptions.UserRestoreException(null,
+                null,
+                null,
+                'User::restore failed: Missing uid or username',
+                null,
+                'Unexpected Error');
+        }
+
+        try {
+            // by including the establishment id in the
+            //  fetch, we are sure to only fetch those
+            //  User records associated to the given
+            //   establishment
+            let fetchQuery = null;
+            
+            if (username) {
+                // fetch by username
+                fetchQuery = {
+                    where: {
+                        establishmentFk: this._establishmentId,
+                    },
+                    include: [
+                        {
+                            model: models.login,
+                            attributes: ['username'],
+                            where: [
+                                username
+                            ]
+                        }
+                    ]
+                };
+            } else {
+                // fetch by username
+                fetchQuery = {
+                    where: {
+                        establishmentFk: this._establishmentId,
+                        id: uid
+                    },
+                    include: [
+                        {
+                            model: models.login,
+                            attributes: ['username']
+                        }
+                    ]
+                };
+            }
+
+            // if history of the User is also required; attach the association
+            //  and order in reverse chronological - note, order on id (not when)
+            //  because ID is primay key and hence indexed
+            if (showHistory) {
+                fetchQuery.include.push({
+                    model: models.userAudit,
+                    as: 'auditEvents'
+                });
+                fetchQuery.order = [
+                    [
+                        {
+                            model: models.userAudit,
+                            as: 'auditEvents'
+                        },
+                        'id',
+                        'DESC'
+                    ]
+                ];
+            }
+
+            const fetchResults = await models.user.findOne(fetchQuery);
+            if (fetchResults && fetchResults.id && Number.isInteger(fetchResults.id)) {
+                // update self - don't use setters because they modify the change state
+                this._isNew = false;
+                this._created = fetchResults.created;
+                this._updated = fetchResults.updated;
+                this._updatedBy = fetchResults.updatedBy;
+
+                if (fetchResults.auditEvents) {
+                    this._auditEvents = fetchResults.auditEvents;
+                }
+
+                // load extendable properties
+                await this._properties.restore(fetchResults, SEQUELIZE_DOCUMENT_TYPE);
+
+                return true;
+            }
+
+            return false;
+
+        } catch (err) {
+            // typically errors when making changes to model or database schema!
+            this._log(User.LOG_ERROR, err);
+
+            throw new UserExceptions.UserRestoreException(null, null, err, null);
+        }
+    };
+
+    // deletes this User from DB
+    // Can throw "UserDeleteException"
+    async delete() {
+        throw new Error('Not implemented');
+    };
+
+    // returns a set of User based on given filter criteria (all if no filters defined) - restricted to the given Establishment
+    static async fetch(establishmentId, filters=null) {
+        if (filters) throw new Error("Filters not implemented");
+
+        const allUsers = [];
+        const fetchResults = await models.user.findAll({
+            where: {
+                establishmentFk: establishmentId
+            },
+            include: [
+                {
+                    model: models.user,
+                    attributes: ['username']
+                  }
+            ],
+            attributes: ['id', 'FullNameValue', 'EmailValue'],
+            order: [
+                ['updated', 'DESC']
+            ]           
+        });
+
+        if (fetchResults) {
+            fetchResults.forEach(thisUser => {
+                allUsers.push({
+                    uid: thisUser.id,
+                    fullname: thisUser.FullNameValue,
+                    email: thisUser.EmailValue,
+                    username: thisUser.login && thisUser.login.username ? thisUser.login.username : null,
+                    created:  thisWorker.created.toJSON(),
+                    updated: thisWorker.updated.toJSON(),
+                    updatedBy: thisWorker.updatedBy
+                })
+            });
+        }
+
+        return allUsers;
+    };
+
+    // helper returns a set 'json ready' objects for representing a User's overall
+    //  change history, from a given set of audit events (those events being created
+    //  or updated only)
+    formatWorkerHistoryEvents(auditEvents) {
+        if (auditEvents) {
+            return auditEvents.filter(thisEvent => ['created', 'updated'].includes(thisEvent.type))
+                               .map(thisEvent => {
+                                    return {
+                                        when: thisEvent.when,
+                                        username: thisEvent.username,
+                                        event: thisEvent.type
+                                    };
+                               });
+        } else {
+            return null;
+        }
+    };
+
+    // helper returns a set 'json ready' objects for representing a User's audit
+    //  history, from a the given set of audit events including those of individual
+    //  User properties)
+    formatWorkerHistory(auditEvents) {
+        if (auditEvents) {
+            return auditEvents.map(thisEvent => {
+                                    return {
+                                        when: thisEvent.when,
+                                        username: thisEvent.username,
+                                        event: thisEvent.type,
+                                        property: thisEvent.property,
+                                        change: thisEvent.event
+                                    };
+                               });
+        } else {
+            return null;
+        }
+    };
+
+
+    // returns a Javascript object which can be used to present as JSON
+    //  showHistory appends the historical account of changes at User and individual property level
+    //  showHistoryTimeline just returns the history set of audit events for the given User
+    toJSON(showHistory=false, showPropertyHistoryOnly=true, showHistoryTimeline=false) {
+        if (!showHistoryTimeline) {
+            // JSON representation of extendable properties
+            const myJSON = this._properties.toJSON(showHistory, showPropertyHistoryOnly);
+
+            // add worker default properties
+            const myDefaultJSON = {
+                id:  this._id
+            };
+
+            myDefaultJSON.created = this.created.toJSON();
+            myDefaultJSON.updated = this.updated.toJSON();
+            myDefaultJSON.updatedBy = this.updatedBy;
+
+            // TODO: JSON schema validation
+            if (showHistory && !showPropertyHistoryOnly) {
+                return {
+                    ...myDefaultJSON,
+                    ...myJSON,
+                    history: this.formatWorkerHistoryEvents(this._auditEvents)
+                };
+            } else {
+                return {
+                    ...myDefaultJSON,
+                    ...myJSON
+                };
+            }
+        } else {
+            return {
+                uid:  this.uid,
+                created: this.created.toJSON(),
+                updated: this.updated.toJSON(),
+                updatedBy: this.updatedBy,
+                history: this.formatWorkerHistory(this._auditEvents)
+            };
+        }
+    }
+
+
+    // HELPERS
+        // returns false if establishment is not valid, otherwise returns
+    //  the establishment id
+    static async validateEstablishment(establishmentId) {
+        if (!establishmentId) return false;
+
+        if (!Number.isInteger(establishmentId)) return false;
+
+        if (establishmentId <= 0) return false;
+
+        let referenceEstablishment;
+        try {
+            referenceEstablishment = await models.establishment.findOne({
+                where: {
+                    id: establishmentId
+                },
+                attributes: ['id'],
+            });
+            if (referenceEstablishment && referenceEstablishment.id && referenceEstablishment.id === establishmentId) return true;
+    
+        } catch (err) {
+            console.error(err);
+        }
+        return false;
+    }
+
+
+    // returns true if all mandatory properties for a User exist and are valid
+    get hasMandatoryProperties() {
+        let allExistAndValid = true;    // assume all exist until proven otherwise
+        try {
+            const fullnameProperty = this._properties.get('Fullname');
+            if (!(fullnameProperty && fullnameProperty.isInitialised && fullnameProperty.valid)) {
+                allExistAndValid = false;
+                this._log(User.LOG_ERROR, 'User::hasMandatoryProperties - missing or invalid fullname');
+            }
+    
+            const jobTitle = this._properties.get('JobTitle');
+            if (!(jobTitle && jobTitle.isInitialised && jobTitle.valid)) {
+                allExistAndValid = false;
+                this._log(User.LOG_ERROR, 'User::hasMandatoryProperties - missing or invalid job title');
+            }
+
+            const emailProperty = this._properties.get('Email');
+            if (!(emailProperty && emailProperty.isInitialised && emailProperty.valid)) {
+                allExistAndValid = false;
+                this._log(User.LOG_ERROR, 'User::hasMandatoryProperties - missing or invalid email');
+            }
+
+            const phoneProperty = this._properties.get('Phone');
+            if (!(phoneProperty && phoneProperty.isInitialised && phoneProperty.valid)) {
+                allExistAndValid = false;
+                this._log(User.LOG_ERROR, 'User::hasMandatoryProperties - missing or invalid phone');
+            }
+    
+        } catch (err) {
+            console.error(err)
+        }
+
+        return allExistAndValid;
+    }
+
+
+};
+
+module.exports.Worker = Worker;
+
+// sub types
+module.exports.WorkerExceptions = WorkerExceptions;

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -505,10 +505,10 @@ class User {
     // returns a Javascript object which can be used to present as JSON
     //  showHistory appends the historical account of changes at User and individual property level
     //  showHistoryTimeline just returns the history set of audit events for the given User
-    toJSON(showHistory=false, showPropertyHistoryOnly=true, showHistoryTimeline=false) {
+    toJSON(showHistory=false, showPropertyHistoryOnly=true, showHistoryTimeline=false, modifiedOnlyProperties=false) {
         if (!showHistoryTimeline) {
             // JSON representation of extendable properties
-            const myJSON = this._properties.toJSON(showHistory, showPropertyHistoryOnly);
+            const myJSON = this._properties.toJSON(showHistory, showPropertyHistoryOnly, modifiedOnlyProperties);
 
             // add worker default properties
             const myDefaultJSON = {

--- a/server/models/classes/user/properties/emailProperty.js
+++ b/server/models/classes/user/properties/emailProperty.js
@@ -14,8 +14,10 @@ exports.UserEmailProperty = class UserEmailProperty extends ChangePropertyProtot
     async restoreFromJson(document) {
         if (document.email) {
             const EMAIL_MAX_LENGTH=120;
+            const emailRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/;
             if (document.email.length > 0 &&
-                document.email.length <= EMAIL_MAX_LENGTH) {
+                document.email.length <= EMAIL_MAX_LENGTH &&
+                emailRegex.test(document.email)) {
                 this.property = document.email;
             } else {
                this.property = null;

--- a/server/models/classes/user/properties/emailProperty.js
+++ b/server/models/classes/user/properties/emailProperty.js
@@ -1,0 +1,54 @@
+// the email property is a value only
+
+exports.UserEmailProperty = class UserEmailProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('Email');
+    }
+
+    static clone() {
+        return new UserEmailProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.email) {
+            const EMAIL_MAX_LENGTH=120;
+            if (document.email.length > 0 &&
+                document.email.length <= EMAIL_MAX_LENGTH) {
+                this.property = document.email;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.EmailValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            EmailValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // email is a simple string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                email: this.property
+            };
+        }
+        
+        return {
+            email: {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/user/properties/emailProperty.js
+++ b/server/models/classes/user/properties/emailProperty.js
@@ -1,4 +1,5 @@
 // the email property is a value only
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
 
 exports.UserEmailProperty = class UserEmailProperty extends ChangePropertyPrototype {
     constructor() {

--- a/server/models/classes/user/properties/fullnameProperty.js
+++ b/server/models/classes/user/properties/fullnameProperty.js
@@ -1,4 +1,5 @@
 // the fullname property is a value only
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
 
 exports.UserFullnameProperty = class UserFullnameProperty extends ChangePropertyPrototype {
     constructor() {

--- a/server/models/classes/user/properties/fullnameProperty.js
+++ b/server/models/classes/user/properties/fullnameProperty.js
@@ -1,0 +1,56 @@
+// the fullname property is a value only
+
+exports.UserFullnameProperty = class UserFullnameProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('Fullname');
+    }
+
+    static clone() {
+        return new UserFullnameProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        // fullname must be non-empty and must be no more than 120 character
+
+        if (document.fullname) {
+            const FULLNAME_MAX_LENGTH=120;
+            if (document.fullname.length > 0 &&
+                document.fullname.length <= FULLNAME_MAX_LENGTH) {
+                this.property = document.fullname;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.FullNameValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            FullNameValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // fullname is a simple string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                fullname: this.property
+            };
+        }
+        
+        return {
+            fullname: {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/user/properties/fullnameProperty.js
+++ b/server/models/classes/user/properties/fullnameProperty.js
@@ -1,9 +1,9 @@
-// the fullname property is a value only
+// the Full Name property is a value only
 const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
 
 exports.UserFullnameProperty = class UserFullnameProperty extends ChangePropertyPrototype {
     constructor() {
-        super('Fullname');
+        super('FullName');      // case snesitive match any database column name
     }
 
     static clone() {
@@ -14,7 +14,7 @@ exports.UserFullnameProperty = class UserFullnameProperty extends ChangeProperty
     async restoreFromJson(document) {
         // fullname must be non-empty and must be no more than 120 character
 
-        if (document.fullname) {
+        if (document.jobTitle) {
             const FULLNAME_MAX_LENGTH=120;
             if (document.fullname.length > 0 &&
                 document.fullname.length <= FULLNAME_MAX_LENGTH) {
@@ -26,6 +26,7 @@ exports.UserFullnameProperty = class UserFullnameProperty extends ChangeProperty
     }
 
     restorePropertyFromSequelize(document) {
+        console.log("WA DEBUG - fullname value: ", document.FullNameValue)
         return document.FullNameValue;
     }
     savePropertyToSequelize() {
@@ -35,7 +36,7 @@ exports.UserFullnameProperty = class UserFullnameProperty extends ChangeProperty
     }
 
     isEqual(currentValue, newValue) {
-        // fullname is a simple string
+        // Full Name is a simple string
         return currentValue && newValue && currentValue === newValue;
     }
 

--- a/server/models/classes/user/properties/fullnameProperty.js
+++ b/server/models/classes/user/properties/fullnameProperty.js
@@ -14,7 +14,7 @@ exports.UserFullnameProperty = class UserFullnameProperty extends ChangeProperty
     async restoreFromJson(document) {
         // fullname must be non-empty and must be no more than 120 character
 
-        if (document.jobTitle) {
+        if (document.fullname) {
             const FULLNAME_MAX_LENGTH=120;
             if (document.fullname.length > 0 &&
                 document.fullname.length <= FULLNAME_MAX_LENGTH) {
@@ -26,7 +26,6 @@ exports.UserFullnameProperty = class UserFullnameProperty extends ChangeProperty
     }
 
     restorePropertyFromSequelize(document) {
-        console.log("WA DEBUG - fullname value: ", document.FullNameValue)
         return document.FullNameValue;
     }
     savePropertyToSequelize() {

--- a/server/models/classes/user/properties/jobTitleProperty.js
+++ b/server/models/classes/user/properties/jobTitleProperty.js
@@ -1,4 +1,5 @@
 // the Job title property is a value only
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
 
 exports.UserJobTitleProperty = class UserJobTitleProperty extends ChangePropertyPrototype {
     constructor() {

--- a/server/models/classes/user/properties/jobTitleProperty.js
+++ b/server/models/classes/user/properties/jobTitleProperty.js
@@ -26,7 +26,6 @@ exports.UserJobTitleProperty = class UserJobTitleProperty extends ChangeProperty
     }
 
     restorePropertyFromSequelize(document) {
-        console.log("WA DEBUG - job title value: ", document.JobTitleValue)
         return document.JobTitleValue;
     }
     savePropertyToSequelize() {

--- a/server/models/classes/user/properties/jobTitleProperty.js
+++ b/server/models/classes/user/properties/jobTitleProperty.js
@@ -12,7 +12,7 @@ exports.UserJobTitleProperty = class UserJobTitleProperty extends ChangeProperty
 
     // concrete implementations
     async restoreFromJson(document) {
-        // fullname must be non-empty and must be no more than 120 character
+        // job title must be non-empty and must be no more than 120 character
 
         if (document.jobTitle) {
             const JOB_TITLE_MAX_LENGTH=120;
@@ -26,6 +26,7 @@ exports.UserJobTitleProperty = class UserJobTitleProperty extends ChangeProperty
     }
 
     restorePropertyFromSequelize(document) {
+        console.log("WA DEBUG - job title value: ", document.JobTitleValue)
         return document.JobTitleValue;
     }
     savePropertyToSequelize() {

--- a/server/models/classes/user/properties/jobTitleProperty.js
+++ b/server/models/classes/user/properties/jobTitleProperty.js
@@ -1,0 +1,56 @@
+// the Job title property is a value only
+
+exports.UserJobTitleProperty = class UserJobTitleProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('JobTitle');
+    }
+
+    static clone() {
+        return new UserJobTitleProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        // fullname must be non-empty and must be no more than 120 character
+
+        if (document.jobTitle) {
+            const JOB_TITLE_MAX_LENGTH=120;
+            if (document.jobTitle.length > 0 &&
+                document.jobTitle.length <= JOB_TITLE_MAX_LENGTH) {
+                this.property = document.jobTitle;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.JobTitleValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            JobTitleValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // Job Title is a simple string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                jobTitle: this.property
+            };
+        }
+        
+        return {
+            jobTitle: {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/user/properties/phoneProperty.js
+++ b/server/models/classes/user/properties/phoneProperty.js
@@ -12,7 +12,7 @@ exports.UserPhoneProperty = class UserPhoneProperty extends ChangePropertyProtot
 
     // concrete implementations
     async restoreFromJson(document) {
-        // fullname must be non-empty and must be no more than 120 character
+        // phone must be non-empty and must be no more than 120 character
 
         const phonePattern = /^[0-9 x(?=ext 0-9+)]{8,50}$/;
         if (document.phone) {

--- a/server/models/classes/user/properties/phoneProperty.js
+++ b/server/models/classes/user/properties/phoneProperty.js
@@ -12,7 +12,7 @@ exports.UserPhoneProperty = class UserPhoneProperty extends ChangePropertyProtot
 
     // concrete implementations
     async restoreFromJson(document) {
-        // phone must be non-empty and must be no more than 120 character
+        // phone must be non-empty and must match given pattern
 
         const phonePattern = /^[0-9 x(?=ext 0-9+)]{8,50}$/;
         if (document.phone) {

--- a/server/models/classes/user/properties/phoneProperty.js
+++ b/server/models/classes/user/properties/phoneProperty.js
@@ -1,4 +1,6 @@
 // the phone property is a value only - but of a specific pattern
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
 exports.UserPhoneProperty = class UserPhoneProperty extends ChangePropertyPrototype {
     constructor() {
         super('Phone');

--- a/server/models/classes/user/properties/phoneProperty.js
+++ b/server/models/classes/user/properties/phoneProperty.js
@@ -1,0 +1,54 @@
+// the phone property is a value only - but of a specific pattern
+exports.UserPhoneProperty = class UserPhoneProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('Phone');
+    }
+
+    static clone() {
+        return new UserPhoneProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        // fullname must be non-empty and must be no more than 120 character
+
+        const phonePattern = /^[0-9 x(?=ext 0-9+)]{8,50}$/;
+        if (document.phone) {
+            if (phonePattern.test(document.phone)) {
+                this.property = document.phone;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.PhoneValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            PhoneValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // phone is a simple string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                phone: this.property
+            };
+        }
+        
+        return {
+            phone: {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/user/properties/securityQuestionAnswerProperty.js
+++ b/server/models/classes/user/properties/securityQuestionAnswerProperty.js
@@ -12,7 +12,7 @@ exports.UserSecurityQuestionAnswerProperty = class UserSecurityQuestionAnswerPro
 
     // concrete implementations
     async restoreFromJson(document) {
-        // fullname must be non-empty and must be no more than 120 character
+        // Security Question Answer must be non-empty and must be no more than 120 character
 
         if (document.securityQuestionAnswer) {
             const SECURITY_QUESTION_MAX_LENGTH=255;

--- a/server/models/classes/user/properties/securityQuestionAnswerProperty.js
+++ b/server/models/classes/user/properties/securityQuestionAnswerProperty.js
@@ -1,4 +1,5 @@
 // the Security Question Answer property is a value only
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
 
 exports.UserSecurityQuestionAnswerProperty = class UserSecurityQuestionAnswerProperty extends ChangePropertyPrototype {
     constructor() {

--- a/server/models/classes/user/properties/securityQuestionAnswerProperty.js
+++ b/server/models/classes/user/properties/securityQuestionAnswerProperty.js
@@ -1,0 +1,56 @@
+// the Security Question Answer property is a value only
+
+exports.UserSecurityQuestionAnswerProperty = class UserSecurityQuestionAnswerProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('SecurityQuestionAnswer');
+    }
+
+    static clone() {
+        return new UserSecurityQuestionAnswerProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        // fullname must be non-empty and must be no more than 120 character
+
+        if (document.securityQuestionAnswer) {
+            const SECURITY_QUESTION_MAX_LENGTH=255;
+            if (document.securityQuestionAnswer.length > 0 &&
+                document.securityQuestionAnswer.length <= SECURITY_QUESTION_MAX_LENGTH) {
+                this.property = document.securityQuestionAnswer;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.SecurityQuestionAnswerValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            SecurityQuestionAnswerValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // Security Question Answer is a simple string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                securityQuestionAnswer: this.property
+            };
+        }
+        
+        return {
+            securityQuestionAnswer: {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/user/properties/securityQuestionProperty.js
+++ b/server/models/classes/user/properties/securityQuestionProperty.js
@@ -1,0 +1,56 @@
+// the Security Question property is a value only
+
+exports.UserSecurityQuestionProperty = class UserSecurityQuestionProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('SecurityQuestion');
+    }
+
+    static clone() {
+        return new UserSecurityQuestionProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        // fullname must be non-empty and must be no more than 120 character
+
+        if (document.securityQuestion) {
+            const SECURITY_QUESTION_MAX_LENGTH=255;
+            if (document.securityQuestion.length > 0 &&
+                document.securityQuestion.length <= SECURITY_QUESTION_MAX_LENGTH) {
+                this.property = document.securityQuestion;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.SecurityQuestionValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            SecurityQuestionValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // Security Question is a simple string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                securityQuestion: this.property
+            };
+        }
+        
+        return {
+            securityQuestion: {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/user/properties/securityQuestionProperty.js
+++ b/server/models/classes/user/properties/securityQuestionProperty.js
@@ -1,4 +1,5 @@
 // the Security Question property is a value only
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
 
 exports.UserSecurityQuestionProperty = class UserSecurityQuestionProperty extends ChangePropertyPrototype {
     constructor() {

--- a/server/models/classes/user/properties/securityQuestionProperty.js
+++ b/server/models/classes/user/properties/securityQuestionProperty.js
@@ -12,7 +12,7 @@ exports.UserSecurityQuestionProperty = class UserSecurityQuestionProperty extend
 
     // concrete implementations
     async restoreFromJson(document) {
-        // fullname must be non-empty and must be no more than 120 character
+        // Security Question must be non-empty and must be no more than 120 character
 
         if (document.securityQuestion) {
             const SECURITY_QUESTION_MAX_LENGTH=255;

--- a/server/models/classes/user/userExceptions.js
+++ b/server/models/classes/user/userExceptions.js
@@ -1,0 +1,101 @@
+class UserException {
+    constructor (id, name, err, safeErr=null) {
+        this._id = id;
+        this._name = name;
+        this._err = err;
+        this._safeErr = safeErr;
+    };
+
+    get id() { return this._id; }
+    get name() { return this._name; }
+
+    // returns a safe message (undisclosed - safe to return by API)
+    get safe()  {
+        if (this._safeErr) {
+            return this._safeErr;
+        } else {
+            return 'error occurred';
+        }
+    };
+
+    // returns a local message (full disclosure)
+    get message() {
+        return this._err;
+    }
+
+    // identifier for reporting error is preferred with uid not id
+    get identifier() {
+        return this._id;
+    }
+};
+
+class UserSaveException extends UserException {
+    // TODO: parse the sequelize error on create failure
+    constructor(id, name, err, safeErr=null) { super(id, name, err, safeErr); };
+
+    get safe()  {
+        if (super.id === null) {
+            return `Failed to create User with identity: ${super.name}:(${super.identifier}).`;
+        } else if (!super.safeErr) {
+            return `Failed to save User with identity: ${super.name}:(${super.identifier}).`;
+        } else {
+            return super.safe;
+        }
+    };
+};
+
+class UserRestoreException extends UserException {
+    static get NOT_FOUND() { return 100; }      // the User as known by id does not exist
+    static get NOT_OWNED() { return 200; }      // the User as known by id does not belong to the Establishment
+
+    constructor(id, name, err, reason=null, safeErr=null) {
+        super(id, name, err, safeErr);
+        this._reason=reason;
+    };
+
+    get safe()  {
+        if (this._reason && this._reason===UserRestoreException.NOT_FOUND) {
+            return `User with identity: ${super.identifier} does not exist.`;
+        } else if (this._reason && this._reason===UserRestoreException.NOT_OWNED) {
+            // safe disclosure!!!
+            return `User with identity: ${super.identifier} does not exist.`;
+        } else if (!super.safe) {
+            return `Failed to restore User with identity: ${super.identifier}.`;
+        } else {
+            return super.safe;
+        }
+    };
+};
+
+class UserJsonException extends UserException {
+    constructor(err, reason=null, safeErr=null) {
+        super(null, null, err, safeErr);
+        this._reason=reason;
+    };
+
+    get safe()  {
+        if (!super.safe) {
+            return `Failed to restore User from JSON: .`;
+        } else {
+            return super.safe;
+        }
+    };
+};
+
+class UserDeleteException extends UserException {
+    constructor(id, name, err, safeErr=null) { super(id, name, err, safeErr); };
+
+    get safe()  {
+        if (!super._safeErr) {
+            return `Failed to delete User with identity: ${super.identifier}.`;
+        } else {
+            return super.safe;
+        }
+    };
+};
+
+
+module.exports.UserSaveException = UserSaveException;
+module.exports.UserRestoreException = UserRestoreException;
+module.exports.UserDeleteException = UserDeleteException;
+module.exports.UserJsonException = UserJsonException;

--- a/server/models/classes/user/userExceptions.js
+++ b/server/models/classes/user/userExceptions.js
@@ -1,12 +1,14 @@
 class UserException {
-    constructor (id, name, err, safeErr=null) {
+    constructor (id, uid, name, err, safeErr=null) {
         this._id = id;
+        this._uid = uid;
         this._name = name;
         this._err = err;
         this._safeErr = safeErr;
     };
 
     get id() { return this._id; }
+    get uid() { return this._uid; }
     get name() { return this._name; }
 
     // returns a safe message (undisclosed - safe to return by API)
@@ -25,13 +27,17 @@ class UserException {
 
     // identifier for reporting error is preferred with uid not id
     get identifier() {
-        return this._id;
+        if (this._uid) {
+            return this._uid;
+        } else {
+            return this._id;
+        }
     }
 };
 
 class UserSaveException extends UserException {
     // TODO: parse the sequelize error on create failure
-    constructor(id, name, err, safeErr=null) { super(id, name, err, safeErr); };
+    constructor(id, uid, name, err, safeErr=null) { super(id, uid, name, err, safeErr); };
 
     get safe()  {
         if (super.id === null) {
@@ -48,8 +54,8 @@ class UserRestoreException extends UserException {
     static get NOT_FOUND() { return 100; }      // the User as known by id does not exist
     static get NOT_OWNED() { return 200; }      // the User as known by id does not belong to the Establishment
 
-    constructor(id, name, err, reason=null, safeErr=null) {
-        super(id, name, err, safeErr);
+    constructor(id, uid, name, err, reason=null, safeErr=null) {
+        super(id, uid, name, err, safeErr);
         this._reason=reason;
     };
 
@@ -69,13 +75,13 @@ class UserRestoreException extends UserException {
 
 class UserJsonException extends UserException {
     constructor(err, reason=null, safeErr=null) {
-        super(null, null, err, safeErr);
+        super(null, null, null, err, safeErr);
         this._reason=reason;
     };
 
     get safe()  {
         if (!super.safe) {
-            return `Failed to restore User from JSON: .`;
+            return `Failed to restore User from JSON.`;
         } else {
             return super.safe;
         }
@@ -83,7 +89,7 @@ class UserJsonException extends UserException {
 };
 
 class UserDeleteException extends UserException {
-    constructor(id, name, err, safeErr=null) { super(id, name, err, safeErr); };
+    constructor(id, uid, name, err, safeErr=null) { super(id, uid, name, err, safeErr); };
 
     get safe()  {
         if (!super._safeErr) {

--- a/server/models/classes/user/userProperties.js
+++ b/server/models/classes/user/userProperties.js
@@ -1,0 +1,31 @@
+// encapsulates all properties of a user, by returning a PropertyManager
+const Manager = require('../properties/manager');
+
+// individual properties
+const fullnameProperty = require('./properties/fullnameProperty').UserFullnameProperty;
+const jobTitleProperty = require('./properties/jobTitleProperty').UserJobTitleProperty;
+const emailProperty = require('./properties/emailProperty').UserEmailProperty;
+const phoneProperty = require('./properties/phoneProperty').UserPhoneProperty;
+const securityQuestionProperty = require('./properties/securityQuestionProperty').UserSecurityQuestionProperty;
+const securityAnswerProperty = require('./properties/securityQuestionAnswerProperty').UserSecurityQuestionAnswerProperty;
+
+class UserPropertyManager {
+    constructor() {
+        this._thisManager = new Manager.PropertyManager();
+
+        this._thisManager.registerProperty(fullnameProperty);
+        this._thisManager.registerProperty(jobTitleProperty);
+        this._thisManager.registerProperty(emailProperty);
+        this._thisManager.registerProperty(phoneProperty);
+        this._thisManager.registerProperty(securityQuestionProperty);
+        this._thisManager.registerProperty(securityAnswerProperty);
+    }
+
+    get manager() {
+        return this._thisManager;
+    }
+}
+
+exports.UserPropertyManager = UserPropertyManager;
+exports.SEQUELIZE_DOCUMENT = Manager.PropertyManager.SEQUELIZE_DOCUMENT;
+exports.JSON_DOCUMENT = Manager.PropertyManager.JSON_DOCUMENT;

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -513,10 +513,10 @@ class Worker {
     // returns a Javascript object which can be used to present as JSON
     //  showHistory appends the historical account of changes at Worker and individual property level
     //  showHistoryTimeline just returns the history set of audit events for the given Worker
-    toJSON(showHistory=false, showPropertyHistoryOnly=true, showHistoryTimeline=false) {
+    toJSON(showHistory=false, showPropertyHistoryOnly=true, showHistoryTimeline=false, modifiedOnlyProperties=false) {
         if (!showHistoryTimeline) {
             // JSON representation of extendable properties
-            const myJSON = this._properties.toJSON(showHistory, showPropertyHistoryOnly);
+            const myJSON = this._properties.toJSON(showHistory, showPropertyHistoryOnly, modifiedOnlyProperties);
 
             // add worker default properties
             const myDefaultJSON = {

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -9,6 +9,12 @@ module.exports = function(sequelize, DataTypes) {
       autoIncrement: true,
       field: '"RegistrationID"'
     },
+    uid: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      unique: true,
+      field: '"UserUID"'
+    },
     establishmentId: {
       type: DataTypes.INTEGER,
       allowNull: false,

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -203,6 +203,11 @@ module.exports = function(sequelize, DataTypes) {
       foreignKey : 'registrationId',
       targetKey: 'id'
     });
+    User.hasMany(models.userAudit, {
+      foreignKey: 'userFk',
+      sourceKey: 'id',
+      as: 'auditEvents'
+    });
   };
   return User;
 };

--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -57,7 +57,7 @@ router.route('/establishment/:id/:userId').get(async (req, res) => {
 
     try {
         if (await thisUser.restore(byUUID, byUsername, showHistory)) {
-            return res.status(200).json(thisUser.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime));
+            return res.status(200).json(thisUser.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime, false));
         } else {
             // not found worker
             return res.status(404).send('Not Found');
@@ -108,9 +108,7 @@ router.route('/establishment/:id/:userId').put(async (req, res) => {
             // this is an update to an existing User, so no mandatory properties!
             if (isValidUser) {
                 await thisUser.save(req.username);
-                return res.status(200).json({
-                    uid: thisUser.uid
-                });
+                return res.status(200).json(thisUser.toJSON(false, false, false, true));
             } else {
                 return res.status(400).send('Unexpected Input.');
             }

--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -8,9 +8,30 @@ const passwordCheck = require('../../utils/security/passwordValidation').isPassw
 
 const bcrypt = require('bcrypt-nodejs');
 
+// all user functionality is encapsulated
+const User = require('../../models/classes/user');
+
 // default route
 router.route('/').get(async (req, res) => {
     res.status(200).send();
+});
+
+
+// returns a list of all users for the given establishment
+router.use('/establishment/:id', Authorization.hasAuthorisedEstablishment);
+router.route('/establishment/:id').get(async (req, res) => {
+    // although the establishment id is passed as a parameter, get the authenticated  establishment id from the req
+    const establishmentId = req.establishmentId;
+
+    try {
+        const allTheseUsers = await User.User.fetch(establishmentId);
+        return res.status(200).json({
+            users: allTheseUsers
+        });
+    } catch (err) {
+        console.error('user::establishment - failed', err);
+        return res.status(503).send(`Failed to get users for establishment having id: ${establishmentId}`);
+    }
 });
 
 
@@ -18,7 +39,7 @@ router.route('/').get(async (req, res) => {
 router.use('/resetPassword', Authorization.isAuthorisedPasswdReset);
 router.route('/resetPassword').post(async (req, res) => {
     const givenPassword = escape(req.body.password);
-    
+    DB
     if (givenPassword === 'undefined') {
         return res.status(400).send('missing password');
     }

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -149,10 +149,10 @@ router.route('/:workerId').put(async (req, res) => {
 
     } catch (err) {
         if (err instanceof Workers.WorkerExceptions.WorkerJsonException) {
-            console.error("Worker POST: ", err.message);
+            console.error("Worker PUT: ", err.message);
             return res.status(400).send(err.safe);
         } else if (err instanceof Workers.WorkerExceptions.WorkerSaveException) {
-            console.error("Worker POST: ", err.message);
+            console.error("Worker PUT: ", err.message);
             return res.status(503).send(err.safe);
         }
     }

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -54,7 +54,7 @@ router.route('/:workerId').get(async (req, res) => {
 
     try {
         if (await thisWorker.restore(workerId, showHistory)) {
-            return res.status(200).json(thisWorker.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime));
+            return res.status(200).json(thisWorker.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime, false));
         } else {
             // not found worker
             return res.status(404).send('Not Found');
@@ -135,9 +135,10 @@ router.route('/:workerId').put(async (req, res) => {
             // this is an update to an existing Worker, so no mandatory properties!
             if (isValidWorker) {
                 await thisWorker.save(req.username);
-                return res.status(200).json({
-                    uid: thisWorker.uid
-                });
+
+                const exceptionalOverrideHeader = req.headers['x-override-put-return-all'];
+                const showModifiedOnly = exceptionalOverrideHeader ? false : true;
+                return res.status(200).json(thisWorker.toJSON(false, false, false, showModifiedOnly));
             } else {
                 return res.status(400).send('Unexpected Input.');
             }

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -421,6 +421,7 @@ router.route('/')
           defaultError = responseErrors.user;
           const userRecord = {
             establishmentId: Estblistmentdata.id,
+            uid: uuid.v4(),
             FullNameValue: Userdata.FullName,
             FullNameSavedAt: Userdata.DateCreated,
             FullNameChangedAt: Userdata.DateCreated,

--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -43,11 +43,11 @@ exports.hasAuthorisedEstablishment = (req, res, next) => {
   
         // must provide the establishment ID and it must be a number
         if (!claim.EstblishmentId || isNaN(parseInt(claim.EstblishmentId))) {
-          console.error('isAuthenticated - missing establishment id parameter');
+          console.error('hasAuthorisedEstablishment - missing establishment id parameter');
           return res.status(400).send(`Unknown Establishment ID: ${req.params.id}`);
         }
         if (claim.EstblishmentId !== parseInt(req.params.id)) {
-          console.error('isAuthenticated - given and known establishment id do not match');
+          console.error(`hasAuthorisedEstablishment - given and known establishment id do not match: given (${req.params.id})/known (${claim.EstblishmentId})`);
           return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
         }
 

--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -35,7 +35,7 @@ exports.hasAuthorisedEstablishment = (req, res, next) => {
   if (token) {
     jwt.verify(token, Token_Secret, function (err, claim) {
       if (err || claim.aud !== 'ADS-WDS' || claim.iss !== thisIss) {
-        return res.status(401).send({
+        return res.status(403).send({
           sucess: false,
           message: 'token is invalid'
         });


### PR DESCRIPTION
This PR is not as big as it first looks.

Trello card: https://trello.com/c/pByUKSW3 - Change User Details.

You've already reviewed and approved much of the Change User Details, with the introduction of the Change Property columns for `User`.

This PRs build on that by introducing the `User` Extended Change class, along with it's six properties:
1. Fullname
2. Job title
3. Email
4. Phone
5. Security Question
6. Security Question Answer

In addition, I've taken the opportunity to payback some debt, by updating the extended change model to return JSON based only on fhe set of properties, and have taken the opportunity to update Workers too (the original debt): https://trello.com/c/0FslUApY.

And because it has been agreed that we're including Worker UID in the URL in the frontend (now deployed to dev), to support the frontend when it comes to working with multiple users (add/delete - which will be next sprint), I've introduced a "uid" to the `User` table. This mimics the `uid` on Worker. But this also required a small update to `registration` to add `uid` on User record create: `server/routes/registration.js` below.

I've raised a subsequent PR for the DB changes: https://github.com/NMDSdevopsServiceAdm/NMDSDB-SFC/pull/30. With Shakir for review.

And of course I have a full suite of automated tests - another #14 tests added: https://github.com/wozzer72/restful-api-qa/pull/8.