### PR TITLE
bugfix | remove local authorities extra row

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,7 +9,6 @@ import { filter } from 'rxjs/operators';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss'],
 })
 export class AppComponent implements OnInit {
   title = 'ng-sfc-v2';

--- a/src/app/features/workplace/data-sharing-with-local-authorities/data-sharing-with-local-authorities.component.ts
+++ b/src/app/features/workplace/data-sharing-with-local-authorities/data-sharing-with-local-authorities.component.ts
@@ -1,14 +1,13 @@
-import { Component } from '@angular/core';
-import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
-import { Router } from '@angular/router';
-import { DataSharingOptions } from '@core/model/data-sharing.model';
 import { BackService } from '@core/services/back.service';
+import { Component } from '@angular/core';
+import { DataSharingOptions } from '@core/model/data-sharing.model';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
 import { LocalAuthorityService } from '@core/services/localAuthority.service';
-import { uniqBy } from 'lodash';
-
 import { Question } from '../question/question.component';
+import { Router } from '@angular/router';
+import { uniqBy } from 'lodash';
 
 @Component({
   selector: 'app-data-sharing-with-local-authorities',
@@ -68,8 +67,6 @@ export class DataSharingWithLocalAuthoritiesComponent extends Question {
         this.localAuthoritiesArray.push(this.createLocalAuthorityItem(authority.custodianCode));
       }
     });
-
-    this.addLocalAuthority();
 
     this.subscriptions.add(
       this.localAuthorityService.getAuthorities().subscribe(authorities => {


### PR DESCRIPTION
- removed `this.addLocalAuthority();` which was ultimately trying to create an authority without a custodianCode and therefore displaying a select dropdown with no authority selected
- remove empty sass file and its reference
- alphabetised imports