### PR TITLE
Establishment additional properties

### DIFF
--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -85,7 +85,7 @@ class Establishment {
         return this._username;
     }
     get name() {
-        return this._name;
+        return this._properties.get('Name') ? this._properties.get('Name').property : null;
     };
     get address() {
         return this._address;
@@ -100,7 +100,7 @@ class Establishment {
         return this._isRegulated;
     };
     get mainService() {
-        return this._mainService;
+        return this._properties.get('MainServiceFK') ? this._properties.get('MainServiceFK').property : null;
     };
     get nmdsId() {
         return this._nmdsId;
@@ -129,15 +129,11 @@ class Establishment {
     }
 
     // external method to initialise the mandatory non-extendable properties
-    initialise(name, address, locationId, postcode, isRegulated, mainServiceId, nmdsId) {
-        this._name = name;
+    initialise(address, locationId, postcode, isRegulated, nmdsId) {
         this._address = address;
         this._postcode = postcode;
         this._isRegulated = isRegulated;
         this._locationId = locationId;
-        this._mainService = {
-            id: mainServiceId
-        };
         this._nmdsId = nmdsId;
     }
 
@@ -188,12 +184,12 @@ class Establishment {
             try {
                 const creationDocument = {
                     uid: this.uid,
-                    NameValue: this._name,
+                    NameValue: this.name,
                     address: this._address,
                     postcode: this._postcode,
                     isRegulated: this._isRegulated,
                     locationId: this._locationId,
-                    MainServiceFKValue: this._mainService.id,
+                    MainServiceFKValue: this.mainService.id,
                     nmdsId: this._nmdsId,
                     updatedBy: savedBy,
                     ShareDataValue: false,
@@ -761,7 +757,7 @@ class Establishment {
                 myDefaultJSON.locationRef = this.locationId;
                 myDefaultJSON.isRegulated = this.isRegulated;
                 myDefaultJSON.nmdsId = this.nmdsId;
-                myDefaultJSON.mainService = ServiceFormatters.singleService(this.mainService);
+                //myDefaultJSON.mainService = ServiceFormatters.singleService(this.mainService);
             }
 
             myDefaultJSON.created = this.created.toJSON();
@@ -802,21 +798,20 @@ class Establishment {
     get hasMandatoryProperties() {
         let allExistAndValid = true;    // assume all exist until proven otherwise
         try {
-            // const fullnameProperty = this._properties.get('FullName');
-            // if (!(fullnameProperty && fullnameProperty.isInitialised && fullnameProperty.valid)) {
-            //     allExistAndValid = false;
-            //     this._log(Establishment.LOG_ERROR, 'User::hasMandatoryProperties - missing or invalid fullname');
-            // }
-    
             const nmdsIdRegex = /^[A-Z]1[\d]{6}$/i; 
             if (!(this._nmdsId && nmdsIdRegex.test(this._nmdsId))) {
                 allExistAndValid = false;
                 this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid NMDS ID');
             }
 
-            if (!(this._name)) {
+            if (!(this.name)) {
                 allExistAndValid = false;
                 this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid name');
+            }
+
+            if (!(this.mainService)) {
+                allExistAndValid = false;
+                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid main service');
             }
 
             if (!(this._address)) {

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -188,12 +188,12 @@ class Establishment {
             try {
                 const creationDocument = {
                     uid: this.uid,
-                    name: this._name,
+                    NameValue: this._name,
                     address: this._address,
                     postcode: this._postcode,
                     isRegulated: this._isRegulated,
                     locationId: this._locationId,
-                    mainServiceId: this._mainService.id,
+                    MainServiceFKValue: this._mainService.id,
                     nmdsId: this._nmdsId,
                     updatedBy: savedBy,
                     ShareDataValue: false,
@@ -456,6 +456,13 @@ class Establishment {
                     ['name', 'ASC']
                   ]
                 },{
+                  model: models.serviceUsers,
+                  as: 'serviceUsers',
+                  attributes: ['id', 'service', 'group', 'seq'],
+                  order: [
+                    ['seq', 'ASC']
+                  ]
+                },{
                   model: models.services,
                   as: 'mainService',
                   attributes: ['id', 'name']
@@ -523,7 +530,7 @@ class Establishment {
                 this._updated = fetchResults.updated;
                 this._updatedBy = fetchResults.updatedBy;
 
-                this._name = fetchResults.name;
+                this._name = fetchResults.NameValue;
                 this._address = fetchResults.address;
                 this._locationId = fetchResults.locationId;
                 this._postcode = fetchResults.postcode;

--- a/server/models/classes/establishment/establishmentProperties.js
+++ b/server/models/classes/establishment/establishmentProperties.js
@@ -12,11 +12,15 @@ const vacanciesProperty = require("./properties/vacanciesProperty").VacanciesPro
 const startersProperty = require("./properties/startersProperty").StartersProperty;
 const leaversProperty = require("./properties/leaversProperty").LeaversProperty;
 const serviceUsersProperty = require("./properties/serviceUsersProperty").ServiceUsersProperty;
+const nameProperty = require("./properties/nameProperty").NameProperty;
+const mainServiceProperty = require("./properties/mainServiceProperty").MainServiceProperty;
 
 class EstablishmentPropertyManager {
     constructor() {
         this._thisManager = new Manager.PropertyManager();
 
+        this._thisManager.registerProperty(nameProperty);
+        this._thisManager.registerProperty(mainServiceProperty);
         this._thisManager.registerProperty(employerTypeProperty);
         this._thisManager.registerProperty(staffProperty);
         this._thisManager.registerProperty(otherServicesProperty);

--- a/server/models/classes/establishment/establishmentProperties.js
+++ b/server/models/classes/establishment/establishmentProperties.js
@@ -11,6 +11,7 @@ const shareWithLAProperty = require("./properties/shareWithLAProperty").ShareWit
 const vacanciesProperty = require("./properties/vacanciesProperty").VacanciesProperty;
 const startersProperty = require("./properties/startersProperty").StartersProperty;
 const leaversProperty = require("./properties/leaversProperty").LeaversProperty;
+const serviceUsersProperty = require("./properties/serviceUsersProperty").ServiceUsersProperty;
 
 class EstablishmentPropertyManager {
     constructor() {
@@ -19,6 +20,7 @@ class EstablishmentPropertyManager {
         this._thisManager.registerProperty(employerTypeProperty);
         this._thisManager.registerProperty(staffProperty);
         this._thisManager.registerProperty(otherServicesProperty);
+        this._thisManager.registerProperty(serviceUsersProperty);
         this._thisManager.registerProperty(capacityServicesProperty);
         this._thisManager.registerProperty(shareProperty);
         this._thisManager.registerProperty(shareWithLAProperty);

--- a/server/models/classes/establishment/properties/mainServiceProperty.js
+++ b/server/models/classes/establishment/properties/mainServiceProperty.js
@@ -1,0 +1,121 @@
+// the main service property is an FK value property only, that needs validation
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+const models = require('../../../index');
+
+exports.MainServiceProperty = class MainServiceProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('MainServiceFK');
+    }
+
+    static clone() {
+        return new MainServiceProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.mainService) {
+            console.log("WA restoring from JSON: ", document.mainService)
+            const validatedService = await this._validateService(document.mainService);
+
+            console.log("WA DEBUG - validated main service: ", validatedService)
+
+            if (validatedService) {
+                this.property = validatedService;
+            } else {
+                // main service if defined must be valid
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        if (document.mainService) {
+            return {
+                id: document.mainService.id,
+                name: document.mainService.name,
+            };
+        }
+    }
+    savePropertyToSequelize() {
+        // as an FK property, we only store the id
+        return {
+            MainServiceFKValue: this.property.id
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // employer type is a simple string
+        return currentValue && newValue && currentValue.id === newValue.id;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                mainService: this.property
+            };
+        }
+        
+        return {
+            mainService: {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+
+    _valid(thisService) {
+        if (!thisService) return false;
+
+        // must exist a id or name
+        if (!(thisService.id || thisService.name)) return false;
+
+        // if id is given, it must be an integer
+        if (thisService.id && !(Number.isInteger(thisService.id))) return false;
+
+        // gets here, and it's valid
+        return true;
+    }
+
+    // returns false if service definition is not valid, otherwise returns
+    //  a well formed service definition using data as given in services reference lookup
+    async _validateService(serviceDef) {
+        const validatedService = null;
+
+        // need the set of all services available
+        let results = await models.services.findAll({
+            order: [
+                ["id", "ASC"]
+            ]
+        });
+
+        if (!results && !Array.isArray(results)) return false;
+
+        if (!this._valid(serviceDef)) {
+            // first check the given data structure
+            return false;
+        }
+
+        // id overrides service, because id is indexed whereas service is not!
+        let referenceService = null;
+        if (serviceDef.id) {
+            referenceService = results.find(thisAllService => {
+                return thisAllService.id === serviceDef.id;
+            });
+        } else {
+            referenceService = results.find(thisAllService => {
+                return thisAllService.name === serviceDef.name;
+            });
+        }
+
+        if (referenceService && referenceService.id) {
+            // found a service match
+            return {
+                id: referenceService.id,
+                name: referenceService.name,
+            };
+        } else {
+            return false;
+        }
+    }
+};

--- a/server/models/classes/establishment/properties/nameProperty.js
+++ b/server/models/classes/establishment/properties/nameProperty.js
@@ -1,0 +1,54 @@
+// the name  property is a value property only
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+exports.NameProperty = class NameProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('Name');
+    }
+
+    static clone() {
+        return new NameProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.name) {
+            const MAX_LENGTH=120;
+            if (document.name.length <= MAX_LENGTH) {
+                this.property = document.name;
+            } else {
+               this.property = null;
+            }
+        }
+    }
+
+    restorePropertyFromSequelize(document) {
+        return document.NameValue;
+    }
+    savePropertyToSequelize() {
+        return {
+            NameValue: this.property
+        };
+    }
+
+    isEqual(currentValue, newValue) {
+        // employer type is a simple string
+        return currentValue && newValue && currentValue === newValue;
+    }
+
+    toJSON(withHistory=false, showPropertyHistoryOnly=true) {
+        if (!withHistory) {
+            // simple form
+            return {
+                name: this.property
+            };
+        }
+        
+        return {
+            name: {
+                currentValue: this.property,
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+};

--- a/server/models/classes/establishment/properties/serviceUsersProperty.js
+++ b/server/models/classes/establishment/properties/serviceUsersProperty.js
@@ -1,0 +1,204 @@
+// the Service Users property is a reflextion table that holds the set of known 'Service Users' referenced against the reference set of "Service Users"
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const ServiceFormatters = require('../../../api/services');
+
+exports.ServiceUsersProperty = class ServiceUsersProperty extends ChangePropertyPrototype {
+    constructor() {
+        super('OtherServices');
+    }
+
+    static clone() {
+        return new ServiceUsersProperty();
+    }
+
+    // concrete implementations
+    async restoreFromJson(document) {
+        if (document.services) {
+            // can be an empty array
+            if (Array.isArray(document.services)) {
+                const validatedServices = await this._validateServices(document.services);
+
+                if (validatedServices) {
+                    this.property = validatedServices;
+
+                } else {
+                    this.property = null;
+                }
+
+            } else {
+                this.property = null;
+            }
+        }
+    }
+
+    // this method takes all services available to this given establishment and merges those services already registered
+    //  against this Establishment, whilst also removing the main service
+    mergeServices(allServices, theseServices, mainService) {
+        // its a simple case of working through each of "theseServices", and setting the "isMyService"
+        if (theseServices && Array.isArray(theseServices)) {
+            theseServices.forEach(thisService => {
+                // find and update the corresponding service in allServices
+                let foundService = allServices ? allServices.find(refService => refService.id === thisService.id) : null;
+                if (foundService) {
+                    foundService.isMyService = true;
+                }
+            });
+        }
+
+        // now remove the main service
+        return allServices ? allServices.filter(refService => refService.id !== mainService.id) : [];
+    };
+
+    restorePropertyFromSequelize(document) {
+        // whilst serialising from DB other services, make a note of main service and all "other" services
+        //  - required in toJSON response
+        this._allServices = this.mergeServices(
+            document.allMyServices,
+            document.otherServices,
+            document.mainService,
+        );
+        this._mainService = document.mainService;
+
+        if (document.otherServices) {
+            return document.otherServices.map(thisService => {
+                return {
+                    id: thisService.id,
+                    name: thisService.name,
+                    category: thisService.category
+                };
+            });
+        }
+    }
+
+    savePropertyToSequelize() {
+        // when saving other services, there is no "Value" column to update - only reflexion records to delete/create
+        const servicesDocument = {
+        };
+
+        // note - only the serviceId is required and that is mapped from the property.services.id; establishmentId will be provided by Establishment class
+        if (this.property && Array.isArray(this.property)) {
+            servicesDocument.additionalModels = {
+                establishmentServices: this.property.map(thisService => {
+                    return {
+                        serviceId: thisService.id
+                    };
+                })
+            };
+        }
+
+        return servicesDocument;
+    }
+
+    isEqual(currentValue, newValue) {
+        // need to compare arrays
+        let arraysEqual = true;
+
+        if (currentValue && newValue && currentValue.length == newValue.length) {
+            // the preconditions are sets are equal in length; compare the array values themselves
+
+            // we haven't got large arrays here; so simply iterate around every
+            //  current value, and confirm it is in the the new data set.
+            //  Array.every will drop out on the first iteration to return false
+            arraysEqual = currentValue.every(thisService => {
+                return newValue.find(newService => newService.id === thisService.id);
+            });
+        } else {
+            // if the arrays are lengths are not equal, then we know they're not equal
+            arraysEqual = false;
+        }
+
+        return arraysEqual;
+    }
+
+    formatOtherServicesResponse(mainService, otherServices, allServices) {
+        return {
+            mainService: ServiceFormatters.singleService(mainService),
+            otherServices: ServiceFormatters.createServicesByCategoryJSON(otherServices, false, false, false),
+            allOtherServices: ServiceFormatters.createServicesByCategoryJSON(allServices, false, false, true),
+        };
+    }
+
+    toJSON(withHistory = false, showPropertyHistoryOnly = true) {
+        if (!withHistory) {
+            // simple form
+            return this.formatOtherServicesResponse(
+                this._mainService,
+                this.property,
+                this._allServices,
+            );
+        }
+
+        return {
+            otherServices: {
+                currentValue: ServiceFormatters.createServicesByCategoryJSON(this.property, false, false, false),
+                ... this.changePropsToJSON(showPropertyHistoryOnly)
+            }
+        };
+    }
+
+    _valid(thisService) {
+        if (!thisService) return false;
+
+        // must exist a id or name
+        if (!(thisService.id || thisService.name)) return false;
+
+        // if id is given, it must be an integer
+        if (thisService.id && !(Number.isInteger(thisService.id))) return false;
+
+        // gets here, and it's valid
+        return true;
+    }
+
+    // returns false if service definitions are not valid, otherwise returns
+    //  a well formed set of service definitions using data as given in services reference lookup
+    async _validateServices(servicesDef) {
+        const setOfValidatedServices = [];
+        let setOfValidatedServicesInvalid = false;
+
+        // need the set of all services defined and available
+        if (this._allServices === null || !Array.isArray(this._allServices)) return false;
+
+        for (let thisService of servicesDef) {
+            if (!this._valid(thisService)) {
+                // first check the given data structure
+                setOfValidatedServicesInvalid = true;
+                break;
+            }
+
+            // id overrides name, because id is indexed whereas name is not!
+            let referenceService = null;
+            if (thisService.id) {
+                referenceService = this._allServices.find(thisAllService => {
+                    return thisAllService.id === thisService.id;
+                });
+            } else {
+                referenceService = this._allServices.find(thisAllService => {
+                    return thisAllService.name === thisService.name;
+                });
+            }
+
+            if (referenceService && referenceService.id) {
+                // found a service match - prevent duplicates by checking if the reference service already exists
+                if (!setOfValidatedServices.find(thisService => thisService.id === referenceService.id)) {
+                    setOfValidatedServices.push({
+                        id: referenceService.id,
+                        name: referenceService.name,
+                        category: referenceService.category
+                    });
+                }
+            } else {
+                setOfValidatedServicesInvalid = true;
+                break;
+            }
+
+        }
+
+        // if having processed each service correctly, return the set of now validated services
+        if (!setOfValidatedServicesInvalid) return setOfValidatedServices;
+
+        return false;
+
+    }
+
+};

--- a/server/models/classes/establishment/properties/serviceUsersProperty.js
+++ b/server/models/classes/establishment/properties/serviceUsersProperty.js
@@ -87,7 +87,6 @@ exports.ServiceUsersProperty = class ServiceUsersProperty extends ChangeProperty
     }
 
     formatServiceUsersResponse(allServices) {
-        console.log("WA DEBUG - formatting to JSON: ", allServices)
         return this.property.map(thisService => {
             return {
                 id: thisService.id,

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -15,12 +15,6 @@ module.exports = function(sequelize, DataTypes) {
       unique: true,
       field: '"EstablishmentUID"'
     },
-    name: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      unique: true,
-      field: '"Name"'
-    },
     address: {
       type: DataTypes.TEXT,
       allowNull: false,
@@ -41,10 +35,56 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: false,
       field: '"IsRegulated"'
     },
-    mainServiceId: {
+    NameValue: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      unique: true,
+      field: '"NameValue"'
+    },
+    NameSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"NameSavedAt"'
+    },
+    NameChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"NameChangedAt"'
+    },
+    NameSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"NameSavedBy"'
+    },
+    NameChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"NameChangedBy"'
+    },
+    MainServiceFKValue: {
       type: DataTypes.INTEGER,
       allowNull: true,
-      field: '"MainServiceId"'
+      field: '"MainServiceFKValue"'
+    },
+    MainServiceFKSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"MainServiceFKSavedAt"'
+    },
+    MainServiceFKChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"MainServiceFKChangedAt"'
+    },
+    MainServiceFKSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"MainServiceFKSavedBy"'
+    },
+    MainServiceFKChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"MainServiceFKChangedBy"'
     },
     EmployerTypeValue: {
       type: DataTypes.ENUM,
@@ -116,6 +156,26 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.TEXT,
       allowNull: true,
       field: '"OtherServicesChangedBy"'
+    },
+    ServiceUsersSavedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"ServiceUsersSavedAt"'
+    },
+    ServiceUsersChangedAt : {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"ServiceUsersChangedAt"'
+    },
+    ServiceUsersSavedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"ServiceUsersSavedBy"'
+    },
+    ServiceUsersChangedBy : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"ServiceUsersChangedBy"'
     },
     CapacityServicesSavedAt : {
       type: DataTypes.DATE,
@@ -306,7 +366,7 @@ module.exports = function(sequelize, DataTypes) {
       as: 'users'
     });
     Establishment.belongsTo(models.services, {
-      foreignKey: 'mainServiceId',
+      foreignKey: 'MainServiceFKValue',
       targetKey: 'id',
       as: 'mainService'
     });
@@ -315,6 +375,12 @@ module.exports = function(sequelize, DataTypes) {
       foreignKey: 'establishmentId',
       targetKey: 'id',
       as: 'otherServices'
+    });
+    Establishment.belongsToMany(models.serviceUsers, {
+      through: 'establishmentServiceUsers',
+      foreignKey: 'establishmentId',
+      targetKey: 'id',
+      as: 'serviceUsers'
     });
     Establishment.hasMany(models.establishmentCapacity, {
       foreignKey: 'establishmentId',

--- a/server/models/establishmentServiceUsers.js
+++ b/server/models/establishmentServiceUsers.js
@@ -1,0 +1,25 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  const EstablishmentServiceUsers = sequelize.define('establishmentServiceUsers', {
+    establishmentId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      field: '"EstablishmentID"'
+    },
+    serviceUserId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      field: '"ServiceUserID"'
+    }
+  }, {
+    tableName: '"EstablishmentServiceUsers"',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+
+  return EstablishmentServiceUsers;
+};

--- a/server/routes/establishments/capacity.js
+++ b/server/routes/establishments/capacity.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router({mergeParams: true});
 
 const Establishment = require('../../models/classes/establishment');
-const filteredProperties = ['CapacityServices'];
+const filteredProperties = ['CapacityServices', 'Name'];
 
 router.route('/').get(async (req, res) => {
   const establishmentId = req.establishmentId;

--- a/server/routes/establishments/employerType.js
+++ b/server/routes/establishments/employerType.js
@@ -4,7 +4,7 @@ const models = require('../../models');
 
 // all user functionality is encapsulated
 const Establishment = require('../../models/classes/establishment');
-const filteredProperties = ['EmployerType'];
+const filteredProperties = ['EmployerType', 'Name'];
 
 // gets current employer type for the known establishment
 router.route('/').get(async (req, res) => {

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -7,6 +7,8 @@ const Authorization = require('../../utils/security/isAuthenticated');
 // all user functionality is encapsulated
 const Establishment = require('../../models/classes/establishment');
 
+const Name = require('./name');
+const MainService = require('./mainService');
 const EmployerType = require('./employerType');
 const Services = require('./services');
 const ServiceUsers = require('./serviceUsers');
@@ -19,6 +21,8 @@ const Worker = require('./worker');
 
 // ensure all establishment routes are authorised
 router.use('/:id', Authorization.hasAuthorisedEstablishment);
+router.use('/:id/name', Name);
+router.use('/:id/mainService', MainService);
 router.use('/:id/employerType', EmployerType);
 router.use('/:id/services', Services);
 router.use('/:id/serviceUsers', ServiceUsers);

--- a/server/routes/establishments/jobs.js
+++ b/server/routes/establishments/jobs.js
@@ -4,7 +4,7 @@ const router = express.Router({mergeParams: true});
 const JobFormatters = require('../../models/api/jobs');
 
 const Establishment = require('../../models/classes/establishment');
-const filteredProperties = ['Vacancies', 'Starters', 'Leavers'];
+const filteredProperties = ['Name', 'Vacancies', 'Starters', 'Leavers'];
 
 // gets current job quotas for the known establishment
 router.route('/').get(async (req, res) => {

--- a/server/routes/establishments/la.js
+++ b/server/routes/establishments/la.js
@@ -4,7 +4,7 @@ const models = require('../../models');
 const LaFormatters = require('../../models/api/la');
 
 const Establishment = require('../../models/classes/establishment');
-const filteredProperties = ['ShareWithLA'];
+const filteredProperties = ['Name', 'ShareWithLA'];
 
 // gets current set of Local Authorities to share with for the known establishment
 router.route('/').get(async (req, res) => {

--- a/server/routes/establishments/mainService.js
+++ b/server/routes/establishments/mainService.js
@@ -1,0 +1,116 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+
+// all user functionality is encapsulated
+const Establishment = require('../../models/classes/establishment');
+const filteredProperties = ['Name', 'MainServiceFK'];
+
+// gets current employer type for the known establishment
+router.route('/').get(async (req, res) => {
+  const establishmentId = req.establishmentId;
+
+  const showHistory = req.query.history === 'full' || req.query.history === 'property' || req.query.history === 'timeline' ? true : false;
+  const showHistoryTime = req.query.history === 'timeline' ? true : false;
+  const showPropertyHistoryOnly = req.query.history === 'property' ? true : false;
+
+  // validating establishment id - must be a V4 UUID or it's an id
+  const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
+  let byUUID = null, byID = null;
+  if (typeof establishmentId === 'string' && uuidRegex.test(establishmentId.toUpperCase())) {
+    byUUID = establishmentId;
+  } else if (Number.isInteger(establishmentId)) {
+    byID = parseInt(escape(establishmentId));
+  } else {
+    // unexpected establishment id
+    return res.status(400).send();
+  }
+
+  const thisEstablishment = new Establishment.Establishment(req.username);
+
+  try {
+    if (await thisEstablishment.restore(byID, byUUID, showHistory)) {
+      // show only brief info on Establishment
+
+      return res.status(200).json(thisEstablishment.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime, false, false, filteredProperties));
+    } else {
+      // not found worker
+      return res.status(404).send('Not Found');
+    }
+
+  } catch (err) {
+    const thisError = new Establishment.EstablishmentExceptions.EstablishmentRestoreException(
+      thisEstablishment.id,
+      thisEstablishment.uid,
+      null,
+      err,
+      null,
+      `Failed to retrieve Establishment with id/uid: ${establishmentId}`);
+
+    console.error('establishment::mainService GET/:eID - failed', thisError.message);
+    return res.status(503).send(thisError.safe);
+  }
+});
+
+// updates the current employer type for the known establishment
+router.route('/').post(async (req, res) => {
+  const establishmentId = req.establishmentId;
+
+  // validating establishment id - must be a V4 UUID or it's an id
+  const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
+  let byUUID = null, byID = null;
+  if (typeof establishmentId === 'string' && uuidRegex.test(establishmentId.toUpperCase())) {
+      byUUID = establishmentId;
+  } else if (Number.isInteger(establishmentId)) {
+    byID = parseInt(escape(establishmentId));
+  } else {
+    // unexpected establishment id
+    return res.status(400).send();
+  }
+  
+  const thisEstablishment = new Establishment.Establishment(req.username);
+
+
+  try {
+    // before updating an Establishment, we need to be sure the Establishment is
+    //  available to the given user. The best way of doing that
+    //  is to restore from given UID
+    // by loading the Establishment before updating it, we have all the facts about
+    //  an Establishment (if needing to make inter-property decisions)
+    if (await thisEstablishment.restore(byID, byUUID)) {
+      // TODO: JSON validation
+
+      // by loading after the restore, only those properties defined in the
+      //  POST body will be updated (peristed)
+      // With this endpoint we're only interested in name
+      const isValidEstablishment = await thisEstablishment.load({
+        mainService: req.body.mainService
+      });
+
+      // this is an update to an existing Establishment, so no mandatory properties!
+      if (isValidEstablishment) {
+        await thisEstablishment.save(req.username);
+
+        return res.status(200).json(thisEstablishment.toJSON(false, false, false, true, false, filteredProperties));
+      } else {
+        return res.status(400).send('Unexpected Input.');
+      }
+        
+    } else {
+      // not found worker
+      return res.status(404).send('Not Found');
+    }
+  } catch (err) {
+    
+    if (err instanceof Establishment.EstablishmentExceptions.EstablishmentJsonException) {
+      console.error("Establishment::mainService POST: ", err.message);
+      return res.status(400).send(err.safe);
+    } else if (err instanceof Establishment.EstablishmentExceptions.EstablishmentSaveException) {
+      console.error("Establishment::mainService POST: ", err.message);
+      return res.status(503).send(err.safe);
+    } else {
+      console.error("Unexpected exception: ", err);
+    }
+  }
+});
+
+module.exports = router;

--- a/server/routes/establishments/name.js
+++ b/server/routes/establishments/name.js
@@ -1,0 +1,116 @@
+const express = require('express');
+const router = express.Router({mergeParams: true});
+
+// all user functionality is encapsulated
+const Establishment = require('../../models/classes/establishment');
+const filteredProperties = ['Name'];
+
+// gets current employer type for the known establishment
+router.route('/').get(async (req, res) => {
+  const establishmentId = req.establishmentId;
+
+  const showHistory = req.query.history === 'full' || req.query.history === 'property' || req.query.history === 'timeline' ? true : false;
+  const showHistoryTime = req.query.history === 'timeline' ? true : false;
+  const showPropertyHistoryOnly = req.query.history === 'property' ? true : false;
+
+  // validating establishment id - must be a V4 UUID or it's an id
+  const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
+  let byUUID = null, byID = null;
+  if (typeof establishmentId === 'string' && uuidRegex.test(establishmentId.toUpperCase())) {
+    byUUID = establishmentId;
+  } else if (Number.isInteger(establishmentId)) {
+    byID = parseInt(escape(establishmentId));
+  } else {
+    // unexpected establishment id
+    return res.status(400).send();
+  }
+
+  const thisEstablishment = new Establishment.Establishment(req.username);
+
+  try {
+    if (await thisEstablishment.restore(byID, byUUID, showHistory)) {
+      // show only brief info on Establishment
+
+      return res.status(200).json(thisEstablishment.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime, false, false, filteredProperties));
+    } else {
+      // not found worker
+      return res.status(404).send('Not Found');
+    }
+
+  } catch (err) {
+    const thisError = new Establishment.EstablishmentExceptions.EstablishmentRestoreException(
+      thisEstablishment.id,
+      thisEstablishment.uid,
+      null,
+      err,
+      null,
+      `Failed to retrieve Establishment with id/uid: ${establishmentId}`);
+
+    console.error('establishment::name GET/:eID - failed', thisError.message);
+    return res.status(503).send(thisError.safe);
+  }
+});
+
+// updates the current employer type for the known establishment
+router.route('/').post(async (req, res) => {
+  const establishmentId = req.establishmentId;
+
+  // validating establishment id - must be a V4 UUID or it's an id
+  const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
+  let byUUID = null, byID = null;
+  if (typeof establishmentId === 'string' && uuidRegex.test(establishmentId.toUpperCase())) {
+      byUUID = establishmentId;
+  } else if (Number.isInteger(establishmentId)) {
+    byID = parseInt(escape(establishmentId));
+  } else {
+    // unexpected establishment id
+    return res.status(400).send();
+  }
+  
+  const thisEstablishment = new Establishment.Establishment(req.username);
+
+
+  try {
+    // before updating an Establishment, we need to be sure the Establishment is
+    //  available to the given user. The best way of doing that
+    //  is to restore from given UID
+    // by loading the Establishment before updating it, we have all the facts about
+    //  an Establishment (if needing to make inter-property decisions)
+    if (await thisEstablishment.restore(byID, byUUID)) {
+      // TODO: JSON validation
+
+      // by loading after the restore, only those properties defined in the
+      //  POST body will be updated (peristed)
+      // With this endpoint we're only interested in name
+      const isValidEstablishment = await thisEstablishment.load({
+        name: req.body.name
+      });
+
+      // this is an update to an existing Establishment, so no mandatory properties!
+      if (isValidEstablishment) {
+        await thisEstablishment.save(req.username);
+
+        return res.status(200).json(thisEstablishment.toJSON(false, false, false, true, false, filteredProperties));
+      } else {
+        return res.status(400).send('Unexpected Input.');
+      }
+        
+    } else {
+      // not found worker
+      return res.status(404).send('Not Found');
+    }
+  } catch (err) {
+    
+    if (err instanceof Establishment.EstablishmentExceptions.EstablishmentJsonException) {
+      console.error("Establishment::name POST: ", err.message);
+      return res.status(400).send(err.safe);
+    } else if (err instanceof Establishment.EstablishmentExceptions.EstablishmentSaveException) {
+      console.error("Establishment::name POST: ", err.message);
+      return res.status(503).send(err.safe);
+    } else {
+      console.error("Unexpected exception: ", err);
+    }
+  }
+});
+
+module.exports = router;

--- a/server/routes/establishments/serviceUsers.js
+++ b/server/routes/establishments/serviceUsers.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router({mergeParams: true});
 
 const Establishment = require('../../models/classes/establishment');
-const filteredProperties = ['ServiceUsers'];
+const filteredProperties = ['Name', 'ServiceUsers'];
 
 router.route('/').get(async (req, res) => {
   const establishmentId = req.establishmentId;
@@ -44,7 +44,7 @@ router.route('/').get(async (req, res) => {
       null,
       `Failed to retrieve Establishment with id/uid: ${establishmentId}`);
 
-    console.error('establishment::services GET/:eID - failed', thisError.message);
+    console.error('establishment::serviceUsers GET/:eID - failed', thisError.message);
     return res.status(503).send(thisError.safe);
   }
 });
@@ -102,10 +102,10 @@ router.route('/').post(async (req, res) => {
   } catch (err) {
     
     if (err instanceof Establishment.EstablishmentExceptions.EstablishmentJsonException) {
-      console.error("Establishment::services POST: ", err.message);
+      console.error("Establishment::serviceUsers POST: ", err.message);
       return res.status(400).send(err.safe);
     } else if (err instanceof Establishment.EstablishmentExceptions.EstablishmentSaveException) {
-      console.error("Establishment::services POST: ", err.message);
+      console.error("Establishment::serviceUsers POST: ", err.message);
       return res.status(503).send(err.safe);
     } else {
       console.error("Unexpected exception: ", err);

--- a/server/routes/establishments/serviceUsers.js
+++ b/server/routes/establishments/serviceUsers.js
@@ -23,7 +23,7 @@ router.route('/').get(async (req, res) => {
     return res.status(400).send();
   }
 
-  /* const thisEstablishment = new Establishment.Establishment(req.username);
+  const thisEstablishment = new Establishment.Establishment(req.username);
 
   try {
     if (await thisEstablishment.restore(byID, byUUID, showHistory)) {
@@ -46,8 +46,7 @@ router.route('/').get(async (req, res) => {
 
     console.error('establishment::services GET/:eID - failed', thisError.message);
     return res.status(503).send(thisError.safe);
-  } */
-  return res.status(200).send({});
+  }
 });
 
 // updates the current set of other services for the known establishment
@@ -66,8 +65,7 @@ router.route('/').post(async (req, res) => {
     return res.status(400).send();
   }
   
-
-  /* const thisEstablishment = new Establishment.Establishment(req.username);
+  const thisEstablishment = new Establishment.Establishment(req.username);
   try {
     // before updating an Establishment, we need to be sure the Establishment is
     //  available to the given user. The best way of doing that
@@ -79,9 +77,9 @@ router.route('/').post(async (req, res) => {
 
       // by loading after the restore, only those properties defined in the
       //  POST body will be updated (peristed)
-      // With this endpoint we're only interested in services
+      // With this endpoint we're only interested in service users
       const isValidEstablishment = await thisEstablishment.load({
-        services: req.body.services
+        serviceUsers: req.body.serviceUsers
       });
 
       // this is an update to an existing Establishment, so no mandatory properties!
@@ -112,8 +110,7 @@ router.route('/').post(async (req, res) => {
     } else {
       console.error("Unexpected exception: ", err);
     }
-  } */
-  return res.status(200).send({});
+  }
 });
 
 module.exports = router;

--- a/server/routes/establishments/services.js
+++ b/server/routes/establishments/services.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router({mergeParams: true});
 
 const Establishment = require('../../models/classes/establishment');
-const filteredProperties = ['OtherServices'];
+const filteredProperties = ['Name', 'OtherServices'];
 
 router.route('/').get(async (req, res) => {
   const establishmentId = req.establishmentId;

--- a/server/routes/establishments/shareData.js
+++ b/server/routes/establishments/shareData.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router({mergeParams: true});
 
 const Establishment = require('../../models/classes/establishment');
-const filteredProperties = ['ShareData'];
+const filteredProperties = ['Name', 'ShareData'];
 
 // gets current 'share data' options for the known establishment
 router.route('/').get(async (req, res) => {

--- a/server/routes/establishments/staff.js
+++ b/server/routes/establishments/staff.js
@@ -4,7 +4,7 @@ const models = require('../../models');
 
 // all user functionality is encapsulated
 const Establishment = require('../../models/classes/establishment');
-const filteredProperties = ['NumberOfStaff'];
+const filteredProperties = ['Name', 'NumberOfStaff'];
 
 // gets current staff for the known establishment
 router.route('/').get(async (req, res) => {

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -19,7 +19,7 @@ router.post('/',async function(req, res) {
           isActive:true
         }
         ,
-        attributes: ['id', 'username', 'isActive', 'invalidAttempt', 'registrationId', 'firstLogin', 'Hash'],
+        attributes: ['id', 'username', 'isActive', 'invalidAttempt', 'registrationId', 'firstLogin', 'Hash', 'lastLogin'],
         include: [ {
           model: models.user,
           attributes: ['id', 'FullNameValue', 'EmailValue', 'isAdmin','establishmentId', "UserRoleValue"],
@@ -52,6 +52,7 @@ router.post('/',async function(req, res) {
             const response = formatSuccessulLoginResponse(
               login.user.FullNameValue,
               login.firstLogin,
+              login.lastLogin,
               login.user.UserRoleValue,
               login.user.establishment,
               login.user.establishment.mainService,
@@ -144,11 +145,12 @@ router.post('/',async function(req, res) {
 });
 
 // TODO: enforce JSON schema
-const formatSuccessulLoginResponse = (fullname, firstLoginDate, role, establishment, mainService, expiryDate) => {
+const formatSuccessulLoginResponse = (fullname, firstLoginDate, lastLoggedDate, role, establishment, mainService, expiryDate) => {
   // note - the mainService can be null
   return {
     fullname,
     isFirstLogin: firstLoginDate ? false : true,
+    lastLoggedIn: lastLoggedDate ? lastLoggedDate.toISOString() : null,
     role,
     establishment: {
       id: establishment.id,

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -25,7 +25,7 @@ router.post('/',async function(req, res) {
           attributes: ['id', 'FullNameValue', 'EmailValue', 'isAdmin','establishmentId', "UserRoleValue"],
           include: [{
             model: models.establishment,
-            attributes: ['id', 'uid', 'name', 'isRegulated', 'nmdsId'],
+            attributes: ['id', 'uid', 'NameValue', 'isRegulated', 'nmdsId'],
             include: [{
               model: models.services,
               as: 'mainService',
@@ -153,7 +153,7 @@ const formatSuccessulLoginResponse = (fullname, firstLoginDate, role, establishm
     establishment: {
       id: establishment.id,
       uid: establishment.uid,
-      name: establishment.name,
+      name: establishment.NameValue,
       isRegulated: establishment.isRegulated,
       nmdsId: establishment.nmdsId
     },

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -424,15 +424,17 @@ router.route('/')
           defaultError = responseErrors.establishment;
           const newEstablishment = new EstablishmentModel(Logindata.UserName);
           newEstablishment.initialise(
-            Estblistmentdata.Name,
             Estblistmentdata.Address,
             Estblistmentdata.LocationID,
             Estblistmentdata.PostCode,
             Estblistmentdata.IsRegulated,
-            Estblistmentdata.MainServiceId,
             Estblistmentdata.NmdsId
           );
           await newEstablishment.load({
+            name: Estblistmentdata.Name,
+            mainService: {
+              id: Estblistmentdata.MainServiceId
+            }
           });    // no Establishment properties on registration
           if (newEstablishment.hasMandatoryProperties && newEstablishment.isValid) {
             await newEstablishment.save(Logindata.UserName, 0, t);


### PR DESCRIPTION
Two trello cards in one branch/PR:
* https://trello.com/c/6y2OTQmB
* https://trello.com/c/6j4x0gui

This is because both introduce one or more change properties to Establishment, so it is more efficient to do both changes in one go.

It's pretty much everything you've seen before.

The "Service Users" can be zero or more reflexion records; hence the new `EstablishmentServiceUsers` sequelize model (for the table) and new association from `Establishment` sequelize model.

A little wierdness on the name property, in that because it (the name) is returned on every establishment endpoint (GET and POST), because it's now a managed property, every endpoint needs both it's target endpint and the "Name" endpoint.

Any question, just ask of course.