### PR TITLE
update validate endpoint

### DIFF
--- a/server/models/BulkImport/csv/metaData.js
+++ b/server/models/BulkImport/csv/metaData.js
@@ -1,4 +1,4 @@
-class metaData {
+class MetaData {
   constructor() {
     this._username = null;
     this._id = null;
@@ -7,7 +7,6 @@ class metaData {
     this._warnings = null;
     this._errors = null;
     this._records = null;
-    this._filenameAndExtension = null;
   };
 
   get userName() {
@@ -21,9 +20,6 @@ class metaData {
   }
   get filename() {
     return this._filename;
-  }
-  get filenameAndExtension() {
-    return this._filenameAndExtension;
   }
   get warnings() {
     return this._warnings;
@@ -51,10 +47,6 @@ class metaData {
     return this._filename = filename;
   }
 
-  set filenameAndExtension(filenameAndExtension) {
-    return this._filenameAndExtension = filenameAndExtension;
-  }
-
   set warnings(warnings) {
     return this._warnings = warnings;
   }
@@ -69,7 +61,7 @@ class metaData {
 
   toJSON() {
     return {
-      filename:this._filenameAndExtension ? this._filenameAndExtension : null ,
+      filename:this._filename ? this._filename : null ,
       records:this._records ? this._records : 0,
       errors:this._errors ? this._errors : 0,
       warnings:this._warnings ? this._warnings : 0
@@ -77,4 +69,4 @@ class metaData {
   }
 };
 
-module.exports.metaData = metaData;
+module.exports.MetaData = MetaData;

--- a/server/models/BulkImport/csv/metaData.js
+++ b/server/models/BulkImport/csv/metaData.js
@@ -1,0 +1,80 @@
+class metaData {
+  constructor() {
+    this._username = null;
+    this._id = null;
+    this._fileType = null;
+    this._filename = null;
+    this._warnings = null;
+    this._errors = null;
+    this._records = null;
+    this._filenameAndExtension = null;
+  };
+
+  get userName() {
+    return this._userName;
+  }
+  get id() {
+    return this._id;
+  }
+  get fileType() {
+    return this._fileType;
+  }
+  get filename() {
+    return this._filename;
+  }
+  get filenameAndExtension() {
+    return this._filenameAndExtension;
+  }
+  get warnings() {
+    return this._warnings;
+  }
+  get errors() {
+    return this._errors;
+  }
+  get records() {
+    return this._records;
+  }
+
+  set userName(userName) {
+    this._UserName = userName;
+  }
+
+  set id(id) {
+    this._id = id;
+  }
+
+  set fileType(fileType) {
+  this._fileType = fileType;
+  }
+
+  set filename(filename) {
+    return this._filename = filename;
+  }
+
+  set filenameAndExtension(filenameAndExtension) {
+    return this._filenameAndExtension = filenameAndExtension;
+  }
+
+  set warnings(warnings) {
+    return this._warnings = warnings;
+  }
+
+  set errors(errors) {
+    return this._errors = errors;
+  }
+
+  set records(records) {
+    return this._records = records;
+  }
+
+  toJSON() {
+    return {
+      filename:this._filenameAndExtension ? this._filenameAndExtension : null ,
+      records:this._records ? this._records : 0,
+      errors:this._errors ? this._errors : 0,
+      warnings:this._warnings ? this._warnings : 0
+    }
+  }
+};
+
+module.exports.metaData = metaData;

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -9,14 +9,14 @@ const s3 = new AWS.S3({
   accessKeyId: appConfig.get('bulkuploaduser.accessKeyId').toString(),
   secretAccessKey: appConfig.get('bulkuploaduser.secretAccessKey').toString(),
   region: appConfig.get('bulkuploaduser.region').toString(),
-  useAccelerateEndpoint: true,
 });
 
 const CsvEstablishmentValidator = require('../../models/BulkImport/csv/establishments').Establishment;
 const CsvWorkerValidator = require('../../models/BulkImport/csv/workers').Worker;
 const CsvTrainingValidator = require('../../models/BulkImport/csv/training').Training;
-  
-var FileStatusEnum = { "New": "new", "Validated": "validated", "Imported": "imported" };
+const metaData = require('../../models/BulkImport/csv/metaData').metaData;
+
+var FileStatusEnum = { "Latest": "latest", "Validated": "validated", "Imported": "imported" };
 var FileValidationStatusEnum = { "Pending": "pending", "Validating": "validating", "Pass": "pass", "PassWithWarnings": "pass with warnings", "Fail": "fail" };
 
 router.route('/signedUrl').get(async function (req, res) {
@@ -27,13 +27,13 @@ router.route('/signedUrl').get(async function (req, res) {
     const myEstablishmentId = Number.isInteger(establishmentId) ? establishmentId.toString() : establishmentId;
     var uploadPreSignedUrl = s3.getSignedUrl('putObject', {
       Bucket: appConfig.get('bulkuploaduser.bucketname').toString(),
-      Key: establishmentId + '/' + FileStatusEnum.New + '/' + req.query.filename,
+      Key: establishmentId + '/' + FileStatusEnum.Latest + '/' + req.query.filename,
       // ACL: 'public-read',
       ContentType: req.query.type,
       Metadata: {
         username,
         establishmentId: myEstablishmentId,
-        validationstatus: FileValidationStatusEnum.Pending
+        validationstatus: FileValidationStatusEnum.Pending,
       },
       Expires: appConfig.get('bulkuploaduser.uploadSignedUrlExpire'),
     });
@@ -46,14 +46,10 @@ router.route('/signedUrl').get(async function (req, res) {
   }
 });
 
-//Key 214/new/Workbook1.csv
-//buc sfcbulkuploadfiles
-
 //TODO: from front end it has to be 3 file names, i have to build the path
 
 // Happy path
 //Concern in download files to local folder; if many user download, or we stream 
-
 //User case0; create 3 files with known sample data for establishment, worker
 //Use case 1: Accept three filenames and make a key default to New
 //Use case 2: First validation, must be three filename, unless do revalidation
@@ -68,51 +64,94 @@ router.route('/signedUrl').get(async function (req, res) {
 
 
 // FOR NASIR:
-//  1. Why a get?
 //  2. If using a POST or PATCH, can pass data as JSON BODY
-//  4. Why is use accelerated endpoint true when creating S3 object?
 //  7. This current approach to validation is "very synchronous"; there is lots we can do yet to optimise this - but we optimise later once we have the process working.
-router.route('/validate').get(async (req, res) => {
+router.route('/validate').put(async (req, res) => {
   const establishmentId = req.establishmentId;
   const username = req.username;
-
-  const establishmentFileKey = establishmentId + '/' + FileStatusEnum.New + '/' + req.query.establishment;
-  const workerFileKey = establishmentId + '/' + FileStatusEnum.New + '/' + req.query.worker;
-  const trainingFileKey = establishmentId + '/' + FileStatusEnum.New + '/' + req.query.training;
-
-
+  const myDownloads = {};
+  const establishmentMetadata = new metaData();
+  const workerMetadata = new metaData();
+  const trainingMetadata = new metaData();
+  
   try {
     // awaits must be within a try/catch block - checking if file exists - saves having to repeatedly download from S3 bucket
-    const establishmentsCSV = await downloadContent(establishmentFileKey);
-    const workersCSV = await downloadContent(workerFileKey);
-    const trainingCSV = await downloadContent(trainingFileKey);
+
+    const params = {
+    Bucket: appConfig.get('bulkuploaduser.bucketname').toString(), 
+    Prefix: `${req.establishmentId}/latest/`
+    };
+    var data = await s3.listObjects(params).promise();
+    //  const establishmentsCSV = null;
+
+    const establishmentRegex = /LOCALESTID,STATUS,ESTNAME,ADDRESS1,ADDRESS2,ADDRES/;
+    const workerRegex = /LOCALESTID,UNIQUEWORKERID,CHGUNIQUEWRKID,STATUS,DI/;
+    const trainingRegex = /LOCALESTID,UNIQUEWORKERID,CATEGORY,DESCRIPTION,DAT/;
+    const createModelPromises = [];
+
+    data.Contents.forEach(a => {
+      createModelPromises.push(  downloadContent(a.Key) );
+    });
+    
+    await Promise.all(createModelPromises).then(function(values){
+       values.forEach(myfile=>{
+          if (establishmentRegex.test(myfile.data.substring(0,50))) {
+            myDownloads.establishments = myfile.data;
+            establishmentMetadata.filename = myfile.filename;
+            establishmentMetadata.filenameAndExtension = myfile.filenameAndExt;
+            establishmentMetadata.fileType = 'Establishment';
+            
+                          
+          } else if (workerRegex.test(myfile.data.substring(0,50))) {
+            myDownloads.workers = myfile.data;
+            workerMetadata.filename = myfile.filename;
+            workerMetadata.filenameAndExtension = myfile.filenameAndExt;
+            workerMetadata.fileType = 'Worker';    
+
+          } else if (trainingRegex.test(myfile.data.substring(0,50))) {
+            myDownloads.trainings = myfile.data;
+            trainingMetadata.filename = myfile.filename;
+            trainingMetadata.filenameAndExtension = myfile.filenameAndExt;
+            trainingMetadata.fileType = 'Training';
+          }        
+        })
+    }).catch(err => {
+        console.error("NM: validate.put", err);
+    }) ;
   
-    const importedEstablishments = await csv().fromString(establishmentsCSV);
-    const importedWorkers = await csv().fromString(workersCSV);
-    const importedTraining = await csv().fromString(trainingCSV);
+    const importedEstablishments = myDownloads.establishments ? await csv().fromString(myDownloads.establishments) : null;
+    const importedWorkers = myDownloads.workers ? await csv().fromString(myDownloads.workers) :  null;
+    const importedTraining = myDownloads.trainings ? await csv().fromString(myDownloads.trainings) : null;
 
     const validationResponse = await validateBulkUploadFiles(
       true,
       username,
       establishmentId,
-      { imported: importedEstablishments, filename: req.query.establishment },
-      { imported: importedWorkers, filename: req.query.worker },
-      { imported: importedTraining, filename: req.query.training })
+      { imported: importedEstablishments, establishmentMetadata: establishmentMetadata  },
+      { imported: importedWorkers, workerMetadata: workerMetadata },
+      { imported: importedTraining, trainingMetadata: trainingMetadata })
 
-    // handle parsing errors
-    if (!validationResponse.status) {
-      return res.status(400).send({});
-
-    } else {
-      return res.status(200).send({});
-    }
+      // handle parsing errors
+      if (!validationResponse.status) {
+        return res.status(400).send({
+          establishment: validationResponse.metaData.establishments.toJSON(),
+          workers: validationResponse.metaData.workers.toJSON(),
+          training: validationResponse.metaData.training.toJSON(),
+        });
+  
+      } else {
+        return res.status(200).send({
+          establishment: validationResponse.metaData.establishments.toJSON(),
+          workers: validationResponse.metaData.workers.toJSON(),
+          training: validationResponse.metaData.training.toJSON(),
+        });
+      }
 
   } catch (err) {
     console.error(err);
     return res.status(503).send({});
   }
 });
-
 
 // alternative (testable) route, which passes the establishment, worker and training CSV as content
 //  return the validation errors as response
@@ -155,16 +194,21 @@ router.route('/validate').post(async (req, res) => {
   }
 });
 
-
 async function downloadContent(key) {
     var params = {
       Bucket: appConfig.get('bulkuploaduser.bucketname').toString(),
       Key: key,
     };
-
+    
+    const filenameRegex=/^(.+\/)*(.+)\.(.+)$/; 
+    
     try {
-      const objData = await s3.getObject(params).promise();
-      return objData.Body.toString();
+      const objData = await s3.getObject(params).promise();      
+      return {
+        data: objData.Body.toString(), 
+        filename: key.match(filenameRegex)[2],
+        filenameAndExt:key.match(filenameRegex)[2] + '.' + key.match(filenameRegex)[3], 
+     };
 
     } catch (err) {
       console.error('api/establishment/bulkupload/downloadFile: ', err);
@@ -199,13 +243,19 @@ async function uploadAsJSON(username, establishmentId, content, key) {
 // if commit is false, then the results of validation are not uploaded to S3
 const validateBulkUploadFiles = async (commit, username , establishmentId, establishments, workers, training) => {
   let status = true;
-  const csvEstablishmentSchemaErrors = [], csvWorkerSchemaErrors = [], csvTrainingSchemaErrors = [];;
+  const csvEstablishmentSchemaErrors = [], csvWorkerSchemaErrors = [], csvTrainingSchemaErrors = [];
   const myEstablishments = [], myWorkers = [], myTrainings = [];
-
+  
+  let establishmentRecords=0;
+  let workerRecords=0;
+  let trainingRecords=0;
+ 
   // parse and process Establishments CSV
-  if (Array.isArray(establishments.imported) && establishments.imported.length > 0) {
+  if (Array.isArray(establishments.imported) && establishments.imported.length > 0 && establishments.establishmentMetadata.fileType == "Establishment") {
     establishments.imported.forEach((thisLine, currentLineNumber) => {
       const lineValidator = new CsvEstablishmentValidator(thisLine, currentLineNumber+2);   // +2 because the first row is CSV headers, and forEach counter is zero index
+      
+      ++establishmentRecords;
 
       // the parsing/validation needs to be forgiving in that it needs to return as many errors in one pass as possible
       lineValidator.validate();
@@ -213,7 +263,8 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, estab
 
       // TODO - not sure this is necessary yet - we can just iterate the collection of Establishments at the end to create the validation JSON document
       if (lineValidator.validationErrors.length > 0) {
-        csvEstablishmentSchemaErrors.push(lineValidator.validationErrors);
+        csvEstablishmentSchemaErrors.push(lineValidator.validationErrors);  
+        establishments.establishmentMetadata.errors += lineValidator.validationErrors.length;    
       }
 
       myEstablishments.push(lineValidator);
@@ -224,11 +275,14 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, estab
     console.error("No establishments");
     status = false;
   }
+  establishments.establishmentMetadata.records = establishmentRecords;
 
   // parse and process Workers CSV
-  if (Array.isArray(workers.imported) && workers.imported.length > 0) {
+  if (Array.isArray(workers.imported) && workers.imported.length > 0 && workers.workerMetadata.fileType == "Worker") {
     workers.imported.forEach((thisLine, currentLineNumber) => {
       const lineValidator = new CsvWorkerValidator(thisLine, currentLineNumber+2);   // +2 because the first row is CSV headers, and forEach counter is zero index
+
+      ++workerRecords;
 
       // the parsing/validation needs to be forgiving in that it needs to return as many errors in one pass as possible
       lineValidator.validate();
@@ -236,6 +290,7 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, estab
 
       if (lineValidator.validationErrors.length > 0) {
         csvWorkerSchemaErrors.push(lineValidator.validationErrors);
+        workers.workerMetadata.errors += lineValidator.validationErrors.length;    
       }
 
       //console.log("WA DEBUG - this worker: ", lineValidator.toJSON());
@@ -245,38 +300,40 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, estab
     console.error("No Workers");
     status = false;
   }
+  workers.workerMetadata.records = workerRecords;
 
   // parse and process Training CSV
-  if (Array.isArray(training.imported) && training.imported.length > 0) {
+  if (Array.isArray(training.imported) && training.imported.length > 0 && training.trainingMetadata.fileType == "Training") {
     training.imported.forEach((thisLine, currentLineNumber) => {
       const lineValidator = new CsvTrainingValidator(thisLine, currentLineNumber+2);   // +2 because the first row is CSV headers, and forEach counter is zero index
 
+      ++trainingRecords;
       // the parsing/validation needs to be forgiving in that it needs to return as many errors in one pass as possible
       lineValidator.validate();
       lineValidator.transform();
 
       if (lineValidator.validationErrors.length > 0) {
         csvTrainingSchemaErrors.push(lineValidator.validationErrors);
+        training.trainingMetadata.errors += lineValidator.validationErrors.length;  
       }
 
-      myTrainings.push(lineValidator);
       //console.log("WA DEBUG - this training: ", lineValidator.toJSON());
+      myTrainings.push(lineValidator);
     });
   } else {
     console.error("No training records");
     status = false;
   }
+  training.trainingMetadata.records = trainingRecords;
 
   // TODO: we have still got to transform/load the establishments, workers/qualifications and training records through the API (model classes yet)
   //       which may yet incur more validation errors - but that is a separate ticket.
 
-
   // upload the converted CSV as JSON to S3
-  myEstablishments.length > 0 && commit ? await uploadAsJSON(username, establishmentId, myEstablishments.map(thisEstablishment => thisEstablishment.toJSON()), `${establishmentId}/intermediary/${establishments.filename}.validation.json`) : true;
-  myWorkers.length > 0 && commit ? await uploadAsJSON(username, establishmentId, myWorkers.map(thisEstablishment => thisEstablishment.toJSON()), `${establishmentId}/intermediary/${workers.filename}.validation.json`) : true;
-  myTrainings.length > 0 && commit ? await uploadAsJSON(username, establishmentId, myTrainings.map(thisEstablishment => thisEstablishment.toJSON()), `${establishmentId}/intermediary/${training.filename}.validation.json`) : true;
+  myEstablishments.length > 0 && commit ? await uploadAsJSON(username, establishmentId, myEstablishments.map(thisEstablishment => thisEstablishment.toJSON()), `${establishmentId}/intermediary/${establishments.establishmentMetadata.filename}.validation.json`) : true;
+  myWorkers.length > 0 && commit ? await uploadAsJSON(username, establishmentId, myWorkers.map(thisEstablishment => thisEstablishment.toJSON()), `${establishmentId}/intermediary/${workers.workerMetadata.filename}.validation.json`) : true;
+  myTrainings.length > 0 && commit ? await uploadAsJSON(username, establishmentId, myTrainings.map(thisEstablishment => thisEstablishment.toJSON()), `${establishmentId}/intermediary/${training.trainingMetadata.filename}.validation.json`) : true;
   
-
   // handle parsing errors
   if (csvEstablishmentSchemaErrors.length > 0 || csvWorkerSchemaErrors.length > 0 || csvTrainingSchemaErrors.length > 0) {
     //console.error('WA DEBUG Establishment validation errors: ', csvEstablishmentSchemaErrors)
@@ -284,12 +341,17 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, estab
     //console.error('NM DEBUG Training validation errors: ', csvTrainingSchemaErrors)
 
     // upload the validation reports to S3
-    commit ? await uploadAsJSON(username, establishmentId, csvEstablishmentSchemaErrors, `${establishmentId}/validation/${establishments.filename}.validation.json`) : true;
-    commit ? await uploadAsJSON(username, establishmentId, csvWorkerSchemaErrors, `${establishmentId}/validation/${workers.filename}.validation.json`) : true;
-    commit ? await uploadAsJSON(username, establishmentId, csvTrainingSchemaErrors, `${establishmentId}/validation/${training.filename}.validation.json`) : true;
+    commit ? await uploadAsJSON(username, establishmentId, csvEstablishmentSchemaErrors, `${establishmentId}/validation/${establishments.establishmentMetadata.filename}.validation.json`) : true;
+    commit ? await uploadAsJSON(username, establishmentId, csvWorkerSchemaErrors, `${establishmentId}/validation/${workers.workerMetadata.filename}.validation.json`) : true;
+    commit ? await uploadAsJSON(username, establishmentId, csvTrainingSchemaErrors, `${establishmentId}/validation/${training.trainingMetadata.filename}.validation.json`) : true;
 
     status = false;
   }
+
+   //upload metadata as json, by filename+metadata.json
+   commit ? await uploadAsJSON(username, establishmentId, establishments.establishmentMetadata, `${establishmentId}/latest/${establishments.establishmentMetadata.filename}.metadata.json`) : true;
+   commit ? await uploadAsJSON(username, establishmentId, workers.workerMetadata, `${establishmentId}/latest/${workers.workerMetadata.filename}.metadata.json`) : true;
+   commit ? await uploadAsJSON(username, establishmentId, training.trainingMetadata, `${establishmentId}/latest/${training.trainingMetadata.filename}.metadata.json`) : true;
 
   return {
     status,
@@ -302,9 +364,15 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, estab
       establishments: myEstablishments.map(thisEstablishment => thisEstablishment.toJSON()),
       workers: myEstablishments.map(thisEstablishment => thisEstablishment.toJSON()),
       training: myEstablishments.map(thisEstablishment => thisEstablishment.toJSON()),
+    },
+    metaData: {
+        establishments: establishments.establishmentMetadata,
+        workers: workers.workerMetadata,      
+        training: training.trainingMetadata
     }
   }
 };
+
 
 router.route('/').get(async (req, res) => {
   const establishmentId = req.establishmentId;


### PR DESCRIPTION
Hello, this is modified validate end point which now returns following to FE upon validation.

1) The method is Put now rather get and there is no need to pass filenames as input
2) The method will retrieve the three files only, first determine its type and then upload it as key latest i.e. 144/latest/test.csv 
3 The method will now calculate type, recrods, error and wrning and  will upload all meta data as object in s3 latest by name of filename.metadata.json.
2) Return response 200 and 400 formatted by establishment,, worker and training.

Here is the tickete with some screenshots
https://trello.com/c/6QIQX5SL
