### PR TITLE
Bugfix/bulk upload file types

### DIFF
--- a/src/app/core/constants/constants.ts
+++ b/src/app/core/constants/constants.ts
@@ -8,4 +8,4 @@ export const PASSWORD_PATTERN = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).{8,50}$/;
 export const INT_PATTERN = /^[0-9]*$/;
 export const FLOAT_PATTERN = /^([0-9]*[.])?[0-9]+$/;
 export const API_PATTERN = /^\/api\//;
-export const FILE_UPLOAD_TYPES = ['text/csv', 'application/zip'];
+export const FILE_UPLOAD_TYPES = ['CSV', 'ZIP'];

--- a/src/app/core/model/bulk-upload.model.ts
+++ b/src/app/core/model/bulk-upload.model.ts
@@ -1,3 +1,7 @@
 export interface PresignedUrlResponse {
   urls: string;
 }
+
+export interface UploadFile extends File {
+  extension: string;
+}

--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -5,15 +5,15 @@ import { FormGroup } from '@angular/forms';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { map } from 'rxjs/operators';
-import { PresignedUrlResponse } from '@core/model/bulk-upload.model';
+import { PresignedUrlResponse, UploadFile } from '@core/model/bulk-upload.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class BulkUploadService {
   public exposeForm$: BehaviorSubject<FormGroup> = new BehaviorSubject(null);
-  public selectedFiles$: BehaviorSubject<Array<File>> = new BehaviorSubject(null);
-  public uploadedFiles$: BehaviorSubject<Array<File>> = new BehaviorSubject(null);
+  public selectedFiles$: BehaviorSubject<Array<UploadFile>> = new BehaviorSubject(null);
+  public uploadedFiles$: BehaviorSubject<Array<UploadFile>> = new BehaviorSubject(null);
 
   constructor(private http: HttpClient, private establishmentService: EstablishmentService) {}
 
@@ -30,16 +30,14 @@ export class BulkUploadService {
       .pipe(map((data: PresignedUrlResponse) => data.urls));
   }
 
-  public uploadFile(file: File, signedURL: string): Observable<any> {
+  public uploadFile(file: UploadFile, signedURL: string): Observable<any> {
     const headers = new HttpHeaders({ 'Content-Type': file.type });
     return this.http.put(signedURL, file, { headers, reportProgress: true });
   }
 
-  public transformFileType(fileType: string): string {
-    return fileType
-      .split('/')
-      .pop()
-      .toUpperCase();
+  public getFileType(fileName: string): string {
+    const parts: Array<string> = fileName.split('.');
+    return parts[parts.length - 1].toUpperCase();
   }
 
   public formErrorsMap(): Array<ErrorDetails> {

--- a/src/app/features/bulk-upload/bulk-upload-page/bulk-upload-page.component.html
+++ b/src/app/features/bulk-upload/bulk-upload-page/bulk-upload-page.component.html
@@ -1,31 +1,12 @@
-<app-error-summary
-  *ngIf="showErrorSummary"
-  [formErrorsMap]="formErrorsMap"
-  [form]="form"
->
-</app-error-summary>
+<app-error-summary *ngIf="showErrorSummary" [formErrorsMap]="formErrorsMap" [form]="form"> </app-error-summary>
 
 <app-dashboard-header></app-dashboard-header>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-5">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-caption-l govuk-!-margin-bottom-0">{{ establishment?.name }}</p>
     <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Bulk upload</h1>
     <p>Bulk upload is used to edit large quantities of staff, workplace and training information.</p>
-
-    <ol class="govuk-list govuk-list--number govuk-!-margin-top-8 govuk-!-padding-left-5">
-      <li class="govuk-!-padding-left-5 govuk-!-font-size-24 govuk-!-padding-bottom-6 govuk-util__bold">
-        <app-check-workplace-references class="govuk-util__block"></app-check-workplace-references>
-      </li>
-      <li
-        class="govuk-!-padding-left-5 govuk-!-font-size-24 govuk-!-padding-bottom-6 govuk-util__bold"
-      >
-        <app-download-data-files class="govuk-util__block"></app-download-data-files>
-      </li>
-      <li class="govuk-!-padding-left-5 govuk-!-font-size-24 govuk-!-padding-bottom-6 govuk-util__bold">
-        <app-upload-data-files class="govuk-util__block"></app-upload-data-files>
-      </li>
-    </ol>
   </div>
   <div class="govuk-grid-column-one-third">
     <!-- TODO uncomment once relevant sections have been developed
@@ -34,5 +15,21 @@
       <li><a [routerLink]="['/']">View bulk upload history</a></li>
     </ul>
     -->
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <ol class="govuk-list govuk-list--number govuk-!-margin-top-8 govuk-!-padding-left-5">
+      <li class="govuk-!-padding-left-5 govuk-!-font-size-24 govuk-!-padding-bottom-6 govuk-util__bold">
+        <app-check-workplace-references class="govuk-util__block"></app-check-workplace-references>
+      </li>
+      <li class="govuk-!-padding-left-5 govuk-!-font-size-24 govuk-!-padding-bottom-6 govuk-util__bold">
+        <app-download-data-files class="govuk-util__block"></app-download-data-files>
+      </li>
+      <li class="govuk-!-padding-left-5 govuk-!-font-size-24 govuk-!-padding-bottom-6 govuk-util__bold">
+        <app-upload-data-files class="govuk-util__block"></app-upload-data-files>
+      </li>
+    </ol>
   </div>
 </div>

--- a/src/app/features/bulk-upload/check-workplace-references/check-workplace-references.component.html
+++ b/src/app/features/bulk-upload/check-workplace-references/check-workplace-references.component.html
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">Check your workplace references</h2>
-<p>Check your workplace and staff references to make sure they are the same as the files you are uploading.</p>
+<p>Check your workplace and staff references to make sure they are the <br />same as the files you are uploading.</p>
 <!--
   TODO uncomment once relevant sections have been developed
   <p *ngIf="***">Last updated on {{ lastUpdated | date: 'd MMMM y' }}</p>

--- a/src/app/features/bulk-upload/files-upload/files-upload.component.html
+++ b/src/app/features/bulk-upload/files-upload/files-upload.component.html
@@ -20,7 +20,6 @@
 
   <app-selected-files-list *ngIf="!filesUploaded"></app-selected-files-list>
 
-  <!-- show upload button when uploading = false or uploaded = false -->
   <div *ngIf="!filesUploading && !filesUploaded">
     <button type="submit" class="govuk-button">
       Upload files

--- a/src/app/features/bulk-upload/files-upload/files-upload.component.ts
+++ b/src/app/features/bulk-upload/files-upload/files-upload.component.ts
@@ -5,6 +5,7 @@ import { forkJoin, Observable } from 'rxjs';
 import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { mergeMap, take } from 'rxjs/operators';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
+import { UploadFile } from '@core/model/bulk-upload.model';
 
 @Component({
   selector: 'app-files-upload',
@@ -12,7 +13,7 @@ import { CustomValidators } from '@shared/validators/custom-form-validators';
 })
 export class FilesUploadComponent implements OnInit {
   private form: FormGroup;
-  private selectedFiles: Array<File>;
+  private selectedFiles: Array<UploadFile>;
   private submitted = false;
   public filesUploading = false;
   public filesUploaded = false;
@@ -40,6 +41,7 @@ export class FilesUploadComponent implements OnInit {
   private onFilesSelection($event: Event): void {
     const target = $event.target || $event.srcElement;
     this.selectedFiles = Array.from(target['files']);
+    this.selectedFiles.map((file: UploadFile) => (file.extension = this.bulkUploadService.getFileType(file.name)));
 
     this.fileUpload.setValidators(CustomValidators.checkFiles(this.fileUpload, this.selectedFiles));
     this.bulkUploadService.selectedFiles$.next(this.selectedFiles);
@@ -61,30 +63,30 @@ export class FilesUploadComponent implements OnInit {
     this.filesUploading = true;
 
     forkJoin(
-      this.selectedFiles.map((file: File) =>
+      this.selectedFiles.map((file: UploadFile) =>
         this.getPresignedUrl(file)
           .pipe(take(1))
           .pipe(mergeMap((signedURL: string) => this.uploadFile(file, signedURL)))
       )
     )
-    .pipe(take(1))
-    .subscribe(
-      () => {
-        this.bulkUploadService.uploadedFiles$.next(this.selectedFiles);
-        this.filesUploading = false;
-        this.filesUploaded = true;
-      },
-      () => {
-        this.filesUploading = false;
-      }
-    );
+      .pipe(take(1))
+      .subscribe(
+        () => {
+          this.bulkUploadService.uploadedFiles$.next(this.selectedFiles);
+          this.filesUploading = false;
+          this.filesUploaded = true;
+        },
+        () => {
+          this.filesUploading = false;
+        }
+      );
   }
 
-  private getPresignedUrl(file: File): Observable<string> {
+  private getPresignedUrl(file: UploadFile): Observable<string> {
     return this.bulkUploadService.getPresignedUrl(file.name);
   }
 
-  private uploadFile(file: File, signedURL: string): Observable<string> {
+  private uploadFile(file: UploadFile, signedURL: string): Observable<string> {
     return this.bulkUploadService.uploadFile(file, signedURL);
   }
 

--- a/src/app/features/bulk-upload/files-upload/files-upload.component.ts
+++ b/src/app/features/bulk-upload/files-upload/files-upload.component.ts
@@ -45,7 +45,10 @@ export class FilesUploadComponent implements OnInit {
 
     this.fileUpload.setValidators(CustomValidators.checkFiles(this.fileUpload, this.selectedFiles));
     this.bulkUploadService.selectedFiles$.next(this.selectedFiles);
-    this.bulkUploadService.exposeForm$.next(this.form);
+
+    if (this.submitted) {
+      this.bulkUploadService.exposeForm$.next(this.form);
+    }
   }
 
   public onSubmit(): void {

--- a/src/app/features/bulk-upload/selected-files-list/selected-files-list.component.html
+++ b/src/app/features/bulk-upload/selected-files-list/selected-files-list.component.html
@@ -9,7 +9,7 @@
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row" *ngFor="let file of selectedFiles">
       <td class="govuk-table__cell" scope="row">{{ file.name }}</td>
-      <td class="govuk-table__cell">{{ transformFileType(file.type) }}</td>
+      <td class="govuk-table__cell">{{ file.extension }}</td>
       <td class="govuk-table__cell">{{ transformFileSize(file.size) }}</td>
     </tr>
   </tbody>

--- a/src/app/features/bulk-upload/selected-files-list/selected-files-list.component.ts
+++ b/src/app/features/bulk-upload/selected-files-list/selected-files-list.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { Subscription } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
+import { UploadFile } from '@core/model/bulk-upload.model';
 
 @Component({
   selector: 'app-selected-files-list',
@@ -9,7 +10,7 @@ import { distinctUntilChanged } from 'rxjs/operators';
 })
 export class SelectedFilesListComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
-  private selectedFiles: Array<File>;
+  private selectedFiles: Array<UploadFile>;
 
   constructor(private bulkUploadService: BulkUploadService) {}
 
@@ -31,13 +32,9 @@ export class SelectedFilesListComponent implements OnInit, OnDestroy {
     }
   }
 
-  public transformFileType(fileType: string): string {
-    return this.bulkUploadService.transformFileType(fileType);
-  }
-
   private setupSubscription(): void {
     this.subscriptions.add(
-      this.bulkUploadService.selectedFiles$.pipe(distinctUntilChanged()).subscribe((selectedFiles: Array<File>) => {
+      this.bulkUploadService.selectedFiles$.pipe(distinctUntilChanged()).subscribe((selectedFiles: Array<UploadFile>) => {
         if (selectedFiles) {
           this.selectedFiles = selectedFiles;
         }

--- a/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.html
+++ b/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.html
@@ -12,7 +12,7 @@
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row" *ngFor="let file of uploadedFiles">
       <td class="govuk-table__cell" scope="row">{{ file.name }}</td>
-      <td class="govuk-table__cell">{{ transformFileType(file.type) }}</td>
+      <td class="govuk-table__cell">{{ file.extension }}</td>
       <td class="govuk-table__cell">-</td>
       <td class="govuk-table__cell">-</td>
       <td class="govuk-table__cell">-</td>

--- a/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.ts
+++ b/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { UploadFile } from '@core/model/bulk-upload.model';
 
 @Component({
   selector: 'app-uploaded-files-list',
@@ -8,7 +9,7 @@ import { Subscription } from 'rxjs';
 })
 export class UploadedFilesListComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
-  private uploadedFiles: Array<File>;
+  private uploadedFiles: Array<UploadFile>;
 
   constructor(private bulkUploadService: BulkUploadService) {}
 
@@ -18,16 +19,12 @@ export class UploadedFilesListComponent implements OnInit, OnDestroy {
 
   public setupSubscription(): void {
     this.subscriptions.add(
-      this.bulkUploadService.uploadedFiles$.subscribe((uploadedFiles: Array<File>) => {
+      this.bulkUploadService.uploadedFiles$.subscribe((uploadedFiles: Array<UploadFile>) => {
         if (uploadedFiles) {
           this.uploadedFiles = uploadedFiles;
         }
       })
     );
-  }
-
-  public transformFileType(fileType: string): string {
-    return this.bulkUploadService.transformFileType(fileType);
   }
 
   ngOnDestroy() {

--- a/src/app/shared/validators/custom-form-validators.ts
+++ b/src/app/shared/validators/custom-form-validators.ts
@@ -1,5 +1,6 @@
 import { AbstractControl, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { FILE_UPLOAD_TYPES } from '@core/constants/constants';
+import { UploadFile } from '@core/model/bulk-upload.model';
 
 export class CustomValidators extends Validators {
   static maxWords(limit: number): ValidatorFn {
@@ -36,7 +37,7 @@ export class CustomValidators extends Validators {
     }
   }
 
-  static checkFiles(fileUpload, files: Array<File>): ValidatorFn {
+  static checkFiles(fileUpload, files: Array<UploadFile>): ValidatorFn {
     const errors: ValidationErrors = {};
     const maxFileSize = 20971520;
 
@@ -44,15 +45,15 @@ export class CustomValidators extends Validators {
       errors['filecount'] = true;
     }
 
-    files.forEach((file: File) => {
+    files.forEach((file: UploadFile) => {
       if (file.size > maxFileSize) {
         errors['filesize'] = true;
         return;
       }
     });
 
-    files.forEach((file: File) => {
-      if (!FILE_UPLOAD_TYPES.includes(file.type)) {
+    files.forEach((file: UploadFile) => {
+      if (!FILE_UPLOAD_TYPES.includes(file.extension)) {
         errors['filetype'] = true;
         return;
       }


### PR DESCRIPTION
- created `FileUpload` interface that extends `File` interface and additionally stores file extension
- fixed bug where file types were not correctly validated
- some updates to markup to match design
- only show error summary if form has been submitted
- prettify files
