### PR TITLE
Page Title Service

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Skills for care</title>
+  <title>Skills for Care</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/index_staging.html
+++ b/index_staging.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Skills for care</title>
+  <title>Skills for Care</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/index_uat.html
+++ b/index_uat.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Skills for care</title>
+  <title>Skills for Care</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -23,73 +23,89 @@ const routes: Routes = [
   {
     path: 'login',
     component: LoginComponent,
+    data: { title: 'Login' },
   },
   {
     path: 'logged-out',
     component: LogoutComponent,
+    data: { title: 'Logged Out' },
   },
   {
     path: 'forgot-your-password',
     component: ForgotYourPasswordComponent,
+    data: { title: 'Forgotten Password' },
   },
   {
     path: 'reset-password',
     component: ResetPasswordComponent,
+    data: { title: 'Reset Password' },
   },
   {
     path: 'your-account',
     component: YourAccountComponent,
     canActivate: [AuthGuard],
+    data: { title: 'Your Account' },
   },
   {
     path: 'change-password',
     component: ChangePasswordComponent,
     canActivate: [AuthGuard],
+    data: { title: 'Change Password' },
   },
   {
     path: 'change-user-details',
     component: ChangeUserDetailsComponent,
     canActivate: [AuthGuard],
+    data: { title: 'Change User Details' },
   },
   {
     path: 'change-user-security',
     component: ChangeUserSecurityComponent,
     canActivate: [AuthGuard],
+    data: { title: 'Change Security Question' },
   },
   {
     path: 'feedback',
     component: FeedbackComponent,
+    data: { title: 'Give us Feedback' },
   },
   {
     path: 'contact-us',
     component: ContactUsComponent,
+    data: { title: 'Contact Us' },
   },
   {
     path: 'terms-and-conditions',
     component: TermsConditionsComponent,
+    data: { title: 'Terms and Conditions' },
   },
   {
     path: 'problem-with-the-service',
     component: ProblemWithTheServiceComponent,
+    data: { title: 'Problem with the Service' },
   },
   {
     path: 'workplace',
     loadChildren: '@features/workplace/workplace.module#WorkplaceModule',
     canActivate: [AuthGuard],
+    data: { title: 'Workplace' },
   },
   {
     path: 'worker',
     loadChildren: '@features/workers/workers.module#WorkersModule',
     canActivate: [AuthGuard],
+    data: { title: 'Staff Records' },
   },
   {
     path: 'registration',
     loadChildren: '@features/registration/registration.module#RegistrationModule',
+    data: { title: 'Registration' },
   },
   {
     path: 'dashboard',
     component: DashboardComponent,
     canActivate: [AuthGuard],
+    data: { title: 'Dashboard' },
   },
   {
     path: '',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import 'core-js';
 
 import { Component, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
+import { TitleService } from '@core/services/title.service';
 import { Angulartics2GoogleGlobalSiteTag } from 'angulartics2/gst';
 import { filter } from 'rxjs/operators';
 
@@ -13,8 +14,13 @@ import { filter } from 'rxjs/operators';
 export class AppComponent implements OnInit {
   title = 'ng-sfc-v2';
 
-  constructor(private router: Router, angulartics: Angulartics2GoogleGlobalSiteTag) {
-    angulartics.startTracking();
+  constructor(
+    private router: Router,
+    private titleService: TitleService,
+    private angulartics: Angulartics2GoogleGlobalSiteTag
+  ) {
+    this.titleService.init('Skills for Care');
+    this.angulartics.startTracking();
   }
 
   ngOnInit() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { ServiceUnavailableComponent } from '@core/components/error/service-unav
 import { FooterComponent } from '@core/components/footer/footer.component';
 import { HeaderComponent } from '@core/components/header/header.component';
 import { HttpInterceptor } from '@core/services/http-interceptor';
+import { TitleService } from '@core/services/title.service';
 import { TrainingService } from '@core/services/training.service';
 import { WindowRef } from '@core/services/window.ref';
 import { TermsConditionsComponent } from '@features/terms-conditions/terms-conditions.component';
@@ -131,6 +132,7 @@ import { YourAccountComponent } from './features/your-account/your-account.compo
     CountryService,
     TrainingService,
     WindowRef,
+    TitleService,
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/core/services/title.service.ts
+++ b/src/app/core/services/title.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { filter, map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TitleService {
+  constructor(private router: Router, private activatedRoute: ActivatedRoute, private title: Title) {}
+
+  public init(baseTitle: string = ''): void {
+    this.router.events
+      .pipe(
+        filter(event => event instanceof NavigationEnd),
+        map(() => this.activatedRoute),
+        map(route => {
+          const titleArray: string[] = [];
+          while (route) {
+            if (route.snapshot.data.title) {
+              titleArray.push(route.snapshot.data.title);
+            }
+            route = route.firstChild;
+          }
+          return titleArray;
+        })
+      )
+      .subscribe(titleArray => {
+        const title = [baseTitle].concat(titleArray);
+        this.setTitle(title.join(' - '));
+      });
+  }
+
+  public setTitle(title: string) {
+    this.title.setTitle(title);
+  }
+}

--- a/src/app/core/services/title.service.ts
+++ b/src/app/core/services/title.service.ts
@@ -33,7 +33,6 @@ export class TitleService {
   }
 
   public setTitle(title: string) {
-    console.log(title);
     this.title.setTitle(title);
   }
 }

--- a/src/app/core/services/title.service.ts
+++ b/src/app/core/services/title.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { uniq } from 'lodash';
 import { filter, map } from 'rxjs/operators';
 
 @Injectable({
@@ -22,7 +23,7 @@ export class TitleService {
             }
             route = route.firstChild;
           }
-          return titleArray;
+          return uniq(titleArray);
         })
       )
       .subscribe(titleArray => {
@@ -32,6 +33,7 @@ export class TitleService {
   }
 
   public setTitle(title: string) {
+    console.log(title);
     this.title.setTitle(title);
   }
 }

--- a/src/app/features/registration/registration-routing.module.ts
+++ b/src/app/features/registration/registration-routing.module.ts
@@ -1,72 +1,91 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { RegulatedByCqcComponent } from '@features/registration/regulated-by-cqc/regulated-by-cqc.component';
-import { SelectWorkplaceComponent } from '@features/registration/select-workplace/select-workplace.component';
 import { RegisterGuard } from '@core/guards/register/register.guard';
-import { ConfirmWorkplaceDetailsComponent } from '@features/registration/confirm-workplace-details/confirm-workplace-details.component';
-import { UserDetailsComponent } from '@features/registration/user-details/user-details.component';
+import {
+  ConfirmAccountDetailsComponent,
+} from '@features/registration/confirm-account-details/confirm-account-details.component';
+import {
+  ConfirmWorkplaceDetailsComponent,
+} from '@features/registration/confirm-workplace-details/confirm-workplace-details.component';
 import { CreateUsernameComponent } from '@features/registration/create-username/create-username.component';
-import { SecurityQuestionComponent } from '@features/registration/security-question/security-question.component';
-import { ConfirmAccountDetailsComponent } from '@features/registration/confirm-account-details/confirm-account-details.component';
+import {
+  EnterWorkplaceAddressComponent,
+} from '@features/registration/enter-workplace-address/enter-workplace-address.component';
 import { RegistrationCompleteComponent } from '@features/registration/registration-complete/registration-complete.component';
-import { SelectWorkplaceAddressComponent } from '@features/registration/select-workplace-address/select-workplace-address.component';
-import { EnterWorkplaceAddressComponent } from '@features/registration/enter-workplace-address/enter-workplace-address.component';
+import { RegulatedByCqcComponent } from '@features/registration/regulated-by-cqc/regulated-by-cqc.component';
+import { SecurityQuestionComponent } from '@features/registration/security-question/security-question.component';
 import { SelectMainServiceComponent } from '@features/registration/select-main-service/select-main-service.component';
+import {
+  SelectWorkplaceAddressComponent,
+} from '@features/registration/select-workplace-address/select-workplace-address.component';
+import { SelectWorkplaceComponent } from '@features/registration/select-workplace/select-workplace.component';
+import { UserDetailsComponent } from '@features/registration/user-details/user-details.component';
 
 const routes: Routes = [
   {
     path: 'regulated-by-cqc',
     component: RegulatedByCqcComponent,
+    data: { title: 'Regulated by CQC' },
   },
   {
     path: 'select-workplace',
     component: SelectWorkplaceComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'Select Workplace' },
   },
   {
     path: 'confirm-workplace-details',
     component: ConfirmWorkplaceDetailsComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'Confirm Workplace Details' },
   },
   {
     path: 'user-details',
     component: UserDetailsComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'User Details' },
   },
   {
     path: 'create-username',
     component: CreateUsernameComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'Create Username' },
   },
   {
     path: 'security-question',
     component: SecurityQuestionComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'Security Question' },
   },
   {
     path: 'confirm-account-details',
     component: ConfirmAccountDetailsComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'Confirm Account Details' },
   },
   {
     path: 'complete',
     component: RegistrationCompleteComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'Complete' },
   },
   {
     path: 'select-workplace-address',
     component: SelectWorkplaceAddressComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'Select Workplace Address' },
   },
   {
     path: 'enter-workplace-address',
     component: EnterWorkplaceAddressComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'Enter Workplace Address' },
   },
   {
     path: 'select-main-service',
     component: SelectMainServiceComponent,
     canActivate: [RegisterGuard],
+    data: { title: 'Select Main Service' },
   },
 ];
 

--- a/src/app/features/workers/workers-routing.module.ts
+++ b/src/app/features/workers/workers-routing.module.ts
@@ -51,14 +51,17 @@ const routes: Routes = [
   {
     path: 'create-staff-record',
     component: CreateStaffRecordComponent,
+    data: { title: 'Create Staff Records' },
   },
   {
     path: 'save-success',
     component: WorkerSaveSuccessComponent,
+    data: { title: 'Success' },
   },
   {
     path: 'delete-success',
     component: DeleteSuccessComponent,
+    data: { title: 'Delete Success' },
   },
   {
     path: ':id',
@@ -68,134 +71,167 @@ const routes: Routes = [
       {
         path: '',
         component: StaffRecordComponent,
+        data: { title: 'Staff Record' },
       },
       {
         path: 'staff-details',
         component: StaffDetailsComponent,
+        data: { title: 'Staff Details' },
       },
       {
         path: 'mental-health-professional',
         component: MentalHealthProfessionalComponent,
+        data: { title: 'Mental Health Professional' },
       },
       {
         path: 'main-job-start-date',
         component: MainJobStartDateComponent,
+        data: { title: 'Main Job Role Start Date' },
       },
       {
         path: 'other-job-roles',
         component: OtherJobRolesComponent,
+        data: { title: 'Other Job Roles' },
       },
       {
         path: 'national-insurance-number',
         component: NationalInsuranceNumberComponent,
+        data: { title: 'National Insurance Number' },
       },
       {
         path: 'date-of-birth',
         component: DateOfBirthComponent,
+        data: { title: 'Date of Birth' },
       },
       {
         path: 'home-postcode',
         component: HomePostcodeComponent,
+        data: { title: 'Home Postcode' },
       },
       {
         path: 'gender',
         component: GenderComponent,
+        data: { title: 'Gender' },
       },
       {
         path: 'disability',
         component: DisabilityComponent,
+        data: { title: 'Disability' },
       },
       {
         path: 'ethnicity',
         component: EthnicityComponent,
+        data: { title: 'Ethnicity' },
       },
       {
         path: 'nationality',
         component: NationalityComponent,
+        data: { title: 'Nationality' },
       },
       {
         path: 'british-citizenship',
         component: BritishCitizenshipComponent,
+        data: { title: 'British Citizenship' },
       },
       {
         path: 'country-of-birth',
         component: CountryOfBirthComponent,
+        data: { title: 'Country of Birth' },
       },
       {
         path: 'year-arrived-uk',
         component: YearArrivedUkComponent,
+        data: { title: 'Year Arrived in the UK' },
       },
       {
         path: 'recruited-from',
         component: RecruitedFromComponent,
+        data: { title: 'Recruited From' },
       },
       {
         path: 'adult-social-care-started',
         component: AdultSocialCareStartedComponent,
+        data: { title: 'Adult Social Care Started' },
       },
       {
         path: 'days-of-sickness',
         component: DaysOfSicknessComponent,
+        data: { title: 'Days of Sickness' },
       },
       {
         path: 'contract-with-zero-hours',
         component: ContractWithZeroHoursComponent,
+        data: { title: 'Contract with Zero Hours' },
       },
       {
         path: 'average-weekly-hours',
         component: AverageWeeklyHoursComponent,
+        data: { title: 'Average Weekly Hours' },
       },
       {
         path: 'weekly-contracted-hours',
         component: WeeklyContractedHoursComponent,
+        data: { title: 'Weekly Contracted Hours' },
       },
       {
         path: 'salary',
         component: SalaryComponent,
+        data: { title: 'Salary' },
       },
       {
         path: 'care-certificate',
         component: CareCertificateComponent,
+        data: { title: 'Care Certificate' },
       },
       {
         path: 'apprenticeship-training',
         component: ApprenticeshipTrainingComponent,
+        data: { title: 'Apprenticeship Training' },
       },
       {
         path: 'social-care-qualification',
         component: SocialCareQualificationComponent,
+        data: { title: 'Social Care Qualification' },
       },
       {
         path: 'social-care-qualification-level',
         component: SocialCareQualificationLevelComponent,
+        data: { title: 'Highest Social Care Qualification Level' },
       },
       {
         path: 'other-qualifications',
         component: OtherQualificationsComponent,
+        data: { title: 'Other Qualifications' },
       },
       {
         path: 'other-qualifications-level',
         component: OtherQualificationsLevelComponent,
+        data: { title: 'Highest Level of Other Qualifications' },
       },
       {
         path: 'summary',
         component: CheckStaffRecordComponent,
+        data: { title: 'Check Answers' },
       },
       {
         path: 'add-qualification',
         component: AddEditQualificationComponent,
+        data: { title: 'Add Qualification' },
       },
       {
         path: 'qualification/:qualificationId',
         component: AddEditQualificationComponent,
+        data: { title: 'Qualification' },
       },
       {
         path: 'add-training',
         component: AddEditTrainingComponent,
+        data: { title: 'Add Training' },
       },
       {
         path: 'training/:trainingRecordId',
         component: AddEditTrainingComponent,
+        data: { title: 'Training' },
       },
     ],
   },

--- a/src/app/features/workers/workers-routing.module.ts
+++ b/src/app/features/workers/workers-routing.module.ts
@@ -47,6 +47,7 @@ const routes: Routes = [
   {
     path: 'start-screen',
     component: CreateStaffRecordStartScreenComponent,
+    data: { title: 'Start' },
   },
   {
     path: 'create-staff-record',

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -17,62 +17,77 @@ import { VacanciesComponent } from './vacancies/vacancies.component';
 const routes: Routes = [
   {
     path: 'start-screen',
+    data: { title: 'Start' },
     // component:
   },
   // FLOW
   {
     path: 'type-of-employer',
     component: TypeOfEmployerComponent,
+    data: { title: 'Type of Employer' },
   },
   {
     path: 'select-other-services',
     component: SelectOtherServicesComponent,
+    data: { title: 'Select Other Services' },
   },
   {
     path: 'capacity-of-services',
     component: ServicesCapacityComponent,
+    data: { title: 'Capacity of Services' },
   },
   {
     path: 'service-users',
     component: ServiceUsersComponent,
+    data: { title: 'Service Users' },
   },
   {
     path: 'share-options',
     component: ShareOptionsComponent,
+    data: { title: 'Data Sharing Options' },
   },
   {
     path: 'share-local-authority',
     component: ShareLocalAuthorityComponent,
+    data: { title: 'Share Data with Local Authority' },
   },
   {
     path: 'vacancies',
     component: VacanciesComponent,
+    data: { title: 'Vacancies' },
   },
   {
     path: 'confirm-vacancies',
     component: ConfirmVacanciesComponent,
+    data: { title: 'Confirm Vacancies' },
   },
   {
     path: 'starters',
     component: StartersComponent,
+    data: { title: 'Starters' },
   },
   {
     path: 'confirm-starters',
     component: ConfirmStartersComponent,
+    data: { title: 'Confirm Starters' },
   },
   {
     path: 'leavers',
     component: LeaversComponent,
+    data: { title: 'Leavers' },
   },
   {
     path: 'confirm-leavers',
     component: ConfirmLeaversComponent,
+    data: { title: 'Confirm Leavers' },
   },
   {
     path: 'volunteers',
+    data: { title: 'Volunteers' },
   },
   {
     path: 'summary',
+    data: { title: 'Check Answers' },
   },
 ];
 


### PR DESCRIPTION
This grabs the Page Title from the data property on the route. It pulls through all of the Parent routes titles to build a page title separated by a hyphen. eg `Skills for Care - Registration - CQC Regulated`