### PR TITLE
Bug | Safari File Upload

### DIFF
--- a/src/app/shared/form-controls/file-control-value-accessor.ts
+++ b/src/app/shared/form-controls/file-control-value-accessor.ts
@@ -1,0 +1,20 @@
+import { Directive, HostListener } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+
+@Directive({
+  // tslint:disable-next-line: directive-selector
+  selector: 'input[type=file]',
+  providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: FileValueAccessorDirective, multi: true }],
+})
+export class FileValueAccessorDirective implements ControlValueAccessor {
+  @HostListener('change', ['$event.target.files']) onChange = _ => {};
+  @HostListener('blur') onTouched = () => {};
+
+  writeValue(value) {}
+  registerOnChange(fn: any) {
+    this.onChange = fn;
+  }
+  registerOnTouched(fn: any) {
+    this.onTouched = fn;
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -29,6 +29,7 @@ import { NumberMax } from './directives/number-max.directive';
 import { NumberPositiveOnly } from './directives/number-positive-only.directive';
 import { Number } from './directives/number.directive';
 import { AbsoluteNumberPipe } from './pipes/absolute-number.pipe';
+import { FileValueAccessorDirective } from './form-controls/file-control-value-accessor';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, RouterModule],
@@ -41,6 +42,7 @@ import { AbsoluteNumberPipe } from './pipes/absolute-number.pipe';
     DatePickerComponent,
     DetailsComponent,
     ErrorSummaryComponent,
+    FileValueAccessorDirective,
     InsetTextComponent,
     MessagesComponent,
     Number,
@@ -68,6 +70,7 @@ import { AbsoluteNumberPipe } from './pipes/absolute-number.pipe';
     DatePickerComponent,
     DetailsComponent,
     ErrorSummaryComponent,
+    FileValueAccessorDirective,
     InsetTextComponent,
     MessagesComponent,
     Number,


### PR DESCRIPTION
Adding ControlValueAccessor to ensure that onchange events are fired for File Inputs in Safari