### PR TITLE
Reformatting the input and reponse for starters, leavers and vacancies

### DIFF
--- a/server/models/classes/establishment/properties/leaversProperty.js
+++ b/server/models/classes/establishment/properties/leaversProperty.js
@@ -125,7 +125,7 @@ exports.LeaversProperty = class LeaversProperty extends ChangePropertyPrototype 
         }
 
         return {
-            Leavers: {
+            leavers: {
                 currentValue: jsonPresentation.Leavers,
                 ... this.changePropsToJSON(showPropertyHistoryOnly)
             }

--- a/server/models/classes/establishment/properties/leaversProperty.js
+++ b/server/models/classes/establishment/properties/leaversProperty.js
@@ -14,11 +14,11 @@ exports.LeaversProperty = class LeaversProperty extends ChangePropertyPrototype 
 
     // concrete implementations
     async restoreFromJson(document) {
-        if (document.jobs && document.jobs.leavers) {
+        if (document.leavers) {
             const jobDeclaration = ["None", "Don't know"];
             // can be an empty array
-            if (Array.isArray(document.jobs.leavers)) {
-                const validatedJobs = await JobHelpers.validateJobs(document.jobs.leavers);
+            if (Array.isArray(document.leavers)) {
+                const validatedJobs = await JobHelpers.validateJobs(document.leavers);
 
                 if (validatedJobs) {
                     this.property = validatedJobs;
@@ -26,8 +26,8 @@ exports.LeaversProperty = class LeaversProperty extends ChangePropertyPrototype 
                 } else {
                     this.property = null;
                 }
-            } else if (jobDeclaration.includes(document.jobs.leavers)) {
-                this.property = document.jobs.leavers;
+            } else if (jobDeclaration.includes(document.leavers)) {
+                this.property = document.leavers;
             } else {
                 // but it must at least be an array, or one of the known enums
                 this.property = null;
@@ -119,8 +119,8 @@ exports.LeaversProperty = class LeaversProperty extends ChangePropertyPrototype 
         if (!withHistory) {
             // simple form - includes 
             return {
-                Leavers: jsonPresentation.Leavers,
-                TotalLeavers: jsonPresentation.TotalLeavers
+                leavers: jsonPresentation.Leavers,
+                totalLeavers: jsonPresentation.TotalLeavers
             };
         }
 

--- a/server/models/classes/establishment/properties/startersProperty.js
+++ b/server/models/classes/establishment/properties/startersProperty.js
@@ -14,11 +14,11 @@ exports.StartersProperty = class StartersProperty extends ChangePropertyPrototyp
 
     // concrete implementations
     async restoreFromJson(document) {
-        if (document.jobs && document.jobs.starters) {
+        if (document.starters) {
             const jobDeclaration = ["None", "Don't know"];
             // can be an empty array
-            if (Array.isArray(document.jobs.starters)) {
-                const validatedJobs = await JobHelpers.validateJobs(document.jobs.starters);
+            if (Array.isArray(document.starters)) {
+                const validatedJobs = await JobHelpers.validateJobs(document.starters);
 
                 if (validatedJobs) {
                     this.property = validatedJobs;
@@ -26,8 +26,8 @@ exports.StartersProperty = class StartersProperty extends ChangePropertyPrototyp
                 } else {
                     this.property = null;
                 }
-            } else if (jobDeclaration.includes(document.jobs.starters)) {
-                this.property = document.jobs.starters;
+            } else if (jobDeclaration.includes(document.starters)) {
+                this.property = document.starters;
             } else {
                 // but it must at least be an array, or one of the known enums
                 this.property = null;
@@ -119,8 +119,8 @@ exports.StartersProperty = class StartersProperty extends ChangePropertyPrototyp
         if (!withHistory) {
             // simple form - includes 
             return {
-                Starters: jsonPresentation.Starters,
-                TotalStarters: jsonPresentation.TotalStarters
+                starters: jsonPresentation.Starters,
+                totalStarters: jsonPresentation.TotalStarters
             };
         }
 

--- a/server/models/classes/establishment/properties/startersProperty.js
+++ b/server/models/classes/establishment/properties/startersProperty.js
@@ -125,7 +125,7 @@ exports.StartersProperty = class StartersProperty extends ChangePropertyPrototyp
         }
 
         return {
-            Starters: {
+            starters: {
                 currentValue: jsonPresentation.Starters,
                 ... this.changePropsToJSON(showPropertyHistoryOnly)
             }

--- a/server/models/classes/establishment/properties/vacanciesProperty.js
+++ b/server/models/classes/establishment/properties/vacanciesProperty.js
@@ -14,11 +14,11 @@ exports.VacanciesProperty = class VacanciesProperty extends ChangePropertyProtot
 
     // concrete implementations
     async restoreFromJson(document) {
-        if (document.jobs && document.jobs.vacancies) {
+        if (document.vacancies) {
             const jobDeclaration = ["None", "Don't know"];
             // can be an empty array
-            if (Array.isArray(document.jobs.vacancies)) {
-                const validatedJobs = await JobHelpers.validateJobs(document.jobs.vacancies);
+            if (Array.isArray(document.vacancies)) {
+                const validatedJobs = await JobHelpers.validateJobs(document.vacancies);
 
                 if (validatedJobs) {
                     this.property = validatedJobs;
@@ -26,8 +26,8 @@ exports.VacanciesProperty = class VacanciesProperty extends ChangePropertyProtot
                 } else {
                     this.property = null;
                 }
-            } else if (jobDeclaration.includes(document.jobs.vacancies)) {
-                this.property = document.jobs.vacancies;
+            } else if (jobDeclaration.includes(document.vacancies)) {
+                this.property = document.vacancies;
             } else {
                 // but it must at least be an array, or one of the known enums
                 this.property = null;
@@ -120,13 +120,13 @@ exports.VacanciesProperty = class VacanciesProperty extends ChangePropertyProtot
         if (!withHistory) {
             // simple form - includes 
             return {
-                Vacancies: jsonPresentation.Vacancies,
-                TotalVacencies: jsonPresentation.TotalVacencies
+                vacancies: jsonPresentation.Vacancies,
+                totalVacancies: jsonPresentation.TotalVacencies
             };
         }
 
         return {
-            Vacancies: {
+            vacancies: {
                 currentValue: jsonPresentation.Vacancies,
                 ... this.changePropsToJSON(showPropertyHistoryOnly)
             }

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -129,7 +129,7 @@ router.route('/uploaded').post(async function (req, res) {
   const uploadedFiles = req.body.files;
 
   const EXPECTED_NUMBHER_OF_FILES = 3;
-  if (!uploadedFiles || !Array.isArray(uploadedFiles) || uploadedFiles.length != EXPECTED_NUMBHER_OF_FILES) {
+  if (!uploadedFiles || !Array.isArray(uploadedFiles) || uploadedFiles.length > EXPECTED_NUMBHER_OF_FILES) {
     return res.status(400).send({});
   }
 

--- a/server/routes/establishments/jobs.js
+++ b/server/routes/establishments/jobs.js
@@ -72,7 +72,9 @@ router.route('/').post(async (req, res) => {
       //  POST body will be updated (peristed)
       // With this endpoint we're only interested in vacancies
       const isValidEstablishment = await thisEstablishment.load({
-        jobs: req.body.jobs,
+        vacancies: req.body.vacancies,
+        starters: req.body.starters,
+        leavers: req.body.leavers,
       });
 
       // this is an update to an existing Establishment, so no mandatory properties!
@@ -86,12 +88,13 @@ router.route('/').post(async (req, res) => {
         };
   
         // amalgamated vacancies, starters and leavers, therefore remove them from parent scope
-        delete resultJSON.Vacancies;
-        delete resultJSON.Starters;
-        delete resultJSON.Leavers;
-        delete resultJSON.TotalVacencies;
-        delete resultJSON.TotalStarters;
-        delete resultJSON.TotalLeavers;
+        delete resultJSON.jobs;
+        // delete resultJSON.Vacancies;
+        // delete resultJSON.Starters;
+        // delete resultJSON.Leavers;
+        // delete resultJSON.TotalVacencies;
+        // delete resultJSON.TotalStarters;
+        // delete resultJSON.TotalLeavers;
 
         // total starters, leavers and vacancies are always
   

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -367,16 +367,16 @@ router.route('/')
           } else {
             throw new RegistrationException(
               `Lookup on services for '${Estblistmentdata.MainService}' being cqc registered (${Estblistmentdata.IsRegulated}) resulted with zero records`,
-              responseErrors.unexpectedMainServiceId.errCode,
-              responseErrors.unexpectedMainServiceId.errMessage
+              responseErrors.unexpectedMainService.errCode,
+              responseErrors.unexpectedMainService.errMessage
             );
           }
           
           if (serviceResults.other && Estblistmentdata.MainServiceOther && Estblistmentdata.MainServiceOther.length > OTHER_MAX_LENGTH){
             throw new RegistrationException(
               `Other field value of '${Estblistmentdata.MainServiceOther}' greater than length ${OTHER_MAX_LENGTH}`,
-              responseErrors.unexpectedMainServiceId.errCode,
-              responseErrors.unexpectedMainServiceId.errMessage
+              responseErrors.unexpectedMainService.errCode,
+              responseErrors.unexpectedMainService.errMessage
             );            
           }
 
@@ -522,6 +522,8 @@ router.route('/')
         if (err instanceof RegistrationException) throw err;
 
         if (!defaultError) defaultError = responseErrors.default;
+
+        console.log("WA DEBUG - exception: ", err)
 
         if (err instanceof EstablishmentSaveException) {
           if (err.message === 'Duplicate Establishment') {

--- a/src/app/core/model/establishment.model.ts
+++ b/src/app/core/model/establishment.model.ts
@@ -92,11 +92,11 @@ export interface Establishment {
   share: Share;
   localAuthorities: LocalAuthority[];
   primaryAuthority: PrimaryAuthority;
-  Vacancies: Vacancy[];
-  TotalVacencies: number;
-  Starters: Starter[];
-  TotalStarters: number;
-  Leavers: Leaver[];
-  TotalLeavers: number;
+  vacancies: Vacancy[];
+  totalVacancies: number;
+  starters: Starter[];
+  totalStarters: number;
+  leavers: Leaver[];
+  totalLeavers: number;
   wdf: WDF;
 }

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -1,11 +1,12 @@
-import { BehaviorSubject, Observable } from 'rxjs';
-import { DataSharingRequest, SharingOptionsModel } from '../model/data-sharing.model';
-import { Establishment } from '@core/model/establishment.model';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, isDevMode } from '@angular/core';
-import { map } from 'rxjs/operators';
-import { PostServicesModel } from '../model/postServices.model';
+import { Establishment } from '@core/model/establishment.model';
 import { AllServicesResponse, ServiceGroup } from '@core/model/services.model';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { DataSharingRequest, SharingOptionsModel } from '../model/data-sharing.model';
+import { PostServicesModel } from '../model/postServices.model';
 
 interface EstablishmentApiResponse {
   id: number;
@@ -93,29 +94,27 @@ export class EstablishmentService {
   }
 
   getJobs() {
-    return this.http.get<any>(`/api/establishment/${this.establishmentId}/jobs`).pipe(map(res => res.jobs));
+    return this.http.get<any>(`/api/establishment/${this.establishmentId}/jobs`);
   }
 
   getVacancies() {
-    return this.http.get<any>(`/api/establishment/${this.establishmentId}/jobs`).pipe(map(res => res.jobs.Vacancies));
+    return this.http.get<any>(`/api/establishment/${this.establishmentId}/jobs`).pipe(map(res => res.vacancies));
   }
 
-  postVacancies(vacancies) {
-    const data = { jobs: { vacancies } };
+  postVacancies(data) {
     return this.http.post<any>(`/api/establishment/${this.establishmentId}/jobs`, data);
   }
 
   getStarters() {
-    return this.http.get<any>(`/api/establishment/${this.establishmentId}/jobs`).pipe(map(res => res.jobs.Starters));
+    return this.http.get<any>(`/api/establishment/${this.establishmentId}/jobs`).pipe(map(res => res.starters));
   }
 
-  postStarters(starters) {
-    const data = { jobs: { starters } };
+  postStarters(data) {
     return this.http.post<any>(`/api/establishment/${this.establishmentId}/jobs`, data);
   }
 
   getLeavers() {
-    return this.http.get<any>(`/api/establishment/${this.establishmentId}/jobs`).pipe(map(res => res.jobs.Leavers));
+    return this.http.get<any>(`/api/establishment/${this.establishmentId}/jobs`).pipe(map(res => res.leavers));
   }
 
   postLeavers(leavers) {

--- a/src/app/features/workplace/confirm-leavers/confirm-leavers.component.html
+++ b/src/app/features/workplace/confirm-leavers/confirm-leavers.component.html
@@ -4,7 +4,7 @@
     <p class="govuk-heading-m">You told us you have:</p>
     <dl class="govuk-list--definition govuk-list--definition-xl govuk-!-margin-bottom-8">
       <dt>Staff who left</dt>
-      <dd>{{ establishment.TotalLeavers }}</dd>
+      <dd>{{ establishment.totalLeavers }}</dd>
     </dl>
     <p>Continue if this is correct or go back and make a change.</p>
     <div class="govuk-button-group">
@@ -26,4 +26,3 @@
     </div>
   </div>
 </div>
-

--- a/src/app/features/workplace/confirm-starters/confirm-starters.component.html
+++ b/src/app/features/workplace/confirm-starters/confirm-starters.component.html
@@ -4,7 +4,7 @@
     <p class="govuk-heading-m">You told us you have:</p>
     <dl class="govuk-list--definition govuk-list--definition-xl govuk-!-margin-bottom-8">
       <dt>New starters</dt>
-      <dd>{{ establishment.TotalStarters }}</dd>
+      <dd>{{ establishment.totalStarters }}</dd>
     </dl>
     <p>Continue if this is correct or go back and make a change.</p>
     <div class="govuk-button-group">

--- a/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.html
+++ b/src/app/features/workplace/confirm-vacancies/confirm-vacancies.component.html
@@ -4,7 +4,7 @@
     <p class="govuk-heading-m">You told us you have:</p>
     <dl class="govuk-list--definition govuk-list--definition-xl govuk-!-margin-bottom-8">
       <dt>Current staff vacancies</dt>
-      <dd>{{ establishment.TotalVacencies }}</dd>
+      <dd>{{ establishment.totalVacancies }}</dd>
     </dl>
     <p>Continue if this is correct or go back and make a change.</p>
     <div class="govuk-button-group">

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -282,21 +282,21 @@
         </ng-container>
 
         <ng-container *ngIf="workplace.wdf.vacancies === 'Yes'">
-          <ng-template [ngIf]="!workplace.Vacancies?.length" [ngIfElse]="vacancies">
+          <ng-template [ngIf]="!workplace.vacancies?.length" [ngIfElse]="vacancies">
             -
           </ng-template>
           <ng-template #vacancies>
-            <ng-container *ngIf="isArray(workplace.Vacancies)">
+            <ng-container *ngIf="isArray(workplace.vacancies)">
               <ul class="govuk-list">
-                <li *ngFor="let vacancy of workplace.Vacancies">{{ vacancy.total }} {{ vacancy.title }}</li>
+                <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy.total }} {{ vacancy.title }}</li>
               </ul>
             </ng-container>
-            <ng-container *ngIf="!isArray(workplace.Vacancies)">
+            <ng-container *ngIf="!isArray(workplace.vacancies)">
               <ng-container *ngIf="workplace.wdf.vacancies === 'No'">
                 <img src="/assets/images/cross-icon.svg" /> Not meeting criteria
               </ng-container>
               <ng-container *ngIf="workplace.wdf.vacancies != 'No'">
-                {{ workplace.Vacancies }}
+                {{ workplace.vacancies }}
               </ng-container>
             </ng-container>
           </ng-template>
@@ -304,21 +304,21 @@
       </ng-container>
 
       <ng-container *ngIf="!displayWDFReport">
-        <ng-template [ngIf]="!workplace.Vacancies?.length" [ngIfElse]="vacancies">
+        <ng-template [ngIf]="!workplace.vacancies?.length" [ngIfElse]="vacancies">
           -
         </ng-template>
         <ng-template #vacancies>
-          <ng-container *ngIf="isArray(workplace.Vacancies)">
+          <ng-container *ngIf="isArray(workplace.vacancies)">
             <ul class="govuk-list">
-              <li *ngFor="let vacancy of workplace.Vacancies">{{ vacancy.total }} {{ vacancy.title }}</li>
+              <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy.total }} {{ vacancy.title }}</li>
             </ul>
           </ng-container>
-          <ng-container *ngIf="!isArray(workplace.Vacancies)">
+          <ng-container *ngIf="!isArray(workplace.vacancies)">
             <ng-container *ngIf="workplace.wdf.vacancies === 'No'">
               <img src="/assets/images/cross-icon.svg" /> Not meeting criteria
             </ng-container>
             <ng-container *ngIf="workplace.wdf.vacancies != 'No'">
-              {{ workplace.Vacancies }}
+              {{ workplace.vacancies }}
             </ng-container>
           </ng-container>
         </ng-template>
@@ -326,11 +326,11 @@
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link" [routerLink]="['/workplace', workplace.id, 'vacancies']">
-        <ng-container *ngIf="!workplace.Vacancies?.length">
+        <ng-container *ngIf="!workplace.vacancies?.length">
           Provide information
           <span class="govuk-visually-hidden"> for</span>
         </ng-container>
-        <ng-container *ngIf="workplace.Vacancies?.length">
+        <ng-container *ngIf="workplace.vacancies?.length">
           Change
         </ng-container>
         <span class="govuk-visually-hidden"> staff vacancies</span>
@@ -343,46 +343,46 @@
       New starters
     </dt>
     <dd class="govuk-summary-list__value">
-      <ng-container *ngIf="isArray(workplace.Starters)">
+      <ng-container *ngIf="isArray(workplace.starters)">
         <ul class="govuk-list">
-          <li *ngFor="let starter of workplace.Starters">{{ starter.total }} {{ starter.title }}</li>
+          <li *ngFor="let starter of workplace.starters">{{ starter.total }} {{ starter.title }}</li>
         </ul>
       </ng-container>
-      <ng-container *ngIf="!isArray(workplace.Starters)">
+      <ng-container *ngIf="!isArray(workplace.starters)">
         <ng-container *ngIf="displayWDFReport">
           <ng-container *ngIf="workplace.wdf.starters === 'No'">
             <img src="/assets/images/cross-icon.svg" /> Not meeting criteria
           </ng-container>
 
           <ng-container *ngIf="workplace.wdf.starters === 'Yes'">
-            <ng-template [ngIf]="!workplace.Starters?.length" [ngIfElse]="starters">
+            <ng-template [ngIf]="!workplace.starters?.length" [ngIfElse]="starters">
               -
             </ng-template>
             <ng-template #starters>
-              <ng-container *ngIf="isArray(workplace.Starters)">
+              <ng-container *ngIf="isArray(workplace.starters)">
                 <ul class="govuk-list">
-                  <li *ngFor="let starter of workplace.Starters">{{ starter.total }} {{ starter.title }}</li>
+                  <li *ngFor="let starter of workplace.starters">{{ starter.total }} {{ starter.title }}</li>
                 </ul>
               </ng-container>
-              <ng-container *ngIf="!isArray(workplace.Starters)">
-                {{ workplace.Starters }}
+              <ng-container *ngIf="!isArray(workplace.starters)">
+                {{ workplace.starters }}
               </ng-container>
             </ng-template>
           </ng-container>
         </ng-container>
 
         <ng-container *ngIf="!displayWDFReport">
-          <ng-template [ngIf]="!workplace.Starters?.length" [ngIfElse]="starters">
+          <ng-template [ngIf]="!workplace.starters?.length" [ngIfElse]="starters">
             -
           </ng-template>
           <ng-template #starters>
-            <ng-container *ngIf="isArray(workplace.Starters)">
+            <ng-container *ngIf="isArray(workplace.starters)">
               <ul class="govuk-list">
-                <li *ngFor="let starter of workplace.Starters">{{ starter.total }} {{ starter.title }}</li>
+                <li *ngFor="let starter of workplace.starters">{{ starter.total }} {{ starter.title }}</li>
               </ul>
             </ng-container>
-            <ng-container *ngIf="!isArray(workplace.Starters)">
-              {{ workplace.Starters }}
+            <ng-container *ngIf="!isArray(workplace.starters)">
+              {{ workplace.starters }}
             </ng-container>
           </ng-template>
         </ng-container>
@@ -390,11 +390,11 @@
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link" [routerLink]="['/workplace', workplace.id, 'starters']">
-        <ng-container *ngIf="!workplace.Starters?.length">
+        <ng-container *ngIf="!workplace.starters?.length">
           Provide information
           <span class="govuk-visually-hidden"> for</span>
         </ng-container>
-        <ng-container *ngIf="workplace.Starters?.length">
+        <ng-container *ngIf="workplace.starters?.length">
           Change
         </ng-container>
         <span class="govuk-visually-hidden"> new starters</span>
@@ -413,45 +413,45 @@
         </ng-container>
 
         <ng-container *ngIf="workplace.wdf.leavers === 'Yes'">
-          <ng-template [ngIf]="!workplace.Leavers?.length" [ngIfElse]="leavers">
+          <ng-template [ngIf]="!workplace.leavers?.length" [ngIfElse]="leavers">
             -
           </ng-template>
           <ng-template #leavers>
-            <ng-container *ngIf="isArray(workplace.Leavers)">
+            <ng-container *ngIf="isArray(workplace.leavers)">
               <ul class="govuk-list">
-                <li *ngFor="let leaver of workplace.Leavers">{{ leaver.total }} {{ leaver.title }}</li>
+                <li *ngFor="let leaver of workplace.leavers">{{ leaver.total }} {{ leaver.title }}</li>
               </ul>
             </ng-container>
-            <ng-container *ngIf="!isArray(workplace.Leavers)">
-              {{ workplace.Leavers }}
+            <ng-container *ngIf="!isArray(workplace.leavers)">
+              {{ workplace.leavers }}
             </ng-container>
           </ng-template>
         </ng-container>
       </ng-container>
 
       <ng-container *ngIf="!displayWDFReport">
-        <ng-template [ngIf]="!workplace.Leavers?.length" [ngIfElse]="leavers">
+        <ng-template [ngIf]="!workplace.leavers?.length" [ngIfElse]="leavers">
           -
         </ng-template>
         <ng-template #leavers>
-          <ng-container *ngIf="isArray(workplace.Leavers)">
+          <ng-container *ngIf="isArray(workplace.leavers)">
             <ul class="govuk-list">
-              <li *ngFor="let leaver of workplace.Leavers">{{ leaver.total }} {{ leaver.title }}</li>
+              <li *ngFor="let leaver of workplace.leavers">{{ leaver.total }} {{ leaver.title }}</li>
             </ul>
           </ng-container>
-          <ng-container *ngIf="!isArray(workplace.Leavers)">
-            {{ workplace.Leavers }}
+          <ng-container *ngIf="!isArray(workplace.leavers)">
+            {{ workplace.leavers }}
           </ng-container>
         </ng-template>
       </ng-container>
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link" [routerLink]="['/workplace', workplace.id, 'leavers']">
-        <ng-container *ngIf="!workplace.Leavers?.length">
+        <ng-container *ngIf="!workplace.leavers?.length">
           Provide information
           <span class="govuk-visually-hidden"> for</span>
         </ng-container>
-        <ng-container *ngIf="workplace.Leavers?.length">
+        <ng-container *ngIf="workplace.leavers?.length">
           Change
         </ng-container>
         <span class="govuk-visually-hidden"> staff leavers</span>


### PR DESCRIPTION
on endpoint `[POST] http://localhost:3000/api/establishment/479/jobs`, removed the prefix with "jobs":
```
{
	"leavers" : [
		{
			"title" : "Activities worker or co-ordinator",
			"total" : 999
		},
		{
			"jobId" : 10,
			"total" : 333
		}
	],
	"vacancies": "None",
	"starters": "Don't know"
}
```

and response is:
```
{
  "id": 479,
  "uid": "98a83eef-e1e1-49f3-89c5-b1287a3cc8dd",
  "name": "WOZiTech Cares Updated",
  "created": "2019-03-15T09:54:10.562Z",
  "updated": "2019-06-15T09:46:14.884Z",
  "updatedBy": "aylingw",
  "vacancies": "None",
  "totalVacancies": 0,
  "starters": "Don't know",
  "totalStarters": 0,
  "leavers": [
    {
      "jobId": 1,
      "title": "Activities worker or co-ordinator",
      "total": 999
    },
    {
      "jobId": 10,
      "title": "Care Worker",
      "total": 333
    }
  ],
  "totalLeavers": 1332
}
```
Note all properties are lowercase prefixed and the spelling correction on `totalVacancies`.

on endpoint `[GET] http://localhost:3000/api/establishment/479` and endpoint `[GET] http://localhost:3000/api/establishment/479/jobs` - both return the same output as above.