### PR TITLE
Bulk upload validations 2 - unique workers/establishments and cross-check on workers/training records

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -5,7 +5,7 @@ class Establishment {
     this._currentLine = currentLine;
     this._lineNumber = lineNumber;
     this._validationErrors = [];
-    this._headers_v1 = ["LOCALESTID","STATUS","ESTNAME","ADDRESS1","ADDRESS2","ADDRESS3","POSTTOWN","POSTCODE","ESTTYPE","OTHERTYPE","IIPSTATUS","PERMCQC","PERMNHSC","PERMLA","SHARELA","REGTYPE","PROVNUM","LOCATIONID","MAINSERVICE","ALLSERVICES","CAPACITY","UTILISATION","SERVICEDESC","SERVICEUSERS","OTHERUSERDESC","TOTALPERMTEMP","ALLJOBROLES","STUDENTCOUNT","STARTERS","LEAVERS","VACANCIES","REASONS","REASONNOS","DESTNOS"];
+    this._headers_v1 = ["LOCALESTID","STATUS","ESTNAME","ADDRESS1","ADDRESS2","ADDRESS3","POSTTOWN","POSTCODE","ESTTYPE","OTHERTYPE","PERMCQC","PERMLA","SHARELA","REGTYPE","PROVNUM","LOCATIONID","MAINSERVICE","ALLSERVICES","CAPACITY","UTILISATION","SERVICEDESC","SERVICEUSERS","OTHERUSERDESC","TOTALPERMTEMP","ALLJOBROLES","STARTERS","LEAVERS","VACANCIES","REASONS","REASONNOS"];
 
 
     // CSV properties
@@ -45,6 +45,7 @@ class Establishment {
     //console.log(`WA DEBUG - current establishment (${this._lineNumber}:`, this._currentLine);
   };
 
+  static get DUPLICATE_ERROR() { return 999; }
   static get MAIN_SERVICE_ERROR() { return 1000; }
   static get LOCAL_ID_ERROR() { return 1010; }
   static get STATUS_ERROR() { return 1020; }
@@ -1425,6 +1426,17 @@ class Establishment {
     return true;
   }
 
+  // add a duplicate validation error to the current set
+  addDuplicate(originalLineNumber) {
+    return {
+      lineNumber: this._lineNumber,
+      errCode: Establishment.DUPLICATE_ERROR,
+      errType: `DUPLICATE_ERROR`,
+      error: `Duplicate of line ${originalLineNumber}`,
+      source: this._currentLine.LOCALESTID,
+    };
+  }
+
   // returns true on success, false is any attribute of Establishment fails
   validate() {
     let status = true;
@@ -1436,7 +1448,6 @@ class Establishment {
     status = !this._validateAddress() ? false : status;
     status = !this._validateEstablishmentType() ? false : status;
 
-    // ignoring IIPSTATUS and PERMNHSC
     status = !this._validateShareWithCQC() ? false : status;
     status = !this._validateShareWithLA() ? false : status;
     status = !this._validateLocalAuthorities() ? false : status;

--- a/server/models/BulkImport/csv/training.js
+++ b/server/models/BulkImport/csv/training.js
@@ -18,6 +18,8 @@ class Training {
     this._notes= null;
   };
 
+  static get UNCHECKED_WORKER_ERROR() { return 997; }
+  static get UNCHECKED_ESTABLISHMENT_ERROR() { return 998; }
   static get LOCALESTID_ERROR() { return 1000; }
   static get UNIQUE_WORKER_ID_ERROR() { return 1010; }
   static get DATE_COMPLETED_ERROR() { return 1020; }
@@ -322,6 +324,28 @@ class Training {
       });
     }
     return true;
+  }
+
+  // add unchecked establishment reference validation error
+  uncheckedEstablishment() {
+    return {
+      lineNumber: this._lineNumber,
+      errCode: Training.UNCHECKED_ESTABLISHMENT_ERROR,
+      errType: `UNCHECKED_ESTABLISHMENT_ERROR`,
+      error: `Unknown establishment/workplace cross reference`,
+      source: this._currentLine.LOCALESTID,
+    };
+  }
+
+  // add unchecked establishment reference validation error
+  uncheckedWorker() {
+    return {
+      lineNumber: this._lineNumber,
+      errCode: Training.UNCHECKED_WORKER_ERROR,
+      errType: `UNCHECKED_WORKER_ERROR`,
+      error: `Unknown worker/staff cross reference`,
+      source: this._currentLine.UNIQUEWORKERID,
+    };
   }
 
   // returns true on success, false is any attribute of Training fails

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -66,6 +66,8 @@ class Worker {
   };
 
   //49 csv columns
+  static get DUPLICATE_ERROR() { return 999; }
+  static get UNCHECKED_ESTABLISHMENT_ERROR() { return 998; }
   static get LOCAL_ID_ERROR() { return 1010; }
   static get UNIQUE_WORKER_ID_ERROR() { return 1020; }
   static get CHANGE_UNIQUE_WORKER_ID_ERROR() { return 1030; }
@@ -1905,6 +1907,28 @@ class Worker {
       this._qualifications = mappedQualifications;
 
     }
+  }
+
+  // add a duplicate validation error to the current set
+  addDuplicate(originalLineNumber) {
+    return {
+      lineNumber: this._lineNumber,
+      errCode: Worker.DUPLICATE_ERROR,
+      errType: `DUPLICATE_ERROR`,
+      error: `Duplicate of line ${originalLineNumber}`,
+      source: this._currentLine.UNIQUEWORKERID,
+    };
+  }
+  
+  // add unchecked establishment reference validation error
+  uncheckedEstablishment() {
+    return {
+      lineNumber: this._lineNumber,
+      errCode: Worker.UNCHECKED_ESTABLISHMENT_ERROR,
+      errType: `UNCHECKED_ESTABLISHMENT_ERROR`,
+      error: `Unknown establishment/workplace cross reference`,
+      source: this._currentLine.LOCALESTID,
+    };
   }
   
   _validateHeaders() {

--- a/server/models/classes/establishment/properties/servicesProperty.js
+++ b/server/models/classes/establishment/properties/servicesProperty.js
@@ -5,7 +5,7 @@ const ServiceFormatters = require('../../../api/services');
 
 const OTHER_MAX_LENGTH=120;
 
-exports.ServicesProperty = class ServicesPropertyProperty extends ChangePropertyPrototype {
+exports.ServicesProperty = class ServicesProperty extends ChangePropertyPrototype {
     constructor() {
         super('OtherServices');
 
@@ -15,7 +15,7 @@ exports.ServicesProperty = class ServicesPropertyProperty extends ChangeProperty
     }
 
     static clone() {
-        return new ServicesPropertyProperty();
+        return new ServicesProperty();
     }
 
     // concrete implementations


### PR DESCRIPTION
As agreed during refinement yesterday, https://trello.com/c/FUtQEhVR card needs to include the additionally identified uniqueness validation on establishments and workers, in addition to the cross-check of workers against establishments, and training against both establishments and workers.

The codes changes are here. The trello card comments includes confirmation of the validation output.

This PR also includes a subtle rename to one of the Establishment properties (`ServicesPropertyProperty`). The double "Property" is not necessary.

Also includes a minor update to the establishment header V1 - removing IIPSTATUS, PERMNHSC, STUDENTCOUNT and DESTNOS columns.