### PR TITLE
bugfix | bulk upload | alignment issues

### DIFF
--- a/src/app/features/bulk-upload/bulk-upload-page/bulk-upload-page.component.html
+++ b/src/app/features/bulk-upload/bulk-upload-page/bulk-upload-page.component.html
@@ -12,20 +12,8 @@
     <p class="govuk-caption-l govuk-!-margin-bottom-0">{{ establishment?.name }}</p>
     <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Bulk upload</h1>
     <p>Bulk upload is used to edit large quantities of staff, workplace and training information.</p>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <!-- TODO uncomment once relevant sections have been developed
-    <ul class="govuk-list">
-      <li><a [routerLink]="['/bulk-upload/home']">View bulk upload codes</a></li>
-      <li><a [routerLink]="['/']">View bulk upload history</a></li>
-    </ul>
-    -->
-  </div>
-</div>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-5">
-  <div class="govuk-grid-column-full">
-    <ol class="govuk-list govuk-list--number govuk-!-padding-left-5">
+    <ol class="govuk-list govuk-list--number govuk-!-margin-top-8 govuk-!-padding-left-5">
       <li class="govuk-!-padding-left-5 govuk-!-font-size-24 govuk-!-padding-bottom-6 govuk-util__bold">
         <app-check-workplace-references class="govuk-util__block"></app-check-workplace-references>
       </li>
@@ -38,5 +26,13 @@
         <app-upload-data-files class="govuk-util__block"></app-upload-data-files>
       </li>
     </ol>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <!-- TODO uncomment once relevant sections have been developed
+    <ul class="govuk-list">
+      <li><a [routerLink]="['/bulk-upload/home']">View bulk upload codes</a></li>
+      <li><a [routerLink]="['/']">View bulk upload history</a></li>
+    </ul>
+    -->
   </div>
 </div>

--- a/src/app/features/bulk-upload/check-workplace-references/check-workplace-references.component.html
+++ b/src/app/features/bulk-upload/check-workplace-references/check-workplace-references.component.html
@@ -1,11 +1,7 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">Check your workplace references</h2>
-    <p>Check your workplace and staff references to make sure they are the same as the files you are uploading.</p>
-    <!--
-      TODO uncomment once relevant sections have been developed
-      <p *ngIf="***">Last updated on {{ lastUpdated | date: 'd MMMM y' }}</p>
-      <a [routerLink]="['/reports']">View workplace references</a>
-    -->
-  </div>
-</div>
+<h2 class="govuk-heading-m">Check your workplace references</h2>
+<p>Check your workplace and staff references to make sure they are the same as the files you are uploading.</p>
+<!--
+  TODO uncomment once relevant sections have been developed
+  <p *ngIf="***">Last updated on {{ lastUpdated | date: 'd MMMM y' }}</p>
+  <a [routerLink]="['/reports']">View workplace references</a>
+-->

--- a/src/app/features/bulk-upload/download-data-files/download-data-files.component.html
+++ b/src/app/features/bulk-upload/download-data-files/download-data-files.component.html
@@ -1,14 +1,10 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m">Download latest data files</h3>
-    <!--
-    TODO uncomment once relevant sections have been developed
-    <p *ngIf="***">Last updated on {{ lastUpdated | date: 'd MMMM y' }}</p>
-    <ul class="govuk-list">
-      <li class="govuk-link"><a [routerLink]="['/bulk-upload/home']">Workplace information</a></li>
-      <li class="govuk-link"><a [routerLink]="['/']">Staff records</a></li>
-      <li class="govuk-link"><a [routerLink]="['/']">Training records</a></li>
-    </ul>
-    -->
-  </div>
-</div>
+<h3 class="govuk-heading-m">Download latest data files</h3>
+<!--
+TODO uncomment once relevant sections have been developed
+<p *ngIf="***">Last updated on {{ lastUpdated | date: 'd MMMM y' }}</p>
+<ul class="govuk-list">
+  <li class="govuk-link"><a [routerLink]="['/bulk-upload/home']">Workplace information</a></li>
+  <li class="govuk-link"><a [routerLink]="['/']">Staff records</a></li>
+  <li class="govuk-link"><a [routerLink]="['/']">Training records</a></li>
+</ul>
+-->

--- a/src/app/features/bulk-upload/upload-data-files/upload-data-files.component.html
+++ b/src/app/features/bulk-upload/upload-data-files/upload-data-files.component.html
@@ -1,17 +1,9 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h4 class="govuk-heading-m">Upload data files</h4>
-    <p class="govuk-caption-m">20Mb maximum file size. Zip larger files</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>choose files to upload</li>
-      <li>check uploaded files</li>
-      <li>complete upload</li>
-    </ul>
-  </div>
-</div>
+<h4 class="govuk-heading-m">Upload data files</h4>
+<p class="govuk-caption-m">20Mb maximum file size. Zip larger files</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>choose files to upload</li>
+  <li>check uploaded files</li>
+  <li>complete upload</li>
+</ul>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <app-files-upload></app-files-upload>
-  </div>
-</div>
+<app-files-upload></app-files-upload>


### PR DESCRIPTION
- second attempt at fixing this but this time a cross browser solution that works in IE, firefox and chrome and no more alignment issues.
- gds classes such as `govuk-grid-row` and column width classes was the root cause for the `<ol>` list to not line up its inner content properly. so have simplified the markup 