### PR TITLE
bugfix | bulk upload files still upload after removal

### DIFF
--- a/src/app/features/bulk-upload/files-upload/files-upload.component.ts
+++ b/src/app/features/bulk-upload/files-upload/files-upload.component.ts
@@ -94,12 +94,15 @@ export class FilesUploadComponent implements OnInit {
   }
 
   public removeFiles(): void {
-    this.fileUpload.clearValidators();
+    this.fileUpload.setValidators(Validators.required);
     this.form.reset();
     this.submitted = false;
     this.selectedFiles = [];
     this.bulkUploadService.selectedFiles$.next(this.selectedFiles);
-    this.bulkUploadService.exposeForm$.next(this.form);
+
+    if (this.submitted) {
+      this.bulkUploadService.exposeForm$.next(this.form);
+    }
   }
 
   public cancelUpload(): void {


### PR DESCRIPTION
- ensure required validator is set whilst clearing other validators when files are removed
- ensure error summary form errors event is only dispatched if submitted flag is true when files are removed