### PR TITLE
bugfix | ie11 details tag polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "convict": "^4.4.1",
     "cookie-parser": "^1.4.3",
     "core-js": "^2.5.4",
+    "details-element-polyfill": "^2.3.1",
     "express-http-proxy": "^1.5.1",
     "express-sanitizer": "^1.0.5",
     "govuk-frontend": "^2.11.0",

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -78,3 +78,4 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
+import 'details-element-polyfill/dist/details-element-polyfill';  // Included with Angular CLI.


### PR DESCRIPTION
this polyfill is required as IE11 doesn't support the collapse/expand behavior thats comes out of the box with modern browsers. 