### PR TITLE
Qualifications API and Training optional properties reset

### DIFF
--- a/server/models/classes/qualification.js
+++ b/server/models/classes/qualification.js
@@ -1,0 +1,677 @@
+/*
+ * qualification.js
+ *
+ * The encapsulation of a Worker's Qualification record, including all properties, all specific validation (not API, but object validation),
+ * saving & restoring of data to database (via sequelize model), construction and deletion.
+ * 
+ * Also includes representation as JSON, in one or more presentations.
+ *
+ * TO NOTE - Qualification is a simplified representation of User, Worker and Establishment; it does not have any managed properties or auditing.
+ */
+const uuid = require('uuid');
+const moment = require('moment');
+
+// database models
+const models = require('../index');
+
+// known qualification types
+const QUALIFICATION_TYPE = [
+    'NVQ',
+    'Any other qualification',
+    'Certificate',
+    'Degree',
+    'Assessor and mentoring',
+    'Award', 
+    'Diploma',
+    'Apprenticeship'
+];
+
+class Qualification {
+    constructor(establishmentId, workerUid) {
+        this._establishmentId = establishmentId;
+        this._workerUid = workerUid;
+        this._id = null;
+        this._uid = null;
+        this._created = null;
+        this._updated = null;
+        this._updatedBy = null;
+
+        // localised attributes - optional on load
+        this._qualification = null;
+        this._type = null;
+        this._year = null;
+        this._other = null;
+        this._notes = null;
+
+        // lifecycle properties
+        this._isNew = false;
+
+        // UUID validator
+        this.uuidV4Regex = /^[A-F\d]{8}-[A-F\d]{4}-4[A-F\d]{3}-[89AB][A-F\d]{3}-[A-F\d]{12}$/i;
+        
+        // default logging level - errors only
+        // TODO: INFO logging on Training; change to LOG_ERROR only
+        this._logLevel = Qualification.LOG_INFO;
+    }
+
+    // returns true if valid worker uid
+    get _isWorkerUidValid() {
+        if (this._workerUid &&
+            this._establishmentId &&
+            this.uuidV4Regex.test(this._workerUid)
+           ) {
+                return true;
+            } else {
+                return false;
+            }
+    }
+
+    // private logging
+    static get LOG_ERROR() { return 100; }
+    static get LOG_WARN() { return 200; }
+    static get LOG_INFO() { return 300; }
+    static get LOG_TRACE() { return 400; }
+    static get LOG_DEBUG() { return 500; }
+
+    set logLevel(logLevel) {
+        this._logLevel = logLevel;
+    }
+
+    _log(level, msg) {
+        if (this._logLevel >= level) {
+            console.log(`TODO: (${level}) - Qualification class: `, msg);
+        }
+    }
+
+    //
+    // attributes
+    //
+    get id() {
+        return this._id;
+    }
+    get uid() {
+        return this._uid;
+    }
+    get workerUid() {
+        return this._workerUid;
+    }
+
+    get created() {
+        return this._created;
+    }
+    get updated() {
+        return this._updated;
+    }
+    get updatedBy() {
+        return this._updatedBy;
+    }
+
+    get qualification() {
+        return this._qualification;
+    };
+    get type() {
+        return this._type;
+    };
+    get year() {
+        return this._year;
+    };
+    get other() {
+        if (this._other === null) return null;
+        return unescape(this._other);
+    };
+    get notes() {
+        if (this._notes === null) return null;
+        return unescape(this._notes);
+    };
+    set qualification(qualification) {
+        this._qualification = qualification;
+    };
+    set type(type) {
+        this._type = type;
+    };
+    set year(year) {
+        this._year = year;
+    };
+    set other(other) {
+        if (other != null) {
+            this._other = other;
+        }
+    };
+    set notes(notes) {
+        if (notes !== null) {
+            this._notes = escape(notes);
+        }
+    };
+
+    // used by save to initialise a new Qualification Record; returns true if having initialised this Qualification Record
+    _initialise() {
+        if (this._uid === null) {
+            this._isNew = true;
+            this._uid = uuid.v4();
+            
+            if (!this._isWorkerUidValid)
+                throw new Error('Qualification initialisation error');
+
+            // note, do not initialise the id as this will be returned by database
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // validates a given qualification record; returns the qualification record if valid
+    async validateQualificationRecord(document) {
+        // to validate a qualification record, need the list of available qualifications
+        const qualifications = await models.workerAvailableQualifications.findAll({
+            attributes: ['id', 'seq', 'group', 'title', 'level', 'from', 'until'],
+            order: [
+                ["seq", "ASC"]
+            ]
+        });
+
+        if (!qualifications || !Array.isArray(qualifications)) {
+            this._log(Qualification.LOG_ERROR, 'Failed to get all training categories');
+            return false;
+        }
+        
+        const validatedQualificationRecord = {};
+        // type
+        if (document.type) {
+            // validate type - enumeration
+            if (!QUALIFICATION_TYPE.includes(document.type)) {
+                this._log(Qualification.LOG_ERROR, 'type failed validation: unexpected (enum) value');
+                return false;
+            }
+
+            validatedQualificationRecord.type = document.type;
+        }
+
+        // qualification category
+        if (document.qualification) {
+            // validate category
+            if (!(document.qualification.id || (document.qualification.title && document.qualification.level))) {
+                this._log(Qualification.LOG_ERROR, 'qualification failed validation: qualification.id or qualification.title and qualification.level must exist');
+                return false;
+            }
+
+            if (document.qualification.id && !Number.isInteger(document.qualification.id)) {
+                this._log(Qualification.LOG_ERROR, 'qualification failed validation: qualification.id must be an integer');
+                return false;
+            }
+            if (document.qualification.level && !Number.isInteger(document.qualification.level)) {
+                this._log(Qualification.LOG_ERROR, 'qualification failed validation: qualification.level must be an integer');
+                return false;
+            }
+            let foundQualification = null;
+            if (document.qualification.id) {
+                foundQualification = qualifications.find(thisQualification => thisQualification.id === document.qualification.id);
+            } else {
+                foundQualification = qualifications.find(thisQualification => {
+                    return thisQualification.title === document.qualification.title && thisQualification.level === document.qualification.level;
+                });
+            }
+            if (!foundQualification) {
+                this._log(Qualification.LOG_ERROR, 'qualification failed validation: qualification.id or qualification.title and qualification.level must exist');
+                return false;
+            } else {
+                validatedQualificationRecord.qualification = {
+                    id: foundQualification.id,
+                    title: foundQualification.title,
+                    level: foundQualification.level,
+                    group: foundQualification.group
+                };
+            }
+
+            // TODO - need to check the current set of qualifications for any duplicates!
+            // TODO - enforce the from/until dates on qualification?
+            // TODO - need to do some validation between type and qualifications - filter on type!
+            // NOTE - no complex validation on pathway, such as, having completed other qualifications first
+        }
+
+        // other - allow for empty string
+        if (document.other !== null && document.other.length >= 0) {
+            // validate other - it's free text
+            const MAX_LENGTH = 100;
+            if (!(document.other.length <= MAX_LENGTH)) {
+                this._log(Qualification.LOG_ERROR, `other failed validation: must be less than ${MAX_LENGTH} characters`);
+                return false;
+            }
+
+            validatedQualificationRecord.other = document.other;
+        }
+
+        // year
+        if (document.year) {
+            // validate year - it's an integer
+            const MAX_AGE = 100;
+            const CURRENT_YEAR = new Date().getFullYear;
+
+            if (!Number.isInteger(document.year) ||
+                document.year < (CURRENT_YEAR-MAX_AGE) ||
+                document.year > CURRENT_YEAR) {
+                this._log(Qualification.LOG_ERROR, `year failed validation: must be an integer, must be <= this year and not more than ${MAX_AGE} years ago`);
+                return false;
+            }
+
+            validatedQualificationRecord.year = document.year;
+        }
+
+        // notes - allow for notes of empty string
+        if (document.notes !== null && document.notes.length >= 0) {
+            // validate title
+            const MAX_LENGTH=500;
+            if (document.notes.length > MAX_LENGTH) {
+                this._log(Qualification.LOG_ERROR, 'notes failed validation: MAX length');
+                return false;
+            }
+
+            validatedQualificationRecord.notes = document.notes;
+        }
+
+        return validatedQualificationRecord;
+    }
+
+    // takes the given JSON document and updates self (internal properties)
+    // Thows "Error" on error.
+    async load(document) {
+        try {
+            const validatedQualificationRecord = await this.validateQualificationRecord(document);
+
+            if (validatedQualificationRecord !== false) {
+                this.type = validatedQualificationRecord.type;
+                this.qualification = validatedQualificationRecord.qualification;
+                this.year = validatedQualificationRecord.year;
+                this.other = validatedQualificationRecord.other;
+                this.notes = validatedQualificationRecord.notes;
+            } else {
+                this._log(Qualification.LOG_ERROR, `Qualification::load - failed`);
+                throw new Error('Failed Validation');
+            }
+        } catch (err) {
+            this._log(Qualification.LOG_ERROR, `Qualification::load - failed: ${err}`);
+            return false;
+        }
+        return this.isValid();
+    }
+
+    // returns true if Qualification is valid, otherwise false
+    isValid() {
+        if (this.hasMandatoryProperties === true) {
+            return true;
+        } else {
+            this._log(Qualification.LOG_ERROR, `Invalid properties`);
+            return false;
+        }
+    }
+
+    // saves the Qualification record to DB. Returns true if saved; false if not.
+    // Throws "Error" on error
+    async save(savedBy, ttl=0, externalTransaction=null) {
+        let mustSave = this._initialise();
+
+        if (!this.uid) {
+            this._log(Qualification.LOG_ERROR, 'Not able to save an unknown qualification uid');
+            throw Error('Invalid Qualification UID');
+        }
+
+        if (mustSave && this._isNew) {
+            // create new Qualification Record
+            try {
+                // must validate the Worker record - to get the workerFk (integer)
+                const workerRecord = await models.worker.findOne({
+                    where: {
+                        establishmentFk: this._establishmentId,
+                        uid: this._workerUid,
+                        archived: false
+                    },
+                    attributes: ['id']
+                });
+
+                if (workerRecord && workerRecord.id) {
+
+                    const now = new Date();
+                    const creationDocument = {
+                        workerFk: workerRecord.id,
+                        uid: this._uid,
+                        created: now,
+                        updated: now,
+                        updatedBy: savedBy,
+                        type: this._type,
+                        qualificationFk: this._qualification.id,
+                        year: this._year,
+                        other: this._other,
+                        notes: this._notes,
+                        attributes: ['uid', 'created', 'updated'],
+                    };
+
+                    //console.log("WA DEBUG creation document: ", creationDocument)
+    
+                    // need to create the Training record only
+                    //  in one transaction
+                    await models.sequelize.transaction(async t => {
+                        // the saving of an Training record can be initiated within
+                        //  an external transaction
+                        const thisTransaction = externalTransaction ? externalTransaction : t;
+    
+                        // now save the document
+                        let creation = await models.workerQualifications.create(creationDocument, {transaction: thisTransaction});
+    
+                        const sanitisedResults = creation.get({plain: true});
+    
+                        this._id = sanitisedResults.ID;
+                        this._created = sanitisedResults.created;
+                        this._updated = sanitisedResults.updated;
+                        this._updatedBy = savedBy;
+                        this._isNew = false;
+    
+                        this._log(Qualification.LOG_INFO, `Created Qualification Record with uid (${this.uid})`);
+                    });
+                } else {
+                    throw new Error('Worker record not found');
+                }
+                
+            } catch (err) {
+                // catch duplicate error
+                if (err.name && err.name === 'SequelizeUniqueConstraintError') {
+                    if (err.parent.constraint && err.parent.constraint === 'Workers_WorkerQualifications_unq') {
+                        throw new Error('Failed to save new Qualification record - duplicate');
+                    }
+                }
+
+                this._log(Qualification.LOG_ERROR, `Failed to save new qualification record: ${err}`);
+                throw new Error('Failed to save new Qualification record');
+            }
+        } else {
+            // we are updating an existing Qualification Record
+            try {
+                const updatedTimestamp = new Date();
+
+                // need to update the existing Qualification record only within a single transaction
+                await models.sequelize.transaction(async t => {
+                    // the saving of an Qualification record can be initiated within
+                    //  an external transaction
+                    const thisTransaction = externalTransaction ? externalTransaction : t;
+
+                    const updateDocument = {
+                        type: this._type,
+                        qualificationFk: this._qualification.id,
+                        year: this._year,
+                        other: this._other,
+                        notes: this._notes,
+                        updated: updatedTimestamp,
+                        updatedBy: savedBy
+                    };
+
+                    // now save the document
+                    let [updatedRecordCount, updatedRows] =
+                        await models.workerQualifications.update(updateDocument,
+                                                           {
+                                                                returning: true,
+                                                                where: {
+                                                                    uid: this.uid
+                                                                },
+                                                                attributes: ['id', 'updated'],
+                                                                transaction: thisTransaction,
+                                                           }
+                                                          );
+
+                    if (updatedRecordCount === 1) {
+                        const updatedRecord = updatedRows[0].get({plain: true});
+
+                        this._updated = updatedRecord.updated;
+                        this._updatedBy = savedBy;
+                        this._id = updatedRecord.ID;
+
+                        this._log(Qualification.LOG_INFO, `Updated Qualification record with uid (${this.uid})`);
+
+                    } else {
+                        this._log(Qualification.LOG_ERROR, `Failed to update resulting Qualification record with id (${this._id})`);
+                        throw new Error('Failed to update Qualification record');
+                    }
+
+                });
+                
+            } catch (err) {
+                this._log(Qualification.LOG_ERROR, `Failed to update Qualification record with id (${this._id})`);
+                throw new Error('Failed to update Qualification record');
+            }
+
+        }
+
+        return mustSave;
+    };
+
+    // loads the Qualification record (with given uid) from DB, but only if it belongs to the given Worker
+    // returns true on success; false if no Qualification Record
+    // Can throw Error exception.
+    async restore(uid) {
+
+        if (!this.uuidV4Regex.test(uid)) {
+            this._log(Qualification.LOG_ERROR, 'Failed to restore Qualification record with invalid UID');
+            throw new Error('Failed to restore');
+        }
+
+        if (!this._establishmentId ||
+            !this._workerUid) {
+            this._log(Qualification.LOG_ERROR, 'Failed to restore Qualification record with unknown worker id and establishment id');
+            throw new Error('Failed to restore');
+        }
+
+        try {
+            // by including the worker id in the fetch, we are sure to only fetch those
+            //  Qualification records associated to the given Worker   
+            const fetchQuery = {
+                where: {
+                    uid: uid,
+                },
+                include: [
+                    {
+                        model: models.worker,
+                        as: 'worker',
+                        attributes: ['id', 'uid'],
+                        where: {
+                            uid: this._workerUid
+                        }
+                    },
+                    {
+                        model: models.workerAvailableQualifications,
+                        as: 'qualification',
+                    }
+                ]
+            };
+
+            const fetchResults = await models.workerQualifications.findOne(fetchQuery);
+            if (fetchResults && fetchResults.id && Number.isInteger(fetchResults.id)) {
+                // update self - don't use setters because they modify the change state
+                this._isNew = false;
+                this._id = fetchResults.id;
+                this._uid = fetchResults.uid;
+
+                this._qualification = {
+                    id: fetchResults.qualificationFk,
+                    group: fetchResults.qualification.group,
+                    title: fetchResults.qualification.title,
+                    level: fetchResults.qualification.level,
+                };
+                this._type = fetchResults.type;
+                this._year = fetchResults.year;
+                this._other = fetchResults.other !== null && fetchResults.other.length === 0 ? null : fetchResults.other;
+                this._notes = fetchResults.notes !== null && fetchResults.notes.length === 0 ? null : fetchResults.notes;
+                
+                this._created = fetchResults.created;
+                this._updated = fetchResults.updated;
+                this._updatedBy = fetchResults.updatedBy;
+
+                return true;
+            }
+
+            return false;
+
+        } catch (err) {
+            // typically errors when making changes to model or database schema!
+            this._log(Qualification.LOG_ERROR, err);
+
+            throw new Error(`Failed to load Qualification record with uid (${this.uid})`);
+        }
+    };
+
+    // deletes this Qualification Record from DB
+    // Can throw "Error"
+    async delete() {
+        if (this._workerUid === null ||
+            this._establishmentId === null) {
+            this._log(Qualification.LOG_ERROR, 'Cannot delete a qualification record having unknown establishment uid or worker uid');
+            throw new Error('Failed to delete');
+        }
+
+        try {
+            // by getting here, we known the Qualification record belongs to the Worker, because it's been validated by restoring the training record first
+            const fetchQuery = {
+                where: {
+                    uid: this._uid,
+                },
+                include: [
+                    {
+                        model: models.worker,
+                        as: 'worker',
+                        attributes: ['id', 'uid'],
+                        where: {
+                            uid: this._workerUid
+                        }
+                    }
+                ]
+            };
+
+            const deleteResults = await models.workerQualifications.destroy(fetchQuery);  // returns the number of records deleted
+            if (deleteResults === 1) {
+                // reset self - don't use setters because they modify the change state
+                this._isNew = false;
+                this._id = null;
+                this._uid = null;
+                this._workerUid = null;
+                this._establishmentId = null;
+
+                this._qualification = null;
+                this._type = null;
+                this._other = null;
+                this._year = null;
+                this._notes = null;
+
+                this._created = null;
+                this._updated = null;
+                this._updatedBy = null;
+
+                return true;
+            }
+
+            return false;
+
+        } catch (err) {
+            // typically errors when making changes to model or database schema!
+            this._log(Qualification.LOG_ERROR, err);
+
+            throw new Error(`Failed to delete Qualification record with uid (${this.uid})`);
+        }
+    };
+
+    // returns a set of Workers' Qualification Records based on given filter criteria (all if no filters defined) - restricted to the given Worker
+    static async fetch(establishmentId, workerId, filters=null) {
+        if (filters) throw new Error("Filters not implemented");
+
+        const allQualificationRecords = [];
+        const fetchResults = await models.workerQualifications.findAll({
+            include: [
+                {
+                    model: models.worker,
+                    as: 'worker',
+                    attributes: ['id', 'uid'],
+                    where: {
+                        uid: workerId
+                    }
+                },
+                {
+                    model: models.workerAvailableQualifications,
+                    as: 'qualification',
+                    attributes: ['id', 'group', 'title', 'level']
+                }
+            ],
+            order: [
+                //['completed', 'DESC'],
+                ['updated', 'DESC']
+            ]           
+        });
+
+        if (fetchResults) {
+            fetchResults.forEach(thisRecord => {
+                allQualificationRecords.push({
+                    uid: thisRecord.uid,
+                    type: thisRecord.type,
+                    qualification: {
+                        group: thisRecord.qualification.group,
+                        title: thisRecord.qualification.title,
+                        level: thisRecord.qualification.level,
+                    },
+                    other: thisRecord.other !== null && thisRecord.other.length > 0 ? unescape(thisRecord.other) : undefined,
+                    year: thisRecord.year,
+                    notes: thisRecord.notes !== null && thisRecord.notes.length > 0 ? unescape(thisRecord.notes) : undefined,
+                    created:  thisRecord.created.toISOString(),
+                    updated: thisRecord.updated.toISOString(),
+                    updatedBy: thisRecord.updatedBy,
+                })
+            });
+        }
+
+        let lastUpdated = null;
+        if (fetchResults && fetchResults.length === 1) {
+            lastUpdated = fetchResults[0];
+        } else if (fetchResults && fetchResults.length > 1) {
+            lastUpdated = fetchResults.reduce((a, b) => { return a.updated > b.updated ? a : b; });;
+        }
+        
+        const response = {
+            workerUid: workerId,
+            count: allQualificationRecords.length,
+            lastUpdated: lastUpdated ? lastUpdated.updated.toISOString() : undefined,
+            qualifications: allQualificationRecords,
+        };
+
+        return response;
+    };
+
+    // returns a Javascript object which can be used to present as JSON
+    toJSON() {
+        // add worker default properties
+        const myDefaultJSON = {
+            uid:  this.uid,
+            workerUid: this._workerUid,
+            created: this.created.toJSON(),
+            updated: this.updated.toJSON(),
+            updatedBy: this.updatedBy,
+            qualification: this.qualification,
+            type: this.type,
+            other: this.other ? this.other : undefined,
+            year: this.year,
+            notes: this._notes !== null ? this.notes : undefined
+        };
+
+        return myDefaultJSON;
+
+    }
+
+    // HELPERS
+    // returns true if all mandatory properties for a Training Record exist and are valid
+    get hasMandatoryProperties() {
+        let allExistAndValid = true;    // assume all exist until proven otherwise
+        
+        // qualification must exist
+        // type must exist
+        // year must exist
+        if (this.qualification === null ||
+            this.year === null ||
+            this.type === null) allExistAndValid = true
+
+        return allExistAndValid;
+    }
+};
+
+module.exports.Qualification = Qualification;

--- a/server/models/classes/qualification.js
+++ b/server/models/classes/qualification.js
@@ -134,12 +134,18 @@ class Qualification {
     };
     set other(other) {
         if (other != null) {
+            // do not escape null
             this._other = other;
+        } else {
+            this._other = null;
         }
     };
     set notes(notes) {
         if (notes !== null) {
+            // do not escape null
             this._notes = escape(notes);
+        } else {
+            this._notes = null;
         }
     };
 
@@ -229,7 +235,7 @@ class Qualification {
         }
 
         // other - allow for empty string
-        if (document.other !== null && document.other.length >= 0) {
+        if (document.other) {
             // validate other - it's free text
             const MAX_LENGTH = 100;
             if (!(document.other.length <= MAX_LENGTH)) {
@@ -238,6 +244,9 @@ class Qualification {
             }
 
             validatedQualificationRecord.other = document.other;
+        } else {
+            // other property not present - resetting
+            validatedQualificationRecord.other = null;
         }
 
         // year
@@ -257,7 +266,7 @@ class Qualification {
         }
 
         // notes - allow for notes of empty string
-        if (document.notes !== null && document.notes.length >= 0) {
+        if (document.notes) {
             // validate title
             const MAX_LENGTH=500;
             if (document.notes.length > MAX_LENGTH) {
@@ -266,6 +275,9 @@ class Qualification {
             }
 
             validatedQualificationRecord.notes = document.notes;
+        } else {
+            // notes not present - resetting
+            validatedQualificationRecord.notes = null;
         }
 
         return validatedQualificationRecord;

--- a/server/models/classes/training.js
+++ b/server/models/classes/training.js
@@ -130,7 +130,12 @@ class Training {
         this._expires = expires;
     };
     set notes(notes) {
-        this._notes = escape(notes);
+        if (notes !== null) {
+            // do not escape null!
+            this._notes = escape(notes);
+        } else {
+            this._notes = null;
+        }
     };
 
     // used by save to initialise a new Trainign Record; returns true if having initialised this Training Record
@@ -247,7 +252,6 @@ class Training {
 
         // expires
         if (document.expires) {
-            // validate expires - must be a valid date
             const expectedDate = moment.utc(document.expires);
             if (!expectedDate.isValid()) {
                 this._log(Training.LOG_ERROR, 'expires failed validation: incorrect date');
@@ -260,6 +264,9 @@ class Training {
             }
 
             validatedTrainingRecord.expires = expectedDate;
+        } else {
+            // expires is not present
+            validatedTrainingRecord.expires = null;
         }
 
         // notes
@@ -272,6 +279,9 @@ class Training {
             }
 
             validatedTrainingRecord.notes = document.notes;
+        } else {
+            // notes not present
+            validatedTrainingRecord.notes = null;
         }
 
         return validatedTrainingRecord;
@@ -282,6 +292,8 @@ class Training {
     async load(document) {
         try {
             const validatedTrainingRecord = await this.validateTrainingRecord(document);
+
+            console.log("WA DEBUG - validatedTrainingRecord: ", validatedTrainingRecord);
 
             if (validatedTrainingRecord !== false) {
                 this.category = validatedTrainingRecord.trainingCategory;

--- a/server/models/classes/training.js
+++ b/server/models/classes/training.js
@@ -293,8 +293,6 @@ class Training {
         try {
             const validatedTrainingRecord = await this.validateTrainingRecord(document);
 
-            console.log("WA DEBUG - validatedTrainingRecord: ", validatedTrainingRecord);
-
             if (validatedTrainingRecord !== false) {
                 this.category = validatedTrainingRecord.trainingCategory;
                 this.title = validatedTrainingRecord.title;

--- a/server/models/workerAvailableQualifications.js
+++ b/server/models/workerAvailableQualifications.js
@@ -1,0 +1,70 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  const WorkerQualifications =  sequelize.define('workerAvailableQualifications', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: false,
+      field: '"ID"'
+    },
+    seq: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: 'Seq'
+    },
+    group: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"Group"'
+    },
+    title: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"Title"'
+    },
+    level: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"Level"'
+    },
+    code: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"Code"'
+    },
+    from: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"From"'
+    },
+    until: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"Until"'
+    },
+    multipleLevels: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      field: '"From"'
+    },
+    socialCareRelevant: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      field: '"RelevantToSocialCare"'
+    },
+    analysisFileCode: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: '"AnalysisFileCode"'
+    },
+  }, {
+    tableName: 'Qualifications',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+
+  return WorkerQualifications;
+};

--- a/server/models/workerQualifications.js
+++ b/server/models/workerQualifications.js
@@ -1,0 +1,85 @@
+/* jshint indent: 2 */
+
+module.exports = function(sequelize, DataTypes) {
+  const WorkerQualifications =  sequelize.define('workerQualifications', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+      field: '"ID"'
+    },
+    uid: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      unique: true,
+      field: '"UID"'
+    },
+    workerFk : {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"WorkerFK"'
+    },
+    qualificationFk : {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"QualificationsFK"'
+    },
+    type: {
+      type: DataTypes.ENUM,
+      allowNull: false,
+      values: ['NVQ', 'Any other qualification', 'Certificate', 'Degree', 'Assessor and mentoring', 'Award',  'Diploma', 'Apprenticeship'],
+      field: '"Type"'
+    },
+    year : {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: '"Year"'
+    },
+    other : {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"Other"'
+    },
+    notes: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: '"Notes"'
+    },
+    created: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'created'
+    },
+    updated: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'updated'
+    },
+    updatedBy: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'updatedby'
+    },
+  }, {
+    tableName: 'WorkerQualifications',
+    schema: 'cqc',
+    createdAt: false,
+    updatedAt: false
+  });
+
+  WorkerQualifications.associate = (models) => {
+    WorkerQualifications.belongsTo(models.worker, {
+      foreignKey: 'workerFk',
+      targetKey: 'id',
+      as: 'worker'
+    });
+    WorkerQualifications.belongsTo(models.workerAvailableQualifications, {
+      foreignKey: 'qualificationFk',
+      targetKey: 'id',
+      as: 'qualification'
+    });
+  };
+
+  return WorkerQualifications;
+};

--- a/server/routes/establishments/qualification/index.js
+++ b/server/routes/establishments/qualification/index.js
@@ -26,6 +26,35 @@ router.route('/').get(async (req, res) => {
     }
 });
 
+// returns the set of qualifications that are available to the given worker; this all qualifications except those
+//  already consumed by this worker
+router.route('/available').get(async (req, res) => {
+    // although the establishment id is passed as a parameter, get the authenticated  establishment id from the req
+    const establishmentId = req.establishmentId;
+    const workerUid = req.params.workerId;
+    const byType = req.query.type;
+
+    const thisQualificationRecord = new Qualification(establishmentId, workerUid);
+
+    try {
+        const remainingQualifications = await thisQualificationRecord.myAvailableQualifications(byType);
+        if (remainingQualifications !== false) {
+            return res.status(200).json({
+                workerId: workerUid,
+                type: byType,
+                count: remainingQualifications.length,
+                qualifications: remainingQualifications
+            });
+        } else {
+            return res.status(400).send();
+        }
+
+    } catch (err) {
+        console.error('Qualification::root - failed', err);
+        return res.status(503).send(`Failed to get available Qualification (Types) for Worker having uid: ${workerUid}`);
+    }
+});
+
 // gets requested qualification record using the qualification uid
 router.route('/:qualificationUid').get(async (req, res) => {
     const establishmentId = req.establishmentId;

--- a/server/routes/establishments/qualification/index.js
+++ b/server/routes/establishments/qualification/index.js
@@ -1,0 +1,159 @@
+// default route for Workers' qualification endpoint
+const express = require('express');
+const router = express.Router({mergeParams: true});
+
+// all user functionality is encapsulated
+const Qualification = require('../../../models/classes/qualification').Qualification;
+
+// NOTE - the Worker route uses middleware to validate the given worker id against the known establishment
+//        prior to all qualification endpoints, thus ensuring we this necessary rigidity on Establishment/Worker relationship
+//        for qualification records.
+
+// returns a list of all qualification records for the given worker UID
+// Inherits the security middleware declared in the Worker route for qualification.
+// Inheirts the "workerUid" parameter declared in the Worker route for qualification.
+router.route('/').get(async (req, res) => {
+    // although the establishment id is passed as a parameter, get the authenticated  establishment id from the req
+    const establishmentId = req.establishmentId;
+    const workerUid = req.params.workerId;
+
+    try {
+        const allQualificationRecords = await Qualification.fetch(establishmentId, workerUid);
+        return res.status(200).json(allQualificationRecords);
+    } catch (err) {
+        console.error('Qualification::root - failed', err);
+        return res.status(503).send(`Failed to get Qualification Records for Worker having uid: ${workerUid}`);
+    }
+});
+
+// gets requested qualification record using the qualification uid
+router.route('/:qualificationUid').get(async (req, res) => {
+    const establishmentId = req.establishmentId;
+    const qualificationUid = req.params.qualificationUid;
+    const workerUid = req.params.workerId;
+
+    const thisQualificationRecord = new Qualification(establishmentId, workerUid);
+
+    try {
+        if (await thisQualificationRecord.restore(qualificationUid)) {
+            return res.status(200).json(thisQualificationRecord.toJSON());
+        } else {
+            // not found qualification record
+            return res.status(404).send('Not Found');
+        }
+
+    } catch (err) {
+        console.error(err);
+        return res.status(503).send();
+    }
+});
+
+// creates given qualification record for the 'given' worker by UID
+router.route('/').post(async (req, res) => {
+    const establishmentId = req.establishmentId;
+    const workerUid = req.params.workerId;
+
+    console.log("WA DEBUG - POST qualification - establishment id/worker id",establishmentId, workerUid);
+    const thisQualificationRecord = new Qualification(establishmentId, workerUid);
+    
+    try {
+        // by loading after the restore, only those properties defined in the
+        //  PUT body will be updated (peristed)
+        const isValidRecord = await thisQualificationRecord.load(req.body);
+
+        // this is an update to an existing User, so no mandatory properties!
+        if (isValidRecord) {
+            await thisQualificationRecord.save(req.username);
+
+            return res.status(200).json(thisQualificationRecord.toJSON());
+        } else {
+            return res.status(400).send('Unexpected Input.');
+        }
+
+    } catch (err) {
+        console.error(err);
+        // catch duplicate exception
+        if (err.message.endsWith('duplicate')) {
+            return res.status(400).send();
+        }
+        return res.status(503).send();
+    }
+});
+
+
+// updates requested qualification record using the qualification uid
+router.route('/:qualificationUid').put(async (req, res) => {
+    const establishmentId = req.establishmentId;
+    const qualificationUid = req.params.qualificationUid;
+    const workerUid = req.params.workerId;
+
+    const thisQualificationRecord = new Qualification(establishmentId, workerUid);
+    
+    try {
+        // before updating a Worker, we need to be sure the Worker is
+        //  available to the given establishment. The best way of doing that
+        //  is to restore from given UID
+        if (await thisQualificationRecord.restore(qualificationUid)) {
+            // TODO: JSON validation
+
+            // by loading after the restore, only those properties defined in the
+            //  PUT body will be updated (peristed)
+            const isValidRecord = await thisQualificationRecord.load(req.body);
+
+            // this is an update to an existing User, so no mandatory properties!
+            if (isValidRecord) {
+                await thisQualificationRecord.save(req.username);
+
+                return res.status(200).json(thisQualificationRecord.toJSON());
+            } else {
+                return res.status(400).send('Unexpected Input.');
+            }
+            
+        } else {
+            // not found worker
+            return res.status(404).send('Not Found');
+        }
+
+    } catch (err) {
+        console.error(err);
+        return res.status(503).send();
+    }
+});
+
+
+// deletes requested qualification record using the qualification uid
+router.route('/:qualificationUid').delete(async (req, res) => {
+    const establishmentId = req.establishmentId;
+    const qualificationUid = req.params.qualificationUid;
+    const workerUid = req.params.workerId;
+
+    const thisQualificationRecord = new Qualification(establishmentId, workerUid);
+    
+    try {
+        // before updating a Worker, we need to be sure the Worker is
+        //  available to the given establishment. The best way of doing that
+        //  is to restore from given UID
+        if (await thisQualificationRecord.restore(qualificationUid)) {
+            // TODO: JSON validation
+
+            // by deleting after the restore we can be sure this qualification record belongs to the given worker
+            const deleteSuccess = await thisQualificationRecord.delete();
+
+            if (deleteSuccess) {
+                return res.status(204).json();
+            } else {
+                return res.status(404).json('Not Found');
+            }
+            
+        } else {
+            // not found worker
+            return res.status(404).send('Not Found');
+        }
+
+    } catch (err) {
+        console.error(err);
+        return res.status(503).send();
+    }
+});
+
+module.exports = router;

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -12,6 +12,7 @@ const Workers = require('../../models/classes/worker');
 
 // child routes
 const TrainingRoutes = require('./training');
+const QualificationRoutes = require('./qualification');
 
 // middleware to validate the establishment on all worker endpoints
 const validateEstablishment = async (req, res, next) => {
@@ -51,6 +52,7 @@ const validateWorker = async (req, res, next) => {
 
 router.use('/', validateEstablishment);
 router.use('/:workerId/training', [validateWorker, TrainingRoutes]);
+router.use('/:workerId/qualification', [validateWorker, QualificationRoutes]);
 
 // gets all workers
 router.route('/').get(async (req, res) => {


### PR DESCRIPTION
Trello card: https://trello.com/c/zkIxMNm0

Introducing Qualifications endpoints:
* GET all records for the given Worker
* GET individual record for the given Worker
* POST (create) record for the given Worker
* PUT (update) record for the given Worker
* DELETE record for the given Worker

Based on the same implementation for Worker Training records; in fact, this implementation was branched off `training-api`; hence the target merge branch is `training-api`. This extends to the routing from `Worker` and reusing the Worker/Estabishment authorisation middleware introduced with the Training API.

Currently missing one API endpoint listed on backend tasks: `[GET] .../api/establishment/:eid/worker/:wid/allQualifications`. I may yet find time to complete this before the review and approval of this PR.

Whilst testing the resetting of Qualifications optional values (other/notes), I realised I had missed such logic on training API. Included here are changes to ` server/models/classes/training.js` to reset optional "expires" and "notes".