### PR TITLE
Redirect with params and fragments

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -35,12 +35,12 @@ import {
 } from './core/error/problem-with-the-service-pages/problem-with-the-service-pages.component';
 import { RegisterGuard } from './core/guards/register/register.guard';
 import { AuthGuard } from './core/services/auth-guard.service';
-import { ForgotYourPasswordComponent } from './features/forgot-your-password/forgot-your-password.component';
-import { ResetPasswordComponent } from './features/reset-password/reset-password.component';
-import { ChangeUserSummaryComponent } from './features/change-user-summary/change-user-summary.component';
 import { ChangePasswordComponent } from './features/change-password/change-password.component';
 import { ChangeUserDetailsComponent } from './features/change-user-details/change-user-details.component';
 import { ChangeUserSecurityComponent } from './features/change-user-security/change-user-security.component';
+import { ChangeUserSummaryComponent } from './features/change-user-summary/change-user-summary.component';
+import { ForgotYourPasswordComponent } from './features/forgot-your-password/forgot-your-password.component';
+import { ResetPasswordComponent } from './features/reset-password/reset-password.component';
 
 const routes: Routes = [
   {
@@ -136,67 +136,56 @@ const routes: Routes = [
   {
     path: 'select-other-services',
     component: SelectOtherServicesComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'type-of-employer',
     component: TypeOfEmployerComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'vacancies',
     component: VacanciesComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'confirm-vacancies',
     component: ConfirmVacanciesComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'starters',
     component: StartersComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'confirm-starters',
     component: ConfirmStartersComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'leavers',
     component: LeaversComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'confirm-leavers',
     component: ConfirmLeaversComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'capacity-of-services',
     component: ServicesCapacityComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'share-local-authority',
     component: ShareLocalAuthorityComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
     path: 'share-options',
     component: ShareOptionsComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {
@@ -218,12 +207,11 @@ const routes: Routes = [
   {
     path: 'worker',
     loadChildren: '@features/workers/workers.module#WorkersModule',
-    canLoad: [AuthGuard],
+    canActivate: [AuthGuard],
   },
   {
     path: 'dashboard',
     component: DashboardComponent,
-    canLoad: [AuthGuard],
     canActivate: [AuthGuard],
   },
   {

--- a/src/app/core/services/auth-guard.service.ts
+++ b/src/app/core/services/auth-guard.service.ts
@@ -1,40 +1,28 @@
 import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  CanActivateChild,
-  CanLoad,
-  Route,
-  Router,
-  RouterStateSnapshot,
-} from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router, RouterStateSnapshot } from '@angular/router';
 
 import { AuthService } from './auth-service';
 
 @Injectable({
   providedIn: 'root',
 })
-export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
+export class AuthGuard implements CanActivate, CanActivateChild {
   constructor(private router: Router, private authService: AuthService) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    return this.checkLogin(state.url);
-  }
-
-  canLoad(route: Route): boolean {
-    return this.checkLogin(`/${route.path}`);
+    return this.checkLogin(route);
   }
 
   canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
     return this.canActivate(route, state);
   }
 
-  private checkLogin(url: string): boolean {
+  private checkLogin(route: ActivatedRouteSnapshot): boolean {
     if (this.authService.isLoggedIn) {
       return true;
     }
 
-    this.authService.redirectUrl = url;
+    this.authService.redirect = { url: route.url, fragment: route.fragment, queryParams: route.queryParams };
     this.router.navigate(['/login']);
     return false;
   }

--- a/src/app/core/services/auth-service.ts
+++ b/src/app/core/services/auth-service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { Params, Router, UrlSegment } from '@angular/router';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { ErrorObservable } from 'rxjs-compat/observable/ErrorObservable';
 
@@ -43,7 +43,7 @@ export class AuthService {
   private _session: LoggedInSession = null;
   private _token: string = null;
 
-  redirectUrl: string = null;
+  public redirect: { url: UrlSegment[]; fragment?: string; queryParams?: Params };
 
   // Observable login stream
   public auth$: Observable<LoginApiModel> = this._auth$.asObservable();


### PR DESCRIPTION
Redirect after Login now uses an object to pass fragments and query parameters to `router.navigate()`