### PR TITLE
WDF Reports Rework

### DIFF
--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -798,7 +798,6 @@ class Establishment {
                 myDefaultJSON.locationRef = this.locationId;
                 myDefaultJSON.isRegulated = this.isRegulated;
                 myDefaultJSON.nmdsId = this.nmdsId;
-                //myDefaultJSON.mainService = ServiceFormatters.singleService(this.mainService);
             }
 
             myDefaultJSON.created = this.created.toJSON();

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -46,7 +46,7 @@ class Establishment {
         this._mainService = null;
         this._nmdsId = null;
         this._lastWdfEligibility = null;
-        this._currentWdfEligibiity = null;
+        this._overallWdfEligibility = null;
 
         // abstracted properties
         const thisEstablishmentManager = new EstablishmentProperties();
@@ -558,7 +558,7 @@ class Establishment {
                 };
                 this._nmdsId = fetchResults.nmdsId;
                 this._lastWdfEligibility = fetchResults.lastWdfEligibility;
-                this._currentWdfEligibiity = fetchResults.currentWdfEligibiity;
+                this._overallWdfEligibility = fetchResults.overallWdfEligibility;
 
                 // if history of the User is also required; attach the association
                 //  and order in reverse chronological - note, order on id (not when)
@@ -890,11 +890,8 @@ class Establishment {
         // this establishment is eligible only if the last eligible date is later than the effective date
         //  the WDF by property will show the current eligibility of each property
         return {
-            isEligible: this._lastWdfEligibility && this._lastWdfEligibility.getTime() > effectiveFrom.getTime() ? true : false,
             lastEligibility: this._lastWdfEligibility ? this._lastWdfEligibility.toISOString() : null,
-            currentEligibility: Object.values(wdfByProperty).every(thisProperty => {
-                return !(thisProperty === 'No');
-            }),
+            isEligible: this._lastWdfEligibility && this._lastWdfEligibility.getTime() > effectiveFrom.getTime() ? true : false,
             ... wdfByProperty
         };
     }
@@ -963,12 +960,9 @@ class Establishment {
     // returns the WDF eligibilty as JSON object
     async wdfToJson() {
         const effectiveFrom = WdfCalculator.effectiveDate;
-        const effectiveTime = WdfCalculator.effectiveTime;
-
-        console.log("WA DEBUG - establishment's wdfToJson - effective date: ", effectiveDate)
-        console.log("WA DEBUG - establishment's wdfToJson - effective time: ", effectiveTime)
         const myWDF = {
             effectiveFrom: effectiveFrom.toISOString(),
+            overalWdfEligible: this._overallWdfEligibility ? this._overallWdfEligibility.toISOString() : false,
             ... await this.isWdfEligible(effectiveFrom)
         };
         return myWDF;

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -383,10 +383,10 @@ class Establishment {
                         // For now, we'll recalculate on every update!
                         const completedProperty = this._properties.get('Completed');
                         if (this._properties.get('Completed') && this._properties.get('Completed').modified) {
-                            await WdfCalculator.calculate(savedBy, this._id, this._uid);
+                            await WdfCalculator.calculate(savedBy, this._id, this._uid, thisTransaction);
                         } else {
                             // TODO - include Completed logic.
-                            await WdfCalculator.calculate(savedBy, this._id, this._uid);
+                            await WdfCalculator.calculate(savedBy, this._id, this._uid, thisTransaction);
                         }
 
                         this._log(Establishment.LOG_INFO, `Updated Establishment with uid (${this.uid}) and name (${this.name})`);
@@ -963,6 +963,10 @@ class Establishment {
     // returns the WDF eligibilty as JSON object
     async wdfToJson() {
         const effectiveFrom = WdfCalculator.effectiveDate;
+        const effectiveTime = WdfCalculator.effectiveTime;
+
+        console.log("WA DEBUG - establishment's wdfToJson - effective date: ", effectiveDate)
+        console.log("WA DEBUG - establishment's wdfToJson - effective time: ", effectiveTime)
         const myWDF = {
             effectiveFrom: effectiveFrom.toISOString(),
             ... await this.isWdfEligible(effectiveFrom)

--- a/server/models/classes/wdfCalculator.js
+++ b/server/models/classes/wdfCalculator.js
@@ -1,0 +1,168 @@
+// this is a singleton used to calculate the overal WDF Eligiblity for an establishment
+//  it also calculates the effective date
+const WdfUtils = require('../../utils/wdfEligibilityDate');
+const models = require('../../models');
+
+class WdfCalculator {
+  constructor() {
+    // initialises with the calculated effective date being this fiscal year
+    this._effectiveDate = WdfUtils.wdfEligibilityDate();
+  }
+
+  get effectiveDate() {
+    return this._effectiveDate;
+  }
+
+  get effectiveTime() {
+    return this._effectiveDate.getTime();
+  }
+
+  // overrides the effective date
+  set effectiveDate(effectiveFrom) {
+    if (effectiveFrom === null) {
+      // resettting the effective date to calculated date from fiscal year
+      this._effectiveDate = WdfUtils.wdfEligibilityDate();
+    } else {
+      this._effectiveDate = effectiveFrom;
+    }
+  }
+
+  // recalculates an establishment's WDF eligibility
+  //   - this method is called internally - not direct from API, hence no user constraint in the find
+  async calculate(savedBy, establishmentID, establishmentUID=null, externalTransaction=null) {
+    console.log("WA DEBUG - recalculating Overall WDF Eligbility for establishment having id/uid: ", establishmentID, establishmentUID);
+
+    try {
+      let thisEstablishment = null;
+      
+      if (establishmentUID) {
+        thisEstablishment = await models.establishment.findOne({
+          attributes: ['id', 'uid', 'lastWdfEligibility', 'overallWdfEligibility', 'NumberOfStaffValue', 'NumberOfStaffSavedAt'],
+          where: {
+            uid: establishmentUID
+          },
+          transaction: externalTransaction
+        });
+      } else {
+        thisEstablishment = await models.establishment.findOne({
+          attributes: ['id', 'uid', 'lastWdfEligibility', 'overallWdfEligibility', 'NumberOfStaffValue', 'NumberOfStaffSavedAt'],
+          where: {
+            id: establishmentID
+          },
+          transaction: externalTransaction
+        });
+      }
+
+      if (thisEstablishment && thisEstablishment.id) {
+        // it's only necessary to recalculate the overal eligibiltiy if this Establishment's Overall Eligibility is not true
+        if (thisEstablishment.overallWdfEligibility &&
+            thisEstablishment.overallWdfEligibility.getTime() > this.effectiveTime) {
+          // already eligibile
+          console.log("WA DEBUG - already eligible")
+          return;
+        }
+
+        console.log("WA DEBUG - not yet eligible")
+        // the establishment must be eligible for the Overall WDF to be eligible
+        if (thisEstablishment.lastWdfEligibility === null |
+            thisEstablishment.lastWdfEligibility.getTime() < this.effectiveTime) {
+          // this establishment fails overal eligibility
+          return;
+        }
+
+        // the establishment must have at least one declared worker record
+        // TODO - confirm if we need to ensure the number of staff has been updated since the effective date
+        console.log("WA DEBUG - establishment is eligible")
+        if (thisEstablishment.NumberOfStaffValue < 1) {
+          return;
+        }
+
+        // all active workers for this establishment
+        console.log("WA DEBUG - establishment has at least one worker")
+        const theseWorkers = await models.worker.findAll({
+          attributes: ['id', 'uid', 'lastWdfEligibility'],
+          where: {
+            establishmentFk: thisEstablishment.id,
+            archived: false
+          },
+          transaction: externalTransaction
+        });
+
+        // the number of active worker records must be the same as the declared Establishment staff
+        console.log(`WA DEBUG - Establishment has #${theseWorkers.length} workers`)
+        if (!(theseWorkers && Array.isArray(theseWorkers) && theseWorkers.length === thisEstablishment.NumberOfStaffValue)) {
+          return;
+        }
+
+        // at least 90% of all current workers must be eligible
+        const allEligibleWorkers = theseWorkers.filter(thisWorker => thisWorker.lastWdfEligibility ? thisWorker.lastWdfEligibility.getTime() > this.effectiveTime : false);
+        console.log(`WA DEBUG - establishment has #${allEligibleWorkers.length} eligible workers`)
+        const weightedStaffEligibility = (allEligibleWorkers.length / theseWorkers.length);
+        console.log(`WA DEBUG - establishment has ${weightedStaffEligibility*100}% eligible workers`)
+        if (weightedStaffEligibility < 0.9) {
+          return;
+        }
+
+        // update establishment's Overall WDF Eligibility and create audit event (within a transaction)
+        await models.sequelize.transaction(async t => {
+          const thisTransaction = externalTransaction ? externalTransaction : t;
+          const updatedTimestamp = new Date();
+
+          const updateDocument = {
+            updated: updatedTimestamp,
+            updatedBy: savedBy,
+            overallWdfEligibility: updatedTimestamp,
+          };
+          let [updatedRecordCount, updatedRows] = await models.establishment.update(
+                    updateDocument,
+                    {
+                        returning: true,
+                        where: {
+                          id: thisEstablishment.id
+                        },
+                        attributes: ['id', 'updated'],
+                        transaction: thisTransaction,
+                    });
+
+          if (updatedRecordCount === 1) {
+            const updatedRecord = updatedRows[0].get({plain: true});
+            const auditEvents = [
+              {
+                establishmentFk: updatedRecord.EstablishmentID,
+                username: savedBy,
+                type: 'overalWdfEligible'
+              },
+              {
+                establishmentFk: updatedRecord.EstablishmentID,
+                username: savedBy,
+                type: 'updated'
+              }
+            ];
+            await models.establishmentAudit.bulkCreate(auditEvents, {transaction: thisTransaction});
+          }
+        });
+
+        // TODO - post to SNS topic
+
+      } else {
+        console.error('WdfCalculator::calculate - Failed to find establishment having id/uid: ', establishmentID, establishmentUID);
+      }
+      
+    } catch (err) {
+      console.error('WdfCalculator::calculate - Failed to fetch establishment/workers: ', err);
+    }
+
+  }
+
+  // reports on WDF Eligibility for the given Establishment
+  async report(establishmentID, establishmentUID) {
+    // TODO
+    console.log("WA DEBUG - recalculating Overall WDF Eligbility for establishment having id/uid: ", establishmentID, establishmentUID);
+  }
+
+}
+
+const THE_WDF_CALCULATOR = new WdfCalculator();
+console.log("WA DEBUG - created Wdf Calculator singleton - effective date: ", THE_WDF_CALCULATOR.effectiveDate);
+
+exports.WdfCalculator = THE_WDF_CALCULATOR;

--- a/server/models/classes/wdfCalculator.js
+++ b/server/models/classes/wdfCalculator.js
@@ -195,8 +195,10 @@ class WdfCalculator {
         // present the Overall WDF Eligibility based on the current effective date
         if (thisEstablishment.overallWdfEligibility &&
             thisEstablishment.overallWdfEligibility.getTime() > this.effectiveTime) {
+          wdfReport.overallWdfEligibility = thisEstablishment.overallWdfEligibility;
           wdfReport.isEligible = true;
         } else {
+          wdfReport.overallWdfEligibility = thisEstablishment.overallWdfEligibility ? thisEstablishment.overallWdfEligibility : undefined;
           wdfReport.isEligible = false;
         }
 

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -809,11 +809,35 @@ class Worker {
 
     _isPropertyWdfBasicEligible(refEpoch, property) {
         // no record given, so test eligibility of this Worker
+        const PER_PROPERTY_ELIGIBLE=0;
+        const RECORD_LEVEL_ELIGIBLE=1;
+        const COMPLETED_PROPERTY_ELIGIBLE=2;
+        const ELIGIBILITY_REFERENCE = PER_PROPERTY_ELIGIBLE;
+
+        let referenceTime = null;
+
+        switch (ELIGIBILITY_REFERENCE) {
+            case PER_PROPERTY_ELIGIBLE:
+              referenceTime = property.savedAt.getTime();
+              break;
+            case RECORD_LEVEL_ELIGIBLE:
+              referenceTime = this._updated.getTime();
+              break;
+            case COMPLETED_PROPERTY_ELIGIBLE:
+              const completedProperty = this._properties.get('Completed');
+              console.log("WA DEBUG - completed property value: ", completedProperty.savedAt)
+              referenceTime = completedProperty && completedProperty.savedAt
+                                    ? completedProperty.savedAt.getTime()
+                                    : null;
+              break;
+        }
+
         return property &&
                 property.property !== null &&
                 property.valid &&
                 property.savedAt &&
-                property.savedAt.getTime() > refEpoch;
+                referenceTime !== null &&
+                referenceTime > refEpoch;
     }
 
     // returns the WDF eligibility of each WDF relevant property as referenced from

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -19,6 +19,9 @@ const WorkerProperties = require('./worker/workerProperties').WorkerPropertyMana
 const JSON_DOCUMENT_TYPE = require('./worker/workerProperties').JSON_DOCUMENT;
 const SEQUELIZE_DOCUMENT_TYPE = require('./worker/workerProperties').SEQUELIZE_DOCUMENT;
 
+// WDF Calculator
+const WdfCalculator = require('./wdfCalculator').WdfCalculator;
+
 class Worker {
     constructor(establishmentId) {
         this._establishmentId = establishmentId;
@@ -45,6 +48,8 @@ class Worker {
 
         // local attributes
         this._reason = null;
+        this._lastWdfEligibility = null;
+        this._currentWdfEligibiity = null;
     }
 
     // returns true if valid establishment id
@@ -229,6 +234,22 @@ class Worker {
                         updatedBy: savedBy
                     };
 
+                    // every time the worker is saved, need to calculate
+                    //  it's current WDF Eligibility, and if it is eligible, update
+                    //  the last WDF Eligibility status
+                    const currentWdfEligibiity = await this.isWdfEligible(WdfCalculator.effectiveDate);
+                    console.log("WA DEBUG - updating Worker - current WDF Eligibility: ", currentWdfEligibiity)
+
+                    let wdfAudit = null;
+                    if (currentWdfEligibiity.currentEligibility) {
+                        console.log("WA DEBUG - updating this worker's last WDF Eligible timestamp")
+                        updateDocument.lastWdfEligibility = updatedTimestamp;
+                        wdfAudit = {
+                            username: savedBy,
+                            type: 'wdfEligible'
+                        };
+                    }
+
                     // now save the document
                     let [updatedRecordCount, updatedRows] =
                         await models.worker.update(updateDocument,
@@ -248,6 +269,7 @@ class Worker {
                         this._updatedBy = savedBy;
                         this._id = updatedRecord.ID;
 
+                        // having updated the record, create the audit event
                         const allAuditEvents = [{
                             workerFk: this._id,
                             username: savedBy,
@@ -257,7 +279,10 @@ class Worker {
                                     workerFk: this._id
                                 };
                             }));
-                            // having updated the record, create the audit event
+                        if (wdfAudit) {
+                            wdfAudit.workerFk = this._id;
+                            allAuditEvents.push(wdfAudit);
+                        }
                         await models.workerAudit.bulkCreate(allAuditEvents, {transaction: thisTransaction});
 
                         // now - work through any additional models having processed all properties (first delete and then re-create)
@@ -292,6 +317,15 @@ class Worker {
                         });
                         await Promise.all(createMmodelPromises);
 
+                        // TODO: ideally I'd like to publish this to pub/sub topic and process async - but do not have pub/sub to hand here
+                        // having updated the Worker, check to see whether it is necessary to recalculate
+                        //  the overall WDF eligibility for this Worker's establishment and all its workers.
+                        //  This decision is done based on if this Worker is being marked as Completed.
+                        const completedProperty = this._properties.get('Completed');
+                        if (completedProperty && completedProperty.modified) {
+                            await WdfCalculator.calculate(savedBy, this._establishmentId, null, thisTransaction);
+                        }
+
                         this._log(Worker.LOG_INFO, `Updated Worker with uid (${this._uid}) and id (${this._id})`);
 
                     } else {
@@ -302,7 +336,6 @@ class Worker {
                                                                     err,
                                                                     `Failed to update resulting worker record with uid: ${this._uid}`);
                     }
-
 
                 });
                 
@@ -410,6 +443,10 @@ class Worker {
                 this._created = fetchResults.created;
                 this._updated = fetchResults.updated;
                 this._updatedBy = fetchResults.updatedBy;
+                this._lastWdfEligibility = fetchResults.lastWdfEligibility;
+                this._currentWdfEligibiity = fetchResults.currentWdfEligibiity;
+
+                console.log("WA DEBUG - Worker eligibility: ", fetchResults.lastWdfEligibility, fetchResults.currentWdfEligibiity)
 
                 // if history of the Worker is also required; attach the association
                 //  and order in reverse chronological - note, order on id (not when)
@@ -524,68 +561,85 @@ class Worker {
     };
 
     // returns a set of Workers based on given filter criteria (all if no filters defined) - restricted to the given Establishment
-    static async fetch(establishmentId, effectiveFrom, filters=null) {
+    static async fetch(establishmentId, establishmentUid, filters=null) {
         const allWorkers = [];
         try {
 
-            const fetchResults = await models.worker.findAll({
-                where: {
-                    establishmentFk: establishmentId,
-                    archived: false
-                },
-                include: [
-                    {
-                        model: models.job,
-                        as: 'mainJob',
-                        attributes: ['id', 'title']
-                      }
-                ],
-                attributes: ['uid', 'NameOrIdValue', 'ContractValue', "CompletedValue", "created", "updated", "updatedBy"],
-                order: [
-                    ['updated', 'DESC']
-                ]           
-            });
+            let fetchResults = null;
+            
+            if (establishmentId) {
+                fetchResults =  await models.worker.findAll({
+                    where: {
+                        establishmentFk: establishmentId,
+                        archived: false
+                    },
+                    include: [
+                        {
+                            model: models.job,
+                            as: 'mainJob',
+                            attributes: ['id', 'title']
+                          }
+                    ],
+                    attributes: ['uid', 'NameOrIdValue', 'ContractValue', "CompletedValue", 'lastWdfEligibility', "created", "updated", "updatedBy"],
+                    order: [
+                        ['updated', 'DESC']
+                    ]
+                });
+            } else {
+                fetchResults =  await models.worker.findAll({
+                    where: {
+                        establishmentFk: establishmentId,
+                        archived: false
+                    },
+                    include: [
+                        {
+                            model: models.job,
+                            as: 'mainJob',
+                            attributes: ['id', 'title']
+                        },
+                        {
+                            model: models.establishment,
+                            as: 'establishment',
+                            attributes: ['id', 'uid'],
+                            where: {
+                                uid: establishmentUid
+                            }
+                        }
+                    ],
+                    attributes: ['uid', 'NameOrIdValue', 'ContractValue', "CompletedValue", 'lastWdfEligibility', "created", "updated", "updatedBy"],
+                    order: [
+                        ['updated', 'DESC']
+                    ]
+                });
+            }
     
             if (fetchResults) {
                 const workerPromise = [];
+                const effectiveFromTime = WdfCalculator.effectiveTime;
+                const effectiveFromIso = WdfCalculator.effectiveDate.toISOString();
 
                 fetchResults.forEach(thisWorker => {
-                    workerPromise.push(
-                        new Promise( async (resolve, reject) => {
-                            const newWorker = new Worker(establishmentId);
-                            try {
-                                await newWorker.restore(thisWorker.uid);
-    
-                                const wdfEligibility = await newWorker.isWdfEligible(effectiveFrom);
-    
-                                allWorkers.push({
-                                    uid: thisWorker.uid,
-                                    nameOrId: thisWorker.NameOrIdValue,
-                                    contract: thisWorker.ContractValue,
-                                    mainJob: {
-                                        jobId: thisWorker.mainJob.id,
-                                        title: thisWorker.mainJob.title
-                                    },
-                                    completed: thisWorker.CompletedValue,
-                                    created:  thisWorker.created.toJSON(),
-                                    updated: thisWorker.updated.toJSON(),
-                                    updatedBy: thisWorker.updatedBy,
-                                    effectiveFrom: effectiveFrom.toISOString(),
-                                    wdfEligible: wdfEligibility.isEligible
-                                });
-
-                                resolve();
-                            } catch (err) {
-                                reject(err);
-                            }
-                        })
-                    );
+                    allWorkers.push({
+                        uid: thisWorker.uid,
+                        nameOrId: thisWorker.NameOrIdValue,
+                        contract: thisWorker.ContractValue,
+                        mainJob: {
+                            jobId: thisWorker.mainJob.id,
+                            title: thisWorker.mainJob.title
+                        },
+                        completed: thisWorker.CompletedValue,
+                        created:  thisWorker.created.toJSON(),
+                        updated: thisWorker.updated.toJSON(),
+                        updatedBy: thisWorker.updatedBy,
+                        effectiveFrom: effectiveFromIso,
+                        wdfEligible: thisWorker.lastWdfEligibility && thisWorker.lastWdfEligibility.getTime() > effectiveFromTime ? true : false
+                    });
                 });
                 await Promise.all(workerPromise);
                 return allWorkers;
             }
         } catch (err) {
-            console.error("Worker::fetch - unexpected exception: ", error);
+            console.error("Worker::fetch - unexpected exception: ", err);
             throw err;
         }
     };
@@ -595,7 +649,7 @@ class Worker {
     //  or updated only)
     formatWorkerHistoryEvents(auditEvents) {
         if (auditEvents) {
-            return auditEvents.filter(thisEvent => ['created', 'updated'].includes(thisEvent.type))
+            return auditEvents.filter(thisEvent => ['created', 'updated', 'wdfEligible'].includes(thisEvent.type))
                                .map(thisEvent => {
                                     return {
                                         when: thisEvent.when,
@@ -794,7 +848,9 @@ class Worker {
         // NOTE - the worker does not have to be completed before it can be eligible for WDF
 
         return {
-            isEligible: Object.values(wdfByProperty).every(thisProperty => {
+            isEligible: this._lastWdfEligibility && this._lastWdfEligibility.getTime() > effectiveFrom.getTime() ? true : false,
+            lastEligibility: this._lastWdfEligibility ? this._lastWdfEligibility.toISOString() : null,
+            currentEligibility: Object.values(wdfByProperty).every(thisProperty => {
                 return !(thisProperty === 'No');
             }),
             ... wdfByProperty
@@ -806,7 +862,7 @@ class Worker {
         const PER_PROPERTY_ELIGIBLE=0;
         const RECORD_LEVEL_ELIGIBLE=1;
         const COMPLETED_PROPERTY_ELIGIBLE=2;
-        const ELIGIBILITY_REFERENCE = PER_PROPERTY_ELIGIBLE;
+        const ELIGIBILITY_REFERENCE = COMPLETED_PROPERTY_ELIGIBLE;
 
         let referenceTime = null;
 
@@ -828,7 +884,6 @@ class Worker {
         return property &&
                 property.property !== null &&
                 property.valid &&
-                property.savedAt &&
                 referenceTime !== null &&
                 referenceTime > refEpoch;
     }
@@ -914,7 +969,8 @@ class Worker {
     }
 
     // returns the WDF eligibilty as JSON object
-    async wdfToJson(effectiveFrom) {
+    async wdfToJson() {
+        const effectiveFrom = WdfCalculator.effectiveDate;
         return {
             effectiveFrom: effectiveFrom.toISOString(),
             ... await this.isWdfEligible(effectiveFrom)

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -49,7 +49,6 @@ class Worker {
         // local attributes
         this._reason = null;
         this._lastWdfEligibility = null;
-        this._currentWdfEligibiity = null;
     }
 
     // returns true if valid establishment id
@@ -238,11 +237,9 @@ class Worker {
                     //  it's current WDF Eligibility, and if it is eligible, update
                     //  the last WDF Eligibility status
                     const currentWdfEligibiity = await this.isWdfEligible(WdfCalculator.effectiveDate);
-                    console.log("WA DEBUG - updating Worker - current WDF Eligibility: ", currentWdfEligibiity)
 
                     let wdfAudit = null;
                     if (currentWdfEligibiity.currentEligibility) {
-                        console.log("WA DEBUG - updating this worker's last WDF Eligible timestamp")
                         updateDocument.lastWdfEligibility = updatedTimestamp;
                         wdfAudit = {
                             username: savedBy,
@@ -444,9 +441,6 @@ class Worker {
                 this._updated = fetchResults.updated;
                 this._updatedBy = fetchResults.updatedBy;
                 this._lastWdfEligibility = fetchResults.lastWdfEligibility;
-                this._currentWdfEligibiity = fetchResults.currentWdfEligibiity;
-
-                console.log("WA DEBUG - Worker eligibility: ", fetchResults.lastWdfEligibility, fetchResults.currentWdfEligibiity)
 
                 // if history of the Worker is also required; attach the association
                 //  and order in reverse chronological - note, order on id (not when)
@@ -849,11 +843,8 @@ class Worker {
         // NOTE - the worker does not have to be completed before it can be eligible for WDF
 
         return {
-            isEligible: this._lastWdfEligibility && this._lastWdfEligibility.getTime() > effectiveFrom.getTime() ? true : false,
             lastEligibility: this._lastWdfEligibility ? this._lastWdfEligibility.toISOString() : null,
-            currentEligibility: Object.values(wdfByProperty).every(thisProperty => {
-                return !(thisProperty === 'No');
-            }),
+            isEligible: this._lastWdfEligibility && this._lastWdfEligibility.getTime() > effectiveFrom.getTime() ? true : false,
             ... wdfByProperty
         };
     }

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -632,7 +632,8 @@ class Worker {
                         updated: thisWorker.updated.toJSON(),
                         updatedBy: thisWorker.updatedBy,
                         effectiveFrom: effectiveFromIso,
-                        wdfEligible: thisWorker.lastWdfEligibility && thisWorker.lastWdfEligibility.getTime() > effectiveFromTime ? true : false
+                        wdfEligible: thisWorker.lastWdfEligibility && thisWorker.lastWdfEligibility.getTime() > effectiveFromTime ? true : false,
+                        wdfEligibilityLastUpdated: thisWorker.lastWdfEligibility ? thisWorker.lastWdfEligibility.toISOString() : undefined
                     });
                 });
                 await Promise.all(workerPromise);

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -35,6 +35,21 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: false,
       field: '"IsRegulated"'
     },
+    overallWdfEligibility: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"OverallWdfEligibility"'
+    },
+    currentWdfEligibiity: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      field: '"CurrentWdfEligibiity"'
+    },
+    lastWdfEligibility: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"LastWdfEligibility"'
+    },
     NameValue: {
       type: DataTypes.TEXT,
       allowNull: false,

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -40,11 +40,6 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       field: '"OverallWdfEligibility"'
     },
-    currentWdfEligibiity: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      field: '"CurrentWdfEligibiity"'
-    },
     lastWdfEligibility: {
       type: DataTypes.DATE,
       allowNull: true,

--- a/server/models/establishmentAudit.js
+++ b/server/models/establishmentAudit.js
@@ -26,7 +26,7 @@ module.exports = function(sequelize, DataTypes) {
     type: {
       type: DataTypes.ENUM,
       allowNull: false,
-      values: ['created', 'updated', 'saved', 'changed', 'delete'],
+      values: ['created', 'updated', 'saved', 'changed', 'delete', 'overalWdfEligible', 'wdfEligible'],
       field: '"EventType"'
     },
     property : {

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -18,11 +18,6 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: false,
       field: '"EstablishmentFK"'
     },
-    currentWdfEligibiity: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      field: '"CurrentWdfEligibiity"'
-    },
     lastWdfEligibility: {
       type: DataTypes.DATE,
       allowNull: true,

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -18,6 +18,16 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: false,
       field: '"EstablishmentFK"'
     },
+    currentWdfEligibiity: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      field: '"CurrentWdfEligibiity"'
+    },
+    lastWdfEligibility: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: '"LastWdfEligibility"'
+    },
     NameOrIdValue: {
       type: DataTypes.TEXT,
       allowNull: false,

--- a/server/models/workerAudit.js
+++ b/server/models/workerAudit.js
@@ -26,7 +26,7 @@ module.exports = function(sequelize, DataTypes) {
     type: {
       type: DataTypes.ENUM,
       allowNull: false,
-      values: ['created', 'updated', 'saved', 'changed'],
+      values: ['created', 'updated', 'saved', 'changed', 'wdfEligible'],
       field: '"EventType"'
     },
     property : {

--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -57,7 +57,7 @@ router.route('/establishment/:id/:userId').get(async (req, res) => {
     const thisUser = new User.User(establishmentId);
 
     try {
-        if (await thisUser.restore(byUUID, byUsername, showHistory)) {
+        if (await thisUser.restore(byUUID, byUsername, showHistory && req.query.history !== 'property')) {
             return res.status(200).json(thisUser.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime, false));
         } else {
             // not found worker

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -75,7 +75,7 @@ router.route('/:id').get(async (req, res) => {
     const thisEstablishment = new Establishment.Establishment(req.username);
 
     try {
-        if (await thisEstablishment.restore(byID, byUUID, showHistory)) {
+        if (await thisEstablishment.restore(byID, byUUID, showHistory && req.query.history !== 'property')) {
             // the property based framework for "other services" and "capacity services"
             //  is returning "allOtherServices" and "allServiceCapacities"
             //  we don't want those on the root GET establishment; only necessary for the

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -57,21 +57,6 @@ router.route('/:id').get(async (req, res) => {
       return res.status(400).send();
     }
 
-    let effectiveFrom = null;    
-    if(isLocal(req) && req.query.effectiveFrom) {
-        // can only override the WDF effective date in local dev/test environments
-        effectiveFrom = new Date(req.query.effectiveFrom);
-        
-        // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2019-03-01T12:30:00.000Z
-
-        if (effectiveFrom.toISOString() !== req.query.effectiveFrom) {
-            console.error('report/wdf/establishment/:eID - effectiveFrom parameter incorrect');
-            return res.status(400).send();
-        }
-    } else {
-        effectiveFrom = WdfUtils.wdfEligibilityDate();
-    }
-
     const thisEstablishment = new Establishment.Establishment(req.username);
 
     try {
@@ -85,7 +70,7 @@ router.route('/:id').get(async (req, res) => {
             delete jsonResponse.allOtherServices;
             delete jsonResponse.allServiceCapacities;
 
-            if (!showHistory) jsonResponse.wdf = await thisEstablishment.wdfToJson(effectiveFrom);
+            if (!showHistory) jsonResponse.wdf = await thisEstablishment.wdfToJson();
 
             // need also to return the WDF eligibility
             return res.status(200).json(jsonResponse);

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -119,7 +119,7 @@ router.route('/:workerId').get(async (req, res) => {
     const thisWorker = new Workers.Worker(establishmentId);
 
     try {
-        if (await thisWorker.restore(workerId, showHistory)) {
+        if (await thisWorker.restore(workerId, showHistory && req.query.history !== 'property')) {
             const jsonResponse = thisWorker.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime, false);
             if (!showHistory) jsonResponse.wdf = await thisWorker.wdfToJson(effectiveFrom);
 

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -61,23 +61,8 @@ router.use('/:workerId/qualification', [validateWorker, QualificationRoutes]);
 router.route('/').get(async (req, res) => {
     const establishmentId = req.establishmentId;
 
-    let effectiveFrom = null;    
-    if(isLocal(req) && req.query.effectiveFrom) {
-        // can only override the WDF effective date in local dev/test environments
-        effectiveFrom = new Date(req.query.effectiveFrom);
-        
-        // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2019-03-01T12:30:00.000Z
-
-        if (effectiveFrom.toISOString() !== req.query.effectiveFrom) {
-            console.error('report/wdf/establishment/:eID - effectiveFrom parameter incorrect');
-            return res.status(400).send();
-        }
-    } else {
-        effectiveFrom = WdfUtils.wdfEligibilityDate();
-    }
-
     try {
-        const allTheseWorkers = await Workers.Worker.fetch(establishmentId, effectiveFrom);
+        const allTheseWorkers = await Workers.Worker.fetch(establishmentId, null);
         return res.status(200).json({
             workers: allTheseWorkers
         });
@@ -100,28 +85,12 @@ router.route('/:workerId').get(async (req, res) => {
     const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
     if (!uuidRegex.test(workerId.toUpperCase())) return res.status(400).send('Unexpected worker id');
 
-    let effectiveFrom = null;    
-    if(isLocal(req) && req.query.effectiveFrom) {
-        // can only override the WDF effective date in local dev/test environments
-        effectiveFrom = new Date(req.query.effectiveFrom);
-        
-        // NOTE - effectiveFrom must include milliseconds and trailing Z - e.g. ?effectiveFrom=2019-03-01T12:30:00.000Z
-
-        if (effectiveFrom.toISOString() !== req.query.effectiveFrom) {
-            console.error('report/wdf/establishment/:eID - effectiveFrom parameter incorrect');
-            return res.status(400).send();
-        }
-    } else {
-        effectiveFrom = WdfUtils.wdfEligibilityDate();
-    }
-
-
     const thisWorker = new Workers.Worker(establishmentId);
 
     try {
         if (await thisWorker.restore(workerId, showHistory && req.query.history !== 'property')) {
             const jsonResponse = thisWorker.toJSON(showHistory, showPropertyHistoryOnly, showHistoryTime, false);
-            if (!showHistory) jsonResponse.wdf = await thisWorker.wdfToJson(effectiveFrom);
+            if (!showHistory) jsonResponse.wdf = await thisWorker.wdfToJson();
 
             return res.status(200).json(jsonResponse);
         } else {

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -132,14 +132,15 @@ router.get('/usernameOrEmail/:usernameOrEmail', async (req, res) => {
 
 router.get('/estbname/:name', async (req, res) => {
   const requestedEstablishmentName = req.params.name;
+
   try {
     const results = await models.establishment.findOne({
       where: {
-        name: requestedEstablishmentName
+        NameValue: requestedEstablishmentName
       }
     });
 
-    if (results && results.id && (requestedEstablishmentName === results.name)) {
+    if (results && results.id && (requestedEstablishmentName === results.NameValue)) {
       return res.status(200).json({
         status: '1',
         message: `Establishment by name '${requestedEstablishmentName}' found`,
@@ -167,12 +168,12 @@ router.get('/estb/:name/:locationid', async (req, res) => {
   try {
     const results = await models.establishment.findOne({
       where: {
-        name: requestedEstablishmentName,
+        NameValue: requestedEstablishmentName,
         locationId: requestedEstablishmentLocationId
       }
     });
 
-    if (results && results.id && (requestedEstablishmentName === results.name)) {
+    if (results && results.id && (requestedEstablishmentName === results.NameValue)) {
       return res.status(200).json({
         status: '1',
         message: `Establishment by name '${requestedEstablishmentName}' and by location id '${requestedEstablishmentLocationId}' found`,


### PR DESCRIPTION
https://trello.com/c/yBCo8FV7

Following a review with Will Fenton, it was highlighted that a workplace attains Overal WDF Eligibility at any time throughout the year, and once attained, keeps it until the effective period restarts.

Will also wanted the calculation to be based on when the user Completes their Establishment or Worker; because Establishment Complete is not yet available, this implementation is based on Establishment update.

This now means having to store the Overall WDF Eligibility. It also means we have to recalculate the Overall WDF Eligibility (which is against an Establishment and all it's Workers) whenever the Establishment or Worker is updated. To keep the code simpler, I've introduced a singleton as the `WdfCalculator` which also encapsulates the "effective from" date.

Thanks