### PR TITLE
Bulk upload validation corrections

### DIFF
--- a/server/models/BulkImport/BUDI/index.js
+++ b/server/models/BulkImport/BUDI/index.js
@@ -203,8 +203,6 @@ class BUDI {
       { "ASC": 'Pool/Bank', "BUDI": 3},
       { "ASC": 'Agency', "BUDI": 4},
       { "ASC": 'Other', "BUDI": 7},       // multiple values mapping to Other; 7 needs to be first in list for the export
-      { "ASC": 'Other', "BUDI": 5},
-      { "ASC": 'Other', "BUDI": 6},
     ];
 
     if (direction == BUDI.TO_ASC) {

--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -636,14 +636,14 @@ class Establishment {
   _validateLocationID() {
     // must be given if "share with CQC" - but if given must be in the format "n-nnnnnnnnn"
     const locationIDRegex = /^[0-9]{1}-[0-9]{8,10}$/;
-    const myLocationID = this._currentLine.PROVNUM;
+    const myLocationID = this._currentLine.LOCATIONID;
 
     if (this._regType  && this._regType == 2 && (!myLocationID || myLocationID.length==0)) {
       this._validationErrors.push({
         lineNumber: this._lineNumber,
         errCode: Establishment.LOCATION_ID_ERROR,
         errType: `LOCATION_ID_ERROR`,
-        error: "Location ID (PROVNUM) must be given as this workplace is CQC regulated",
+        error: "Location ID (LOCATIONID) must be given as this workplace is CQC regulated",
         source: myLocationID,
       });
       return false;
@@ -653,7 +653,7 @@ class Establishment {
         lineNumber: this._lineNumber,
         errCode: Establishment.LOCATION_ID_ERROR,
         errType: `LOCATION_ID_ERROR`,
-        error: "Location ID (PROVNUM) must be in the format 'n-nnnnnnnnn'",
+        error: "Location ID (LOCATIONID) must be in the format 'n-nnnnnnnnn'",
         source: myLocationID,
       });
       return false;
@@ -877,7 +877,7 @@ class Establishment {
     }
 
     // and the number of utilisations/capacities must equal the number of all services
-    if (listOfCapacities.length !== this._allServices.length) {
+    if (listOfCapacities.length !== (this._allServices ? this._allServices.length : 0)) {
       localValidationErrors.push({
         lineNumber: this._lineNumber,
         errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
@@ -892,7 +892,7 @@ class Establishment {
     const MAX_CAP_UTIL=999999999;
     const areCapacitiesValid = listOfCapacities.every(thisCapacity => {
       return thisCapacity === null ||
-             thisCapacity.length==0 ? true : !Number.isNaN(parseInt(thisCapacity)) &&  parseInt(thisCapacity) < MAX_CAP_UTIL
+             thisCapacity.length==0 ? true : !Number.isNaN(parseInt(thisCapacity)) &&  parseInt(thisCapacity) < MAX_CAP_UTIL;
     });
     if (!areCapacitiesValid) {
       localValidationErrors.push({
@@ -904,8 +904,9 @@ class Establishment {
       });
     }
     const areUtilisationsValid = listOfUtilisations.every(thisUtilisation => {
-      thisUtilisation === null ||
-      thisUtilisation.length==0 ? true : !Number.isNaN(parseInt(thisUtilisation) || parseInt(thisUtilisation) < MAX_CAP_UTIL)
+      console.log("WA DEBUG - this utilisation: ", thisUtilisation, parseInt(thisUtilisation), Number.isNaN(parseInt(thisUtilisation)))
+      return thisUtilisation === null ||
+            thisUtilisation.length==0 ? true : !Number.isNaN(parseInt(thisUtilisation)) && parseInt(thisUtilisation) < MAX_CAP_UTIL;
     });
     if (!areUtilisationsValid) {
       localValidationErrors.push({
@@ -1647,7 +1648,7 @@ class Establishment {
               lineNumber: this._lineNumber,
               errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
               errType: `CAPACITY_UTILISATION_USERS_ERROR`,
-              error: `Capacities (CAPACITY): position ${index+1} is unknown capacity`,
+              error: `Capacities (CAPACITY): position ${index+1} is unexpected capacity (no expected capacity for given service: ${this._allServices[index]})`,
               source: this._currentLine.CAPACITY,
             });
           }
@@ -1882,7 +1883,7 @@ class Establishment {
       mainService: {
         id: this._mainService
       },
-      allServices: this._allServices.map((thisService, index) => {
+      allServices: this._allServices ? this._allServices.map((thisService, index) => {
         const returnThis = {
           id: thisService,
         };
@@ -1892,7 +1893,7 @@ class Establishment {
         }
 
         return returnThis;
-      }),
+      }) : undefined,
       serviceUsers: this._allServiceUsers.map((thisService, index) => {
         const returnThis = {
           id: thisService,
@@ -1951,7 +1952,7 @@ class Establishment {
       mainService: {
         id: this._mainService     // during BUDI lookup, it returns the main service as an id
       },
-      services: this._allServices
+      services: this._allServices ? this._allServices
         .filter(thisService => thisService !== this._mainService)   // main service cannot appear in otherServices
         .map((thisService, index) => {
           const returnThis = {
@@ -1963,7 +1964,7 @@ class Establishment {
           }
 
           return returnThis;
-        }),
+        }) : undefined,
       serviceUsers: this._allServiceUsers
         .map((thisService, index) => {
           const returnThis = {
@@ -2015,7 +2016,7 @@ class Establishment {
     if (changeProperties.capacities.length == 0) {
       changeProperties.capacities = undefined;
     }
-    if (changeProperties.services.length == 0) {
+    if (changeProperties.services && changeProperties.services.length == 0) {
       changeProperties.services = undefined;
     }
 


### PR DESCRIPTION
https://trello.com/c/nAtfBMoi

On re-test, Ann found an error I had introduced for utilisation validation; fixed as a result of some poor copying of revised capacity validation.
* ALLSERVICES trap for mandatory was not previously tested, and consequently there were are few code failures expecting `this._allServices` to be not null failing (HTTP 503).
* LOCATIONID; validating against PROVID (twice); dam copy 'n' paste.

https://trello.com/c/pquWOjG2 - Worker validation errors resulting from initial test
* CARECERT & APPRENTICE - 0 is not a valid option (careless predicate on integer value rather than original string value)

https://trello.com/c/BQDpmGEl - Worker validation errors resulting from Jackie's test
* GENDER - is optional
* EMPLSTATUS - 5 and 6 should error
* SALARYRATE - 4 should error
* SALARY/HOURLY - bulk import specific cross-validation erroring (we don't differentiate in Worker entity)