### PR TITLE
Adding support for tribal hashing of migrated tribal user accounts

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -216,6 +216,11 @@ module.exports = function(sequelize, DataTypes) {
       default: false,
       field: '"AdminUser"'
     },
+    tribalId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      field: '"TribalID"'
+    },
     created: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -258,7 +258,7 @@ router.route('/changePassword').post(async (req, res) => {
 
         if (login && login.username === req.username && login.user.id) {
             // now authenticate the given current password
-            login.comparePassword(currentPassword, async (err, isMatch) => {
+            login.comparePassword(currentPassword, null, false, async (err, isMatch, rehashTribal) => {
                 if (isMatch && !err) {
                     await models.sequelize.transaction(async t => {
                         // login account found - update the passowrd, reset invalid attempts

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -1,9 +1,12 @@
- var express = require('express');
- const models = require('../models/index');
- const passport = require('passport');
- var router = express.Router();
- require('../utils/security/passport')(passport);
+var express = require('express');
+const models = require('../models/index');
+const passport = require('passport');
+var router = express.Router();
+require('../utils/security/passport')(passport);
 const Login = require('../models').login;
+const crypto = require('crypto');
+const bcrypt = require('bcrypt-nodejs');
+
 
 const generateJWT = require('../utils/security/generateJWT');
 const isAuthorised = require('../utils/security/isAuthenticated').isAuthorised;
@@ -12,6 +15,19 @@ const uuid = require('uuid');
 const config = require('..//config/config');
 
 const sendMail = require('../utils/email/notify-email').sendPasswordReset;
+
+const tribalHashCompare = (password, salt, expectedHash) => {
+  const hash = crypto.createHash('sha256');
+  hash.update(`${password}${salt}`, 'ucs2');     // .NET C# Unicode encoding defaults to UTF-16
+
+  const calculatedHash = hash.digest('base64');
+
+  if (calculatedHash === expectedHash) {
+    return true;
+  } else {
+    return false;
+  }
+};
 
 router.post('/',async function(req, res) {
    Login
@@ -22,10 +38,10 @@ router.post('/',async function(req, res) {
           },
           isActive:true
         },
-        attributes: ['id', 'username', 'isActive', 'invalidAttempt', 'registrationId', 'firstLogin', 'Hash', 'lastLogin'],
+        attributes: ['id', 'username', 'isActive', 'invalidAttempt', 'registrationId', 'firstLogin', 'Hash', 'lastLogin', 'tribalHash', 'tribalSalt'],
         include: [ {
           model: models.user,
-          attributes: ['id', 'FullNameValue', 'EmailValue', 'isAdmin', 'isPrimary', 'establishmentId', "UserRoleValue"],
+          attributes: ['id', 'FullNameValue', 'EmailValue', 'isAdmin', 'isPrimary', 'establishmentId', "UserRoleValue", 'tribalId'],
           include: [{
             model: models.establishment,
             attributes: ['id', 'uid', 'NameValue', 'isRegulated', 'nmdsId', 'isParent', 'parentUid'],
@@ -46,7 +62,20 @@ router.post('/',async function(req, res) {
           });
         }
 
-        login.comparePassword(escape(req.body.password), async (err, isMatch) => {
+        // if this found login account is a migrated tribal account, and there is no current hash, then
+        //  we need to first validate password using tribal hashing
+        let tribalErr = null;
+        let tribalHashValidated = false;
+        if (login.user.tribalId !== null && login.Hash === null) {
+          tribalHashValidated = true;
+          const tribalHashCompareReset = tribalHashCompare(req.body.password, login.tribalSalt, login.tribalHash);
+
+          if (tribalHashCompareReset === false) {
+            tribalErr = 'Failed to authenticate using tribal hash';
+          }
+        }
+
+        login.comparePassword(escape(req.body.password), tribalErr, tribalHashValidated, async (err, isMatch, rehashTribal) => {
           if (isMatch && !err) {
             const loginTokenTTL = config.get('jwt.ttl.login');
 
@@ -72,6 +101,14 @@ router.post('/',async function(req, res) {
                 invalidAttempt: 0,
                 lastLogin: new Date(),
               };
+
+              // if this is a migrated tribal user's first login, and consequently, the compare is successful
+              //   but they still have no "Hash", we need to create a hash and store it.
+              if (rehashTribal) {
+                loginUpdate.Hash =  await bcrypt.hashSync(req.body.password, bcrypt.genSaltSync(10), null)
+              }
+
+
               if (!login.firstLogin) {
                 loginUpdate.firstLogin = new Date();
               }


### PR DESCRIPTION
https://trello.com/c/cfj4ZW7y

It's not my best code ever in respect to the login callback, but the twists and turns in the successful/unsuccessful logins with audit events and updating failed attempt counters, meant I wanted to reuse as much of that as possible.

I've tested this code on local database with existing non-migrated users. I've tested this code on Tribal migrated database, on migrated users by forcing a reset "Tribal Hash" on one user.

I've also re-run successfully all my regression tests, which highlighted the "changePassword" impact too.

All is good. But I need to get this in to dev to be sure from a new build perspective.