### PR TITLE
Wdf report api stub

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,6 +39,9 @@ var user = require('./server/routes/accounts/user');
 var workerLeaveReasons = require('./server/routes/workerReason');
 var serviceUsers = require('./server/routes/serviceUsers');
 
+// reports
+var ReportsRoute = require('./server/routes/reports/index');
+
 var errors = require('./server/routes/errors');
 
 // test only routes - helpers to setup and execute automated tests
@@ -152,7 +155,7 @@ app.use('/api/establishment', [cacheMiddleware.nocache,establishments]);
 app.use('/api/feedback', [cacheMiddleware.nocache, feedback]);
 app.use('/api/test', [cacheMiddleware.nocache,testOnly]);
 app.use('/api/user', [cacheMiddleware.nocache, user]);
-
+app.use('/api/reports', [cacheMiddleware.nocache, ReportsRoute]);
 
 
 app.get('*', function(req, res) {

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -841,6 +841,57 @@ class Establishment {
 
         return allExistAndValid;
     }
+
+    // returns true if this establishment is WDF eligible as referenced from the
+    //  given effective date; otherwise returns false
+    async isWdfEligible(effectiveFrom) {
+        // TODO - mocked data
+        return Math.random() >= 0.5;
+    }
+
+    _isPropertyWdfBasicEligible(refEpoch, property) {
+        return property &&
+               property.valid &&
+               property.savedAt &&
+               property.savedAt.getTime() > refEpoch;
+    }
+
+    // returns the WDF eligibility of each WDF relevant property as referenced from
+    //  the given effect date
+    async wdf(effectiveFrom) {
+        const myWdf = {};
+        const effectiveFromEpoch = effectiveFrom.getTime();
+
+        // employer type
+        myWdf['employerType'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('EmployerType'));
+
+        // main service & Other Service & Service Capacities & Service Users
+        myWdf['mainService'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('MainServiceFK'));
+        myWdf['otherService'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('OtherServices'));
+        myWdf['capacities'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('CapacityServices'));
+        myWdf['serviceUsers'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('ServiceUsers'));
+
+        // vacancies, starters and leavers
+        myWdf['vacancies'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('Vacancies'));
+        myWdf['starters'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('Starters'));
+        myWdf['leavers'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('Leavers'));
+
+        // TODO - mock data
+        const numStaff = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('NumberOfStaff')) ? this._properties.get('NumberOfStaff').property : 0;
+        myWdf['staff'] = numStaff === 0 ? false : Math.random() >= 0.5;                // TODO - cross-check numStaff against #workers (regardless of whether completed or not)
+        myWdf['weightedStaff'] = Math.random() >= 0.5;                                 // TODO - true if >= 90% of #workers completed
+        
+        return myWdf;
+    }
+
+    // returns the WDF eligibilty as JSON object
+    async wdfToJson(effectiveFrom) {
+        return {
+            effectiveFrom: effectiveFrom.toISOString(),
+            isEligible: await this.isWdfEligible(effectiveFrom),
+            ... await this.wdf(effectiveFrom)
+        };
+    }    
 };
 
 module.exports.Establishment = Establishment;

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -851,6 +851,7 @@ class Establishment {
 
     _isPropertyWdfBasicEligible(refEpoch, property) {
         return property &&
+               property.property !== null &&
                property.valid &&
                property.savedAt &&
                property.savedAt.getTime() > refEpoch;
@@ -891,7 +892,7 @@ class Establishment {
             isEligible: await this.isWdfEligible(effectiveFrom),
             ... await this.wdf(effectiveFrom)
         };
-    }    
+    }
 };
 
 module.exports.Establishment = Establishment;

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -3,6 +3,7 @@ const express = require('express');
 const router = express.Router();
 
 const Authorization = require('../../utils/security/isAuthenticated');
+const isLocal = require('../../utils/security/isLocalTest').isLocal;
 const WdfUtils = require('../../utils/wdfEligibilityDate');
 
 // all user functionality is encapsulated
@@ -57,7 +58,8 @@ router.route('/:id').get(async (req, res) => {
     }
 
     let effectiveFrom = null;    
-    if(req.query.effectiveFrom) {
+    if(isLocal(req) && req.query.effectiveFrom) {
+        // can only override the WDF effective date in local dev/test environments
         effectiveFrom = new Date(req.query.effectiveFrom);
         
         // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2019-03-01T12:30:00.000Z

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -29,8 +29,24 @@ router.use('/', validateEstablishment);
 // gets all workers
 router.route('/').get(async (req, res) => {
     const establishmentId = req.establishmentId;
+
+    let effectiveFrom = null;    
+    if(isLocal(req) && req.query.effectiveFrom) {
+        // can only override the WDF effective date in local dev/test environments
+        effectiveFrom = new Date(req.query.effectiveFrom);
+        
+        // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2019-03-01T12:30:00.000Z
+
+        if (effectiveFrom.toISOString() !== req.query.effectiveFrom) {
+            console.error('report/wdf/establishment/:eID - effectiveFrom parameter incorrect');
+            return res.status(400).send();
+        }
+    } else {
+        effectiveFrom = WdfUtils.wdfEligibilityDate();
+    }
+
     try {
-        const allTheseWorkers = await Workers.Worker.fetch(establishmentId);
+        const allTheseWorkers = await Workers.Worker.fetch(establishmentId, effectiveFrom);
         return res.status(200).json({
             workers: allTheseWorkers
         });

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -5,6 +5,9 @@
 const express = require('express');
 const router = express.Router({mergeParams: true});
 
+const isLocal = require('../../utils/security/isLocalTest').isLocal;
+const WdfUtils = require('../../utils/wdfEligibilityDate');
+
 // all worker functionality is encapsulated
 const Workers = require('../../models/classes/worker');
 
@@ -50,11 +53,30 @@ router.route('/:workerId').get(async (req, res) => {
     const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
     if (!uuidRegex.test(workerId.toUpperCase())) return res.status(400).send('Unexpected worker id');
 
+    let effectiveFrom = null;    
+    if(isLocal(req) && req.query.effectiveFrom) {
+        // can only override the WDF effective date in local dev/test environments
+        effectiveFrom = new Date(req.query.effectiveFrom);
+        
+        // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2019-03-01T12:30:00.000Z
+
+        if (effectiveFrom.toISOString() !== req.query.effectiveFrom) {
+            console.error('report/wdf/establishment/:eID - effectiveFrom parameter incorrect');
+            return res.status(400).send();
+        }
+    } else {
+        effectiveFrom = WdfUtils.wdfEligibilityDate();
+    }
+
+
     const thisWorker = new Workers.Worker(establishmentId);
 
     try {
         if (await thisWorker.restore(workerId, showHistory)) {
-            return res.status(200).json(thisWorker.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime, false));
+            const jsonResponse = thisWorker.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime, false);
+            if (!showHistory) jsonResponse.wdf = await thisWorker.wdfToJson(effectiveFrom);
+
+            return res.status(200).json(jsonResponse);
         } else {
             // not found worker
             return res.status(404).send('Not Found');

--- a/server/routes/reports/index.js
+++ b/server/routes/reports/index.js
@@ -1,0 +1,14 @@
+// default route for reports
+const express = require('express');
+const router = express.Router();
+
+const WDF = require('./wdf');
+
+// ensure all establishment routes are authorised
+router.use('/wdf', WDF);
+
+router.route('/').get(async (req, res) => {
+    return res.status(501).send();
+});
+
+module.exports = router;

--- a/server/routes/reports/wdf/index.js
+++ b/server/routes/reports/wdf/index.js
@@ -15,9 +15,10 @@ const Establishment = require('../../../models/classes/establishment');
 router.use('/establishment/:id', Authorization.hasAuthorisedEstablishment);
 router.route('/establishment/:id').get(async (req, res) => {
     const establishmentId = req.establishmentId;
-    let effectiveFrom = null;
-    
-    if(req.query.effectiveFrom) {
+
+    let effectiveFrom = null;    
+    if(isLocal(req) && req.query.effectiveFrom) {
+        // can only override the WDF effective date in local dev/test environments
         effectiveFrom = new Date(req.query.effectiveFrom);
         
         // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2019-03-01T12:30:00.000Z

--- a/server/routes/reports/wdf/index.js
+++ b/server/routes/reports/wdf/index.js
@@ -2,7 +2,9 @@
 const express = require('express');
 const router = express.Router();
 
+// security
 const Authorization = require('../../../utils/security/isAuthenticated');
+const isLocal = require('../../../utils/security/isLocalTest').isLocal;
 
 // all user functionality is encapsulated
 const Establishment = require('../../../models/classes/establishment');
@@ -57,7 +59,8 @@ router.route('/establishment/:id').get(async (req, res) => {
                 isEligible: Math.random() >= 0.5,
                 workplace: Math.random() >= 0.5,
                 staff: Math.random() >= 0.5,
-            }
+            },
+            customEffectiveFrom: isLocal(req) ? true : undefined
         });
 
     } catch (err) {

--- a/server/routes/reports/wdf/index.js
+++ b/server/routes/reports/wdf/index.js
@@ -5,6 +5,7 @@ const router = express.Router();
 // security
 const Authorization = require('../../../utils/security/isAuthenticated');
 const isLocal = require('../../../utils/security/isLocalTest').isLocal;
+const WdfUtils = require('../../../utils/wdfEligibilityDate');
 
 // all user functionality is encapsulated
 const Establishment = require('../../../models/classes/establishment');
@@ -19,21 +20,14 @@ router.route('/establishment/:id').get(async (req, res) => {
     if(req.query.effectiveFrom) {
         effectiveFrom = new Date(req.query.effectiveFrom);
         
-        // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2018-04-01T00:00:00.000Z
+        // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2019-03-01T12:30:00.000Z
 
         if (effectiveFrom.toISOString() !== req.query.effectiveFrom) {
             console.error('report/wdf/establishment/:eID - effectiveFrom parameter incorrect');
             return res.status(400).send();
         }
     } else {
-        // calculate the effective from date
-        const today = new Date();
-        const yearStartMonth = 3;           // April (months start at 0)
-        if (today.getMonth() < 3) {
-            effectiveFrom = new Date(Date.UTC(today.getFullYear()-1, 3, 1));
-        } else {
-            effectiveFrom = new Date(Date.UTC(today.getFullYear(), 3, 1));
-        }
+        effectiveFrom = WdfUtils.wdfEligibilityDate();
     }
 
     // validating establishment id - must be a V4 UUID or it's an id

--- a/server/routes/reports/wdf/index.js
+++ b/server/routes/reports/wdf/index.js
@@ -1,0 +1,69 @@
+// WDF report route
+const express = require('express');
+const router = express.Router();
+
+const Authorization = require('../../../utils/security/isAuthenticated');
+
+// all user functionality is encapsulated
+const Establishment = require('../../../models/classes/establishment');
+
+// gets requested establishment
+// optional parameter - "history" must equal "none" (default), "property", "timeline" or "full"
+router.use('/establishment/:id', Authorization.hasAuthorisedEstablishment);
+router.route('/establishment/:id').get(async (req, res) => {
+    const establishmentId = req.establishmentId;
+    let effectiveFrom = null;
+    
+    if(req.query.effectiveFrom) {
+        effectiveFrom = new Date(req.query.effectiveFrom);
+        
+        // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2018-04-01T00:00:00.000Z
+
+        if (effectiveFrom.toISOString() !== req.query.effectiveFrom) {
+            console.error('report/wdf/establishment/:eID - effectiveFrom parameter incorrect');
+            return res.status(400).send();
+        }
+    } else {
+        // calculate the effective from date
+        const today = new Date();
+        const yearStartMonth = 3;           // April (months start at 0)
+        if (today.getMonth() < 3) {
+            effectiveFrom = new Date(Date.UTC(today.getFullYear()-1, 3, 1));
+        } else {
+            effectiveFrom = new Date(Date.UTC(today.getFullYear(), 3, 1));
+        }
+    }
+
+    // validating establishment id - must be a V4 UUID or it's an id
+    const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
+    let byUUID = null, byID = null;
+    if (typeof establishmentId === 'string' && uuidRegex.test(establishmentId.toUpperCase())) {
+        byUUID = establishmentId;
+    } else if (Number.isInteger(establishmentId)) {
+      byID = parseInt(escape(establishmentId));
+    } else {
+      // unexpected establishment id
+      return res.status(400).send();
+    }
+
+    const thisEstablishment = new Establishment.Establishment(req.username);
+
+    try {
+        return res.status(200).send({
+            establishmentUid: establishmentId,
+            timestamp: new Date().toISOString(),
+            effectiveFrom: effectiveFrom.toISOString(),
+            wdf: {
+                isEligible: Math.random() >= 0.5,
+                workplace: Math.random() >= 0.5,
+                staff: Math.random() >= 0.5,
+            }
+        });
+
+    } catch (err) {
+        console.error('report/wdf/establishment/:eID - failed', err);
+        return res.status(503).send();
+    }
+});
+
+module.exports = router;

--- a/server/utils/wdfEligibilityDate.js
+++ b/server/utils/wdfEligibilityDate.js
@@ -1,0 +1,10 @@
+exports.wdfEligibilityDate = () => {
+  // calculate the effective from date
+  const today = new Date();
+  const yearStartMonth = 3;           // April (months start at 0)
+  if (today.getMonth() < yearStartMonth) {
+      return new Date(Date.UTC(today.getFullYear()-1, 3, 1));
+  } else {
+      return new Date(Date.UTC(today.getFullYear(), 3, 1));
+  }
+};


### PR DESCRIPTION
Hey Denny

I've worked through the API changes for WDF Eligibility reporting.

I've implemented all API endpoints, including the passing of optional "effective from" date.

All the endpoints return WDF eligibility data in a format that I believe will be useful for you.

The dashboard WDF results are pure mock data (random).

The Establishment WDF results are mainly factual (just have some voodoo stuff to do in regards to the set of Workers); but you have the WDF eligibility by property.

The Worker WDF results are factual; I've raised an issue with Maria about needing better acceptance critiera to handle the inter-property calculations.

The Workers (staff list summary) is factual.

I've not written any automated tests yet, cause wanting to get this to you early so we have plenty of time to play around with formatting data across the APIs so it useful/capable for you.

Looking for your approval here so I can deploy to dev so you can have the endpoints available for your development.

Thanks