### PR TITLE
bugfix | fix validation type name casing

### DIFF
--- a/src/app/features/registration/create-username/create-username.component.html
+++ b/src/app/features/registration/create-username/create-username.component.html
@@ -24,7 +24,7 @@
             {{ getFormErrorMessage('username', 'required') }}
           </span>
           <span *ngIf="getUsername.hasError('maxLength')">
-            {{ getFormErrorMessage('username', 'maxLength') }}
+            {{ getFormErrorMessage('username', 'maxlength') }}
           </span>
           <span *ngIf="getUsername.hasError('usernameExists')">
             {{ getFormErrorMessage('username', 'usernameExists') }}

--- a/src/app/features/registration/create-username/create-username.component.ts
+++ b/src/app/features/registration/create-username/create-username.component.ts
@@ -95,7 +95,7 @@ export class CreateUsernameComponent implements OnInit, OnDestroy {
             message: 'Please enter your username.',
           },
           {
-            name: 'maxLength',
+            name: 'maxlength',
             message: 'Your username must be no longer than 50 characters.',
           },
           {

--- a/src/app/features/registration/security-question/security-question.component.html
+++ b/src/app/features/registration/security-question/security-question.component.html
@@ -20,8 +20,8 @@
           <span *ngIf="getSecurityQuestion.hasError('required')">
             {{ getFormErrorMessage('securityQuestion', 'required') }}
           </span>
-          <span *ngIf="getSecurityQuestion.hasError('maxLength')">
-            {{ getFormErrorMessage('securityQuestion', 'maxLength') }}
+          <span *ngIf="getSecurityQuestion.hasError('maxlength')">
+            {{ getFormErrorMessage('securityQuestion', 'maxlength') }}
           </span>
         </span>
         <input
@@ -43,8 +43,8 @@
           <span *ngIf="getSecurityAnswer.hasError('required')">
             {{ getFormErrorMessage('securityAnswer', 'required') }}
           </span>
-          <span *ngIf="getSecurityAnswer.hasError('maxLength')">
-            {{ getFormErrorMessage('securityAnswer', 'maxLength') }}
+          <span *ngIf="getSecurityAnswer.hasError('maxlength')">
+            {{ getFormErrorMessage('securityAnswer', 'maxlength') }}
           </span>
         </span>
         <input

--- a/src/app/features/registration/security-question/security-question.component.ts
+++ b/src/app/features/registration/security-question/security-question.component.ts
@@ -63,7 +63,7 @@ export class SecurityQuestionComponent implements OnInit, OnDestroy {
             message: 'Please enter your security question.',
           },
           {
-            name: 'maxLength',
+            name: 'maxlength',
             message: `The security question must be no longer than ${this.securityDetailsMaxLength} characters.`,
           },
         ],
@@ -76,7 +76,7 @@ export class SecurityQuestionComponent implements OnInit, OnDestroy {
             message: 'Please enter your security answer.',
           },
           {
-            name: 'maxLength',
+            name: 'maxlength',
             message: `The security answer must be no longer than ${this.securityDetailsMaxLength} characters.`,
           },
         ],


### PR DESCRIPTION
when accessing errors in the template `maxLength` is exposed in lowercase so this fix is to ensure the error is accessible and to prevent any console errors