### PR TITLE
Removing Validation around Total Staff

### DIFF
--- a/src/app/core/services/worker.service.ts
+++ b/src/app/core/services/worker.service.ts
@@ -164,11 +164,8 @@ export class WorkerService {
       );
   }
 
-  setCreateStaffResponse(success: number, failed: number) {
-    this.createStaffResponse = {
-      success,
-      failed,
-    };
+  setCreateStaffResponse(success: number) {
+    this.createStaffResponse = success;
   }
 
   getCreateStaffResponse() {

--- a/src/app/features/dashboard/staff-records-tab/staff-records-tab.component.html
+++ b/src/app/features/dashboard/staff-records-tab/staff-records-tab.component.html
@@ -9,28 +9,29 @@
   </div>
 </div>
 <div class="row">
-  <div *ngIf="createStaffResponse?.success" class="col-12">
+  <div *ngIf="createStaffResponse" class="col-12">
     <app-status title="&#10003; Success.">
-      {{ createStaffResponse.success | i18nPlural: {
+      {{ createStaffResponse | i18nPlural: {
           '=1': '# staff record has been saved.',
           'other': '# staff records have been saved.'
         }
       }}
     </app-status>
   </div>
-
-  <div *ngIf="createStaffResponse?.failed" class="col-12">
-    <app-status title="&#10007; Failed." status="fail">
-      {{ createStaffResponse.failed | i18nPlural: {
-          '=1': '# staff record has not been saved.',
-          'other': '# staff records have not been saved.'
-        }
-      }}
-    </app-status>
-  </div>
   <div *ngIf="incomplete" class="col-12">
     <p><strong>What you need to do next.</strong></p>
-    <p>Provide more information for {{ incomplete }} staff records.</p>
+
+    <app-inset-text *ngIf="totalStaff > workers.length" color="todo">
+      You said you have {{ totalStaff }} members of staff.<br />
+      You need to update your Number of Staff or complete {{ totalStaff - workers.length }} more staff records.
+    </app-inset-text>
+
+    <app-inset-text *ngIf="totalStaff < workers.length" color="todo">
+      You have created more staff records than you have members of staff ({{ totalStaff }}).<br />
+      You need to update your Number of Staff to {{ workers.length }} or delete some records.
+    </app-inset-text>
+
+    <p *ngIf="totalStaff === workers.length">Provide more information for {{ incomplete }} staff records.</p>
   </div>
 </div>
 <div class="row">
@@ -41,7 +42,7 @@
           <th class="govuk-table__header" scope="col">Staff name</th>
           <th class="govuk-table__header" scope="col">Job role</th>
           <th class="govuk-table__header" scope="col">Last updated</th>
-          <th class="govuk-table__header" scope="col">Status</th>
+          <th *ngIf="totalStaff === workers.length" class="govuk-table__header" scope="col">Status</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -52,7 +53,7 @@
           </td>
           <td class="govuk-table__cell">{{ worker.mainJob.title }}</td>
           <td class="govuk-table__cell">{{ worker.updated | amTimeAgo }}</td>
-          <td class="govuk-table__cell"><a *ngIf="!worker.completed" [routerLink]="['/worker', worker.uid, worker.mainJob?.jobId === 27 ? 'mental-health-professional' : 'main-job-start-date']" class="icon-link icon-flag">Provide more information</a></td>
+          <td *ngIf="totalStaff === workers.length" class="govuk-table__cell"><a *ngIf="!worker.completed" [routerLink]="['/worker', worker.uid, worker.mainJob?.jobId === 27 ? 'mental-health-professional' : 'main-job-start-date']" class="icon-link icon-flag">Provide more information</a></td>
         </tr>
       </tbody>
     </table>

--- a/src/app/features/dashboard/staff-records-tab/staff-records-tab.component.ts
+++ b/src/app/features/dashboard/staff-records-tab/staff-records-tab.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Worker } from '@core/model/worker.model';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Subscription } from 'rxjs';
 
@@ -10,16 +11,38 @@ import { Subscription } from 'rxjs';
 export class StaffRecordsTabComponent implements OnInit, OnDestroy {
   public createStaffResponse = null;
   public workers: Worker[];
+  public totalStaff: number;
+  public errors;
   public incomplete = 0;
   private subscriptions: Subscription = new Subscription();
 
-  constructor(private workerService: WorkerService) {}
+  constructor(private establishmentService: EstablishmentService, private workerService: WorkerService) {}
+
+  get addMore() {
+    return `
+      You said you have ${this.totalStaff} members of staff.<br />
+      You need to update your Number of Staff or complete ${this.totalStaff - this.workers.length} more staff records.
+    `;
+  }
+
+  get removeRecords() {
+    return `
+      You have created more staff records than you have members of staff (${this.totalStaff}).<br />
+      You need to update your Number of Staff to ${this.workers.length} or delete some records.
+    `;
+  }
 
   ngOnInit() {
     this.subscriptions.add(
       this.workerService.getAllWorkers().subscribe(data => {
         this.workers = data;
         this.incomplete = this.workers.filter(worker => !worker.completed).length;
+      })
+    );
+
+    this.subscriptions.add(
+      this.establishmentService.getStaff().subscribe(totalStaff => {
+        this.totalStaff = totalStaff;
       })
     );
 

--- a/src/app/features/dashboard/staff-records-tab/staff-records-tab.component.ts
+++ b/src/app/features/dashboard/staff-records-tab/staff-records-tab.component.ts
@@ -18,20 +18,6 @@ export class StaffRecordsTabComponent implements OnInit, OnDestroy {
 
   constructor(private establishmentService: EstablishmentService, private workerService: WorkerService) {}
 
-  get addMore() {
-    return `
-      You said you have ${this.totalStaff} members of staff.<br />
-      You need to update your Number of Staff or complete ${this.totalStaff - this.workers.length} more staff records.
-    `;
-  }
-
-  get removeRecords() {
-    return `
-      You have created more staff records than you have members of staff (${this.totalStaff}).<br />
-      You need to update your Number of Staff to ${this.workers.length} or delete some records.
-    `;
-  }
-
   ngOnInit() {
     this.subscriptions.add(
       this.workerService.getAllWorkers().subscribe(data => {

--- a/src/app/features/workers/create-staff-record/create-staff-record.component.html
+++ b/src/app/features/workers/create-staff-record/create-staff-record.component.html
@@ -3,16 +3,6 @@
     <a routerLink="/worker/start-screen"> <span class="arrow"></span>Back </a>
   </div>
 
-  <app-error-summary
-    *ngIf="form.errors?.addMoreRecords && submitted"
-    [errors]="form.errors.addMoreRecords">
-  </app-error-summary>
-
-  <app-error-summary
-    *ngIf="form.errors?.removeRecords && submitted"
-    [errors]="form.errors.removeRecords">
-  </app-error-summary>
-
   <form novalidate (ngSubmit)="submitHandler()" [formGroup]="form">
     <h1 class="h1">Create your staff records</h1>
 
@@ -50,7 +40,7 @@
     <div formArrayName="staffRecords" class="staff-records">
       <div class="row staff-record fs-19" *ngFor="let staffRecord of form.get('staffRecords').controls; let i = index" [formGroupName]="i">
         <div class="tb-cell col-2 pt-4 pb-4 pr-2">
-          <strong>Staff record {{ i + 1 }}</strong>
+          <strong>Staff record {{ i + 1 + totalWorkers }}</strong>
         </div>
         <div class="tb-cell col-4 pt-4 pb-4 pr-2">
           {{ staffRecord.get('nameOrId').value }}

--- a/src/app/features/workers/create-staff-record/create-staff-record.component.html
+++ b/src/app/features/workers/create-staff-record/create-staff-record.component.html
@@ -9,13 +9,15 @@
     <div class="form-group">
       <div class="field-group mb-5">
         <label>
-          Total number of staff
+          Total number of staff {{ establishmentStaff }}
           <div *ngIf="form.controls.totalStaff.errors?.min || form.controls.totalStaff.errors?.max" class="alert alert-danger">
             <p class="pt-4">Total number of staff must be between 0 and 999.</p>
           </div>
           <div *ngIf="form.controls.totalStaff.errors?.required" class="alert alert-danger">
             <p class="pt-4">Total number of staff is required.</p>
           </div>
+          <p *ngIf="establishmentStaff >= 0" class="mt-4">This is the total number of staff at your workplace.</p>
+          <p *ngIf="!(establishmentStaff >= 0)" class="mt-4">This includes all the staff you have already told us you have.</p>
           <span class="example">This includes permanent, temporary, pool/bank or agency staff</span>
           <input
             type="number"

--- a/src/app/features/workers/create-staff-record/create-staff-record.component.ts
+++ b/src/app/features/workers/create-staff-record/create-staff-record.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { AbstractControl, FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Component, ElementRef, OnDestroy, OnInit } from '@angular/core';
+import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Contracts } from '@core/constants/contracts.enum';
 import { Job } from '@core/model/job.model';
@@ -31,10 +31,10 @@ export class CreateStaffRecordComponent implements OnInit, OnDestroy {
     private jobService: JobService,
     private messageService: MessageService,
     private formBuilder: FormBuilder,
-    private router: Router
+    private router: Router,
+    private elementRef: ElementRef
   ) {
     this.addStaffRecord = this.addStaffRecord.bind(this);
-    this.totalStaffValidator = this.totalStaffValidator.bind(this);
   }
 
   get displayAddMore() {
@@ -79,7 +79,6 @@ export class CreateStaffRecordComponent implements OnInit, OnDestroy {
       totalStaff: [0, [Validators.min(0), Validators.max(999), Validators.required]],
       staffRecords: this.formBuilder.array([this.createStaffRecordsItem()], this.staffRecordsRequiredValidator),
     });
-    this.form.setValidators([this.totalStaffValidator]);
   }
 
   ngOnDestroy() {
@@ -100,6 +99,9 @@ export class CreateStaffRecordComponent implements OnInit, OnDestroy {
   openStaffRecord(index: number) {
     this.closeStaffRecords();
     this.staffRecordsControl.controls[index].patchValue({ active: true });
+    setTimeout(() => {
+      this.elementRef.nativeElement.querySelector(`.staff-record:nth-of-type(${index + 1})`).scrollIntoView(true);
+    });
   }
 
   closeStaffRecords() {
@@ -129,32 +131,6 @@ export class CreateStaffRecordComponent implements OnInit, OnDestroy {
     }
   }
 
-  totalStaffValidator(form: AbstractControl) {
-    const totalStaff = form.get('totalStaff');
-
-    if (totalStaff.value > this.calculatedTotalStaff) {
-      return {
-        addMoreRecords: [
-          {
-            text: `You said you have ${totalStaff.value} members of staff but you only have ${
-              this.calculatedTotalStaff
-            }.`,
-          },
-          { text: `You need to complete ${totalStaff.value - this.calculatedTotalStaff} more records.` },
-        ],
-      };
-    } else if (totalStaff.value < this.calculatedTotalStaff) {
-      return {
-        removeRecords: [
-          { text: `You said you have ${totalStaff.value} members of staff but you have created more.` },
-          { text: `You need to update your Number of Staff to ${this.calculatedTotalStaff} or delete some records.` },
-        ],
-      };
-    }
-
-    return null;
-  }
-
   staffRecordsRequiredValidator(control: FormArray) {
     if (!control.controls.some(c => !isNull(c.get('uid').value))) {
       return { required: true };
@@ -167,6 +143,8 @@ export class CreateStaffRecordComponent implements OnInit, OnDestroy {
     this.submitted = true;
 
     if (this.form.valid) {
+      this.updateTotalStaff();
+      this.workerService.setCreateStaffResponse(this.staffRecordsControl.length);
       this.router.navigate(['/dashboard'], { fragment: 'staff-records' });
     } else {
       const unsavedIndex = this.staffRecordsControl.controls.findIndex(control => {
@@ -176,6 +154,8 @@ export class CreateStaffRecordComponent implements OnInit, OnDestroy {
       if (unsavedIndex >= 0) {
         this.openStaffRecord(unsavedIndex);
         this.saveStaffRecord(unsavedIndex);
+      } else {
+        this.elementRef.nativeElement.querySelector('form').scrollIntoView(true);
       }
     }
   }

--- a/src/app/features/workers/create-staff-record/create-staff-record.component.ts
+++ b/src/app/features/workers/create-staff-record/create-staff-record.component.ts
@@ -20,6 +20,7 @@ export class CreateStaffRecordComponent implements OnInit, OnDestroy {
   public contractsAvailable: Array<string> = [];
   public jobsAvailable: Job[] = [];
   public totalWorkers = 0;
+  public establishmentStaff: number;
   public form: FormGroup;
   public submitted = false;
   private tempTotalStaff: number = null;
@@ -57,6 +58,7 @@ export class CreateStaffRecordComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.establishmentService.getStaff().subscribe(establishmentStaff => {
         if (establishmentStaff) {
+          this.establishmentStaff = establishmentStaff;
           const totalStaff = establishmentStaff ? establishmentStaff : 0;
           this.tempTotalStaff = totalStaff;
           this.form.controls.totalStaff.patchValue(totalStaff);


### PR DESCRIPTION
Updating Skeleton Records to be less complex when validating against total staff number

* Remove Total Staff validation
* Fix success message on Staff Records tab
* Add prompt to Staff Records tab when Total Staff and Staff Records amount doesn't match
* Change Staff records displayed index to reflect total staff records
* Hide "Provide more information" link when entered Total Staff does not equal Staff Records.
* Added scrolling to the open record