### PR TITLE
GOV.UK Framework | Workplace | Confirm Vacancies

### DIFF
--- a/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.html
+++ b/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.html
@@ -2,14 +2,14 @@
   <h1 class="govuk-panel__title">Current staff vacancies</h1>
   <div class="govuk-panel__body">
     <p class="govuk-heading-m">You told us you have:</p>
-    <dl class="govuk-list--definition govuk-!-margin-bottom-8">
-      <dt>current staff vacancies</dt>
+    <dl class="govuk-list--definition govuk-list--definition-xl govuk-!-margin-bottom-8">
+      <dt>Current staff vacancies</dt>
       <dd>{{ establishment.TotalVacencies }}</dd>
     </dl>
     <p>Continue if this is correct or go back and make a change.</p>
     <div class="govuk-button-group">
       <a
-        class="govuk-button govuk-!-margin-right-8"
+        class="govuk-button govuk-!-margin-right-8 govuk-!-margin-bottom-0"
         role="button"
         [routerLink]="['/workplace', this.establishment.id, 'starters']"
       >
@@ -17,7 +17,7 @@
       </a>
       <span class="govuk-visually-hidden">or</span>
       <a
-        class="govuk-button govuk-button--link"
+        class="govuk-button govuk-button--link govuk-!-margin-bottom-0"
         role="button"
         [routerLink]="['/workplace', this.establishment.id, 'vacancies']"
       >

--- a/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.html
+++ b/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.html
@@ -1,16 +1,27 @@
-<div class="main-page-container confirmation-page col-12">
-  <h1 class="h1">Current staff vacancies</h1>
-
-  <h2>You told us you have:</h2>
-  <div class="facts">
-    <span class="amount">{{total}}</span>
-    <span class="label">current staff vacancies</span>
+<div class="govuk-panel govuk-panel--interruption">
+  <h1 class="govuk-panel__title">Current staff vacancies</h1>
+  <div class="govuk-panel__body">
+    <h2 class="govuk-heading-m">You told us you have:</h2>
+    <dl class="govuk-list--definition govuk-!-margin-bottom-8">
+      <dt>current staff vacancies</dt>
+      <dd>{{ establishment.TotalVacencies }}</dd>
+    </dl>
+    <p>Continue if this is correct or go back and make a change.</p>
+    <div class="govuk-button-group">
+      <a
+        class="govuk-button govuk-!-margin-right-8"
+        role="button"
+        [routerLink]="['/workplace', this.establishment.id, 'starters']"
+      >
+        Save and continue
+      </a>
+      <a
+        class="govuk-button govuk-button--link"
+        role="button"
+        [routerLink]="['/workplace', this.establishment.id, 'vacancies']"
+      >
+        Make a change
+      </a>
+    </div>
   </div>
-
-  <h2>Continue if this is correct or go back and make a change.</h2>
-  <button type="button" class="btn btn-primary" (click)="submitHandler()">Save and continue</button>
-  <app-messages></app-messages>
-
-  <button type="button" class="btn btn-link" (click)="makeChangeHandler()">Make a change</button>
-  <app-messages></app-messages>
 </div>

--- a/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.html
+++ b/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.html
@@ -1,7 +1,7 @@
 <div class="govuk-panel govuk-panel--interruption">
   <h1 class="govuk-panel__title">Current staff vacancies</h1>
   <div class="govuk-panel__body">
-    <h2 class="govuk-heading-m">You told us you have:</h2>
+    <p class="govuk-heading-m">You told us you have:</p>
     <dl class="govuk-list--definition govuk-!-margin-bottom-8">
       <dt>current staff vacancies</dt>
       <dd>{{ establishment.TotalVacencies }}</dd>
@@ -15,6 +15,7 @@
       >
         Save and continue
       </a>
+      <span class="govuk-visually-hidden">or</span>
       <a
         class="govuk-button govuk-button--link"
         role="button"

--- a/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.ts
+++ b/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.ts
@@ -1,37 +1,28 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Establishment } from '@core/model/establishment.model';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { map } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-confirm-vacancies',
   templateUrl: './confirm-vacancies.component.html',
 })
 export class ConfirmVacanciesComponent implements OnInit, OnDestroy {
-  private subscriptions = [];
+  public establishment: Establishment;
+  private subscriptions: Subscription = new Subscription();
 
-  total: number;
-
-  constructor(private router: Router, private establishmentService: EstablishmentService) {}
-
-  makeChangeHandler() {
-    this.router.navigate(['/workplace', 'vacancies']);
-  }
-
-  submitHandler() {
-    this.router.navigate(['/workplace', 'starters']);
-  }
+  constructor(private establishmentService: EstablishmentService) {}
 
   ngOnInit() {
-    this.subscriptions.push(
-      this.establishmentService
-        .getJobs()
-        .pipe(map(jobs => jobs.TotalVacencies))
-        .subscribe(total => (this.total = total))
+    this.subscriptions.add(
+      this.establishmentService.establishment$.pipe(take(1)).subscribe(establishment => {
+        this.establishment = establishment;
+      })
     );
   }
 
   ngOnDestroy() {
-    this.subscriptions.forEach(s => s.unsubscribe());
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/assets/scss/components/_panel.scss
+++ b/src/assets/scss/components/_panel.scss
@@ -3,18 +3,16 @@
   text-align: left;
 
   * {
-    color: #fff;
+    color: govuk-colour('white');;
   }
 
-  a {
-    color: #fff;
-  }
+  a,
   a:link,
   a:visited {
-    color: #fff;
+    color: govuk-colour('white');;
   }
   a:hover {
-    color: #f2f2f2;
+    color: govuk-colour('grey-4');
   }
 
   .govuk-list--definition {
@@ -26,7 +24,7 @@
 
   .govuk-button:not(.govuk-button--link) {
     background-color: govuk-colour('white');
-    box-shadow: 0 2px 0 rgba(#000, 0.25);
+    box-shadow: 0 2px 0 govuk-colour('black');
 
     &:link,
     &:visited {

--- a/src/assets/scss/components/_panel.scss
+++ b/src/assets/scss/components/_panel.scss
@@ -1,0 +1,26 @@
+.govuk-panel--interruption {
+  background-color: govuk-colour('blue');
+  text-align: left;
+
+  * {
+    color: #fff;
+  }
+
+  a {
+    color: #fff;
+  }
+  a:link,
+  a:visited {
+    color: #fff;
+  }
+  a:hover {
+    color: #f2f2f2;
+  }
+
+  .govuk-list--definition {
+    dt,
+    dd {
+      color: govuk-colour('blue');
+    }
+  }
+}

--- a/src/assets/scss/components/_panel.scss
+++ b/src/assets/scss/components/_panel.scss
@@ -23,4 +23,19 @@
       color: govuk-colour('blue');
     }
   }
+
+  .govuk-button:not(.govuk-button--link) {
+    background-color: govuk-colour('white');
+    box-shadow: 0 2px 0 rgba(#000, 0.25);
+
+    &:link,
+    &:visited {
+      color: govuk-colour('blue');
+    }
+
+    &:hover,
+    &:focus {
+      background-color: govuk-colour('grey-3');
+    }
+  }
 }

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -1,3 +1,5 @@
+/* autoprefixer grid: on */
+
 @import '~govuk-frontend/settings/all';
 
 $govuk-global-styles: true;

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -25,6 +25,7 @@ body {
 @import 'components/header';
 @import 'components/input';
 @import 'components/inset-text';
+@import 'components/panel';
 @import 'components/progress';
 @import 'components/radios';
 @import 'components/summary-list';

--- a/src/assets/scss/partials/_lists.scss
+++ b/src/assets/scss/partials/_lists.scss
@@ -11,27 +11,80 @@
 }
 
 .govuk-list--definition {
-  display: flex;
-  flex-flow: column-reverse wrap;
+  display: grid;
+
   margin: 0;
   @include govuk-responsive-margin(4, 'bottom');
-  width: govuk-grid-width('one-third');
-  background-color: govuk-colour('grey-3');
+
+  grid-template-columns: 1fr;
+  @include govuk-media-query($from: tablet) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
 
   dt {
-    @include govuk-responsive-margin(3, 'left');
-    @include govuk-responsive-margin(3, 'right');
-    @include govuk-responsive-margin(3, 'bottom');
-    margin-top: 0;
+    @include govuk-responsive-padding(3, 'left');
+    @include govuk-responsive-padding(3, 'right');
+    @include govuk-responsive-padding(3, 'bottom');
+    margin: 0;
 
-    @include govuk-font(24, 'bold');
+    @include govuk-font(19);
+    background-color: govuk-colour('grey-3');
   }
-  dd {
-    @include govuk-responsive-margin(3, 'top');
-    @include govuk-responsive-margin(3, 'left');
-    @include govuk-responsive-margin(3, 'right');
-    margin-bottom: 0;
 
-    @include govuk-font(80, 'bold');
+  dd {
+    @include govuk-responsive-padding(3, 'top');
+    @include govuk-responsive-padding(3, 'left');
+    @include govuk-responsive-padding(3, 'right');
+    margin: 0;
+
+    @include govuk-font(19, 'bold');
+    background-color: govuk-colour('grey-3');
+  }
+
+  &.govuk-list--definition-xl {
+    dt {
+      @include govuk-font(24, 'bold');
+    }
+    dd {
+      @include govuk-font(80, 'bold');
+    }
+  }
+
+  @for $i from 1 through 3 {
+    dt:nth-of-type(#{$i}) {
+      grid-row-start: 2;
+      grid-row-end: 3;
+      grid-column-start: $i;
+      grid-column-end: $i + 1;
+
+      @if $i > 1 {
+        &:before {
+          content: '&nbsp;';
+          color: transparent;
+          display: block;
+          position: absolute;
+          margin-left: -15px;
+          border-left: 1px solid govuk-colour('grey-1');
+        }
+      }
+    }
+
+    dd:nth-of-type(#{$i}) {
+      grid-row-start: 1;
+      grid-row-end: 2;
+      grid-column-start: $i;
+      grid-column-end: $i + 1;
+
+      @if $i > 1 {
+        &:before {
+          content: '&nbsp;';
+          color: transparent;
+          display: block;
+          position: absolute;
+          margin-left: -15px;
+          border-left: 1px solid govuk-colour('grey-1');
+        }
+      }
+    }
   }
 }

--- a/src/assets/scss/partials/_lists.scss
+++ b/src/assets/scss/partials/_lists.scss
@@ -9,3 +9,27 @@
     }
   }
 }
+
+.govuk-list--definition {
+  display: flex;
+  flex-flow: column-reverse wrap;
+  margin: 0;
+  @include govuk-responsive-margin(4, 'bottom');
+  width: govuk-grid-width('one-third');
+  background-color: govuk-colour('grey-3');
+
+  dt {
+    @include govuk-responsive-margin(3, 'left');
+    @include govuk-responsive-margin(3, 'right');
+    @include govuk-responsive-margin(3, 'bottom');
+    margin-top: 0;
+    @include govuk-font(24, 'bold');
+  }
+  dd {
+    @include govuk-responsive-margin(3, 'top');
+    @include govuk-responsive-margin(3, 'left');
+    @include govuk-responsive-margin(3, 'right');
+    margin-bottom: 0;
+    @include govuk-font(80, 'bold');
+  }
+}

--- a/src/assets/scss/partials/_lists.scss
+++ b/src/assets/scss/partials/_lists.scss
@@ -23,6 +23,7 @@
     @include govuk-responsive-margin(3, 'right');
     @include govuk-responsive-margin(3, 'bottom');
     margin-top: 0;
+
     @include govuk-font(24, 'bold');
   }
   dd {
@@ -30,6 +31,7 @@
     @include govuk-responsive-margin(3, 'left');
     @include govuk-responsive-margin(3, 'right');
     margin-bottom: 0;
+
     @include govuk-font(80, 'bold');
   }
 }


### PR DESCRIPTION
Extended the Panel SCSS to include an interruption card https://github.com/alphagov/govuk-design-system-backlog/issues/27
Added Definition List SCSS to display block of 3 list items, using CSS Grids, making sure it's prefixed for IE.

Updating Confirm Vacancies to use the GOV.UK Design Framework