### PR TITLE
Aws secrets manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # IDE - VSCode
 .vscode/*
 !.vscode/settings.json
+!.vscode/launch.json
 !.vscode/tasks.json
 !.vscode/extensions.json
 .vs/*

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
-!.vscode/launch.json
 !.vscode/extensions.json
 .vs/*
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+
         {
             "type": "node",
             "request": "attach",
@@ -15,6 +16,13 @@
             "request": "launch",
             "name": "Launch Program",
             "program": "${workspaceFolder}/server.js"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch via npm version 10.15",
+            "program": "${workspaceFolder}/server.js",
+            "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v10.15.3/bin/node"
         }
     ]
 }

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 
 // app config
+var AppConfig = require('./server/config/appConfig');
 var config = require('./server/config/config');
 
 // caching middleware - ref and transactional
@@ -47,7 +48,6 @@ var errors = require('./server/routes/errors');
 
 // test only routes - helpers to setup and execute automated tests
 var testOnly = require('./server/routes/testOnly');
-
 
 var app = express();
 
@@ -159,7 +159,6 @@ app.use('/api/test', [cacheMiddleware.nocache,testOnly]);
 app.use('/api/user', [cacheMiddleware.nocache, user]);
 app.use('/api/reports', [cacheMiddleware.nocache, ReportsRoute]);
 
-
 app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'dist/index.html'));
 });
@@ -195,11 +194,19 @@ app.use(function(err, req, res, next) {
     });
 });
 
-var debug = require('debug')('server');
-const listenPort = parseInt(config.get('listen.port'), 10);
-app.set('port', listenPort);
-app.listen(app.get('port'));
+const startApp = () => {
+    const listenPort = parseInt(config.get('listen.port'), 10);
+    app.set('port', listenPort);
+    app.listen(app.get('port'));
+    console.log('Listening on port: ' + app.get('port'));
+};
 
-console.log('Listening on port: ' + app.get('port'));
+if (AppConfig.ready) {
+    startApp();
+} else {
+    AppConfig.on(AppConfig.READY_EVENT, () => {
+        startApp();
+    });
+}
 
 module.exports = app;

--- a/server/aws/secrets.js
+++ b/server/aws/secrets.js
@@ -1,0 +1,145 @@
+const AWS = require('aws-sdk');
+
+let myLocalSecrets = null;
+
+const initialiseSecrets = async (region, wallet) => {
+  const secrets = new AWS.SecretsManager({
+    region
+  });
+
+  try {
+    if (!wallet) throw new Error('wallet must be defined');
+
+    const mySecretsValue = await secrets.getSecretValue({SecretId: wallet}).promise();
+    if (typeof mySecretsValue.SecretString !== 'undefined') {
+      const mySecrets = JSON.parse(mySecretsValue.SecretString);
+  
+      if (typeof mySecrets == 'undefined') {
+        throw new Error(`Unexpected parsing of secrets wallet: ${wallet}`);
+      }
+  
+      myLocalSecrets = {
+        SLACK_URL: mySecrets.SLACK_URL,
+        DB_HOST: mySecrets.DB_HOST,
+        DB_PASS: mySecrets.DB_PASS,
+        Token_Secret: mySecrets.Token_Secret,
+        NOTIFY_KEY: mySecrets.NOTIFY_KEY,
+        DB_ROOT_CRT: mySecrets.DB_ROOT_CRT,
+        DB_APP_USER_KEY: mySecrets.DB_APP_USER_KEY,
+        DB_APP_USER_CERT: mySecrets.DB_APP_USER_CERT,
+      };
+    }
+
+  } catch (err) {
+    console.error('Failed to load AWS secrets: ', err);
+  }
+};
+
+const resetSecrets = () => {
+  myLocalSecrets = null;
+};
+
+const dbHost = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.DB_HOST) {
+      throw new Error('Unknown DB_HOST secret');
+    } else {
+      return myLocalSecrets.DB_HOST;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+}
+
+const dbPass = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.DB_PASS) {
+      throw new Error('Unknown DB_PASS secret');
+    } else {
+      return myLocalSecrets.DB_PASS;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+}
+
+const jwtSecret = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.Token_Secret) {
+      throw new Error('Unknown Token_Secret secret');
+    } else {
+      return myLocalSecrets.Token_Secret;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+}
+
+const slackUrl = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.SLACK_URL) {
+      throw new Error('Unknown SLACK_URL secret');
+    } else {
+      return myLocalSecrets.SLACK_URL;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+}
+
+const  govNotify = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.NOTIFY_KEY) {
+      throw new Error('Unknown NOTIFY_KEY secret');
+    } else {
+      return myLocalSecrets.NOTIFY_KEY;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+}
+
+const dbAppUserKey = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.DB_APP_USER_KEY) {
+      throw new Error('Unknown DB_APP_USER_KEY secret');
+    } else {
+      return myLocalSecrets.DB_APP_USER_KEY;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+};
+const dbAppUserCertificate = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.DB_APP_USER_CERT) {
+      throw new Error('Unknown DB_APP_USER_CERT secret');
+    } else {
+      return myLocalSecrets.DB_APP_USER_CERT;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+};
+const dbAppRootCertificate = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.DB_ROOT_CRT) {
+      throw new Error('Unknown DB_ROOT_CRT secret');
+    } else {
+      return myLocalSecrets.DB_ROOT_CRT;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+};
+
+
+module.exports.initialiseSecrets = initialiseSecrets;
+module.exports.dbHost = dbHost;
+module.exports.dbPass = dbPass;
+module.exports.jwtSecret = jwtSecret;
+module.exports.slackUrl = slackUrl;
+module.exports.govNotify = govNotify;
+module.exports.dbAppUserKey = dbAppUserKey;
+module.exports.dbAppUserCertificate = dbAppUserCertificate;
+module.exports.dbAppRootCertificate = dbAppRootCertificate;

--- a/server/config/appConfig.js
+++ b/server/config/appConfig.js
@@ -1,0 +1,26 @@
+// AppConfig is an emitter wrapper around Convict "config" and is used to notify when
+//  application configuration is ready, which, when introducing AWS Secrets Manager
+//  is not necessarily immediately on startup.
+const EventEmitter = require('events');
+
+class ConfigEmitter extends EventEmitter {
+  constructor() {
+    super();
+    this._ready = false;
+  };
+
+  get READY_EVENT() {
+    return 'Ready';
+  };
+
+  get ready() {
+    return this._ready;
+  }
+
+  set ready(status) {
+    this._ready = status;
+  }
+};
+const AppConfig = new ConfigEmitter();
+
+module.exports = AppConfig;

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -258,6 +258,11 @@ const config = convict({
     }
   },
   bulkupload: {
+    region: {
+      doc: 'AWS region override for bulk upload S3 only',
+      format: '*',
+      default: 'eu-west-2',
+    },
     bucketname: {
       doc: 'Bucket used to upload all client related csv files',
       format: '*',

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -1,6 +1,12 @@
+
 const convict = require('convict');
 const fs = require('fs');
 const yaml = require('js-yaml');
+
+// AWS Secrets Manager override
+const AWSSecrets = require('../aws/secrets');
+
+const AppConfig = require('./appConfig');
 
 // Define schema
 const config = convict({
@@ -90,23 +96,47 @@ const config = convict({
         default: false,
         env: "DB_CLIENT_SSL_STATUS"
       },
-      certificate: {
-        doc: 'The full path location of the client certificate file',
-        format: String,
-        default: 'TBC',
-        env: "DB_CLIENT_SSL_CERTIFICATE"
+      usingFiles: {
+        doc: 'If true, retrieves client certificate, client key and root certificate from file; if false, using data values',
+        format: 'Boolean',
+        default: true,
       },
-      key: {
-        doc: 'The full path location of the client key file',
-        format: String,
-        default: 'TBC',
-        env: "DB_CLIENT_SSL_KEY"
+      files: {
+        certificate: {
+          doc: 'The full path location of the client certificate file',
+          format: String,
+          default: 'TBC',
+          env: "DB_CLIENT_SSL_CERTIFICATE"
+        },
+        key: {
+          doc: 'The full path location of the client key file',
+          format: String,
+          default: 'TBC',
+          env: "DB_CLIENT_SSL_KEY"
+        },
+        ca: {
+          doc: 'The full path location of the server certificate (authority - ca) file',
+          format: String,
+          default: 'TBC',
+          env: "DB_CLIENT_SSL_CA"
+        }
       },
-      ca: {
-        doc: 'The full path location of the server certificate (authority - ca) file',
-        format: String,
-        default: 'TBC',
-        env: "DB_CLIENT_SSL_CA"
+      data: {
+        certificate: {
+          doc: 'The client certificate',
+          format: String,
+          default: 'TBC',
+        },
+        key: {
+          doc: 'The client key',
+          format: String,
+          default: 'TBC',
+        },
+        ca: {
+          doc: 'The server certificate (authority - ca)',
+          format: String,
+          default: 'TBC',
+        }  
       }
     },
     pool: {
@@ -208,28 +238,30 @@ const config = convict({
           default: 0
       }
   },
-  bulkuploaduser: {
-    accessKeyId: {
-      doc: 'Access key for AWS IAM user',
-      format: '*',
-      default: '',
-      env: 'ACCESS_KEY_ID',
-    },
-    secretAccessKey: {
-      doc: 'Bulk user secret key needed to upload file programmatically from aws sdk',
-      format: '*',
-      default: '',
-      env: 'SECRET_ACCESS_KEY',
-    },
-    bucketname: {
-      doc: 'Bucket used to upload all client related csv files',
-      format: '*',
-      default: 'sfcbulkuploadfiles',
-    },
+  aws: {
     region: {
       doc: 'AWS region',
       format: '*',
       default: 'eu-west-2',
+    },
+    secrets: {
+      use: {
+        doc: 'Whether to use AWS Secret Manager to retrieve sensitive information, e.g. DB_PASS. If false, expect to read from environment variables.',
+        format: 'Boolean',
+        default: false
+      },
+      wallet: {
+        doc: 'The name of the AWS Secrets Manager wallet to recall from',
+        format: String,
+        default: 'bob'
+      }
+    }
+  },
+  bulkupload: {
+    bucketname: {
+      doc: 'Bucket used to upload all client related csv files',
+      format: '*',
+      default: 'sfcbulkuploadfiles',
     },
     uploadSignedUrlExpire: {
       doc: 'The duration in seconds for the upload signed URL to expire',
@@ -253,4 +285,38 @@ config.load(envConfigfile);
 config.validate(
     {allowed: 'strict'}
 );
+
+// now, if defined, load secrets from AWS Secret Manager
+if (config.get('aws.secrets.use')) {
+  AWSSecrets.initialiseSecrets(
+    config.get('aws.region'),
+    config.get('aws.secrets.wallet')
+  ).then(ret => {
+    // DB_HOST
+    config.set('db.host', AWSSecrets.dbHost());
+    config.set('db.password', AWSSecrets.dbPass());
+
+    // const certificate = AWSSecrets.dbAppUserCertificate();
+    // console.log("WA DEBUG - AWS Secrets - original certificate: ", certificate);
+    // console.log("WA DEBUG - AWS Secrets - modified certificate: ", certificate.replace(/\\n/g, "\n"));
+
+    config.set('db.client_ssl.data.certificate', AWSSecrets.dbAppUserCertificate().replace(/\\n/g, "\n"));
+    config.set('db.client_ssl.data.key', AWSSecrets.dbAppUserKey().replace(/\\n/g, "\n"));
+    config.set('db.client_ssl.data.ca', AWSSecrets.dbAppRootCertificate().replace(/\\n/g, "\n"));
+
+
+    // console.log("New database host: ", config.get('db.host'));
+    // console.log("New database password: ", config.get('db.password'));
+    // console.log("New database client certificate: ", config.get('db.client_ssl.data.certificate'));
+    // console.log("New database client key: ", config.get('db.client_ssl.data.key'));
+    // console.log("New database root cert: ", config.get('db.client_ssl.data.ca'));
+
+    AppConfig.ready = true;
+    AppConfig.emit(AppConfig.READY_EVENT);
+  });
+} else {
+  // emit something here
+  AppConfig.ready = true;
+}
+
 module.exports = config;

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -20,4 +20,8 @@ jwt:
     ttl:
         login: 30
 
+bulkupload:
+    region: eu-west-2
+    bucketname: sfc-bulkupload-dev
+
 # no notify definition - not used in development

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -1,7 +1,23 @@
+aws:
+    region: eu-west-1
+    secrets:
+        use: true
+        wallet: dev/api
+
+db:
+    pool: 5
+    ssl: true
+    username: sfcapp
+    client_ssl:
+        status: true
+        usingFiles: false
+
 slack:
     level : 3     # enables Slack notifications
+
 jwt:
     iss: 'sfcdev.cloudapps.digital'
     ttl:
         login: 30
+
 # no notify definition - not used in development

--- a/server/config/localhost.yaml
+++ b/server/config/localhost.yaml
@@ -11,10 +11,10 @@ jwt:
         login: 60
 db:
     pool: 5
-    ssl: true
+    ssl: false
     username: sfcapp
     client_ssl:
-        status: true
+        status: false
         usingFiles: false
 log:
     sequelize: false

--- a/server/config/localhost.yaml
+++ b/server/config/localhost.yaml
@@ -1,7 +1,7 @@
 aws:
     region: eu-west-1
     secrets:
-        use: true
+        use: false
         wallet: dev/api
 slack:
     level: 0    # disables Slack notifications
@@ -20,4 +20,5 @@ log:
     sequelize: false
 
 bulkupload:
-    bucketname: sfcbulkuploadfiles
+    region: eu-west-2
+    bucketname: sfc-bulkupload-dev

--- a/server/config/localhost.yaml
+++ b/server/config/localhost.yaml
@@ -1,3 +1,8 @@
+aws:
+    region: eu-west-1
+    secrets:
+        use: true
+        wallet: dev/api
 slack:
     level: 0    # disables Slack notifications
 jwt:
@@ -6,15 +11,13 @@ jwt:
         login: 60
 db:
     pool: 5
-    ssl: false
-
+    ssl: true
+    username: sfcapp
     client_ssl:
-        status: false
-        # certificate: 'E:/mycert.crt'
-        # key: 'E:/mykey.key'
-        # ca: 'E:/myca.crt'
+        status: true
+        usingFiles: false
 log:
     sequelize: false
 
-bulkuploaduser:
+bulkupload:
     bucketname: sfcbulkuploadfiles

--- a/server/config/production.yaml
+++ b/server/config/production.yaml
@@ -3,12 +3,15 @@ aws:
     secrets:
         use: true
         wallet: prod/api
+
 slack:
     level : 3     # enables Slack notifications
+
 jwt:
     iss: 'asc-wds.skillsforcare.org.uk'
     ttl:
         login: 5
+
 db:
     pool: 5
     ssl: true
@@ -16,10 +19,13 @@ db:
     client_ssl:
         status: true
         usingFiles: false
+
 notify:
     replyTo: '44e98371-2e44-4c6b-ad76-235136be0f8a'
     templates:
         resetPassword: 'fd430f0d-6609-400a-b171-cf124453ec1c'
         addUser: 'f20e9cbe-920d-4b1f-b05d-bac1ca8d5b54'
+
 bulkupload:
-    bucketname: sfcbulkuploadfiles-prod
+    region: eu-west-2
+    bucketname: sfc-bulkupload-prod

--- a/server/config/production.yaml
+++ b/server/config/production.yaml
@@ -1,3 +1,8 @@
+aws:
+    region: eu-west-1
+    secrets:
+        use: true
+        wallet: prod/api
 slack:
     level : 3     # enables Slack notifications
 jwt:
@@ -6,9 +11,15 @@ jwt:
         login: 5
 db:
     pool: 5
-    ssl: true       // enables SSL
+    ssl: true
+    username: sfcapp
+    client_ssl:
+        status: true
+        usingFiles: false
 notify:
     replyTo: '44e98371-2e44-4c6b-ad76-235136be0f8a'
     templates:
         resetPassword: 'fd430f0d-6609-400a-b171-cf124453ec1c'
         addUser: 'f20e9cbe-920d-4b1f-b05d-bac1ca8d5b54'
+bulkupload:
+    bucketname: sfcbulkuploadfiles-prod

--- a/server/config/test.yaml
+++ b/server/config/test.yaml
@@ -2,7 +2,7 @@ aws:
     region: eu-west-1
     secrets:
         use: true
-        wallet: test/api
+        wallet: staging/api
 
 db:
     pool: 5
@@ -14,15 +14,19 @@ db:
 
 slack:
     level : 3     # enables Slack notifications
+
 jwt:
     iss: 'sfcstaging.cloudapps.digital'
     ttl:
         login: 10
+
 notify:
     replyTo: '73711295-a4da-4303-9127-65be2a409681'
     templates:
         resetPassword: 'f2c43610-9ec9-4271-b9b1-dd55569b191c'
         addUser: 'e581eea2-4206-4c90-8594-4357960e3e74'
 
+
 bulkupload:
-    bucketname: sfcbulkuploadfiles-staging
+    region: eu-west-2
+    bucketname: sfc-bulkupload-staging

--- a/server/config/test.yaml
+++ b/server/config/test.yaml
@@ -26,7 +26,6 @@ notify:
         resetPassword: 'f2c43610-9ec9-4271-b9b1-dd55569b191c'
         addUser: 'e581eea2-4206-4c90-8594-4357960e3e74'
 
-
 bulkupload:
     region: eu-west-2
     bucketname: sfc-bulkupload-staging

--- a/server/config/test.yaml
+++ b/server/config/test.yaml
@@ -1,3 +1,17 @@
+aws:
+    region: eu-west-1
+    secrets:
+        use: true
+        wallet: test/api
+
+db:
+    pool: 5
+    ssl: true
+    username: sfcapp
+    client_ssl:
+        status: true
+        usingFiles: false
+
 slack:
     level : 3     # enables Slack notifications
 jwt:
@@ -9,3 +23,6 @@ notify:
     templates:
         resetPassword: 'f2c43610-9ec9-4271-b9b1-dd55569b191c'
         addUser: 'e581eea2-4206-4c90-8594-4357960e3e74'
+
+bulkupload:
+    bucketname: sfcbulkuploadfiles-staging

--- a/server/models/BulkImport/BUDI/index.js
+++ b/server/models/BulkImport/BUDI/index.js
@@ -55,7 +55,6 @@ class BUDI {
             serviceId: thisCapacity.serviceId,
           };
         });
-
     }
   }
 
@@ -1155,10 +1154,23 @@ class BUDI {
   // more to come
 }
 
-BUDI.initialize()
-  .then()
-  .catch(err => {
-    console.error("Failed to initialise BUDI: ", err);
+// and now to initialise BUDI
+if (dbmodels.status.ready) {
+  BUDI.initialize()
+    .then()
+    .catch(err => {
+      console.error("Failed to initialise BUDI: ", err);
+    });
+} else {
+  dbmodels.status.on(dbmodels.status.READY_EVENT, () => {
+    // initialising BUDI
+    BUDI.initialize()
+      .then()
+      .catch(err => {
+        console.error("Failed to initialise BUDI: ", err);
+      });
   });
+}
+
 
 exports.BUDI = BUDI;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,10 +1,31 @@
 'use strict';
+const EventEmitter = require('events');
+const AppConfig = require('../config/appConfig');
 const appConfig = require('../config/config');
 const fs = require('fs');
 const path = require('path');
 const Sequelize = require('sequelize');
 const basename = path.basename(__filename);
 const db = {};
+
+
+class DBEmitter extends EventEmitter {
+  constructor() {
+    super();
+    this._ready = false;
+  };
+
+  get READY_EVENT() { return 'Ready'};
+
+  get ready() {
+    return this._ready;
+  }
+
+  set ready(status) {
+    this._ready = status;
+  }
+};
+db.status = new DBEmitter();
 
 let sequelize;
 const config = {};
@@ -22,12 +43,15 @@ config.dialectOptions = {
 config.logging = appConfig.get('log.sequelize');
 
 if (appConfig.get('db.client_ssl.status')) {
-  config.dialectOptions.ssl = {
-    rejectUnauthorized : false,
-    ca   : fs.readFileSync(appConfig.get('db.client_ssl.ca')).toString(),
-    key  : fs.readFileSync(appConfig.get('db.client_ssl.key')).toString(),
-    cert : fs.readFileSync(appConfig.get('db.client_ssl.certificate')).toString(),
-  };
+  // when initialising SSL direct from config, can only use files.
+  if (appConfig.get('db.client_ssl.usingFiles')) {
+    config.dialectOptions.ssl = {
+      rejectUnauthorized : false,
+      ca   : fs.readFileSync(appConfig.get('db.client_ssl.files.ca')).toString(),
+      key  : fs.readFileSync(appConfig.get('db.client_ssl.files.key')).toString(),
+      cert : fs.readFileSync(appConfig.get('db.client_ssl.files.certificate')).toString(),
+    };
+  }
 }
 
 // setup connection pool
@@ -37,11 +61,7 @@ config.pool = {
   //idle: 10000,
 };
 
-if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config);
-} else {
-  sequelize = new Sequelize(config.database, config.username, config.password, config);
-}
+sequelize = new Sequelize(config.database, config.username, config.password, config);
 
 fs
   .readdirSync(__dirname)
@@ -61,5 +81,40 @@ Object.keys(db).forEach(modelName => {
 
 db.sequelize = sequelize;
 db.Sequelize = Sequelize;
+
+
+if (AppConfig.ready) {
+  // the config is ready, so the config properties are true and thus the database is ready to use
+  db.status.ready = true;
+} else {
+  // the config is not ready yet; database password/host may yet change, so wait for confirmation
+  //   the config is ready
+
+  AppConfig.on(AppConfig.READY_EVENT, () => {
+    // rebind sensitive database connections
+    sequelize.connectionManager.config.host = appConfig.get('db.host');
+    sequelize.connectionManager.config.password = appConfig.get('db.password');
+
+
+    // when initialising on config "ready" can only use SSL data
+    if (appConfig.get('db.client_ssl.status')) {
+      if (!appConfig.get('db.client_ssl.usingFiles')) {
+        sequelize.connectionManager.config.dialectOptions.ssl = {
+          rejectUnauthorized : false,
+          ca   : appConfig.get('db.client_ssl.data.ca'),
+          key  : appConfig.get('db.client_ssl.data.key'),
+          cert : appConfig.get('db.client_ssl.data.certificate'),
+        };
+      }
+    }
+
+    sequelize.connectionManager.pool.clear();
+
+    // now the database is ready
+    db.status.ready = true;
+    db.status.emit(db.status.READY_EVENT);
+  });
+
+}
 
 module.exports = db;

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -6,9 +6,7 @@ const csv = require('csvtojson');
 
 const router = express.Router();
 const s3 = new AWS.S3({
-  accessKeyId: appConfig.get('bulkuploaduser.accessKeyId').toString(),
-  secretAccessKey: appConfig.get('bulkuploaduser.secretAccessKey').toString(),
-  region: appConfig.get('bulkuploaduser.region').toString(),
+  region: appConfig.get('aws.region').toString(),
 });
 
 const CsvEstablishmentValidator = require('../../models/BulkImport/csv/establishments').Establishment;
@@ -32,7 +30,7 @@ const ignoreRoot = /.*\/$/;
 router.route('/uploaded').get(async (req, res) => {
   try {
     const params = {
-      Bucket: appConfig.get('bulkuploaduser.bucketname').toString(), 
+      Bucket: appConfig.get('bulkupload.bucketname').toString(), 
       Prefix: `${req.establishmentId}/latest/`
     };
 
@@ -76,7 +74,7 @@ router.route('/uploaded/*').get(async (req, res) => {
   const requestedKey = req.params['0'];
 
   const params = {
-    Bucket: appConfig.get('bulkuploaduser.bucketname').toString(), 
+    Bucket: appConfig.get('bulkupload.bucketname').toString(), 
     Prefix: `${req.establishmentId}/latest/`
   };
 
@@ -93,9 +91,9 @@ router.route('/uploaded/*').get(async (req, res) => {
       size: objHeadData.ContentLength,
       key: requestedKey,
       signedUrl : s3.getSignedUrl('getObject', {
-        Bucket: appConfig.get('bulkuploaduser.bucketname').toString(),
+        Bucket: appConfig.get('bulkupload.bucketname').toString(),
         Key: requestedKey,
-        Expires: appConfig.get('bulkuploaduser.uploadSignedUrlExpire')
+        Expires: appConfig.get('bulkupload.uploadSignedUrlExpire')
       })       
     };
 
@@ -137,7 +135,7 @@ router.route('/uploaded').post(async function (req, res) {
   try {
     // drop all in latest
     let listParams = {
-      Bucket: appConfig.get('bulkuploaduser.bucketname').toString(), 
+      Bucket: appConfig.get('bulkupload.bucketname').toString(), 
       Prefix: `${myEstablishmentId}/latest/`
     };
     const latestObjects = await s3.listObjects(listParams).promise();
@@ -171,7 +169,7 @@ router.route('/uploaded').post(async function (req, res) {
     if (deleteKeys.length > 0) {
       // now delete the objects in one go
       const deleteParams = {
-        Bucket: appConfig.get('bulkuploaduser.bucketname').toString(), 
+        Bucket: appConfig.get('bulkupload.bucketname').toString(), 
         Delete: {
           Objects: deleteKeys,
           Quiet: true,
@@ -183,7 +181,7 @@ router.route('/uploaded').post(async function (req, res) {
     uploadedFiles.forEach(thisFile => {
       if (thisFile.filename) {
         thisFile.signedUrl = s3.getSignedUrl('putObject', {
-          Bucket: appConfig.get('bulkuploaduser.bucketname').toString(),
+          Bucket: appConfig.get('bulkupload.bucketname').toString(),
           Key: myEstablishmentId + '/' + FileStatusEnum.Latest + '/' + thisFile.filename,
           // ACL: 'public-read',
           ContentType: req.query.type,
@@ -192,7 +190,7 @@ router.route('/uploaded').post(async function (req, res) {
             establishmentId: myEstablishmentId,
             validationstatus: FileValidationStatusEnum.Pending,
           },
-          Expires: appConfig.get('bulkuploaduser.uploadSignedUrlExpire'),
+          Expires: appConfig.get('bulkupload.uploadSignedUrlExpire'),
         });
         signedUrls.push(thisFile);
       }
@@ -213,7 +211,7 @@ router.route('/signedUrl').get(async function (req, res) {
   try {
     const myEstablishmentId = Number.isInteger(establishmentId) ? establishmentId.toString() : establishmentId;
     var uploadPreSignedUrl = s3.getSignedUrl('putObject', {
-      Bucket: appConfig.get('bulkuploaduser.bucketname').toString(),
+      Bucket: appConfig.get('bulkupload.bucketname').toString(),
       Key: establishmentId + '/' + FileStatusEnum.Latest + '/' + req.query.filename,
       // ACL: 'public-read',
       ContentType: req.query.type,
@@ -222,7 +220,7 @@ router.route('/signedUrl').get(async function (req, res) {
         establishmentId: myEstablishmentId,
         validationstatus: FileValidationStatusEnum.Pending,
       },
-      Expires: appConfig.get('bulkuploaduser.uploadSignedUrlExpire'),
+      Expires: appConfig.get('bulkupload.uploadSignedUrlExpire'),
     });
     res.json({ urls: uploadPreSignedUrl });
     res.end();
@@ -262,7 +260,7 @@ router.route('/validate').put(async (req, res) => {
   try {
     // awaits must be within a try/catch block - checking if file exists - saves having to repeatedly download from S3 bucket
     const params = {
-      Bucket: appConfig.get('bulkuploaduser.bucketname').toString(), 
+      Bucket: appConfig.get('bulkupload.bucketname').toString(), 
       Prefix: `${req.establishmentId}/latest/`
     };
     const data = await s3.listObjects(params).promise();
@@ -450,7 +448,7 @@ router.route('/validate').post(async (req, res) => {
 
 async function downloadContent(key) {
     var params = {
-      Bucket: appConfig.get('bulkuploaduser.bucketname').toString(),
+      Bucket: appConfig.get('bulkupload.bucketname').toString(),
       Key: key,
     };
     
@@ -474,7 +472,7 @@ async function uploadAsJSON(username, establishmentId, content, key) {
   const myEstablishmentId = Number.isInteger(establishmentId) ? establishmentId.toString() : establishmentId;
 
   var params = {
-    Bucket: appConfig.get('bulkuploaduser.bucketname').toString(),
+    Bucket: appConfig.get('bulkupload.bucketname').toString(),
     Key: key,
     Body: JSON.stringify(content, null, 2),
     ContentType: 'application/json',

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -6,7 +6,7 @@ const csv = require('csvtojson');
 
 const router = express.Router();
 const s3 = new AWS.S3({
-  region: appConfig.get('aws.region').toString(),
+  region: appConfig.get('bulkupload.region').toString(),
 });
 
 const CsvEstablishmentValidator = require('../../models/BulkImport/csv/establishments').Establishment;


### PR DESCRIPTION
https://trello.com/c/OxdRoU55

Incorporates AWS Secret Manager with convict configuration, to allow overriding of sensitive information.

Introduces AppConfig emitter, to broadcast when the convict configuration had been updated following successful initialisation from AWS Secret Manager.

The express server now waits for the config ready event.

The sequelize configuration also now rebind on the config ready event, thus restoring connection pool once sensitive properties are made available, namely, database host, password and client SSL certs.

Sequelize model now broadcasts when it is ready, which is then consumed by BUDI singleton, to ensure it does try to initialise with "not yet ready" sequelize parameters.

And finally, had to refactor the way client SSL certs/keys are presented to sequelize, differentiating between files (if running on localhost) to pure data if running from AWS Secret Manager.