### PR TITLE
make IE11 show validation errors

### DIFF
--- a/src/app/features/bulk-upload/files-upload/files-upload.component.ts
+++ b/src/app/features/bulk-upload/files-upload/files-upload.component.ts
@@ -94,6 +94,7 @@ export class FilesUploadComponent implements OnInit {
   }
 
   public removeFiles(): void {
+    this.fileUpload.clearValidators();
     this.form.reset();
     this.submitted = false;
     this.selectedFiles = [];

--- a/src/app/shared/validators/custom-form-validators.ts
+++ b/src/app/shared/validators/custom-form-validators.ts
@@ -60,7 +60,8 @@ export class CustomValidators extends Validators {
     });
 
     if (Object.keys(errors).length) {
-      return fileUpload.setErrors(errors);
+      // timeout needed for IE11
+      setTimeout(() => fileUpload.setErrors(errors));
     }
 
     return null;


### PR DESCRIPTION
- clear sync validators for fileUpload when files are cleared
- use a timeout when setting sync validators for file upload to fix validation for IE11