### PR TITLE
Validation rules now apply to from/until returned from Qualification API

### DIFF
--- a/src/app/core/model/qualification.model.ts
+++ b/src/app/core/model/qualification.model.ts
@@ -53,6 +53,7 @@ export interface Qualification {
   id: number;
   code?: number;
   from?: string;
+  until?: string;
   level?: string;
   title?: string;
   group?: string;

--- a/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
+++ b/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
@@ -32,6 +32,7 @@
             [group]="form.get(item.key)"
             [worker]="worker"
             [type]="item"
+            [yearValidators]="yearValidators"
             [qualification]="record?.qualification?.group === item.value ? record.qualification : null"
           ></app-qualification-form>
         </ng-container>

--- a/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.ts
+++ b/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { QualificationRequest, QualificationResponse, QualificationType } from '@core/model/qualification.model';
 import { Worker } from '@core/model/worker.model';
@@ -18,7 +18,7 @@ export class AddEditQualificationComponent implements OnInit {
   public qualificationId: string;
   public record: QualificationResponse;
   public worker: Worker;
-  public yearValidators: Validators[];
+  public yearValidators: ValidatorFn[];
   private subscriptions: Subscription = new Subscription();
 
   constructor(

--- a/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.ts
+++ b/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.ts
@@ -18,6 +18,7 @@ export class AddEditQualificationComponent implements OnInit {
   public qualificationId: string;
   public record: QualificationResponse;
   public worker: Worker;
+  public yearValidators: Validators[];
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -25,7 +26,16 @@ export class AddEditQualificationComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private workerService: WorkerService
-  ) {}
+  ) {
+    this.yearValidators = [
+      Validators.max(moment().year()),
+      Validators.min(
+        moment()
+          .subtract(100, 'years')
+          .year()
+      ),
+    ];
+  }
 
   ngOnInit() {
     this.form = this.formBuilder.group({
@@ -74,17 +84,7 @@ export class AddEditQualificationComponent implements OnInit {
   createQualificationGroup(): FormGroup {
     return this.formBuilder.group({
       qualification: [null],
-      year: [
-        null,
-        [
-          Validators.max(moment().year()),
-          Validators.min(
-            moment()
-              .subtract(100, 'years')
-              .year()
-          ),
-        ],
-      ],
+      year: [null, this.yearValidators],
       notes: [null, Validators.maxLength(500)],
     });
   }

--- a/src/app/features/workers/add-edit-qualification/qualification-form/qualification-form.component.html
+++ b/src/app/features/workers/add-edit-qualification/qualification-form/qualification-form.component.html
@@ -20,11 +20,11 @@
       <label for="year">
         Year achieved
       </label>
-      <div *ngIf="group.get('year').hasError('max')" class="alert alert-danger">
-        <p>Year achieved can not be a date in the future</p>
-      </div>
       <div *ngIf="group.get('year').hasError('min')" class="alert alert-danger">
-        <p>Year achieved can not be more that 100 years in the past</p>
+        <p>Year achieved can not be before {{ group.get('year').getError('min').min }}</p>
+      </div>
+      <div *ngIf="group.get('year').hasError('max')" class="alert alert-danger">
+        <p>Year achieved can not be after {{ group.get('year').getError('max').max }}</p>
       </div>
       <input type="number" formControlName="year" class="form-control col-3" maxlength="4" />
     </div>

--- a/src/app/features/workers/add-edit-qualification/qualification-form/qualification-form.component.ts
+++ b/src/app/features/workers/add-edit-qualification/qualification-form/qualification-form.component.ts
@@ -1,8 +1,9 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, Validators } from '@angular/forms';
 import { Qualification, QualificationType } from '@core/model/qualification.model';
 import { Worker } from '@core/model/worker.model';
 import { WorkerService } from '@core/services/worker.service';
+import * as moment from 'moment';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -14,6 +15,7 @@ export class QualificationFormComponent implements OnInit, OnDestroy {
   @Input() group: FormGroup;
   @Input() type: { key: string; value: string };
   @Input() qualification: any;
+  @Input() yearValidators;
   public qualifications: Qualification[];
   private subscriptions: Subscription = new Subscription();
 
@@ -27,6 +29,31 @@ export class QualificationFormComponent implements OnInit, OnDestroy {
           this.qualifications = qualifications;
         })
     );
+
+    this.group.get('qualification').valueChanges.subscribe(value => {
+      const year = this.group.get('year');
+      const extraValidators = [];
+      const qualification = this.qualifications.find(qualification => (qualification.id = value));
+
+      console.log(qualification);
+
+      year.clearValidators();
+
+      if (qualification.from) {
+        const from = moment(qualification.from);
+        extraValidators.push(Validators.min(from.year()));
+      }
+
+      if (qualification.until) {
+        const until = moment(qualification.until);
+        extraValidators.push(Validators.max(until.year()));
+      }
+
+      console.log(extraValidators);
+
+      year.setValidators(this.yearValidators.concat(extraValidators));
+      year.updateValueAndValidity();
+    });
   }
 
   ngOnDestroy() {

--- a/src/app/features/workers/add-edit-qualification/qualification-form/qualification-form.component.ts
+++ b/src/app/features/workers/add-edit-qualification/qualification-form/qualification-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { FormGroup, Validators } from '@angular/forms';
+import { FormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { Qualification, QualificationType } from '@core/model/qualification.model';
 import { Worker } from '@core/model/worker.model';
 import { WorkerService } from '@core/services/worker.service';
@@ -14,8 +14,8 @@ export class QualificationFormComponent implements OnInit, OnDestroy {
   @Input() worker: Worker;
   @Input() group: FormGroup;
   @Input() type: { key: string; value: string };
-  @Input() qualification: any;
-  @Input() yearValidators;
+  @Input() qualification: Qualification;
+  @Input() yearValidators: ValidatorFn[];
   public qualifications: Qualification[];
   private subscriptions: Subscription = new Subscription();
 
@@ -32,10 +32,8 @@ export class QualificationFormComponent implements OnInit, OnDestroy {
 
     this.group.get('qualification').valueChanges.subscribe(value => {
       const year = this.group.get('year');
-      const extraValidators = [];
+      const extraValidators: ValidatorFn[] = [];
       const qualification = this.qualifications.find(qualification => (qualification.id = value));
-
-      console.log(qualification);
 
       year.clearValidators();
 
@@ -48,8 +46,6 @@ export class QualificationFormComponent implements OnInit, OnDestroy {
         const until = moment(qualification.until);
         extraValidators.push(Validators.max(until.year()));
       }
-
-      console.log(extraValidators);
 
       year.setValidators(this.yearValidators.concat(extraValidators));
       year.updateValueAndValidity();

--- a/src/app/features/workers/delete-qualification-dialog/delete-qualification-dialog.component.html
+++ b/src/app/features/workers/delete-qualification-dialog/delete-qualification-dialog.component.html
@@ -25,12 +25,12 @@
       {{ data.record.qualification.title }}
     </dd>
   </div>
-  <div class="govuk-summary-list__row">
+  <div *ngIf="data.record.qualification?.level" class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       Qualification level
     </dt>
     <dd class="govuk-summary-list__value">
-      {{ data.record.qualification.level }}
+      {{ data.record.qualification?.level }}
     </dd>
   </div>
 </dl>

--- a/src/app/features/workers/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
+++ b/src/app/features/workers/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
@@ -2,7 +2,7 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Started of completed Care Certificate
+      Started or completed Care Certificate
     </dt>
     <dd class="govuk-summary-list__value">
       {{ worker.careCertificate || '-' }}


### PR DESCRIPTION
Validation rules were missed where a Qualification had imposed a from and/or until date in which it could be achieved. This has now been applied and overwrites the -100 years and future date rules where applicable.