### PR TITLE
Establishment full audit

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -20,6 +20,11 @@ const config = convict({
       doc: 'Not yet used, but will be the default log level',
       format: String,
       default: 'NONE'
+    },
+    sequelize: {
+      doc: 'Whether to log sequelize SQL statements',
+      format: 'Boolean',
+      default: false
     }
   },
   listen: {

--- a/server/config/localhost.yaml
+++ b/server/config/localhost.yaml
@@ -5,3 +5,5 @@ jwt:
 db:
     pool: 5
     ssl: false
+log:
+    sequelize: false

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -588,6 +588,7 @@ class Establishment {
                 locationRef: this.locationId,
                 isRegulated: this.isRegulated,
                 nmdsId: this.nmdsId,
+                mainService: this.mainService,
             };
 
             myDefaultJSON.created = this.created.toJSON();

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -605,7 +605,7 @@ class Establishment {
                 mainService: ServiceFormatters.singleService(this._establishmentResults.mainService),
                 otherServices: ServiceFormatters.createServicesByCategoryJSON(this._establishmentResults.otherServices),
                 capacities: CapacityFormatters.capacitiesJSON(this._establishmentResults.capacity),
-                jobs: JobFormatters.jobsByTypeJSON(this._establishmentResults.jobs),
+                jobs: JobFormatters.jobsByTypeJSON(this._establishmentResults),
             };
 
             myDefaultJSON.created = this.created.toJSON();
@@ -623,7 +623,8 @@ class Establishment {
                 return {
                     ...myDefaultJSON,
                     ...myJSON
-                };
+            
+               };
             }
         } else {
             return {

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -1,0 +1,679 @@
+/*
+ * establishment.js
+ *
+ * The encapsulation of a Establishment, including all properties, all specific validation (not API, but object validation),
+ * saving & restoring of data to database (via sequelize model), construction and deletion.
+ * 
+ * Also includes representation as JSON, in one or more presentations.
+ */
+const uuid = require('uuid');
+
+// database models
+const models = require('../index');
+
+// notifications
+
+
+// exceptions
+const EstablishmentExceptions = require('./establishment/establishmentExceptions');
+
+// User properties
+const EstablishmentProperties = require('./establishment/establishmentProperties').EstablishmentPropertyManager;
+const JSON_DOCUMENT_TYPE = require('./user/userProperties').JSON_DOCUMENT;
+const SEQUELIZE_DOCUMENT_TYPE = require('./user/userProperties').SEQUELIZE_DOCUMENT;
+
+class Establishment {
+    constructor(username) {
+        this._username = username;
+        this._id = null;
+        this._uid = null;
+        this._created = null;
+        this._updated = null;
+        this._updatedBy = null;
+        this._auditEvents = null;
+
+        // localised attributes
+        this._name = null;
+        this._address = null;
+        this._locationId = null;
+        this._postcode = null;
+        this._isRegulated = null;
+        this._mainService = null;
+        this._nmdsId = null;
+
+        // abstracted properties
+        const thisEstablishmentManager = new EstablishmentProperties();
+        this._properties =thisEstablishmentManager.manager;
+
+        // change properties
+        this._isNew = false;
+        
+        // default logging level - errors only
+        // TODO: INFO logging on User; change to LOG_ERROR only
+        this._logLevel = Establishment.LOG_INFO;
+    }
+
+    // private logging
+    static get LOG_ERROR() { return 100; }
+    static get LOG_WARN() { return 200; }
+    static get LOG_INFO() { return 300; }
+    static get LOG_TRACE() { return 400; }
+    static get LOG_DEBUG() { return 500; }
+
+    set logLevel(logLevel) {
+        this._logLevel = logLevel;
+    }
+
+    _log(level, msg) {
+        if (this._logLevel >= level) {
+            console.log(`TODO: (${level}) - User class: `, msg);
+        }
+    }
+
+    //
+    // attributes
+    //
+    get id() {
+        return this._id;
+    }
+    get uid() {
+        return this._uid;
+    }
+    get username() {
+        return this._username;
+    }
+    get name() {
+        return this._name;
+    };
+    get address() {
+        return this._address;
+    };
+    get locationId() {
+        return this._locationId;
+    };
+    get postcode() {
+        return this._postcode;
+    };
+    get isRegulated() {
+        return this._isRegulated;
+    };
+    get mainService() {
+        return this._mainService;
+    };
+    get nmdsId() {
+        return this._nmdsId;
+    }
+    get created() {
+        return this._created;
+    }
+    get updated() {
+        return this._updated;
+    }
+    get updatedBy() {
+        return this._updatedBy;
+    }
+
+    // used by save to initialise a new Establishment; returns true if having initialised this Establishment
+    _initialise() {
+        if (this._uid === null) {
+            this._isNew = true;
+            this._uid = uuid.v4();
+            
+            // note, do not initialise the id as this will be returned by database
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // external method to initialise the mandatory non-extendable properties
+    initialise(name, address, locationId, postcode, isRegulated, mainServiceId, nmdsId) {
+        this._name = name;
+        this._address = address;
+        this._postcode = postcode;
+        this._isRegulated = isRegulated;
+        this._locationId = locationId;
+        this._mainService = {
+            id: mainServiceId
+        };
+        this._nmdsId = nmdsId;
+    }
+
+    // takes the given JSON document and creates an Establishment's set of extendable properties
+    // Returns true if the resulting Establishment is valid; otherwise false
+    async load(document) {
+        try {
+            await this._properties.restore(document, JSON_DOCUMENT_TYPE);
+
+        } catch (err) {
+            this._log(Establishment.LOG_ERROR, `Establishment::load - failed: ${err}`);
+            throw new EstablishmentExceptions.EstablishmentJsonException(
+                err,
+                null,
+                'Failed to load Establishment from JSON');
+        }
+
+        return this.isValid();
+    }
+
+    // returns true if Establishment is valid, otherwise false
+    isValid() {
+        if (this._properties.isValid === true) {
+            return true;
+        } else {
+            this._log(Establishment.LOG_ERROR, `Establishment invalid properties: ${thisUserIsValid.toString()}`);
+            return false;
+        }
+    }
+
+    // saves the Establishment to DB. Returns true if saved; false is not.
+    // Throws "EstablishmentSaveException" on error
+    async save(savedBy, ttl=0) {
+        let mustSave = this._initialise();
+
+        if (!this.uid) {
+            this._log(Establishment.LOG_ERROR, 'Not able to save an unknown uid');
+            throw new UserExceptions.UserSaveException(null,
+                this.uid,
+                this.name,
+                'Not able to save an unknown uid',
+                'Establishment does not exist');
+        }
+
+        if (mustSave && this._isNew) {
+            // create new User
+            try {
+                const creationDocument = {
+                    uid: this.uid,
+                    name: this._name,
+                    address: this._address,
+                    postcode: this._postcode,
+                    isRegulated: this._isRegulated,
+                    locationId: this._locationId,
+                    mainServiceId: this._mainService.id,
+                    nmdsId: this._nmdsId,
+                    updatedBy: savedBy,
+                    attributes: ['id', 'created', 'updated'],
+                };
+
+                // need to create the Establishment record and the Establishment Audit event
+                //  in one transaction
+                await models.sequelize.transaction(async t => {
+                    // now append the extendable properties.
+                    // Note - although the POST (create) has a default
+                    //   set of mandatory properties, there is no reason
+                    //   why we cannot create an Establishment record with more properties
+                    const modifedCreationDocument = this._properties.save(savedBy, creationDocument);
+
+                    // check all mandatory parameters have been provided
+                    if (!this.hasMandatoryProperties) {
+                        throw 'Missing Mandatory properties';
+                    }
+
+                    // now save the document
+                    let creation = await models.establishment.create(modifedCreationDocument, {transaction: t});
+
+                    const sanitisedResults = creation.get({plain: true});
+
+                    this._id = sanitisedResults.EstablishmentID;
+                    this._created = sanitisedResults.created;
+                    this._updated = sanitisedResults.updated;
+                    this._updatedBy = savedBy;
+                    this._isNew = false;
+
+                    // having the user we can now create the audit record; injecting the userFk
+                    const allAuditEvents = [{
+                        establishmentFk: this._id,
+                        username: savedBy,
+                        type: 'created'}].concat(this._properties.auditEvents.map(thisEvent => {
+                            return {
+                                ...thisEvent,
+                                establishmentFk: this._id
+                            };
+                        }));
+                    await models.establishmentAudit.bulkCreate(allAuditEvents, {transaction: t});
+
+                    this._log(Establishment.LOG_INFO, `Created Establishment with uid (${this.uid}), id (${this._id}) and name (${this.name})`);
+                });
+                
+            } catch (err) {
+                // need to handle duplicate Establishment
+                if (err.name && err.name === 'SequelizeUniqueConstraintError') {
+                    if (err.parent.constraint && ( err.parent.constraint === 'Establishment_unique_registration_with_locationid' || err.parent.constraint === 'Establishment_unique_registration')) {
+                        throw new EstablishmentExceptions.EstablishmentSaveException(null, this.uid, this.name, 'Duplicate Establishment', 'Duplicate Establishment');
+                    }
+                } else {
+                    throw new EstablishmentExceptions.EstablishmentSaveException(null, this.uid, this.name, err, null);
+                }
+            }
+        } else {
+            // we are updating an existing Establishment
+            try {
+                const updatedTimestamp = new Date();
+
+                // need to update the existing Establishment record and add an
+                //  updated audit event within a single transaction
+                await models.sequelize.transaction(async t => {
+                    // now append the extendable properties
+                    const modifedUpdateDocument = this._properties.save(savedBy, {});
+
+                    const updateDocument = {
+                        ...modifedUpdateDocument,
+                        updated: updatedTimestamp,
+                        updatedBy: savedBy
+                    };
+
+                    // now save the document
+                    let [updatedRecordCount, updatedRows] =
+                        await models.establishment.update(
+                            updateDocument,
+                            {
+                                returning: true,
+                                where: {
+                                    uid: this.uid
+                                },
+                                attributes: ['id', 'updated'],
+                                transaction: t,
+                            }
+                        );
+
+                    if (updatedRecordCount === 1) {
+                        const updatedRecord = updatedRows[0].get({plain: true});
+
+                        this._updated = updatedRecord.updated;
+                        this._updatedBy = savedBy;
+                        this._id = updatedRecord.EstablishmentID;
+
+                        const allAuditEvents = [{
+                            establishmentFk: this._id,
+                            username: savedBy,
+                            type: 'updated'}].concat(this._properties.auditEvents.map(thisEvent => {
+                                return {
+                                    ...thisEvent,
+                                    establishmentFk: this._id
+                                };
+                            }));
+                            // having updated the record, create the audit event
+                        await models.establishmentAudit.bulkCreate(allAuditEvents, {transaction: t});
+
+                        // now - work through any additional models having processed all properties (first delete and then re-create)
+                        const additionalModels = this._properties.additionalModels;
+                        const additionalModelsByname = Object.keys(additionalModels);
+                        const deleteModelPromises = [];
+                        additionalModelsByname.forEach(async thisModelByName => {
+                            deleteModelPromises.push(
+                                models[thisModelByName].destroy({
+                                    where: {
+                                        establishmentFk: this._id
+                                    }
+                                  })
+                            );
+                        });
+                        await Promise.all(deleteModelPromises);
+                        const createModelPromises = [];
+                        additionalModelsByname.forEach(async thisModelByName => {
+                            const thisModelData = additionalModels[thisModelByName];
+                            createModelPromises.push(
+                                models[thisModelByName].bulkCreate(thisModelData.map(thisRecord => {
+                                    return {
+                                        ...thisRecord,
+                                        establishmentFk: this._id
+                                    };
+                                }))
+                            );
+                        });
+                        await Promise.all(createModelPromises);
+
+                        this._log(Establishment.LOG_INFO, `Updated Establishment with uid (${this.uid}) and name (${this.name})`);
+
+                    } else {
+                        throw new UserExceptions.UserSaveException(null, this.uid, this.name, err, `Failed to update resulting establishment record with id: ${this._id}`);
+                    }
+
+                });
+                
+            } catch (err) {
+                throw new UserExceptions.UserSaveException(null, this.uid, this.name, err, `Failed to update establishment record with id: ${this._id}`);
+            }
+
+        }
+
+        return mustSave;
+    };
+
+    // loads the Establishment (with given id or uid) from DB, but only if it belongs to the known User
+    // returns true on success; false if no User
+    // Can throw EstablishmentRestoreException exception.
+    async restore(id, uid, showHistory=false) {
+        if (!id && !uid) {
+            throw new EstablishmentExceptions.EstablishmentRestoreException(null,
+                null,
+                null,
+                'User::restore failed: Missing id or uid',
+                null,
+                'Unexpected Error');
+        }
+
+        try {
+            // by including the user id in the
+            //  fetch, we are sure to only fetch those
+            //  Establishment records associated to the known
+            //   user
+            let fetchQuery = null;
+            
+            if (uid) {
+                // fetch by uid
+                fetchQuery = {
+                    // attributes: ['id', 'uid'],
+                    where: {
+                        uid,
+                    },
+                    include: [
+                        {
+                            model: models.user,
+                            as: 'users',
+                            attributes: ['id'],
+                            where: {
+                                archived: false,
+                            },
+                            include: [
+                                {
+                                    model: models.login,
+                                    attributes: ['username'],
+                                    where: {
+                                        username: this._username,
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                };
+            } else {
+                // fetch by id
+                fetchQuery = {
+                    // attributes: ['id', 'uid'],
+                    where: {
+                        id,
+                    },
+                    include: [
+                        {
+                            model: models.user,
+                            as: 'users',
+                            attributes: ['id'],
+                            where: {
+                                archived: false,
+                            },
+                            include: [
+                                {
+                                    model: models.login,
+                                    attributes: ['username'],
+                                    where: {
+                                        username: this._username,
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                };
+            }
+
+            // now join across the other dependent tables
+            fetchQuery.include = fetchQuery.include.concat([
+                {
+                  model: models.services,
+                  as: 'otherServices',
+                  attributes: ['id', 'name', 'category'],
+                  order: [
+                    ['category', 'ASC'],
+                    ['name', 'ASC']
+                  ]
+                },{
+                  model: models.services,
+                  as: 'mainService',
+                  attributes: ['id', 'name']
+                },{
+                  model: models.establishmentCapacity,
+                  as: 'capacity',
+                  attributes: ['id', 'answer'],
+                  include: [{
+                    model: models.serviceCapacity,
+                    as: 'reference',
+                    attributes: ['id', 'question']
+                  }]
+                },
+                {
+                  model: models.establishmentJobs,
+                  as: 'jobs',
+                  attributes: ['id', 'type', 'total'],
+                  order: [
+                    ['type', 'ASC']
+                  ],
+                  include: [{
+                    model: models.job,
+                    as: 'reference',
+                    attributes: ['id', 'title'],
+                    order: [
+                      ['title', 'ASC']
+                    ]
+                  }]
+                },
+                {
+                  model: models.establishmentLocalAuthority,
+                  as: 'localAuthorities',
+                  attributes: ['id', 'cssrId', 'cssr'],
+                }
+              ]
+            );
+
+            // if history of the User is also required; attach the association
+            //  and order in reverse chronological - note, order on id (not when)
+            //  because ID is primay key and hence indexed
+            if (showHistory) {
+                fetchQuery.include.push({
+                    model: models.establishmentAudit,
+                    as: 'auditEvents'
+                });
+                fetchQuery.order = [
+                    [
+                        {
+                            model: models.establishmentAudit,
+                            as: 'auditEvents'
+                        },
+                        'id',
+                        'DESC'
+                    ]
+                ];
+            }
+
+            const fetchResults = await models.establishment.findOne(fetchQuery);
+            if (fetchResults && fetchResults.id && Number.isInteger(fetchResults.id)) {
+                // update self - don't use setters because they modify the change state
+                this._isNew = false;
+                this._id = fetchResults.id;
+                this._uid = fetchResults.uid;
+                this._created = fetchResults.created;
+                this._updated = fetchResults.updated;
+                this._updatedBy = fetchResults.updatedBy;
+
+                this._name = fetchResults.name;
+                this._address = fetchResults.address;
+                this._locationId = fetchResults.locationId;
+                this._postcode = fetchResults.postcode;
+                this._isRegulated = fetchResults.isRegulated;
+                this._mainService = {
+                    id: fetchResults.mainService.id,
+                    name: fetchResults.mainService.name
+                };
+                this._nmdsId = fetchResults.nmdsId;
+
+                if (fetchResults.auditEvents) {
+                    this._auditEvents = fetchResults.auditEvents;
+                }
+
+                // load extendable properties
+                await this._properties.restore(fetchResults, SEQUELIZE_DOCUMENT_TYPE);
+
+                return true;
+            }
+
+            return false;
+
+        } catch (err) {
+            // typically errors when making changes to model or database schema!
+            this._log(Establishment.LOG_ERROR, err);
+
+            throw new EstablishmentExceptions.EstablishmentRestoreException(null, this.uid, null, err, null);
+        }
+    };
+
+    // deletes this User from DB
+    // Can throw "UserDeleteException"
+    async delete() {
+        throw new EstablishmentExceptions.EstablishmentDeleteException(null, null, null, 'Not implemented', 'Not implemented');
+    };
+
+    // helper returns a set 'json ready' objects for representing an Establishments's overall
+    //  change history, from a given set of audit events (those events being created
+    //  or updated only)
+    formatHistoryEvents(auditEvents) {
+        if (auditEvents) {
+            return auditEvents.filter(thisEvent => ['created', 'updated'].includes(thisEvent.type))
+                               .map(thisEvent => {
+                                    return {
+                                        when: thisEvent.when,
+                                        username: thisEvent.username,
+                                        event: thisEvent.type
+                                    };
+                               });
+        } else {
+            return null;
+        }
+    };
+
+    // helper returns a set 'json ready' objects for representing an Establishment's audit
+    //  history, from a the given set of audit events including those of individual
+    //  Establishment properties)
+    formatHistory(auditEvents) {
+        if (auditEvents) {
+            return auditEvents.map(thisEvent => {
+                                    return {
+                                        when: thisEvent.when,
+                                        username: thisEvent.username,
+                                        event: thisEvent.type,
+                                        property: thisEvent.property,
+                                        change: thisEvent.event
+                                    };
+                               });
+        } else {
+            return null;
+        }
+    };
+
+
+    // returns a Javascript object which can be used to present as JSON
+    //  showHistory appends the historical account of changes at User and individual property level
+    //  showHistoryTimeline just returns the history set of audit events for the given User
+    toJSON(showHistory=false, showPropertyHistoryOnly=true, showHistoryTimeline=false, modifiedOnlyProperties=false) {
+        if (!showHistoryTimeline) {
+            // JSON representation of extendable properties
+            const myJSON = this._properties.toJSON(showHistory, showPropertyHistoryOnly, modifiedOnlyProperties);
+
+            // add Establishment default properties
+            const myDefaultJSON = {
+                id: this.id,
+                uid:  this.uid,
+                name: this.name,
+                address: this.address,
+                postcode: this.postcode,
+                locationRef: this.locationId,
+                isRegulated: this.isRegulated,
+                nmdsId: this.nmdsId,
+            };
+
+            myDefaultJSON.created = this.created.toJSON();
+            myDefaultJSON.updated = this.updated.toJSON();
+            myDefaultJSON.updatedBy = this.updatedBy;
+
+            // TODO: JSON schema validation
+            if (showHistory && !showPropertyHistoryOnly) {
+                return {
+                    ...myDefaultJSON,
+                    ...myJSON,
+                    history: this.formatHistoryEvents(this._auditEvents)
+                };
+            } else {
+                return {
+                    ...myDefaultJSON,
+                    ...myJSON
+                };
+            }
+        } else {
+            return {
+                id: this.id,
+                uid:  this.uid,
+                name: this.name,
+                created: this.created.toJSON(),
+                updated: this.updated.toJSON(),
+                updatedBy: this.updatedBy,
+                history: this.formatHistory(this._auditEvents)
+            };
+        }
+    }
+
+
+    // HELPERS
+
+    // returns true if all mandatory properties for an Establishment exist and are valid
+    get hasMandatoryProperties() {
+        let allExistAndValid = true;    // assume all exist until proven otherwise
+        try {
+            // const fullnameProperty = this._properties.get('FullName');
+            // if (!(fullnameProperty && fullnameProperty.isInitialised && fullnameProperty.valid)) {
+            //     allExistAndValid = false;
+            //     this._log(Establishment.LOG_ERROR, 'User::hasMandatoryProperties - missing or invalid fullname');
+            // }
+    
+            const nmdsIdRegex = /^[A-Z]1[\d]{6}$/i; 
+            if (!(this._nmdsId && nmdsIdRegex.test(this._nmdsId))) {
+                allExistAndValid = false;
+                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid NMDS ID');
+            }
+
+            if (!(this._name)) {
+                allExistAndValid = false;
+                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid name');
+            }
+
+            if (!(this._address)) {
+                allExistAndValid = false;
+                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid address');
+            }
+
+            if (!(this._postcode)) {
+                allExistAndValid = false;
+                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid postcode');
+            }
+
+            if (!(this._isRegulated)) {
+                allExistAndValid = false;
+                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing regulated flag');
+            }
+
+            // location id can be null for a Non-CQC site
+            if (this._isRegulated && this._locationId === null) {
+                allExistAndValid = false;
+                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid Location ID for a (CQC) Regulated workspace');
+            }
+
+        } catch (err) {
+            console.error(err)
+        }
+
+        return allExistAndValid;
+    }
+};
+
+module.exports.Establishment = Establishment;
+
+// sub types
+module.exports.EstablishmentExceptions = EstablishmentExceptions;

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -13,6 +13,12 @@ const models = require('../index');
 
 // notifications
 
+// temp formatters
+const ServiceFormatters = require('../api/services');
+const CapacityFormatters = require('../api/capacity');
+const ShareFormatters = require('../api/shareData');
+const JobFormatters = require('../api/jobs');
+
 
 // exceptions
 const EstablishmentExceptions = require('./establishment/establishmentExceptions');
@@ -506,6 +512,9 @@ class Establishment {
                 };
                 this._nmdsId = fetchResults.nmdsId;
 
+                // TODO - remove this property once all the individual properties are done
+                this._establishmentResults = fetchResults;
+
                 if (fetchResults.auditEvents) {
                     this._auditEvents = fetchResults.auditEvents;
                 }
@@ -579,6 +588,7 @@ class Establishment {
             const myJSON = this._properties.toJSON(showHistory, showPropertyHistoryOnly, modifiedOnlyProperties);
 
             // add Establishment default properties
+            //  using the default formatters
             const myDefaultJSON = {
                 id: this.id,
                 uid:  this.uid,
@@ -589,6 +599,13 @@ class Establishment {
                 isRegulated: this.isRegulated,
                 nmdsId: this.nmdsId,
                 mainService: this.mainService,
+                employerType: this._establishmentResults.employerType,
+                numberOfStaff: this._establishmentResults.numberOfStaff,
+                share: ShareFormatters.shareDataJSON(this._establishmentResults, this._establishmentResults.localAuthorities),
+                mainService: ServiceFormatters.singleService(this._establishmentResults.mainService),
+                otherServices: ServiceFormatters.createServicesByCategoryJSON(this._establishmentResults.otherServices),
+                capacities: CapacityFormatters.capacitiesJSON(this._establishmentResults.capacity),
+                jobs: JobFormatters.jobsByTypeJSON(this._establishmentResults.jobs),
             };
 
             myDefaultJSON.created = this.created.toJSON();

--- a/server/models/classes/establishment/establishmentExceptions.js
+++ b/server/models/classes/establishment/establishmentExceptions.js
@@ -1,0 +1,123 @@
+class EstablishmentException {
+    constructor (id, uid, name, err, safeErr=null) {
+        this._id = id;
+        this._uid = uid;
+        this._name = name;
+        this._err = err;
+        this._safeErr = safeErr;
+    };
+
+    get id() { return this._id; }
+    get uid() { return this._uid; }
+    get name() { return this._name; }
+
+    // returns a safe message (undisclosed - safe to return by API)
+    get safe()  {
+        if (this._safeErr) {
+            return this._safeErr;
+        } else {
+            return 'error occurred';
+        }
+    };
+
+    // returns a local message (full disclosure)
+    get message() {
+        return this._err;
+    }
+
+    // identifier for reporting error is preferred with uid not id
+    get identifier() {
+        if (this._uid) {
+            return this._uid;
+        } else {
+            return this._id;
+        }
+    }
+};
+
+class EstablishmentSaveException extends EstablishmentException {
+    // TODO: parse the sequelize error on create failure
+    constructor(id, uid, name, err, safeErr=null) { super(id, uid, name, err, safeErr); };
+
+    get safe()  {
+        if (super.id === null) {
+            return `Failed to create Establishment with identity: ${super.name}:(${super.identifier}).`;
+        } else if (!super.safeErr) {
+            return `Failed to save Establishment with identity: ${super.name}:(${super.identifier}).`;
+        } else {
+            return super.safe;
+        }
+    };
+};
+
+class EstablishmentRestoreException extends EstablishmentException {
+    static get NOT_FOUND() { return 100; }      // the Establishment as known by id does not exist
+    static get NOT_OWNED() { return 200; }      // the Establishment as known by id does not belong to the User
+
+    constructor(id, uid, name, err, reason=null, safeErr=null) {
+        super(id, uid, name, err, safeErr);
+        this._reason=reason;
+    };
+
+    get safe()  {
+        if (this._reason && this._reason===UserRestoreException.NOT_FOUND) {
+            return `Establishment with identity: ${super.identifier} does not exist.`;
+        } else if (this._reason && this._reason===UserRestoreException.NOT_OWNED) {
+            // safe disclosure!!!
+            return `Establishment with identity: ${super.identifier} does not exist.`;
+        } else if (!super.safe) {
+            return `Failed to restore Establishment with identity: ${super.identifier}.`;
+        } else {
+            return super.safe;
+        }
+    };
+};
+
+class EstablishmentJsonException extends EstablishmentException {
+    constructor(err, reason=null, safeErr=null) {
+        super(null, null, null, err, safeErr);
+        this._reason=reason;
+    };
+
+    get safe()  {
+        if (!super.safe) {
+            return `Failed to restore Establishment from JSON.`;
+        } else {
+            return super.safe;
+        }
+    };
+};
+
+class EstablishmentDeleteException extends EstablishmentException {
+    constructor(id, uid, name, err, safeErr=null) { super(id, uid, name, err, safeErr); };
+
+    get safe()  {
+        if (!super._safeErr) {
+            return `Failed to delete Establishment with identity: ${super.identifier}.`;
+        } else {
+            return super.safe;
+        }
+    };
+};
+
+class EstablishmentValidationException extends EstablishmentException {
+    constructor(err, reason=null, safeErr=null) {
+        super(null, null, null, err, safeErr);
+        this._reason=reason;
+    };
+
+    get safe()  {
+        if (!super.safe) {
+            return `Establishment failed validation.`;
+        } else {
+            return super.safe;
+        }
+    };
+};
+
+
+module.exports.EstablishmentSaveException = EstablishmentSaveException;
+module.exports.EstablishmentRestoreException = EstablishmentRestoreException;
+module.exports.EstablishmentDeleteException = EstablishmentDeleteException;
+module.exports.EstablishmentJsonException = EstablishmentJsonException;
+module.exports.EstablishmentValidationException = EstablishmentValidationException;

--- a/server/models/classes/establishment/establishmentProperties.js
+++ b/server/models/classes/establishment/establishmentProperties.js
@@ -8,7 +8,7 @@ class EstablishmentPropertyManager {
     constructor() {
         this._thisManager = new Manager.PropertyManager();
 
-        this._thisManager.registerProperty(employerTypeProperty);
+        //this._thisManager.registerProperty(employerTypeProperty);
     }
 
     get manager() {

--- a/server/models/classes/establishment/establishmentProperties.js
+++ b/server/models/classes/establishment/establishmentProperties.js
@@ -1,0 +1,21 @@
+// encapsulates all properties of a user, by returning a PropertyManager
+const Manager = require('../properties/manager');
+
+// individual properties
+const employerTypeProperty = require('./properties/employerTypeProperty').EmployerTypeProperty;
+
+class EstablishmentPropertyManager {
+    constructor() {
+        this._thisManager = new Manager.PropertyManager();
+
+        this._thisManager.registerProperty(employerTypeProperty);
+    }
+
+    get manager() {
+        return this._thisManager;
+    }
+}
+
+exports.EstablishmentPropertyManager = EstablishmentPropertyManager;
+exports.SEQUELIZE_DOCUMENT = Manager.PropertyManager.SEQUELIZE_DOCUMENT;
+exports.JSON_DOCUMENT = Manager.PropertyManager.JSON_DOCUMENT;

--- a/server/models/classes/establishment/properties/employerTypeProperty.js
+++ b/server/models/classes/establishment/properties/employerTypeProperty.js
@@ -1,0 +1,54 @@
+// the email property is a value Rolenly
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+exports.EmployerTypeProperty = class EmployerTypeProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('EmployerType');
+    }
+
+    static clone() {
+        return new EmployerTypeProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.employerType) {
+            const ALLOWED_EMPLOYER_TYPES=['Private Sector', 'Voluntary / Charity', 'Other', 'Local Authority (generic/other)', 'Local Authority (adult services)'];
+            if (ALLOWED_EMPLOYER_TYPES.includes(document.employerType)) {
+                this.property = document.employerType;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.EmployerTypeValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            EmployerTypeValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // employer type is a simple (enum) string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                employerType: this.property
+            };
+        }
+        
+        return {
+            employerType: {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -264,7 +264,7 @@ class User {
         let mustSave = this._initialise();
 
         if (!this.uid) {
-            this._log(Worker.LOG_ERROR, 'Not able to save an unknown uid');
+            this._log(User.LOG_ERROR, 'Not able to save an unknown uid');
             throw new UserExceptions.UserSaveException(null,
                 this.uid,
                 this.fullname,

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -9,6 +9,12 @@ module.exports = function(sequelize, DataTypes) {
       autoIncrement: true,
       field: '"EstablishmentID"'
     },
+    uid: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      unique: true,
+      field: '"EstablishmentUID"'
+    },
     name: {
       type: DataTypes.TEXT,
       allowNull: false,

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -89,6 +89,23 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: false,
       field: '"NmdsID"'
     },
+    created: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+      field: 'created'
+    },
+    updated: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+      field: 'updated'
+    },
+    updatedBy: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'updatedby'
+    },
   }, {
     tableName: '"Establishment"',
     schema: 'cqc',

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -120,6 +120,11 @@ module.exports = function(sequelize, DataTypes) {
   });
 
   Establishment.associate = (models) => {
+    Establishment.hasMany(models.user, {
+      foreignKey: 'establishmentId',
+      sourceKey: 'id',
+      as: 'users'
+    });
     Establishment.belongsTo(models.services, {
       foreignKey: 'mainServiceId',
       targetKey: 'id',
@@ -145,6 +150,11 @@ module.exports = function(sequelize, DataTypes) {
       foreignKey: 'establishmentId',
       sourceKey: 'id',
       as: 'localAuthorities'
+    });
+    Establishment.hasMany(models.establishmentAudit, {
+      foreignKey: 'establishmentFk',
+      sourceKey: 'id',
+      as: 'auditEvents'
     });
   };
 

--- a/server/models/establishmentAudit.js
+++ b/server/models/establishmentAudit.js
@@ -1,0 +1,50 @@
+module.exports = function(sequelize, DataTypes) {
+  const EstablishmentAudit = sequelize.define('establishmentAudit', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+      field: '"ID"'
+    },
+    establishmentFk: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"EstablishmentFK"'
+    },
+    username : {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"Username"'
+    },
+    when: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+      field: '"When"'
+    },
+    type: {
+      type: DataTypes.ENUM,
+      allowNull: false,
+      values: ['created', 'updated', 'saved', 'changed', 'delete'],
+      field: '"EventType"'
+    },
+    property : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"PropertyName"'
+    },
+    event : {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      field: '"ChangeEvents"'
+    }
+  }, {
+    tableName: '"EstablishmentAudit"',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false,    // intentionally keeping these false; updated timestamp will be managed within the Worker business model not this DB model
+  });
+
+  return EstablishmentAudit;
+};

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -19,6 +19,7 @@ config.dialect = appConfig.get('db.dialect');
 config.dialectOptions = {
   ssl: appConfig.get('db.ssl')
 };
+config.logging = appConfig.get('log.sequelize');
 
 // setup connection pool
 config.pool = {

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -117,7 +117,10 @@ const formatEstablishmentResponse = (establishment) => {
     mainService: ServiceFormatters.singleService(establishment.mainService),
     otherServices: ServiceFormatters.createServicesByCategoryJSON(establishment.otherServices),
     capacities: CapacityFormatters.capacitiesJSON(establishment.capacity),
-    jobs: JobFormatters.jobsByTypeJSON(establishment.jobs)
+    jobs: JobFormatters.jobsByTypeJSON(establishment.jobs),
+    created: establishment.created,
+    updated: establishment.updated,
+    updatedBy: establishment.updatedBy
   };
 }
 

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -105,6 +105,7 @@ const formatEstablishmentResponse = (establishment) => {
   //           some attributes (viz. locationId below)
   return {
     id: establishment.id,
+    uid: establishment.uid,
     name: establishment.name,
     address: establishment.address,
     postcode: establishment.postcode,

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -36,7 +36,7 @@ router.use('/:id/worker', Worker);
 // gets requested establishment
 // optional parameter - "history" must equal "none" (default), "property", "timeline" or "full"
 router.use('/:id/alt', Authorization.hasAuthorisedEstablishment);
-router.route('/:id/alt').get(async (req, res) => {
+router.route('/:id').get(async (req, res) => {
     const establishmentId = req.establishmentId;
     const showHistory = req.query.history === 'full' || req.query.history === 'property' || req.query.history === 'timeline' ? true : false;
     const showHistoryTime = req.query.history === 'timeline' ? true : false;
@@ -79,7 +79,7 @@ router.route('/:id/alt').get(async (req, res) => {
 });
 
 // gets all there is to know about an Establishment
-router.route('/:id').get(async (req, res) => {
+router.route('/:id/alt').get(async (req, res) => {
   const establishmentId = req.establishmentId;
 
   try {

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -167,7 +167,7 @@ const formatEstablishmentResponse = (establishment) => {
     mainService: ServiceFormatters.singleService(establishment.mainService),
     otherServices: ServiceFormatters.createServicesByCategoryJSON(establishment.otherServices),
     capacities: CapacityFormatters.capacitiesJSON(establishment.capacity),
-    jobs: JobFormatters.jobsByTypeJSON(establishment.jobs),
+    jobs: JobFormatters.jobsByTypeJSON(establishment),
     created: establishment.created,
     updated: establishment.updated,
     updatedBy: establishment.updatedBy

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -25,7 +25,7 @@ router.post('/',async function(req, res) {
           attributes: ['id', 'FullNameValue', 'EmailValue', 'isAdmin','establishmentId', "UserRoleValue"],
           include: [{
             model: models.establishment,
-            attributes: ['id', 'name', 'isRegulated', 'nmdsId'],
+            attributes: ['id', 'uid', 'name', 'isRegulated', 'nmdsId'],
             include: [{
               model: models.services,
               as: 'mainService',
@@ -152,6 +152,7 @@ const formatSuccessulLoginResponse = (fullname, firstLoginDate, role, establishm
     role,
     establishment: {
       id: establishment.id,
+      uid: establishment.uid,
       name: establishment.name,
       isRegulated: establishment.isRegulated,
       nmdsId: establishment.nmdsId

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -45,7 +45,7 @@ router.post('/',async function(req, res) {
 
         login.comparePassword(escape(req.body.password), async (err, isMatch) => {
           if (isMatch && !err) {
-            const token = generateJWT.loginJWT(12, login.user.establishmentId, req.body.username, login.user.UserRoleValue);
+            const token = generateJWT.loginJWT(12, login.user.establishment.id, login.user.establishment.uid, req.body.username, login.user.UserRoleValue);
             var date = new Date().getTime();
             date += (12 * 60 * 60 * 1000);          
    

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -403,7 +403,9 @@ router.route('/')
 
           // now create establishment
           defaultError = responseErrors.establishment;
+          Estblistmentdata.eUID = uuid.v4();
           const establishmentCreation = await models.establishment.create({
+            uid: Estblistmentdata.eUID,
             name: Estblistmentdata.Name,
             address: Estblistmentdata.Address,
             locationId: Estblistmentdata.LocationID,
@@ -431,7 +433,6 @@ router.route('/')
             },
             {transaction: t}
           );
-
 
           // now create user
           defaultError = responseErrors.user;
@@ -522,7 +523,8 @@ router.route('/')
             "status" : 1,
             "message" : "Establishment and primary user successfully created",
             "establishmentId" : Estblistmentdata.id,
-            "primaryUser" : Logindata.UserName.postcode,
+            "establishmentUid" : Estblistmentdata.eUID,
+            "primaryUser" : Logindata.UserName,
             "nmdsId": Estblistmentdata.NmdsId ? Estblistmentdata.NmdsId : 'undefined'
           }); 
         });

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -413,10 +413,24 @@ router.route('/')
             shareData: false,
             shareWithCQC: false,
             shareWithLA: false,
-            nmdsId: Estblistmentdata.NmdsId
+            nmdsId: Estblistmentdata.NmdsId,
+            created: Userdata.DateCreated,
+            updated: Userdata.DateCreated,
+            updatedBy: Logindata.UserName
           }, {transaction: t});
           const sanitisedEstablishmentResults = establishmentCreation.get({plain: true});
           Estblistmentdata.id = sanitisedEstablishmentResults.EstablishmentID;
+
+          // audit the creation of Establishment
+          await models.establishmentAudit.create(
+            {
+              establishmentFk: Estblistmentdata.id,
+              username: Logindata.UserName,
+              when: Userdata.DateCreated,
+              type: 'created'
+            },
+            {transaction: t}
+          );
 
 
           // now create user
@@ -469,6 +483,17 @@ router.route('/')
 
           const sanitisedUserResults = userCreation.get({plain: true});
           Userdata.registrationID = sanitisedUserResults.RegistrationID;
+
+          // audit the creation of User
+          await models.userAudit.create(
+            {
+              userFk: Userdata.registrationID,
+              username: Logindata.UserName,
+              when: Userdata.DateCreated,
+              type: 'created'
+            },
+            {transaction: t}
+          );
 
           // now create login
           defaultError = responseErrors.login;

--- a/server/utils/security/generateJWT.js
+++ b/server/utils/security/generateJWT.js
@@ -4,9 +4,10 @@ const Authorization = require('./isAuthenticated');
 const Token_Secret = Authorization.getTokenSecret();
 
 // this generates the login JWT
-exports.loginJWT = (ttlHours, establishmentId, username, role) => {
+exports.loginJWT = (ttlHours, establishmentId, establishmentUid, username, role) => {
   var claims = {
     EstblishmentId: establishmentId,
+    EstablishmentUID: establishmentUid,
     role,
     sub: username,
     aud: config.get('jwt.aud.login'),

--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -46,18 +46,35 @@ exports.hasAuthorisedEstablishment = (req, res, next) => {
         // must provide the establishment ID and it must be a number
         if (!claim.EstblishmentId || isNaN(parseInt(claim.EstblishmentId))) {
           console.error('hasAuthorisedEstablishment - missing establishment id parameter');
-          return res.status(400).send(`Unknown Establishment ID: ${req.params.id}`);
+          return res.status(400).send(`Unknown Establishment ID`);
         }
-        if (claim.EstblishmentId !== parseInt(req.params.id)) {
-          console.error(`hasAuthorisedEstablishment - given and known establishment id do not match: given (${req.params.id})/known (${claim.EstblishmentId})`);
-          return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
+        const uuidV4Regex = /^[A-F\d]{8}-[A-F\d]{4}-4[A-F\d]{3}-[89AB][A-F\d]{3}-[A-F\d]{12}$/i;
+        if (!claim.EstablishmentUID || !uuidV4Regex.test(claim.EstablishmentUID)) {
+          console.error('hasAuthorisedEstablishment - missing establishment uid parameter');
+          return res.status(400).send(`Unknown Establishment UID`);
         }
 
-        req.establishmentId =   claim.EstblishmentId ;        
+        // the given parameter could be a UUID or integer
+        if (uuidV4Regex.test(req.params.id)) {
+          // establishment id in params is a UUID - tests against UID in claim
+          if (claim.EstablishmentUID !== req.params.id) {
+            console.error(`hasAuthorisedEstablishment - given and known establishment uid do not match: given (${req.params.id})/known (${claim.EstablishmentUID})`);
+            return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
+          }
+
+          req.establishmentId=   claim.EstablishmentUID;
+        } else {
+          if (claim.EstblishmentId !== parseInt(req.params.id)) {
+            console.error(`hasAuthorisedEstablishment - given and known establishment id do not match: given (${req.params.id})/known (${claim.EstblishmentId})`);
+            return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
+          }
+
+          req.establishmentId =   claim.EstblishmentId;
+        }
+
         req.username= claim.sub;
         req.role = claim.role;
         next();
-        
       }     
     });
  


### PR DESCRIPTION
Nasir

The PR covers the work so far on https://trello.com/c/jaqBQdQg. This card will have a lot of changes, so I thought I'd get this one in first.

This covers a lot of ground by introducing the Establishment Extended Property class, along with the exceptions/property manager. I've updated the existing GET endpoint with a new presentation using this Establishment Extended Property class (renaming the old presentation endpoint to end in `alt`).

I've proven the restore from DB and the presentation to JSON, including updating my integration tests for the timeline and full history.

But significantly in this PR, I've introduce Establishment UID (complementing Worker UID and User UID); the framework makes good on UUIDs.

This impacts:
1. Registration - to create the UUID
2. Login - to return the UUID and to generate JWT with the UUID
3. Authorisation middleware - to validate on UUID

Oh, and yes I've included a small change to control the sequelize logging. With all these extended properties and with more and more joins across tables, the console is filling up with huge SQL statements. By default, logging will be disabled in all the target environments.