### PR TITLE
Worker "no change" assertions

### DIFF
--- a/server/models/classes/worker/properties/annualHourlyPayProperty.js
+++ b/server/models/classes/worker/properties/annualHourlyPayProperty.js
@@ -96,7 +96,7 @@ exports.WorkerAnnualHourlyPayProperty = class WorkerAnnualHourlyPayProperty exte
             rateEqual = true;
         }
 
-        return currentValue && newValue && currentValue === newValue && rateEqual;
+        return currentValue && newValue && currentValue.value === newValue.value && rateEqual;
     }
 
     toJSON(withHistory=false, showPropertyHistoryOnly=true) {

--- a/server/models/classes/worker/properties/daysSickProperty.js
+++ b/server/models/classes/worker/properties/daysSickProperty.js
@@ -77,7 +77,7 @@ exports.WorkerDaysSickProperty = class WorkerDaysSickProperty extends ChangeProp
             daysEqual = true;
         }
 
-        return currentValue && newValue && currentValue === newValue && daysEqual;
+        return currentValue && newValue && currentValue.value === newValue.value && daysEqual;
     }
 
     toJSON(withHistory=false, showPropertyHistoryOnly=true) {

--- a/server/models/classes/worker/properties/nationalInsuranceProperty.js
+++ b/server/models/classes/worker/properties/nationalInsuranceProperty.js
@@ -38,7 +38,7 @@ exports.WorkerNationalInsuranceNumberProperty = class WorkerNationalInsuranceNum
 
     isEqual(currentValue, newValue) {
         // a simple string compare
-        currentValue && newValue && currentValue === newValue;
+        return currentValue && newValue && currentValue === newValue;
     }
 
     toJSON(withHistory=false, showPropertyHistoryOnly=true) {

--- a/server/models/classes/worker/properties/socialCareStartDateProperty.js
+++ b/server/models/classes/worker/properties/socialCareStartDateProperty.js
@@ -79,7 +79,7 @@ exports.WorkerSocialCareStartDateProperty = class WorkerSocialCareStartDatePrope
             yearEqual = true;
         }
 
-        return currentValue && newValue && currentValue === newValue && yearEqual;
+        return currentValue && newValue && currentValue.value === newValue.value && yearEqual;
     }
 
     toJSON(withHistory=false, showPropertyHistoryOnly=true) {

--- a/server/models/classes/worker/properties/yearArrivedProperty.js
+++ b/server/models/classes/worker/properties/yearArrivedProperty.js
@@ -76,7 +76,7 @@ exports.WorkerYearArrivedProperty = class WorkerYearArrivedProperty extends Chan
             yearEqual = true;
         }
 
-        return currentValue && newValue && currentValue === newValue && yearEqual;
+        return currentValue && newValue && currentValue.value == newValue.value && yearEqual;
     }
 
     toJSON(withHistory=false, showPropertyHistoryOnly=true) {


### PR DESCRIPTION
Hi Nasir

Ann raised observation against the Worker change history, where some properties were showing as changed, when their data had not.

I've taken the opportunity to improve upon my Worker integration to assert on "no change", using a method I prove while delivering upon the User Change Details you've just reviewed.

It highlighted there five properties where change was being incorrectly cited. I've fixed the properties and once again I have a full successful regression run against all Worker properties.

Complementary PR for the automated integration tests: https://github.com/wozzer72/restful-api-qa/pull/9