### PR TITLE
Feature/gds select workplace address page

### DIFF
--- a/src/app/core/components/header/header.component.ts
+++ b/src/app/core/components/header/header.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { AuthService } from '@core/services/auth-service';
+import { AuthService } from '@core/services/auth.service';
 import { IdleService } from '@core/services/idle.service';
 
 @Component({

--- a/src/app/core/guards/register/register.guard.ts
+++ b/src/app/core/guards/register/register.guard.ts
@@ -19,6 +19,10 @@ export class RegisterGuard implements CanActivate {
     if (this.registrationInProgress) {
       return true;
     }
+    // TODO remove me
+    else {
+      return true;
+    }
 
     this.router.navigate(['/registration/regulated-by-cqc']);
     return false;

--- a/src/app/core/guards/register/register.guard.ts
+++ b/src/app/core/guards/register/register.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
-import { RegistrationService } from '../../services/registration.service';
+import { RegistrationService } from '@core/services/registration.service';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/core/guards/register/register.guard.ts
+++ b/src/app/core/guards/register/register.guard.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
 import { RegistrationService } from '../../services/registration.service';
-import { LocationAddress } from '@core/model/location-address.model';
+import { LocationAddress } from '@core/model/location.model';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/core/guards/register/register.guard.ts
+++ b/src/app/core/guards/register/register.guard.ts
@@ -1,23 +1,22 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
 import { RegistrationService } from '../../services/registration.service';
-import { LocationAddress } from '@core/model/location.model';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RegisterGuard implements CanActivate {
-  private locationAddresses: Array<LocationAddress>;
+  private registrationInProgress: boolean;
 
   constructor(private registrationService: RegistrationService, private router: Router) {}
 
   canActivate() {
-    this.registrationService.locationAddresses$.subscribe(
-      (locationAddresses: Array<LocationAddress>) => this.locationAddresses = locationAddresses
+    this.registrationService.registrationInProgress$.subscribe(
+      (registrationInProgress: boolean) => this.registrationInProgress = registrationInProgress
     );
 
     // check if registration process has started
-    if (this.locationAddresses) {
+    if (this.registrationInProgress) {
       return true;
     }
 

--- a/src/app/core/guards/register/register.guard.ts
+++ b/src/app/core/guards/register/register.guard.ts
@@ -19,10 +19,6 @@ export class RegisterGuard implements CanActivate {
     if (this.registrationInProgress) {
       return true;
     }
-    // TODO remove me
-    else {
-      return true;
-    }
 
     this.router.navigate(['/registration/regulated-by-cqc']);
     return false;

--- a/src/app/core/model/location.model.ts
+++ b/src/app/core/model/location.model.ts
@@ -11,8 +11,8 @@ export interface LocationAddress {
 }
 
 export interface LocationSearchResponse {
-  success: number;
-  message: string;
   locationdata?: Array<LocationAddress>;
+  message: string;
   postcodedata?: Array<LocationAddress>;
+  success: number;
 }

--- a/src/app/core/model/location.model.ts
+++ b/src/app/core/model/location.model.ts
@@ -9,3 +9,10 @@ export interface LocationAddress {
   postalCode: string;
   townCity: string;
 }
+
+export interface LocationSearchResponse {
+  success: number;
+  message: string;
+  locationdata?: Array<LocationAddress>;
+  postcodedata?: Array<LocationAddress>;
+}

--- a/src/app/core/model/registration.model.ts
+++ b/src/app/core/model/registration.model.ts
@@ -1,17 +1,5 @@
-import { LocationAddress } from '@core/model/location-address.model';
+import { LocationAddress } from '@core/model/location.model';
 import { UserDetails } from '@core/model/userDetails.model';
-
-export interface RegistrationModel {
-  success: number;
-  message: string;
-  // TODO to remove
-  userRoute: {
-    currentPage: number;
-    route: [];
-  };
-  locationdata: Array<LocationAddress>;
-  postcodedata: Array<LocationAddress>;
-}
 
 export interface RegistrationPayload extends LocationAddress {
   user: UserDetails;

--- a/src/app/core/services/auth-guard.service.ts
+++ b/src/app/core/services/auth-guard.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router, RouterStateSnapshot } from '@angular/router';
 
-import { AuthService } from './auth-service';
+import { AuthService } from './auth.service';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/core/services/auth-interceptor.ts
+++ b/src/app/core/services/auth-interceptor.ts
@@ -2,7 +2,7 @@ import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/c
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
-import { AuthService } from './auth-service';
+import { AuthService } from './auth.service';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -7,13 +7,6 @@ import { ErrorObservable } from 'rxjs-compat/observable/ErrorObservable';
 import { LoginCredentials } from '../model/login-credentials.model';
 import { RegistrationTrackerError } from '../model/registrationTrackerError.model';
 
-// TODO do we still need it?
-const initialRegistration: LoginCredentials = {
-  // Example initial dummy data
-  username: 'Uname3',
-  password: 'Bob',
-};
-
 interface LoggedInMainService {
   id: number;
   name: string;
@@ -32,13 +25,12 @@ interface LoggedInSession {
   mainService: LoggedInMainService;
 }
 
-// TODO this file should be renamed to auth.service
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
   // Observable login source
-  private _auth$: BehaviorSubject<LoginCredentials> = new BehaviorSubject<LoginCredentials>(initialRegistration);
+  private _auth$: BehaviorSubject<LoginCredentials> = new BehaviorSubject<LoginCredentials>(null);
 
   // hold the response from login
   private _session: LoggedInSession = null;

--- a/src/app/core/services/http-error-handler.service.ts
+++ b/src/app/core/services/http-error-handler.service.ts
@@ -3,7 +3,7 @@ import { Injectable, isDevMode } from '@angular/core';
 import { Router } from '@angular/router';
 import { throwError } from 'rxjs';
 
-import { AuthService } from './auth-service';
+import { AuthService } from './auth.service';
 import { MessageService } from './message.service';
 
 @Injectable({

--- a/src/app/core/services/registration.service.ts
+++ b/src/app/core/services/registration.service.ts
@@ -24,27 +24,23 @@ export class RegistrationService {
     return this.http.post<any>('/api/registration/', registrationPayload);
   }
 
-  getLocationByPostCode(id: string) {
+  public getLocationByPostCode(id: string): Observable<LocationSearchResponse> {
     return this.http.get<LocationSearchResponse>(`/api/locations/pc/${id}`);
   }
 
-  getLocationByLocationId(id: string) {
+  public getLocationByLocationId(id: string): Observable<LocationSearchResponse> {
     return this.http.get<LocationSearchResponse>(`/api/locations/lid/${id}`);
   }
 
-  public getAddressByPostCode(postcode: string): Observable<LocationSearchResponse> {
+  public getAddressesByPostCode(postcode: string): Observable<LocationSearchResponse> {
     return this.http.get<LocationSearchResponse>(`/api/postcodes/${postcode}`);
   }
 
-  getUpdatedAddressByPostCode(postcode: string) {
-    return this.http.get<LocationSearchResponse>(`/api/postcodes/${postcode}`);
-  }
-
-  public getServicesByCategory(isRegulated: boolean) {
+  public getServicesByCategory(isRegulated: boolean): Observable<any>  {
     return this.http.get(`/api/services/byCategory?cqc=${isRegulated}`);
   }
 
-  getUsernameDuplicate(id: string) {
+  public getUsernameDuplicate(id: string): Observable<any>  {
     return this.http.get(`/api/registration/username/${id}`);
   }
 

--- a/src/app/core/services/registration.service.ts
+++ b/src/app/core/services/registration.service.ts
@@ -48,10 +48,6 @@ export class RegistrationService {
     return this.http.get(`/api/registration/username/${id}`);
   }
 
-  public updateState(inProgress: boolean): void {
-    this.registrationInProgress$.next(inProgress);
-  }
-
   public isRegulated(location: LocationAddress): boolean {
     return location.isRegulated === true || location.locationId ? true : false;
   }

--- a/src/app/core/services/registration.service.ts
+++ b/src/app/core/services/registration.service.ts
@@ -11,7 +11,7 @@ import { SecurityDetails } from '@core/model/security-details.model';
   providedIn: 'root',
 })
 export class RegistrationService {
-  public registration$: BehaviorSubject<LocationSearchResponse> = new BehaviorSubject(null);
+  public registrationInProgress$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public locationAddresses$: BehaviorSubject<Array<LocationAddress>> = new BehaviorSubject(null);
   public selectedLocationAddress$: BehaviorSubject<LocationAddress> = new BehaviorSubject(null);
   public selectedWorkplaceService$: BehaviorSubject<WorkplaceService> = new BehaviorSubject(null);
@@ -48,8 +48,8 @@ export class RegistrationService {
     return this.http.get(`/api/registration/username/${id}`);
   }
 
-  public updateState(data): void {
-    this.registration$.next(data);
+  public updateState(inProgress: boolean): void {
+    this.registrationInProgress$.next(inProgress);
   }
 
   public isRegulated(location: LocationAddress): boolean {

--- a/src/app/core/services/registration.service.ts
+++ b/src/app/core/services/registration.service.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { LocationAddress } from '@core/model/location-address.model';
-import { RegistrationModel, RegistrationPayload } from '@core/model/registration.model';
+import { LocationAddress, LocationSearchResponse } from '@core/model/location.model';
+import { RegistrationPayload } from '@core/model/registration.model';
 import { WorkplaceService } from '@core/model/workplace-service.model';
 import { LoginCredentials } from '@core/model/login-credentials.model';
 import { SecurityDetails } from '@core/model/security-details.model';
@@ -11,7 +11,7 @@ import { SecurityDetails } from '@core/model/security-details.model';
   providedIn: 'root',
 })
 export class RegistrationService {
-  public registration$: BehaviorSubject<RegistrationModel> = new BehaviorSubject(null);
+  public registration$: BehaviorSubject<LocationSearchResponse> = new BehaviorSubject(null);
   public locationAddresses$: BehaviorSubject<Array<LocationAddress>> = new BehaviorSubject(null);
   public selectedLocationAddress$: BehaviorSubject<LocationAddress> = new BehaviorSubject(null);
   public selectedWorkplaceService$: BehaviorSubject<WorkplaceService> = new BehaviorSubject(null);
@@ -20,24 +20,24 @@ export class RegistrationService {
 
   constructor(private http: HttpClient) {}
 
-  public postRegistration(registrationPayload: RegistrationPayload): Observable<RegistrationModel> {
-    return this.http.post<RegistrationModel>('/api/registration/', registrationPayload);
+  public postRegistration(registrationPayload: RegistrationPayload): Observable<any> {
+    return this.http.post<any>('/api/registration/', registrationPayload);
   }
 
   getLocationByPostCode(id: string) {
-    return this.http.get<RegistrationModel>(`/api/locations/pc/${id}`);
+    return this.http.get<LocationSearchResponse>(`/api/locations/pc/${id}`);
   }
 
   getLocationByLocationId(id: string) {
-    return this.http.get<RegistrationModel>(`/api/locations/lid/${id}`);
+    return this.http.get<LocationSearchResponse>(`/api/locations/lid/${id}`);
   }
 
-  public getAddressByPostCode(postcode: string): Observable<RegistrationModel> {
-    return this.http.get<RegistrationModel>(`/api/postcodes/${postcode}`);
+  public getAddressByPostCode(postcode: string): Observable<LocationSearchResponse> {
+    return this.http.get<LocationSearchResponse>(`/api/postcodes/${postcode}`);
   }
 
   getUpdatedAddressByPostCode(postcode: string) {
-    return this.http.get<RegistrationModel>(`/api/postcodes/${postcode}`);
+    return this.http.get<LocationSearchResponse>(`/api/postcodes/${postcode}`);
   }
 
   public getServicesByCategory(isRegulated: boolean) {

--- a/src/app/features/change-password/change-password.component.ts
+++ b/src/app/features/change-password/change-password.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 
-import { AuthService } from '@core/services/auth-service';
+import { AuthService } from '@core/services/auth.service';
 import { UserService } from '@core/services/user.service';
 import { Subscription } from 'rxjs';
 import { UserDetails } from '@core/model/userDetails.model';

--- a/src/app/features/change-password/confirmation/confirmation.component.ts
+++ b/src/app/features/change-password/confirmation/confirmation.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { AuthService } from '../../../core/services/auth-service';
+import { AuthService } from '@core/services/auth.service';
 
 @Component({
   selector: 'app-confirmation',

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { DEFAULT_DATE_DISPLAY_FORMAT } from '@core/constants/constants';
-import { AuthService } from '@core/services/auth-service';
+import { AuthService } from '@core/services/auth.service';
 import { UserService } from '@core/services/user.service';
 
 @Component({

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { NavigationExtras, Router } from '@angular/router';
 import { LoginCredentials } from '@core/model/login-credentials.model';
-import { AuthService } from '@core/services/auth-service';
+import { AuthService } from '@core/services/auth.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { IdleService } from '@core/services/idle.service';
 import { Subscription } from 'rxjs';

--- a/src/app/features/logout/logout.component.ts
+++ b/src/app/features/logout/logout.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { AuthService } from '@core/services/auth-service';
+import { AuthService } from '@core/services/auth.service';
 import { IdleService } from '@core/services/idle.service';
 
 @Component({

--- a/src/app/features/registration/confirm-account-details/confirm-account-details.component.ts
+++ b/src/app/features/registration/confirm-account-details/confirm-account-details.component.ts
@@ -4,7 +4,7 @@ import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
-import { LocationAddress } from '@core/model/location-address.model';
+import { LocationAddress } from '@core/model/location.model';
 import { LoginCredentials } from '@core/model/login-credentials.model';
 import { RegistrationPayload } from '@core/model/registration.model';
 import { RegistrationService } from '@core/services/registration.service';

--- a/src/app/features/registration/confirm-workplace-details/confirm-workplace-details.component.ts
+++ b/src/app/features/registration/confirm-workplace-details/confirm-workplace-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { RegistrationService } from '../../../core/services/registration.service';
 import { Subscription } from 'rxjs';
-import { LocationAddress } from '@core/model/location-address.model';
+import { LocationAddress } from '@core/model/location.model';
 import { WorkplaceService } from '@core/model/workplace-service.model';
 
 @Component({

--- a/src/app/features/registration/enter-workplace-address/enter-workplace-address.component.ts
+++ b/src/app/features/registration/enter-workplace-address/enter-workplace-address.component.ts
@@ -5,7 +5,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { debounceTime } from 'rxjs/operators';
 
 import { RegistrationService } from '../../../core/services/registration.service';
-import { RegistrationModel } from '../../../core/model/registration.model';
+import { LocationSearchResponse } from '@core/model/locationSearchResponse';
 
 @Component({
   selector: 'app-enter-workplace-address',
@@ -14,7 +14,7 @@ import { RegistrationModel } from '../../../core/model/registration.model';
 })
 export class EnterWorkplaceAddressComponent implements OnInit {
   enterWorkplaceAddressForm: FormGroup;
-  registration: RegistrationModel;
+  registration: LocationSearchResponse;
 
   currentSection: number;
   lastSection: number;

--- a/src/app/features/registration/enter-workplace-address/enter-workplace-address.component.ts
+++ b/src/app/features/registration/enter-workplace-address/enter-workplace-address.component.ts
@@ -4,8 +4,8 @@ import { FormGroup, FormBuilder, Validators, AbstractControl } from '@angular/fo
 import { Router, ActivatedRoute } from '@angular/router';
 import { debounceTime } from 'rxjs/operators';
 
-import { RegistrationService } from '../../../core/services/registration.service';
-import { LocationSearchResponse } from '@core/model/locationSearchResponse';
+import { RegistrationService } from '@core/services/registration.service';
+import { LocationSearchResponse } from '@core/model/location.model';
 
 @Component({
   selector: 'app-enter-workplace-address',

--- a/src/app/features/registration/enter-workplace-address/enter-workplace-address.component.ts
+++ b/src/app/features/registration/enter-workplace-address/enter-workplace-address.component.ts
@@ -5,7 +5,6 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { debounceTime } from 'rxjs/operators';
 
 import { RegistrationService } from '@core/services/registration.service';
-import { LocationSearchResponse } from '@core/model/location.model';
 
 @Component({
   selector: 'app-enter-workplace-address',
@@ -14,7 +13,6 @@ import { LocationSearchResponse } from '@core/model/location.model';
 })
 export class EnterWorkplaceAddressComponent implements OnInit {
   enterWorkplaceAddressForm: FormGroup;
-  registration: LocationSearchResponse;
 
   currentSection: number;
   lastSection: number;
@@ -113,8 +111,6 @@ export class EnterWorkplaceAddressComponent implements OnInit {
       wpNameInput: ['', [Validators.required, Validators.maxLength(120)]]
     });
 
-    this._registrationService.registration$.subscribe(registration => this.registration = registration);
-
     this.loadExistingValues();
 
     // -- START -- Validation check watchers
@@ -198,8 +194,6 @@ export class EnterWorkplaceAddressComponent implements OnInit {
     );
 
     // -- END -- Validation check watchers
-
-    this.setSectionNumbers();
   }
 
   // -- START -- Set validation handlers
@@ -266,22 +260,22 @@ export class EnterWorkplaceAddressComponent implements OnInit {
 
   loadExistingValues() {
 
-    if ((this.registration.locationdata[0].hasOwnProperty('locationName')) && (this.registration.locationdata[0].locationName === '')) {
-      const postcodeValue = this.registration.locationdata[0].postalCode;
-      const address1Value = this.registration.locationdata[0].addressLine1;
-      const address2Value = this.registration.locationdata[0].addressLine2;
-      const townCityValue = this.registration.locationdata[0].townCity;
-      const countyValue = this.registration.locationdata[0].county;
-
-      this.enterWorkplaceAddressForm.setValue({
-        postcodeInput: postcodeValue,
-        address1Input: address1Value,
-        address2Input: address2Value,
-        townCityInput: townCityValue,
-        countyInput: countyValue,
-        wpNameInput: '',
-      });
-    }
+    // if ((this.registration.locationdata[0].hasOwnProperty('locationName')) && (this.registration.locationdata[0].locationName === '')) {
+    //   const postcodeValue = this.registration.locationdata[0].postalCode;
+    //   const address1Value = this.registration.locationdata[0].addressLine1;
+    //   const address2Value = this.registration.locationdata[0].addressLine2;
+    //   const townCityValue = this.registration.locationdata[0].townCity;
+    //   const countyValue = this.registration.locationdata[0].county;
+    //
+    //   this.enterWorkplaceAddressForm.setValue({
+    //     postcodeInput: postcodeValue,
+    //     address1Input: address1Value,
+    //     address2Input: address2Value,
+    //     townCityInput: townCityValue,
+    //     countyInput: countyValue,
+    //     wpNameInput: '',
+    //   });
+    // }
   }
 
   onSubmit() {
@@ -311,38 +305,17 @@ export class EnterWorkplaceAddressComponent implements OnInit {
     const countyValue = this.enterWorkplaceAddressForm.get('countyInput').value;
     const wpNameValue = this.enterWorkplaceAddressForm.get('wpNameInput').value;
 
-    // this._registrationService.registration$.subscribe(registration => this.registration = registration);
-
-    this.registration.locationdata[0]['postalCode'] = postcodeValue;
-    this.registration.locationdata[0]['addressLine1'] = address1Value;
-    this.registration.locationdata[0]['addressLine2'] = address2Value;
-    this.registration.locationdata[0]['townCity'] = townCityValue;
-    this.registration.locationdata[0]['county'] = countyValue;
-    this.registration.locationdata[0]['locationName'] = wpNameValue;
-
-    const updateRegistration = this.registration.locationdata[0];
-
-    this.updateSectionNumbers(this.registration);
-
-    this._registrationService.updateState(this.registration);
+    // this.registration.locationdata[0]['postalCode'] = postcodeValue;
+    // this.registration.locationdata[0]['addressLine1'] = address1Value;
+    // this.registration.locationdata[0]['addressLine2'] = address2Value;
+    // this.registration.locationdata[0]['townCity'] = townCityValue;
+    // this.registration.locationdata[0]['county'] = countyValue;
+    // this.registration.locationdata[0]['locationName'] = wpNameValue;
+    //
+    // const updateRegistration = this.registration.locationdata[0];
 
     this.router.navigate(['/registration/select-main-service']);
 
-  }
-
-  setSectionNumbers() {
-    this.currentSection = this.registration.userRoute.currentPage;
-    this.backLink = this.registration.userRoute.route[this.currentSection - 1];
-
-    this.currentSection = this.currentSection + 1;
-    this.lastSection = 8;
-  }
-
-  updateSectionNumbers(data) {
-    data['userRoute'] = this.registration.userRoute;
-    data.userRoute['currentPage'] = this.currentSection;
-    data.userRoute['route'] = this.registration.userRoute['route'];
-    data.userRoute['route'].push('/registration/enter-workplace-address');
   }
 
 }

--- a/src/app/features/registration/find-workplace-address/find-workplace-address.component.html
+++ b/src/app/features/registration/find-workplace-address/find-workplace-address.component.html
@@ -1,0 +1,39 @@
+<app-error-summary
+  *ngIf="submitted && form.invalid"
+  [formErrorsMap]="formErrorsMap"
+  [form]="form"
+  [serverError]="serverError"
+>
+</app-error-summary>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Find your workplace address?</h1>
+
+    <form novalidate [formGroup]="form" (ngSubmit)="onSubmit()">
+      <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && getPostcode.errors">
+        <label class="govuk-label" for="postcode">
+          Postcode
+        </label>
+        <span *ngIf="submitted && getPostcode.errors" id="postcode-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span>
+          <ng-container *ngIf="getPostcode.hasError('required')">
+            {{ getFormErrorMessage('postcode', 'required') }}
+          </ng-container>
+          <ng-container *ngIf="getPostcode.hasError('maxlength')">
+            {{ getFormErrorMessage('postcode', 'maxlength') }}
+          </ng-container>
+        </span>
+        <input
+          class="govuk-input govuk-input--width-10"
+          formControlName="postcode"
+          id="postcode"
+          name="postcode"
+          [class.govuk-input--error]="submitted && getPostcode.errors"
+          type="text"
+        />
+        <button type="submit" class="govuk-button govuk-!-margin-left-3 govuk-!-margin-bottom-0">Find address</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/src/app/features/registration/find-workplace-address/find-workplace-address.component.spec.ts
+++ b/src/app/features/registration/find-workplace-address/find-workplace-address.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FindWorkplaceAddressComponent } from './find-workplace-address.component';
+
+describe('FindWorkplaceAddressComponent', () => {
+  let component: FindWorkplaceAddressComponent;
+  let fixture: ComponentFixture<FindWorkplaceAddressComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FindWorkplaceAddressComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FindWorkplaceAddressComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/registration/find-workplace-address/find-workplace-address.component.ts
+++ b/src/app/features/registration/find-workplace-address/find-workplace-address.component.ts
@@ -1,0 +1,128 @@
+import { BackService } from '@core/services/back.service';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
+import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+import { LocationSearchResponse } from '@core/model/location.model';
+import { RegistrationService } from '@core/services/registration.service';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-find-workplace-address',
+  templateUrl: './find-workplace-address.component.html',
+})
+export class FindWorkplaceAddressComponent implements OnInit, OnDestroy {
+  private form: FormGroup;
+  private formErrorsMap: Array<ErrorDetails>;
+  private serverError: string;
+  private serverErrorsMap: Array<ErrorDefinition>;
+  private submitted = false;
+  private subscriptions: Subscription = new Subscription();
+
+  constructor(
+    private backService: BackService,
+    private errorSummaryService: ErrorSummaryService,
+    private fb: FormBuilder,
+    private registrationService: RegistrationService,
+    private router: Router,
+  ) {}
+
+  ngOnInit() {
+    this.setupForm();
+    this.setupFormErrorsMap();
+    this.setupServerErrorsMap();
+    this.setBackLink();
+  }
+
+  get getPostcode() {
+    return this.form.get('postcode');
+  }
+
+  private setupForm(): void {
+    this.form = this.fb.group({
+      postcode: ['', [Validators.required, Validators.maxLength(8)]],
+    });
+  }
+
+  private setupFormErrorsMap(): void {
+    this.formErrorsMap = [
+      {
+        item: 'postcode',
+        type: [
+          {
+            name: 'required',
+            message: 'Please enter a postcode.',
+          },
+          {
+            name: 'maxlength',
+            message: 'Invalid postcode.',
+          },
+        ],
+      },
+    ];
+  }
+
+  private setupServerErrorsMap(): void {
+    this.serverErrorsMap = [
+      {
+        name: 400,
+        message: 'No results found.',
+      },
+      {
+        name: 404,
+        message: 'Invalid postcode.',
+      },
+      {
+        name: 503,
+        message: 'Database error.',
+      },
+    ];
+  }
+
+  private getAddressesByPostCode(): void {
+    this.subscriptions.add(
+      this.registrationService.getAddressesByPostCode(this.getPostcode.value).subscribe(
+        (data: LocationSearchResponse) => {
+          this.registrationService.locationAddresses$.next(data.postcodedata);
+          this.router.navigate(['/registration/select-workplace-address']);
+        },
+        (error: HttpErrorResponse) => {
+          this.serverError = this.errorSummaryService.getServerErrorMessage(error.status, this.serverErrorsMap);
+          this.errorSummaryService.scrollToErrorSummary();
+        }
+      )
+    );
+  }
+
+  private onSubmit(): void {
+    this.submitted = true;
+    this.errorSummaryService.syncFormErrorsEvent.next(true);
+
+    if (this.form.valid) {
+      this.getAddressesByPostCode();
+    } else {
+      this.errorSummaryService.scrollToErrorSummary();
+    }
+  }
+
+  private setBackLink(): void {
+    this.backService.setBackLink({ url: ['/registration/select-workplace-address'] });
+  }
+
+  /**
+   * Pass in formGroup or formControl name and errorType
+   * Then return error message
+   * @param item
+   * @param errorType
+   */
+  public getFormErrorMessage(item: string, errorType: string): string {
+    return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+}

--- a/src/app/features/registration/registration-complete/registration-complete.component.ts
+++ b/src/app/features/registration/registration-complete/registration-complete.component.ts
@@ -1,7 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { RegistrationService } from '@core/services/registration.service';
 
 @Component({
   selector: 'app-registration-complete',
   templateUrl: './registration-complete.component.html'
 })
-export class RegistrationCompleteComponent {}
+export class RegistrationCompleteComponent implements OnInit {
+
+  constructor(private registrationService: RegistrationService) {}
+
+  ngOnInit(): void {
+    this.registrationService.registrationInProgress$.next(false);
+  }
+
+}

--- a/src/app/features/registration/registration-routing.module.ts
+++ b/src/app/features/registration/registration-routing.module.ts
@@ -20,6 +20,7 @@ import {
 } from '@features/registration/select-workplace-address/select-workplace-address.component';
 import { SelectWorkplaceComponent } from '@features/registration/select-workplace/select-workplace.component';
 import { YourDetailsComponent } from '@features/registration/your-details/your-details.component';
+import { FindWorkplaceAddressComponent } from '@features/registration/find-workplace-address/find-workplace-address.component';
 
 const routes: Routes = [
   {
@@ -68,6 +69,12 @@ const routes: Routes = [
     component: RegistrationCompleteComponent,
     canActivate: [RegisterGuard],
     data: { title: 'Complete' },
+  },
+  {
+    path: 'find-workplace-address',
+    component: FindWorkplaceAddressComponent,
+    canActivate: [RegisterGuard],
+    data: { title: 'Find Workplace Address' },
   },
   {
     path: 'select-workplace-address',

--- a/src/app/features/registration/registration.module.ts
+++ b/src/app/features/registration/registration.module.ts
@@ -14,16 +14,18 @@ import { SelectWorkplaceComponent } from '@features/registration/select-workplac
 import { SharedModule } from '@shared/shared.module';
 import { YourDetailsComponent } from '@features/registration/your-details/your-details.component';
 import { RegistrationRoutingModule } from '@features/registration/registration-routing.module';
+import { FindWorkplaceAddressComponent } from './find-workplace-address/find-workplace-address.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, RegistrationRoutingModule],
   declarations: [
     ConfirmAccountDetailsComponent,
     ConfirmWorkplaceDetailsComponent,
-    RegulatedByCqcComponent,
     CreateUsernameComponent,
     EnterWorkplaceAddressComponent,
+    FindWorkplaceAddressComponent,
     RegistrationCompleteComponent,
+    RegulatedByCqcComponent,
     SecurityQuestionComponent,
     SelectMainServiceComponent,
     SelectWorkplaceAddressComponent,

--- a/src/app/features/registration/regulated-by-cqc/regulated-by-cqc.component.ts
+++ b/src/app/features/registration/regulated-by-cqc/regulated-by-cqc.component.ts
@@ -15,7 +15,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 })
 export class RegulatedByCqcComponent implements OnInit, OnDestroy {
   public form: FormGroup;
-  private registration: LocationSearchResponse;
   public submitted = false;
 
   public formErrorsMap: Array<ErrorDetails>;
@@ -56,10 +55,6 @@ export class RegulatedByCqcComponent implements OnInit, OnDestroy {
     this.setupForm();
     this.setupFormErrorsMap();
     this.setupServerErrorsMap();
-
-    this.subscriptions.add(
-      this.registrationService.registration$.subscribe((registration: LocationSearchResponse) => this.registration = registration)
-    );
   }
 
   private setupForm(): void {

--- a/src/app/features/registration/regulated-by-cqc/regulated-by-cqc.component.ts
+++ b/src/app/features/registration/regulated-by-cqc/regulated-by-cqc.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { RegistrationModel } from '@core/model/registration.model';
+import { LocationSearchResponse } from '@core/model/location.model';
 import { RegistrationService } from '@core/services/registration.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
@@ -15,7 +15,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 })
 export class RegulatedByCqcComponent implements OnInit, OnDestroy {
   public form: FormGroup;
-  private registration: RegistrationModel;
+  private registration: LocationSearchResponse;
   public submitted = false;
 
   public formErrorsMap: Array<ErrorDetails>;
@@ -58,7 +58,7 @@ export class RegulatedByCqcComponent implements OnInit, OnDestroy {
     this.setupServerErrorsMap();
 
     this.subscriptions.add(
-      this.registrationService.registration$.subscribe((registration: RegistrationModel) => this.registration = registration)
+      this.registrationService.registration$.subscribe((registration: LocationSearchResponse) => this.registration = registration)
     );
   }
 
@@ -191,28 +191,28 @@ export class RegulatedByCqcComponent implements OnInit, OnDestroy {
     if (this.regulatedPostcode.value.length) {
       this.subscriptions.add(
         this.registrationService.getLocationByPostCode(this.regulatedPostcode.value).subscribe(
-          (data: RegistrationModel) => this.onSuccess(data),
+          (data: LocationSearchResponse) => this.onSuccess(data),
           (error: HttpErrorResponse) => this.onError(error)
         )
       );
     } else if (this.locationId.value.length) {
       this.subscriptions.add(
         this.registrationService.getLocationByLocationId(this.locationId.value).subscribe(
-          (data: RegistrationModel) => this.onSuccess(data),
+          (data: LocationSearchResponse) => this.onSuccess(data),
           (error: HttpErrorResponse) => this.onError(error)
         )
       );
     } else if (this.nonRegulatedPostcode.value.length) {
       this.subscriptions.add(
         this.registrationService.getAddressByPostCode(this.nonRegulatedPostcode.value).subscribe(
-          (data: RegistrationModel) => this.onSuccess(data),
+          (data: LocationSearchResponse) => this.onSuccess(data),
           (error: HttpErrorResponse) => this.onError(error)
         )
       );
     }
   }
 
-  private onSuccess(data: RegistrationModel): void {
+  private onSuccess(data: LocationSearchResponse): void {
     if (data.success === 1) {
       this.registrationService.locationAddresses$.next(data.locationdata || data.postcodedata);
       if (data.locationdata) {

--- a/src/app/features/registration/regulated-by-cqc/regulated-by-cqc.component.ts
+++ b/src/app/features/registration/regulated-by-cqc/regulated-by-cqc.component.ts
@@ -199,7 +199,7 @@ export class RegulatedByCqcComponent implements OnInit, OnDestroy {
       );
     } else if (this.nonRegulatedPostcode.value.length) {
       this.subscriptions.add(
-        this.registrationService.getAddressByPostCode(this.nonRegulatedPostcode.value).subscribe(
+        this.registrationService.getAddressesByPostCode(this.nonRegulatedPostcode.value).subscribe(
           (data: LocationSearchResponse) => this.onSuccess(data),
           (error: HttpErrorResponse) => this.onError(error)
         )

--- a/src/app/features/registration/regulated-by-cqc/regulated-by-cqc.component.ts
+++ b/src/app/features/registration/regulated-by-cqc/regulated-by-cqc.component.ts
@@ -208,6 +208,8 @@ export class RegulatedByCqcComponent implements OnInit, OnDestroy {
   }
 
   private onSuccess(data: LocationSearchResponse): void {
+    this.registrationService.registrationInProgress$.next(true);
+
     if (data.success === 1) {
       this.registrationService.locationAddresses$.next(data.locationdata || data.postcodedata);
       if (data.locationdata) {

--- a/src/app/features/registration/select-main-service/select-main-service.component.ts
+++ b/src/app/features/registration/select-main-service/select-main-service.component.ts
@@ -3,7 +3,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { LocationAddress } from '@core/model/location-address.model';
+import { LocationAddress } from '@core/model/location.model';
 import { RegistrationService } from '@core/services/registration.service';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';

--- a/src/app/features/registration/select-workplace-address/select-workplace-address.component.html
+++ b/src/app/features/registration/select-workplace-address/select-workplace-address.component.html
@@ -1,67 +1,102 @@
-<div class="sub-page-container col-12">
+<app-error-summary
+  *ngIf="submitted && form.invalid"
+  [formErrorsMap]="formErrorsMap"
+  [form]="form"
+  [serverError]="serverError"
+>
+</app-error-summary>
 
-  <div id="back" class="back-link">
-    <a routerLink="/registration/regulated-by-cqc">
-      <span class="arrow"></span>Back
-    </a>
-  </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Select your workplace address</h1>
+    <p>We couldn’t find your workplace from CQC, select the appropriate address below.</p>
 
-  <!-- <p class="h5">Section 2 of 9</p> -->
-  <h1 class="h1">Select your workplace address</h1>
+    <div>form.valid = {{ form.valid }}</div>
+    <div>getPostcode.errors = {{ getPostcode.errors | json  }}</div>
+    <div>getAddress.errors = {{ getAddress.errors | json  }}</div>
 
-  <p class="main-body-text mb-5 d-block col-12 col-md-7 p-0">We couldn’t find your workplace from CQC, select the appropriate address below</p>
-
-  <form novalidate
-        [formGroup]="selectWorkplaceAddressForm">
-
-    <div class="form-group mb-5">
-      <div class="col-12 col-md-7 p-0">
-
-        <div class="field-group updatePostcode" [ngClass]="{'is-invalid': postcodeApiError }">
-
-          <span class="invalid-feedback">
-            <span class="main-body-text mb-2" *ngIf="postcodeApiError">
-              Invalid Postcode
-            </span>
-          </span>
-
-          <div class="row ml-0 mb-5" *ngIf="editPostcode">
-            <input placeholder="" type="text" id="postcode" class="form-control col-md-4 d-inline-block" formControlName="postcodeInput" />
-            <button class="btn btn-secondary d-inline-block align-top ml-4" (click)="updatePostcode()">Update</button>
-          </div>
-          <div class="row mb-5" *ngIf="!editPostcode">
-            <div class="main-body-text-bold col-5 col-sm-3">{{ postcodeValue }}</div>
-            <div class="main-body-text col-5 col-sm-3 pl-0"><span class="text-link" title="Edit postcode" (click)="postcodeChange()">Change</span></div>
-          </div>
-        </div>
-
-        <div class="field-group" [ngClass]="{'is-invalid': selectAddressMessage, 'd-none': postcodeApiError }">
-
-          <span class="invalid-feedback">
-            <span class="main-body-text mb-2" *ngIf="selectAddressMessage">
-              Select your address
-            </span>
-          </span>
-
-          <select class="col-12 col-md-10 pl-2 pr-2" id="selectWorkplaceAddress" formControlName="selectWorkplaceAddressSelected">
-            <option value="" hidden disabled>Please select your workplace address</option>
-            <option value="{{i}}" *ngFor="let item of registration.postcodedata; let i = index;">{{ item.locationName ? item.locationName + ', ' : '' }}{{ item.addressLine1 }}, {{ item.addressLine2 }} - {{ item.townCity }} {{ item.postalCode }}</option>
-          </select>
-        </div>
-
+    <form novalidate [formGroup]="form" (ngSubmit)="onSubmit()">
+      <div
+        class="govuk-form-group"
+        *ngIf="editPostcode"
+        [class.govuk-form-group--error]="submitted && getPostcode.errors"
+      >
+        <label class="govuk-label" for="postcode">
+          Password
+        </label>
+        <span *ngIf="submitted && getPostcode.errors" id="postcode-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span>
+          <ng-container *ngIf="getPostcode.hasError('required')">
+            {{ getFormErrorMessage('postcode', 'required') }}
+          </ng-container>
+          <ng-container *ngIf="getPostcode.hasError('maxlength')">
+            {{ getFormErrorMessage('postcode', 'maxlength') }}
+          </ng-container>
+        </span>
+        <input
+          class="govuk-input"
+          formControlName="postcode"
+          id="postcode"
+          name="postcode"
+          [class.govuk-input--error]="submitted && getPostcode.errors"
+          type="text"
+        />
       </div>
 
-    </div>
+      <!--      <div class="form-group mb-5">-->
+      <!--        <div class="col-12 col-md-7 p-0">-->
+      <!--          <div class="field-group updatePostcode" [ngClass]="{ 'is-invalid': postcodeApiError }">-->
+      <!--            <span class="invalid-feedback">-->
+      <!--              <span class="main-body-text mb-2" *ngIf="postcodeApiError">-->
+      <!--                Invalid Postcode-->
+      <!--              </span>-->
+      <!--            </span>-->
 
-    <div class="col-12  mt-4 mb-5 p-0">
-      <a class="text-link" routerLink="/registration/enter-workplace-address" title="I can't find my address">I can't find my address</a>
-    </div>
+      <!--            <div class="row ml-0 mb-5" *ngIf="editPostcode">-->
+      <!--              <input-->
+      <!--                placeholder=""-->
+      <!--                type="text"-->
+      <!--                id="postcode"-->
+      <!--                class="form-control col-md-4 d-inline-block"-->
+      <!--                formControlName="postcodeInput"-->
+      <!--              />-->
+      <!--              <button class="btn btn-secondary d-inline-block align-top ml-4" (click)="updatePostcode()">Update</button>-->
+      <!--            </div>-->
+      <!--            <div class="row mb-5" *ngIf="!editPostcode">-->
+      <!--              <div class="main-body-text-bold col-5 col-sm-3">{{ postcodeValue }}</div>-->
+      <!--              <div class="main-body-text col-5 col-sm-3 pl-0">-->
+      <!--                <span class="text-link" title="Edit postcode" (click)="postcodeChange()">Change</span>-->
+      <!--              </div>-->
+      <!--            </div>-->
+      <!--          </div>-->
 
-    <div class="btn-container">
-      <button class="btn btn-primary" type="submit" (click)="save()">Continue</button>
-    </div>
+      <!--          <div class="field-group" [ngClass]="{ 'is-invalid': selectAddressMessage, 'd-none': postcodeApiError }">-->
+      <!--            <span class="invalid-feedback">-->
+      <!--              <span class="main-body-text mb-2" *ngIf="selectAddressMessage">-->
+      <!--                Select your address-->
+      <!--              </span>-->
+      <!--            </span>-->
 
-  </form>
+      <!--            <select-->
+      <!--              class="col-12 col-md-10 pl-2 pr-2"-->
+      <!--              id="selectWorkplaceAddress"-->
+      <!--              formControlName="selectWorkplaceAddressSelected"-->
+      <!--            >-->
+      <!--              <option value="" hidden disabled>Please select your workplace address</option>-->
+      <!--              <option value="{{ i }}" *ngFor="let item of registration.postcodedata; let i = index"-->
+      <!--                >{{ item.locationName ? item.locationName + ', ' : '' }}{{ item.addressLine1 }},-->
+      <!--                {{ item.addressLine2 }} - {{ item.townCity }} {{ item.postalCode }}</option-->
+      <!--              >-->
+      <!--            </select>-->
+      <!--          </div>-->
+      <!--        </div>-->
+      <!--      </div>-->
 
+      <p>
+        <a [routerLink]="['/registration/enter-workplace-address']">I can't find my address</a>
+      </p>
 
+      <button class="govuk-button" type="submit">Continue</button>
+    </form>
+  </div>
 </div>

--- a/src/app/features/registration/select-workplace-address/select-workplace-address.component.html
+++ b/src/app/features/registration/select-workplace-address/select-workplace-address.component.html
@@ -2,7 +2,6 @@
   *ngIf="submitted && form.invalid"
   [formErrorsMap]="formErrorsMap"
   [form]="form"
-  [serverError]="serverError"
 >
 </app-error-summary>
 

--- a/src/app/features/registration/select-workplace-address/select-workplace-address.component.html
+++ b/src/app/features/registration/select-workplace-address/select-workplace-address.component.html
@@ -8,95 +8,48 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Select your workplace address</h1>
-    <p>We couldn’t find your workplace from CQC, select the appropriate address below.</p>
+    <h1 class="govuk-heading-l">What is your workplace address?</h1>
 
-    <div>form.valid = {{ form.valid }}</div>
-    <div>getPostcode.errors = {{ getPostcode.errors | json  }}</div>
-    <div>getAddress.errors = {{ getAddress.errors | json  }}</div>
+    <p class="govuk-!-margin-bottom-2">
+      <strong>Postcode</strong>
+    </p>
+    <p class="govuk-!-margin-bottom-6">
+      <strong>{{ enteredPostcode }}</strong>
+      <a [routerLink]="['/registration/find-workplace-address']" class="govuk-!-margin-left-6">Change</a>
+    </p>
 
     <form novalidate [formGroup]="form" (ngSubmit)="onSubmit()">
-      <div
-        class="govuk-form-group"
-        *ngIf="editPostcode"
-        [class.govuk-form-group--error]="submitted && getPostcode.errors"
-      >
-        <label class="govuk-label" for="postcode">
-          Password
+      <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && getAddress.errors">
+        <label class="govuk-label" for="address">
+          Select an address
         </label>
-        <span *ngIf="submitted && getPostcode.errors" id="postcode-error" class="govuk-error-message">
+        <span *ngIf="submitted && getAddress.errors" id="address-error" class="govuk-error-message">
           <span class="govuk-visually-hidden">Error:</span>
-          <ng-container *ngIf="getPostcode.hasError('required')">
-            {{ getFormErrorMessage('postcode', 'required') }}
-          </ng-container>
-          <ng-container *ngIf="getPostcode.hasError('maxlength')">
-            {{ getFormErrorMessage('postcode', 'maxlength') }}
-          </ng-container>
+          {{ getFormErrorMessage('address', 'required') }}
         </span>
-        <input
-          class="govuk-input"
-          formControlName="postcode"
-          id="postcode"
-          name="postcode"
-          [class.govuk-input--error]="submitted && getPostcode.errors"
-          type="text"
-        />
+        <select
+          class="govuk-select"
+          [class.govuk-select--error]="submitted && getAddress.errors"
+          formControlName="address"
+          id="address"
+          name="address"
+          (change)="onLocationChange($event.target.value)"
+        >
+          <option [value]="" disabled>{{ locationAddresses.length }} addresses found</option>
+          <option
+            *ngFor="let location of locationAddresses"
+            [value]="location.addressLine1"
+          >
+            {{ getLocationName(location) }}
+          </option>
+        </select>
       </div>
-
-      <!--      <div class="form-group mb-5">-->
-      <!--        <div class="col-12 col-md-7 p-0">-->
-      <!--          <div class="field-group updatePostcode" [ngClass]="{ 'is-invalid': postcodeApiError }">-->
-      <!--            <span class="invalid-feedback">-->
-      <!--              <span class="main-body-text mb-2" *ngIf="postcodeApiError">-->
-      <!--                Invalid Postcode-->
-      <!--              </span>-->
-      <!--            </span>-->
-
-      <!--            <div class="row ml-0 mb-5" *ngIf="editPostcode">-->
-      <!--              <input-->
-      <!--                placeholder=""-->
-      <!--                type="text"-->
-      <!--                id="postcode"-->
-      <!--                class="form-control col-md-4 d-inline-block"-->
-      <!--                formControlName="postcodeInput"-->
-      <!--              />-->
-      <!--              <button class="btn btn-secondary d-inline-block align-top ml-4" (click)="updatePostcode()">Update</button>-->
-      <!--            </div>-->
-      <!--            <div class="row mb-5" *ngIf="!editPostcode">-->
-      <!--              <div class="main-body-text-bold col-5 col-sm-3">{{ postcodeValue }}</div>-->
-      <!--              <div class="main-body-text col-5 col-sm-3 pl-0">-->
-      <!--                <span class="text-link" title="Edit postcode" (click)="postcodeChange()">Change</span>-->
-      <!--              </div>-->
-      <!--            </div>-->
-      <!--          </div>-->
-
-      <!--          <div class="field-group" [ngClass]="{ 'is-invalid': selectAddressMessage, 'd-none': postcodeApiError }">-->
-      <!--            <span class="invalid-feedback">-->
-      <!--              <span class="main-body-text mb-2" *ngIf="selectAddressMessage">-->
-      <!--                Select your address-->
-      <!--              </span>-->
-      <!--            </span>-->
-
-      <!--            <select-->
-      <!--              class="col-12 col-md-10 pl-2 pr-2"-->
-      <!--              id="selectWorkplaceAddress"-->
-      <!--              formControlName="selectWorkplaceAddressSelected"-->
-      <!--            >-->
-      <!--              <option value="" hidden disabled>Please select your workplace address</option>-->
-      <!--              <option value="{{ i }}" *ngFor="let item of registration.postcodedata; let i = index"-->
-      <!--                >{{ item.locationName ? item.locationName + ', ' : '' }}{{ item.addressLine1 }},-->
-      <!--                {{ item.addressLine2 }} - {{ item.townCity }} {{ item.postalCode }}</option-->
-      <!--              >-->
-      <!--            </select>-->
-      <!--          </div>-->
-      <!--        </div>-->
-      <!--      </div>-->
 
       <p>
         <a [routerLink]="['/registration/enter-workplace-address']">I can't find my address</a>
       </p>
 
-      <button class="govuk-button" type="submit">Continue</button>
+      <button class="govuk-button govuk-!-margin-top-6" type="submit">Continue</button>
     </form>
   </div>
 </div>

--- a/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
@@ -1,13 +1,13 @@
 import { BackService } from '@core/services/back.service';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
+import { ErrorDetails } from '@core/model/errorSummary.model';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
-import { HttpErrorResponse } from '@angular/common/http';
-import { LocationAddress, LocationSearchResponse } from '@core/model/location.model';
+import { LocationAddress } from '@core/model/location.model';
 import { RegistrationService } from '@core/services/registration.service';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
+import { filter } from 'lodash';
 
 @Component({
   selector: 'app-select-workplace-address',
@@ -19,11 +19,8 @@ export class SelectWorkplaceAddressComponent implements OnInit, OnDestroy {
   private formErrorsMap: Array<ErrorDetails>;
   private locationAddresses: Array<LocationAddress>;
   private selectedLocationAddress: LocationAddress;
-  private serverError: string;
-  private serverErrorsMap: Array<ErrorDefinition>;
   private submitted = false;
   private subscriptions: Subscription = new Subscription();
-  private editPostcode = false;
 
   constructor(
     private backService: BackService,
@@ -37,33 +34,16 @@ export class SelectWorkplaceAddressComponent implements OnInit, OnDestroy {
     return this.form.get('address');
   }
 
-  get getPostcode() {
-    return this.form.get('postcode');
-  }
-
   ngOnInit() {
-    // TODO remove
-    this.registrationService.selectedLocationAddress$.next({
-      addressLine1: '14A',
-      addressLine2: 'DUKE ROAD',
-      county: 'REDBRIDGE',
-      locationName: '',
-      postalCode: 'IG6 1NQ',
-      townCity: 'ILFORD',
-    });
-    // TODO remove
-
     this.setupForm();
     this.setupSubscriptions();
     this.setupFormErrorsMap();
-    this.setupServerErrorsMap();
     this.setBackLink();
   }
 
   private setupForm(): void {
     this.form = this.fb.group({
       address: ['', [Validators.required]],
-      postcode: '',
     });
   }
 
@@ -92,37 +72,7 @@ export class SelectWorkplaceAddressComponent implements OnInit, OnDestroy {
             message: 'Please select an address.',
           },
         ],
-      },
-      {
-        item: 'postcode',
-        type: [
-          {
-            name: 'required',
-            message: 'Please enter a postcode.',
-          },
-          {
-            name: 'maxlength',
-            message: 'Invalid postcode.',
-          },
-        ],
-      },
-    ];
-  }
-
-  private setupServerErrorsMap(): void {
-    this.serverErrorsMap = [
-      {
-        name: 400,
-        message: 'No results found.',
-      },
-      {
-        name: 404,
-        message: 'Invalid postcode.',
-      },
-      {
-        name: 503,
-        message: 'Database error.',
-      },
+      }
     ];
   }
 
@@ -130,35 +80,10 @@ export class SelectWorkplaceAddressComponent implements OnInit, OnDestroy {
     this.backService.setBackLink({ url: ['/registration/regulated-by-cqc'] });
   }
 
-  private changePostcode(): void {
-    this.editPostcode = true;
-    this.getPostcode.setValidators([Validators.required, Validators.maxLength(8)]);
-    this.getPostcode.updateValueAndValidity();
-
-    if (this.getAddress.valid) {
-      this.getAddressesByPostCode();
-    } else {
-      this.onSubmit();
-    }
-  }
-
-  private getAddressesByPostCode(): void {
-    this.subscriptions.add(
-      this.registrationService.getAddressesByPostCode(this.getPostcode.value).subscribe(
-        (data: LocationSearchResponse) => {
-          this.registrationService.locationAddresses$.next(data.postcodedata);
-          this.editPostcode = false;
-        },
-        (error: HttpErrorResponse) => {
-          this.serverError = this.errorSummaryService.getServerErrorMessage(error.status, this.serverErrorsMap);
-          this.errorSummaryService.scrollToErrorSummary();
-        }
-      )
-    );
-  }
-
-  private onAddressChange($event: LocationAddress): void {
-    this.registrationService.selectedLocationAddress$.next($event);
+  private onLocationChange(addressLine1: string): void {
+    const selectedLocation: LocationAddress = filter(this.locationAddresses, ['addressLine1', addressLine1])[0];
+    console.log('selectedLocation', selectedLocation);
+    this.registrationService.selectedLocationAddress$.next(selectedLocation);
   }
 
   private onSubmit(): void {
@@ -178,6 +103,12 @@ export class SelectWorkplaceAddressComponent implements OnInit, OnDestroy {
     } else {
       this.router.navigate(['/registration/select-main-service']);
     }
+  }
+
+  private getLocationName(location: LocationAddress): string {
+    let name: string = location.locationName.length ? `${location.locationName}, ` : '';
+    name += `${location.addressLine1}, ${location.addressLine2} - ${location.townCity} ${location.postalCode}`;
+    return name;
   }
 
   /**

--- a/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
@@ -82,7 +82,6 @@ export class SelectWorkplaceAddressComponent implements OnInit, OnDestroy {
 
   private onLocationChange(addressLine1: string): void {
     const selectedLocation: LocationAddress = filter(this.locationAddresses, ['addressLine1', addressLine1])[0];
-    console.log('selectedLocation', selectedLocation);
     this.registrationService.selectedLocationAddress$.next(selectedLocation);
   }
 

--- a/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
@@ -3,8 +3,8 @@ import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 
 import { Router } from '@angular/router';
 
-import { RegistrationService } from '../../../core/services/registration.service';
-import { RegistrationModel } from '../../../core/model/registration.model';
+import { RegistrationService } from '@core/services/registration.service';
+import { LocationSearchResponse } from '@core/model/location.model';
 
 @Component({
   selector: 'app-select-workplace-address',
@@ -12,7 +12,7 @@ import { RegistrationModel } from '../../../core/model/registration.model';
 })
 export class SelectWorkplaceAddressComponent implements OnInit {
   selectWorkplaceAddressForm: FormGroup;
-  registration: RegistrationModel;
+  registration: LocationSearchResponse;
   selectedAddress: string;
   editPostcode: boolean;
   postcodeValue: string;
@@ -130,7 +130,7 @@ export class SelectWorkplaceAddressComponent implements OnInit {
     }
 
     this._registrationService.getUpdatedAddressByPostCode(this.postcodeValue).subscribe(
-      (data: RegistrationModel) => {
+      (data: LocationSearchResponse) => {
         this.setRegulatedCheckFalse(data);
         this._registrationService.updateState(data);
       },

--- a/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
@@ -12,7 +12,6 @@ import { LocationSearchResponse } from '@core/model/location.model';
 })
 export class SelectWorkplaceAddressComponent implements OnInit {
   selectWorkplaceAddressForm: FormGroup;
-  registration: LocationSearchResponse;
   selectedAddress: string;
   editPostcode: boolean;
   postcodeValue: string;
@@ -43,14 +42,13 @@ export class SelectWorkplaceAddressComponent implements OnInit {
       this.selectWorkplaceAddressChanged(value);
     });
 
-    this._registrationService.registration$.subscribe(registration => (this.registration = registration));
     this.editPostcode = false;
 
     // Check if postcode already exists on load
-    this.checkExistingPostcode(this.registration);
+    // this.checkExistingPostcode(this.registration);
 
     // set not registered
-    this.setRegulatedCheckFalse(this.registration);
+    // this.setRegulatedCheckFalse(this.registration);
   }
 
   setRegulatedCheckFalse(data) {

--- a/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/registration/select-workplace-address/select-workplace-address.component.ts
@@ -46,8 +46,6 @@ export class SelectWorkplaceAddressComponent implements OnInit {
     this._registrationService.registration$.subscribe(registration => (this.registration = registration));
     this.editPostcode = false;
 
-    this.setSectionNumbers();
-
     // Check if postcode already exists on load
     this.checkExistingPostcode(this.registration);
 
@@ -91,8 +89,6 @@ export class SelectWorkplaceAddressComponent implements OnInit {
 
       postcodeObj.locationdata[0]['isRegulated'] = false;
 
-      this.updateSectionNumbers(postcodeObj);
-
       this._registrationService.updateState(postcodeObj);
 
       if (this.registration.locationdata[0].locationName === '') {
@@ -101,21 +97,6 @@ export class SelectWorkplaceAddressComponent implements OnInit {
         this.router.navigate(['/registration/select-main-service']);
       }
     }
-  }
-
-  setSectionNumbers() {
-    this.currentSection = this.registration.userRoute.currentPage;
-    this.backLink = this.registration.userRoute.route[this.currentSection - 1];
-
-    this.currentSection = this.currentSection + 1;
-    this.lastSection = 8;
-  }
-
-  updateSectionNumbers(data) {
-    data['userRoute'] = this.registration.userRoute || {};
-    data.userRoute['currentPage'] = this.currentSection;
-    data.userRoute['route'] = (this.registration.userRoute && this.registration.userRoute['route']) || [];
-    data.userRoute['route'].push('/registration/select-workplace-address');
   }
 
   postcodeChange() {

--- a/src/app/features/registration/select-workplace/select-workplace.component.ts
+++ b/src/app/features/registration/select-workplace/select-workplace.component.ts
@@ -3,7 +3,7 @@ import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { RegistrationService } from '@core/services/registration.service';
-import { LocationAddress } from '@core/model/location-address.model';
+import { LocationAddress } from '@core/model/location.model';
 import { ErrorDetails } from '@core/model/errorSummary.model';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { filter } from 'lodash';

--- a/src/app/features/your-account/your-account.component.ts
+++ b/src/app/features/your-account/your-account.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { UserService } from '../../core/services/user.service';
-import { AuthService } from '@core/services/auth-service';
+import { AuthService } from '@core/services/auth.service';
 import { Subscription } from 'rxjs';
 import { UserDetails } from '@core/model/userDetails.model';
 


### PR DESCRIPTION
- the `select workplace address` screen has now been split in to 2 screens as per rich's latest designs, the change postcode logic will be on a new route called `find-workplace-address` which is also included in this pr
- I'm going to work on `enter-workplace-address.component` in my next pr so please ignore the comment out code for now