### PR TITLE
Parents and subs access establishments and workers

### DIFF
--- a/resources/establishment_types.schema.json
+++ b/resources/establishment_types.schema.json
@@ -89,10 +89,10 @@
             "type" : "string",
             "enum" : ["Workplace", "Parent"]
         },
-        "DataOwnerPermissions" : {
-            "description" : "Associated with an Establishment, this represents permissions granted to the owner (typically the parent). If workplace, then only workplace no worker access. If staff, then owner has access to both workplace and staff.",
+        "ParentPermissions" : {
+            "description" : "Associated with an Establishment, this represents permissions granted to the parent. If Workplace, then only workplace no worker access. If Workplace and Staff, then parent has access to both workplace and staff. If null/not present, parent has no access.",
             "type" : "string",
-            "enum" : ["Workplace", "Staff"]
+            "enum" : ["Workplace", "Workplace and Staff"]
         },
         "EstablishmentName" : {
             "description": "the name of the Establishment",
@@ -1354,7 +1354,7 @@
                 "dataOnwer" : {
                     "$ref" : "#/definitions/DataOwner"
                 },
-                "dataOwnerPermissions" : {
+                "parentPermissions" : {
                     "$ref" : "#/definitions/DataOwnerPermissions"
                 },
                 "mainService" : {

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -51,7 +51,7 @@ class Establishment {
         this._parentUid = null;
         this._parentId = null;
         this._dataOwner = null;
-        this._dataOwnerPermissions = null;
+        this._parentPermissions = null;
 
         // abstracted properties
         const thisEstablishmentManager = new EstablishmentProperties();
@@ -136,8 +136,8 @@ class Establishment {
         return this._dataOwner;
     }
 
-    get dataOwnerPermissions() {
-        return this._dataOwnerPermissions;
+    get parentPermissions() {
+        return this._parentPermissions;
     }
 
     get numberOfStaff() {
@@ -536,7 +536,7 @@ class Establishment {
                 this._parentId = fetchResults.parentId;
                 this._parentUid = fetchResults.parentUid;
                 this._dataOwner = fetchResults.dataOwner;
-                this._dataOwnerPermissions = fetchResults.dataOwnerPermissions;
+                this._parentPermissions = fetchResults.parentPermissions;
 
                 // if history of the User is also required; attach the association
                 //  and order in reverse chronological - note, order on id (not when)
@@ -779,7 +779,7 @@ class Establishment {
                 myDefaultJSON.isParent = this.isParent;
                 myDefaultJSON.parentUid = this.parentUid;
                 myDefaultJSON.dataOwner = this.dataOwner;
-                myDefaultJSON.dataOwnerPermissions = this.dataOwnerPermissions;
+                myDefaultJSON.parentPermissions = this.isParent ? undefined : this.parentPermissions;
             }
 
             myDefaultJSON.created = this.created.toJSON();

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -452,23 +452,6 @@ class Establishment {
                     id,
                 },
                 include: [
-                    {
-                        model: models.user,
-                        as: 'users',
-                        attributes: ['id'],
-                        where: {
-                            archived: false,
-                        },
-                        include: [
-                            {
-                                model: models.login,
-                                attributes: ['username'],
-                                where: {
-                                    username: this._username,
-                                }
-                            }
-                        ]
-                    }
                 ]
             };
 
@@ -936,9 +919,6 @@ class Establishment {
 
         // main service & Other Service & Service Capacities & Service Users
         myWdf['mainService'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('MainServiceFK')) ? 'Yes' : 'No';
-        
-        
-        console.log("WA DEBUG - other services check: ", this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('OtherServices')))
         myWdf['otherService'] = this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('OtherServices')) ? 'Yes' : 'No';
 
         // capacities eligibility is only relevant to the main service capacities (other services' capacities are not relevant)

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -52,8 +52,6 @@ class User {
         this._logLevel = User.LOG_INFO;
 
         this._trackingUUID = trackingUUID;
-
-        console.log("WA DEBUG - User class constructor")
     }
 
     // returns true if valid establishment id

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -889,7 +889,7 @@ class User {
 
         // first - get the user's primary establishment (every user will have a primary establishment)
         const fetchResults = await models.establishment.findOne({
-            attributes: ['uid', 'isParent', 'parentUid', 'dataOwner', 'dataOwnerPermissions', 'NameValue', 'updated'],
+            attributes: ['uid', 'isParent', 'parentUid', 'dataOwner', 'parentPermissions', 'NameValue', 'updated'],
             include: [
                 {
                     model: models.services,
@@ -912,7 +912,7 @@ class User {
             if (myRole === 'Edit' && isParent) {
                 // get all subsidaries associated with this parent
                 allSubResults = await models.establishment.findAll({
-                    attributes: ['uid', 'isParent', 'dataOwner', 'parentUid', 'dataOwnerPermissions', 'NameValue', 'updated'],
+                    attributes: ['uid', 'isParent', 'dataOwner', 'parentUid', 'parentPermissions', 'NameValue', 'updated'],
                     include: [
                         {
                             model: models.services,
@@ -946,7 +946,7 @@ class User {
                 name: primaryEstablishmentRecord.NameValue,
                 mainService: primaryEstablishmentRecord.mainService.name,
                 dataOwner: primaryEstablishmentRecord.dataOwner,
-                dataOwnerPermissions: primaryEstablishmentRecord.dataOwnerPermissions,
+                parentPermissions: isParent ? undefined : primaryEstablishmentRecord.parentPermissions,
             }
         };
         
@@ -957,12 +957,11 @@ class User {
                     return {
                         uid: thisSub.uid,
                         updated: thisSub.updated,
-                        isParent: thisSub.isParent,
                         parentUid: thisSub.parentUid,
                         name: thisSub.NameValue,
                         mainService: thisSub.mainService.name,
                         dataOwner: thisSub.dataOwner,
-                        dataOwnerPermissions: thisSub.dataOwnerPermissions,    
+                        parentPermissions: thisSub.parentPermissions,    
                     };
                 })
             };

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -68,11 +68,11 @@ module.exports = function(sequelize, DataTypes) {
       field: '"Owner"',
       default: 'Workplace',
     },
-    dataOwnerPermissions: {
+    parentPermissions: {
       type: DataTypes.ENUM,
       allowNull: true,
       values: ['Workplace','Worker'],
-      field: '"OwnerDataAccess"',
+      field: '"ParentAccess"',
     },
     NameValue: {
       type: DataTypes.TEXT,

--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -549,7 +549,6 @@ router.route('/my/establishments').get(async (req, res) => {
         await thisUser.restore(null, theLoggedInUser, false);
 
         const myEstablishments = await thisUser.myEstablishments(isParent, null);
-        console.info("/user/my/establishments: ", myEstablishments);
         return res.status(200).send(myEstablishments);
 
     } catch (err) {

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -22,26 +22,43 @@ const validateWorker = async (req, res, next) => {
     const workerId = req.params.workerId;
     const establishmentId = req.establishmentId;
 
-    // validating worker id - must be a V4 UUID
-    const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
-    if (!uuidRegex.test(workerId.toUpperCase())) return res.status(400).send('Unexpected worker id');
-
-    const thisWorker = new Workers.Worker(establishmentId);
-
-    try {
-        if (await thisWorker.restore(workerId, false)) {
-            next();
-        } else {
-            // not found worker
-            return res.status(404).send('Not Found');
+    // if the request for this worker is by a user associated with parent, and the requested establishment is
+    //  not their primary establishment, then they must have been granted "staff" level permission to access the worker
+    if (req.isParent && req.establishmentId !== req.establishment.id) {
+        // the requestor is both a parent and they are requesting against non-primary establishment (aka a subsidiary)
+        if (req.dataOwnerPermissions === null ||
+            req.dataOwnerPermissions !== "Staff") {
+                console.error("validateWorker authorisation - parent is requesting a subdiaries worker without required permission");
+                return res.status(403).send('Not Found');
         }
+    }
 
-    } catch (err) {
-        console.error('worker::validateWorker - failed', err);
-        return res.status(503).send();
+
+    if (workerId) {
+        // validating worker id - must be a V4 UUID
+        const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
+        if (!uuidRegex.test(workerId.toUpperCase())) return res.status(400).send('Unexpected worker id');
+
+        const thisWorker = new Workers.Worker(establishmentId);
+
+        try {
+            if (await thisWorker.restore(workerId, false)) {
+                next();
+            } else {
+                // not found worker
+                return res.status(404).send('Not Found');
+            }
+
+        } catch (err) {
+            console.error('worker::validateWorker - failed', err);
+            return res.status(503).send();
+        }
+    } else {
+        next();
     }
 };
 
+router.use('/', validateWorker);
 router.use('/:workerId/training', [validateWorker, TrainingRoutes]);
 router.use('/:workerId/qualification', [validateWorker, QualificationRoutes]);
 

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -26,8 +26,8 @@ const validateWorker = async (req, res, next) => {
     //  not their primary establishment, then they must have been granted "staff" level permission to access the worker
     if (req.isParent && req.establishmentId !== req.establishment.id) {
         // the requestor is both a parent and they are requesting against non-primary establishment (aka a subsidiary)
-        if (req.dataOwnerPermissions === null ||
-            req.dataOwnerPermissions !== "Staff") {
+        if (req.parentPermissions === null ||
+            req.parentPermissions !== "Workplace and Staff") {
                 console.error("validateWorker authorisation - parent is requesting a subdiaries worker without required permission");
                 return res.status(403).send('Not Found');
         }

--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -60,59 +60,105 @@ exports.hasAuthorisedEstablishment = (req, res, next) => {
           return res.status(400).send(`Unknown Establishment UID`);
         }
 
-        // the given parameter could be a UUID or integer
+        // the given parameter could be a UUID or integer - first authorised against known primary establishment
         let establishmentIdIsUID = false;
+        let isAuthorised = false;
         if (uuidV4Regex.test(req.params.id)) {
           // establishment id in params is a UUID - tests against UID in claim
           establishmentIdIsUID = true;
-          if (claim.EstablishmentUID !== req.params.id) {
-            console.error(`hasAuthorisedEstablishment - given and known establishment uid do not match: given (${req.params.id})/known (${claim.EstablishmentUID})`);
-            return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
+          if (claim.EstablishmentUID === req.params.id) {
+            req.establishmentId=claim.EstablishmentUID;
+            isAuthorised = true;
           }
-
-          req.establishmentId=   claim.EstablishmentUID;
         } else {
-          if (claim.EstblishmentId !== parseInt(req.params.id)) {
-            console.error(`hasAuthorisedEstablishment - given and known establishment id do not match: given (${req.params.id})/known (${claim.EstblishmentId})`);
-            return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
+          if (claim.EstblishmentId === parseInt(req.params.id)) {
+            req.establishmentId = claim.EstblishmentId;
+            isAuthorised = true;
           }
-
-          req.establishmentId =   claim.EstblishmentId;
         }
 
-        req.username= claim.sub;
-        req.isParent = claim.isParent;
-        req.role = claim.role;
-        req.establishment = {
-          id: claim.EstblishmentId,
-          uid: establishmentIdIsUID ? claim.EstablishmentUID : null
-        };
-
-        // having settled all claims, it is necessary to normalise req.establishmentId so it is always the establishment primary key
-        if (establishmentIdIsUID) {
+        // if still not authorised - and only if this user is attributed to a parent establishment
+        //  then follow up by checking against any of the known subsidaries of this parent establishment
+        //  including that of the given establishment (only known by it's UID)
+        if (isAuthorised === false && claim.isParent) {
           models.establishment.findOne({
-            attributes: ['id'],
+            attributes: ['id', 'dataOwnerPermissions'],
             where: {
-              uid: req.establishment.uid
+              parentId: claim.EstblishmentId,
+              uid: req.params.id,
             }
           })
           .then(record => record.get())
           .then(establishment => {
+            // this is a known subsidairy of this given parent establishment
+            
+            // but, so be able to access the subsidary, then the permissions must not be null
+            if (establishment.dataOwnerPermissions === null) {
+              console.error(`Found subsidiary establishment (${req.params.id}) for this known parent (${claim.EstblishmentId}/${claim.EstablishmentUID}), but access has not been given`);
+              // failed to find establishment by UUID - being a subsidairy of this known parent
+              return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
+            }
+
             req.establishmentId = establishment.id;
+            req.dataOwnerPermissions = establishment.dataOwnerPermissions;    // this will be required for Worker level access tests .../server/routes/establishments/worker.js::validateWorker
+
+            // we now know the 
+            establishmentIdIsUID = false;
+
+            // restore claims
+            req.username= claim.sub;
+            req.isParent = claim.isParent;
+            req.role = claim.role;
+            req.establishment = {
+              id: claim.EstblishmentId,
+              uid: establishmentIdIsUID ? claim.EstablishmentUID : null
+            };
+
             next();
           })
           .catch(err => {
-            // failed to find establishment by UUID - not authorised
+            // failed to find establishment by UUID - being a subsidairy of this known parent
+            console.error(`Failed to find subsidiary establishment (${req.params.id}) for this known parent (${claim.EstblishmentId}/${claim.EstablishmentUID})`);
             return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
           });
+        } else if (isAuthorised === false) {
+          console.error(`hasAuthorisedEstablishment - given and known establishment id do not match: given (${req.params.id})/known (${claim.EstblishmentId}/${claim.EstablishmentUID})`);
+          return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
         } else {
-          // it's already primary key
-          next();
+          // gets here and all is authorised
+          req.username= claim.sub;
+          req.isParent = claim.isParent;
+          req.role = claim.role;
+          req.establishment = {
+            id: claim.EstblishmentId,
+            uid: establishmentIdIsUID ? claim.EstablishmentUID : null
+          };
+
+          // having settled all claims, it is necessary to normalise req.establishmentId so it is always the establishment primary key
+          if (establishmentIdIsUID) {
+            models.establishment.findOne({
+              attributes: ['id'],
+              where: {
+                uid: req.establishment.uid
+              }
+            })
+            .then(record => record.get())
+            .then(establishment => {
+              req.establishmentId = establishment.id;
+              next();
+            })
+            .catch(err => {
+              // failed to find establishment by UUID - not authorised
+              console.error(`FATAL - Authorised against primary establishment (${claim.EstblishmentId}/${claim.EstablishmentUID}), but failed to normalise the establishment UUID`);
+              return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
+            });
+          } else {
+            // it's already primary key
+            next();
+          }
         }
       }     
     });
- 
-
   } else {
     // not authenticated
     res.status(401).send('Requires authorisation');

--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -82,7 +82,7 @@ exports.hasAuthorisedEstablishment = (req, res, next) => {
         //  including that of the given establishment (only known by it's UID)
         if (isAuthorised === false && claim.isParent) {
           models.establishment.findOne({
-            attributes: ['id', 'dataOwnerPermissions'],
+            attributes: ['id', 'parentPermissions'],
             where: {
               parentId: claim.EstblishmentId,
               uid: req.params.id,
@@ -92,15 +92,15 @@ exports.hasAuthorisedEstablishment = (req, res, next) => {
           .then(establishment => {
             // this is a known subsidairy of this given parent establishment
             
-            // but, so be able to access the subsidary, then the permissions must not be null
-            if (establishment.dataOwnerPermissions === null) {
+            // but, to be able to access the subsidary, then the permissions must not be null
+            if (establishment.parentPermissions === null) {
               console.error(`Found subsidiary establishment (${req.params.id}) for this known parent (${claim.EstblishmentId}/${claim.EstablishmentUID}), but access has not been given`);
               // failed to find establishment by UUID - being a subsidairy of this known parent
               return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
             }
 
             req.establishmentId = establishment.id;
-            req.dataOwnerPermissions = establishment.dataOwnerPermissions;    // this will be required for Worker level access tests .../server/routes/establishments/worker.js::validateWorker
+            req.parentPermissions = establishment.parentPermissions;    // this will be required for Worker level access tests .../server/routes/establishments/worker.js::validateWorker
 
             // we now know the 
             establishmentIdIsUID = false;


### PR DESCRIPTION
Hi Nasir

https://trello.com/c/ikScd2O3

Well, this is the last of the big changes for this "parent and subs - view subsidiaries".

This one changes the very rigid authorisation that restricts establishments to users of the establishments only.

The main crux of the changes are in: `server/utils/security/isAuthenticated.js`. It might serve best for me to walk you through over appear.in.

I'm not overly happy with the code; because its middleware, I'm having to use promise callbacks which makes conditional paths hard! Whilst there is some duplication, there is a much bigger piece of work pending around permissions in general, where I expect such authentication logic to be completed encapsulated.

Thanks