### PR TITLE
LA is equal use "CssrId" in comparison

### DIFF
--- a/server/models/classes/establishment/properties/shareWithLAProperty.js
+++ b/server/models/classes/establishment/properties/shareWithLAProperty.js
@@ -85,7 +85,7 @@ exports.ShareWithLAProperty = class ShareWithLAProperty extends ChangePropertyPr
             //  current value, and confirm it is in the the new data set.
             //  Array.every will drop out on the first iteration to return false
             arraysEqual = currentValue.every(thisAuthority => {
-                return newValue.find(thatAuthority => thatAuthority.custodianCode === thisAuthority.custodianCode);
+                return newValue.find(thatAuthority => thatAuthority.cssrId === thisAuthority.cssrId);
             });
         } else {
             // if the arrays are lengths are not equal, then we know they're not equal


### PR DESCRIPTION
https://trello.com/c/XKIVxy98 - whilst delivering on the GDS changes, testing identified an update fault on Local Authorities, whereby it was actually updating the data store.

Many weeks ago, we refactored Local Authorities within the backend and database, but we agreed to keep the API exposed interface the same (Local Authorities and custodian codes).

Unfortunately, the `isEqual` didn't keep up and still referenced the old `custodianCode` assumed from the database.