### PR TITLE
Three new country and nationality BUDI mappings. Removed "stateless" …

### DIFF
--- a/server/models/BulkImport/BUDI/index.js
+++ b/server/models/BulkImport/BUDI/index.js
@@ -198,30 +198,9 @@ class BUDI {
           };
           break;
 
-        case 2:
-          mappedEstType = {
-            type: 'Other',
-            other: 'Statutory: Local Authority (children services)'
-          };
-          break;
-          
         case 3:
           mappedEstType = {
             type: 'Local Authority (generic/other)',
-          };
-          break;
-
-        case 4:
-          mappedEstType = {
-            type: 'Other',
-            other: 'Statutory:  Local Authority Owned'
-          };
-          break;
-        
-        case 5:
-          mappedEstType = {
-            type: 'Other',
-            other: 'Statutory: Health'
           };
           break;
 
@@ -237,11 +216,14 @@ class BUDI {
           };
           break;
 
+        case 8:
+          mappedEstType = {
+            type: 'Other',
+          };
+          break;
+  
         default:
-          mappedEstType =  {
-              type: 'Other',
-              other: ''
-            };
+          // return null
       }
     } else {
       switch (originalCode) {
@@ -624,7 +606,9 @@ class BUDI {
       { "ASC": 223, "BUDI": 887},
       { "ASC": 224, "BUDI": 894},
       { "ASC": 112, "BUDI": 895},
-      { "ASC": 896, "BUDI": 896},      
+      { "ASC": 60, "BUDI": 534},
+      { "ASC": 60, "BUDI": 535},
+      { "ASC": 109, "BUDI": 897},
     ];
 
     if (direction == BUDI.TO_ASC) {
@@ -885,7 +869,10 @@ class BUDI {
       { "ASC": 201, "BUDI" : 882},
       { "ASC": 255, "BUDI" : 887},
       { "ASC": 256, "BUDI" : 894},
-      { "ASC": 261, "BUDI" : 895},      
+      { "ASC": 261, "BUDI" : 895},
+      { "ASC": 262, "BUDI" : 535},
+      { "ASC": 263, "BUDI" : 897},
+      { "ASC": 264, "BUDI" : 534},
     ];
 
     if (direction == BUDI.TO_ASC) {
@@ -970,12 +957,130 @@ class BUDI {
   }
 
   // maps qualification types
-  // TODO - no BUDI mapping on quals yet!!!!!
   static qualifications(direction, originalCode) {
+    const fixedMapping = [
+      { "BUDI": 1, "ASC": 97 },
+      { "BUDI": 2, "ASC": 98 },
+      { "BUDI": 3, "ASC": 96 },
+      { "BUDI": 4, "ASC": 93 },
+      { "BUDI": 5, "ASC": 94 },
+      { "BUDI": 6, "ASC": 95 },
+      { "BUDI": 7, "ASC": 112 },
+      { "BUDI": 8, "ASC": 24 },
+      { "BUDI": 9, "ASC": 99 },
+      { "BUDI": 10, "ASC": 100 },
+      { "BUDI": 11, "ASC": 112 },
+      { "BUDI": 12, "ASC": 25 },
+      { "BUDI": 13, "ASC": 102 },
+      { "BUDI": 14, "ASC": 107 },
+      { "BUDI": 15, "ASC": 106 },
+      { "BUDI": 16, "ASC": 72 },
+      { "BUDI": 17, "ASC": 89 },
+      { "BUDI": 18, "ASC": 71 },
+      { "BUDI": 19, "ASC": 16 },
+      { "BUDI": 20, "ASC": 1 },
+      { "BUDI": 21, "ASC": 112 },
+      { "BUDI": 22, "ASC": 14 },
+      { "BUDI": 23, "ASC": 112 },
+      { "BUDI": 24, "ASC": 112 },
+      { "BUDI": 25, "ASC": 15 },
+      { "BUDI": 26, "ASC": 26 },
+      { "BUDI": 27, "ASC": 114 },
+      { "BUDI": 28, "ASC": 116 },
+      { "BUDI": 29, "ASC": 112 },
+      { "BUDI": 30, "ASC": 112 },
+      { "BUDI": 31, "ASC": 112 },
+      { "BUDI": 32, "ASC": 115 },
+      { "BUDI": 33, "ASC": 113 },
+      { "BUDI": 34, "ASC": 111 },
+      { "BUDI": 35, "ASC": 109 },
+      { "BUDI": 36, "ASC": 110 },
+      { "BUDI": 37, "ASC": 117 },
+      { "BUDI": 38, "ASC": 118 },
+      { "BUDI": 39, "ASC": 119 },
+      { "BUDI": 41, "ASC": 20 },
+      { "BUDI": 42, "ASC": 30 },
+      { "BUDI": 43, "ASC": 28 },
+      { "BUDI": 44, "ASC": 91 },
+      { "BUDI": 45, "ASC": 91 },
+      { "BUDI": 46, "ASC": 91 },
+      { "BUDI": 47, "ASC": 91 },
+      { "BUDI": 48, "ASC": 4 },
+      { "BUDI": 49, "ASC": 5 },
+      { "BUDI": 50, "ASC": 60 },
+      { "BUDI": 51, "ASC": 61 },
+      { "BUDI": 52, "ASC": 10 },
+      { "BUDI": 53, "ASC": 80 },
+      { "BUDI": 54, "ASC": 81 },
+      { "BUDI": 55, "ASC": 82 },
+      { "BUDI": 56, "ASC": 83 },
+      { "BUDI": 57, "ASC": 84 },
+      { "BUDI": 58, "ASC": 85 },
+      { "BUDI": 59, "ASC": 112 },
+      { "BUDI": 60, "ASC": 112 },
+      { "BUDI": 61, "ASC": 112 },
+      { "BUDI": 62, "ASC": 86 },
+      { "BUDI": 63, "ASC": 87 },
+      { "BUDI": 64, "ASC": 88 },
+      { "BUDI": 65, "ASC": 134 },
+      { "BUDI": 66, "ASC": 134 },
+      { "BUDI": 67, "ASC": 21 },
+      { "BUDI": 68, "ASC": 22 },
+      { "BUDI": 69, "ASC": 91 },
+      { "BUDI": 70, "ASC": 91 },
+      { "BUDI": 71, "ASC": 91 },
+      { "BUDI": 72, "ASC": 23 },
+      { "BUDI": 73, "ASC": 32 },
+      { "BUDI": 74, "ASC": 19 },
+      { "BUDI": 76, "ASC": 64 },
+      { "BUDI": 77, "ASC": 65 },
+      { "BUDI": 78, "ASC": 112 },
+      { "BUDI": 79, "ASC": 112 },
+      { "BUDI": 80, "ASC": 112 },
+      { "BUDI": 81, "ASC": 112 },
+      { "BUDI": 82, "ASC": 103 },
+      { "BUDI": 83, "ASC": 104 },
+      { "BUDI": 84, "ASC": 105 },
+      { "BUDI": 85, "ASC": 17 },
+      { "BUDI": 86, "ASC": 2 },
+      { "BUDI": 87, "ASC": 45 },
+      { "BUDI": 88, "ASC": 9 },
+      { "BUDI": 89, "ASC": 69 },
+      { "BUDI": 90, "ASC": 12 },
+      { "BUDI": 91, "ASC": 18 },
+      { "BUDI": 92, "ASC": 130 },
+      { "BUDI": 93, "ASC": 62 },
+      { "BUDI": 94, "ASC": 66 },
+      { "BUDI": 95, "ASC": 67 },
+      { "BUDI": 96, "ASC": 11 },
+      { "BUDI": 97, "ASC": 27 },
+      { "BUDI": 98, "ASC": 59 },
+      { "BUDI": 99, "ASC": 6 },
+      { "BUDI": 100, "ASC": 7 },
+      { "BUDI": 101, "ASC": 101 },
+      { "BUDI": 102, "ASC": 63 },
+      { "BUDI": 103, "ASC": 8 },
+      { "BUDI": 104, "ASC": 75 },
+      { "BUDI": 105, "ASC": 76 },
+      { "BUDI": 106, "ASC": 27 },
+      { "BUDI": 107, "ASC": 3 },
+      { "BUDI": 108, "ASC": 47 },
+      { "BUDI": 109, "ASC": 74 },
+      { "BUDI": 110, "ASC": 31 },
+      { "BUDI": 111, "ASC": 27 },
+      { "BUDI": 112, "ASC": 28 },
+      { "BUDI": 113, "ASC": 134 },
+      { "BUDI": 114, "ASC": 135 },
+      { "BUDI": 115, "ASC": 90 },
+      { "BUDI": 116, "ASC": 91 },
+    ];
+
     if (direction == BUDI.TO_ASC) {
-      return originalCode+1;
+      const found = fixedMapping.find(thisQualification => thisQualification.BUDI == originalCode);
+      return found ? found.ASC : null;
     } else {
-      return originalCode-1;
+      const found = fixedMapping.find(thisQualification => thisSpecialist.ASC == originalCode)
+      return found ? found.BUDI : null;
     }
   }
   

--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -1526,10 +1526,17 @@ class Establishment {
     // integer in source; enum in target
     if (this._establishmentType) {
       const mappedType = BUDI.establishmentType(BUDI.TO_ASC, this._establishmentType);
-      this._establishmentType = mappedType.type;
 
-      if (this._establishmentTypeOther === null && mappedType.type === 'Other' && mappedType.other) {
-        this._establishmentTypeOther = mappedType.other;
+      if (mappedType === null) {
+        this._validationErrors.push({
+          lineNumber: this._lineNumber,
+          errCode: Establishment.ESTABLISHMENT_TYPE_ERROR,
+          errType: `ESTABLISHMENT_TYPE_ERROR`,
+          error: `Establishment Type (ESTTYPE): ${this._establishmentType} is unknown`,
+          source: this._currentLine.ESTTYPE,
+        });
+      } else {
+        this._establishmentType = mappedType.type;
       }
     }
   }


### PR DESCRIPTION
* https://trello.com/c/uwf6pf7q
Following review with Maria on the BUDI questions on the CSV parser/validation card, only small changes required:

1. Employer Type - 2, 4 and 5 - no longer accepted, should result in error. Had to modify (CSV) `Establishment::_transformEstablishmentType` to catch mapping error.
2. no changes to services, service types, jobs or recruitment - all missing codes are intentional and should result in error
3. qualifications - I did a spot check and found the qualifications mapping I did on migration a perfect fit.

* https://trello.com/c/c0mR47WJ
Of the original BUDI questions, a new trello card was created for countries/qualifications.