### PR TITLE
Parents and subs - login API

### DIFF
--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -15,6 +15,10 @@
             "type" : "integer",
             "minimum" : 0
         },
+        "total" : {
+            "type" : "integer",
+            "minimum" : 0
+        },
         "Username" : {
             "type" : "string",
             "minLength": 3,
@@ -173,6 +177,24 @@
             },
             "required" : ["id"]
         },
+        "ServiceUser" : {
+            "description" : "A User of the Services at an Establishment",
+            "properties" : {
+                "id" : {
+                    "description" : "the unique reference of the service user type",
+                    "$ref" : "#/definitions/ID"
+                },
+                "name" : {
+                    "description" : "the display name of the service user type",
+                    "$ref" : "#/definitions/ServiceName"
+                },
+                "group" : {
+                    "description"  : "the group of this service user",
+                    "$ref" : "#/definitions/ServiceCategory"
+                }
+            },
+            "required" : ["id"]
+        },
         "ServiceGroup" : {
             "description" : "A collection of services having the same cateogory",
             "type" : "object",
@@ -185,6 +207,23 @@
                     "type" : "array",
                     "items" : {
                         "$ref" : "#/definitions/Service"
+                    },
+                    "minItems": 1
+                }
+            }
+        },
+        "ServiceUsersGroup" : {
+            "description" : "A collection of service users having the same group",
+            "type" : "object",
+            "properties" : {
+                "group" : {
+                    "$ref" : "#/definitions/ServiceCategory"
+                },
+                "services" : {
+                    "description" : "All the service users attributed to this service user group",
+                    "type" : "array",
+                    "items" : {
+                        "$ref" : "#/definitions/ServiceUser"
                     },
                     "minItems": 1
                 }
@@ -1269,6 +1308,10 @@
                     "description" : "The unique reference for this estasblishment",
                     "$ref" : "#/definitions/ID"
                 },
+                "uid" : {
+                    "description" : "The unique reference for this estasblishment - to replace (establishment::id)",
+                    "$ref" : "#/definitions/Uid"
+                },
                 "name" : {
                     "description" : "The given name ofthis establishment",
                     "$ref" : "#/definitions/EstablishmentName"
@@ -1289,6 +1332,15 @@
                     "description": "True if this establishment is regulated by CQC",
                     "type": "boolean"
                 },
+                "isParent" : {
+                    "description": "Flag (true/false) indicating whether this Establishment is a parent of others",
+                    "type" : "boolean",
+                    "default" : false
+                },
+                "parentUID" : {
+                    "description": "Optional - if this Establishment (sub) belongs to another, this is the reference (UUID) to that parent Establishment",
+                    "$ref" : "#/definitions/Uid"
+                },
                 "mainService" : {
                     "description" : "(Optionally), the primary service associated with this Establishment",
                     "$ref" : "#/definitions/Service"
@@ -1301,8 +1353,18 @@
                     "description": "Optionally, the establishment can be associated with more than just the main service",
                     "type" : "array",
                     "items" : {
-                        "$ref" : "#/definitions/ServiceGroup"
+                        "$ref" : "#/definitions/Service"
                     }
+                },
+                "serviceUsers" : {
+                    "description": "Optionally, the establishment can be associated with one or more service user types",
+                    "type" : "array",
+                    "items" : {
+                        "$ref" : "#/definitions/ServiceUser"
+                    }
+                },
+                "capacities" : {
+                    "description" : "TBC"
                 },
                 "allOtherServices" : {
                     "description": "Optionally, the list of all services available to this Establishment based on CQC (isRegistered), with those services already associated to this Establishment highlighted",
@@ -1315,11 +1377,41 @@
                     "description" : "Whether to share, and if so, the share options (LA/CQC)",
                     "$ref" : "#/definitions/ShareOptions"
                 },
+                "localAuthorities" : {
+                    "description" : "TBC"
+                },
+                "primaryAuthority" : {
+                    "description" : "TBC"
+                },
                 "numberOfStaff" : {
                     "description" : "The number of staff reported at this Establishment",
                     "type" : "integer",
                     "minimum": 0,
                     "maximum": 999
+                },
+                "TotalVacencies" : {
+                    "description" : "The total number of Vacancies",
+                    "type" : "#/definitions/total"
+                },
+                "Vacancies" : {
+                    "description" : "TBC"
+                },
+                "TotalStarters" : {
+                    "description" : "The total number of Starters",
+                    "type" : "#/definitions/total"
+                },
+                "Starters" : {
+                    "description" : "TBC"
+                },
+                "TotalLeavers" : {
+                    "description" : "The total number of Leavers",
+                    "type" : "#/definitions/total"
+                },
+                "Leavers" : {
+                    "description" : "TBC"
+                },
+                "wdf" : {
+                    "description" : "TBC"
                 },
                 "workers" : {
                     "description": "An Establishment has zero or more Workers",
@@ -1327,6 +1419,21 @@
                     "items" : [
                         { "$ref" : "#/definitions/Worker" }
                     ]
+                },
+                "createdAt" : {
+                    "description" : "When the worker record was created",
+                    "type" : "date-time"
+                },
+                "updatedAt" : {
+                    "description": "When the worker record was last updated",
+                    "type" : "date-time"
+                },
+                "updatedBy" : {
+                    "description" : "The username of the last person to update the Worker",
+                    "type" : "string"
+                },
+                "history" : {
+                    "$ref" : "#/definitions/ChangeHistory"
                 }
             },
             "required" : ["id", "name"]

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -47,6 +47,9 @@ class Establishment {
         this._nmdsId = null;
         this._lastWdfEligibility = null;
         this._overallWdfEligibility = null;
+        this._isParent = false;
+        this._parentUid = null;
+        this._parentId = null;
 
         // abstracted properties
         const thisEstablishmentManager = new EstablishmentProperties();
@@ -120,6 +123,13 @@ class Establishment {
         return this._updatedBy;
     }
 
+    get isParent() {
+        return this._isParent;
+    }
+    get parentUid() {
+        return this._parentUid;
+    }
+
     get numberOfStaff() {
         return this._properties.get('NumberOfStaff') ? this._properties.get('NumberOfStaff').property : 0;
     }
@@ -189,13 +199,14 @@ class Establishment {
         }
 
         if (mustSave && this._isNew) {
-            // create new User
+            // create new Establishment
             try {
                 const creationDocument = {
                     uid: this.uid,
                     NameValue: this.name,
                     address: this._address,
                     postcode: this._postcode,
+                    isParent: this._isParent,
                     isRegulated: this._isRegulated,
                     locationId: this._locationId,
                     MainServiceFKValue: this.mainService.id,
@@ -559,6 +570,9 @@ class Establishment {
                 this._nmdsId = fetchResults.nmdsId;
                 this._lastWdfEligibility = fetchResults.lastWdfEligibility;
                 this._overallWdfEligibility = fetchResults.overallWdfEligibility;
+                this._isParent = fetchResults.isParent;
+                this._parentId = fetchResults.parentId;
+                this._parentUid = fetchResults.parentUid;
 
                 // if history of the User is also required; attach the association
                 //  and order in reverse chronological - note, order on id (not when)

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -45,6 +45,22 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       field: '"LastWdfEligibility"'
     },
+    isParent: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      default: false,
+      field: '"IsParent"'
+    },
+    parentId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"ParentID"'
+    },
+    parentUid: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: '"ParentUID"'
+    },
     NameValue: {
       type: DataTypes.TEXT,
       allowNull: false,

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -28,7 +28,7 @@ router.post('/',async function(req, res) {
           attributes: ['id', 'FullNameValue', 'EmailValue', 'isAdmin', 'isPrimary', 'establishmentId', "UserRoleValue"],
           include: [{
             model: models.establishment,
-            attributes: ['id', 'uid', 'NameValue', 'isRegulated', 'nmdsId'],
+            attributes: ['id', 'uid', 'NameValue', 'isRegulated', 'nmdsId', 'isParent', 'parentUid'],
             include: [{
               model: models.services,
               as: 'mainService',
@@ -50,7 +50,7 @@ router.post('/',async function(req, res) {
           if (isMatch && !err) {
             const loginTokenTTL = config.get('jwt.ttl.login');
 
-            const token = generateJWT.loginJWT(loginTokenTTL, login.user.establishment.id, login.user.establishment.uid, req.body.username.toLowerCase(), login.user.UserRoleValue);
+            const token = generateJWT.loginJWT(loginTokenTTL, login.user.establishment.id, login.user.establishment.uid, login.user.establishment.isParent, req.body.username.toLowerCase(), login.user.UserRoleValue);
             var date = new Date().getTime();
             date += (loginTokenTTL * 60  * 1000);
    
@@ -167,7 +167,9 @@ const formatSuccessulLoginResponse = (fullname, firstLoginDate, isPrimary, lastL
       uid: establishment.uid,
       name: establishment.NameValue,
       isRegulated: establishment.isRegulated,
-      nmdsId: establishment.nmdsId
+      nmdsId: establishment.nmdsId,
+      isParent: establishment.isParent,
+      parentUid: establishment.parentUid ? establishment.parentUid : undefined
     },
     mainService: {
       id: mainService ? mainService.id : null,

--- a/server/utils/security/generateJWT.js
+++ b/server/utils/security/generateJWT.js
@@ -4,17 +4,16 @@ const Authorization = require('./isAuthenticated');
 const Token_Secret = Authorization.getTokenSecret();
 
 // this generates the login JWT
-exports.loginJWT = (ttlMinutes, establishmentId, establishmentUid, username, role) => {
+exports.loginJWT = (ttlMinutes, establishmentId, establishmentUid, isParent, username, role) => {
   var claims = {
     EstblishmentId: establishmentId,
     EstablishmentUID: establishmentUid,
     role,
+    isParent,
     sub: username,
     aud: config.get('jwt.aud.login'),
     iss: config.get('jwt.iss')
   };
-
-  console.log("WA DEBUG: Login ttl in: ", ttlMinutes)
 
   return jwt.sign(JSON.parse(JSON.stringify(claims)), Token_Secret, {expiresIn: `${ttlMinutes}m`});   
 };


### PR DESCRIPTION
This first parent & subs PR inrtoduces the "is parent" and "parent ID/UID" attributes for Establishment - including the DB schema changes.

All current registrations are standalone; so is parent defaults to false and parent ID/UID is always NULL.

Login API response has been updated to return the "is parent" status; for now, it will be necessary to manually update the Establishment record in the database to change to true. Actions to make parent/make a sub are not yet in sprint scope.

Login JWT also updated to include "is parent" status. I need this for a new API I will next develop to return the set of associated subs for a parent establishment.

_Apologies for the extensive updates on Establishment JSON Schema type. Whilst I was updating it for parent/subs I realised it was out of date. Some of the attributes are placeholders - TBC; I have tech debt card on JSON schema validation._