### PR TITLE
bugfix | only prefill form if user has previously checked other services

### DIFF
--- a/src/app/features/workplace/other-services/other-services.component.ts
+++ b/src/app/features/workplace/other-services/other-services.component.ts
@@ -78,15 +78,19 @@ export class OtherServicesComponent extends Question {
 
   private preFillForm(): void {
     const allOtherServices = this.establishmentService.establishment.otherServices;
-    allOtherServices.forEach((data: ServiceGroup) => this.allOtherServices.push(...data.services));
 
-    this.allOtherServices.forEach((service: Service) => {
-      this.form.get('otherServices').value.push(service.id);
+    if (allOtherServices) {
+      allOtherServices.forEach((data: ServiceGroup) => this.allOtherServices.push(...data.services));
 
-      if (service.other) {
-        this.form.get(`additionalOtherService${service.id}`).setValue(service.other);
-      }
-    });
+      this.allOtherServices.forEach((service: Service) => {
+        this.form.get('otherServices').value.push(service.id);
+
+        if (service.other) {
+          this.form.get(`additionalOtherService${service.id}`).setValue(service.other);
+        }
+      });
+    }
+
     this.renderForm = true;
   }
 


### PR DESCRIPTION
bugfix | only prefill form if user has previously checked other services as BE omits the otherServices property from get establishment call altogether rather than sending back an empty array