### PR TITLE
Bulk upload normalise api validations

### DIFF
--- a/server/models/BulkImport/BUDI/index.js
+++ b/server/models/BulkImport/BUDI/index.js
@@ -1087,7 +1087,7 @@ class BUDI {
       { "BUDI": 98, "ASC": 59 },
       { "BUDI": 99, "ASC": 6 },
       { "BUDI": 100, "ASC": 7 },
-      { "BUDI": 101, "ASC": 101 },
+      { "BUDI": 101, "ASC": 68 },
       { "BUDI": 102, "ASC": 63 },
       { "BUDI": 103, "ASC": 8 },
       { "BUDI": 104, "ASC": 75 },

--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -45,7 +45,8 @@ class Establishment {
     //console.log(`WA DEBUG - current establishment (${this._lineNumber}:`, this._currentLine);
   };
 
-  static get DUPLICATE_ERROR() { return 999; }
+  static get DUPLICATE_ERROR() { return 998; }
+  static get HEADERS_ERROR() { return 999; }
   static get MAIN_SERVICE_ERROR() { return 1000; }
   static get LOCAL_ID_ERROR() { return 1010; }
   static get STATUS_ERROR() { return 1020; }
@@ -70,29 +71,25 @@ class Establishment {
   static get REASONS_FOR_LEAVING_ERROR() { return 1360; }
 
 
-  static get NAME_WARNING() { return 2000; }
-  static get MAIN_SERVICE_WARNING() { return 2010; }
-  static get ESTABLISHMENT_TYPE_WARNING() { return 2020; }
-  static get SHARE_WITH_WARNING() { return 2030; }
-  static get TOTAL_PERM_TEMP_WARNING() { return 2040; }
-  static get LOCAL_AUTHORITIES_WARNING() { return 2050; }
-  static get REGTYPE_WARNING() { return 2060; }
-  static get PROV_ID_WARNING() { return 2070; }
-  static get LOCATION_ID_WARNING() { return 2080; }
-  static get ALL_SERVICES_WARNING() { return 2090; }
-  static get SERVICE_USERS_WARNING() { return 2100; }
-  static get CAPACITY_UTILISATION_WARNING() { return 2110; }
-  static get VACANCIES_WARNING() { return 2120; }
-  static get STARTERS_WARNING() { return 2130; }
-  static get LEAVERS_WARNING() { return 2140; }
+  static get MAIN_SERVICE_WARNING() { return 2000; }
+  static get NAME_WARNING() { return 2030; }
+  static get ADDRESS_WARNING() { return 2040; }
+  static get ESTABLISHMENT_TYPE_WARNING() { return 2070; }
+  static get SHARE_WITH_WARNING() { return 2070; }
+  static get TOTAL_PERM_TEMP_WARNING() { return 2200; }
+  static get LOCAL_AUTHORITIES_WARNING() { return 2090; }
+  static get REGTYPE_WARNING() { return 2100; }
+  static get PROV_ID_WARNING() { return 2105; }
+  static get LOCATION_ID_WARNING() { return 2110; }
+  static get ALL_SERVICES_WARNING() { return 2120; }
+  static get SERVICE_USERS_WARNING() { return 2130; }
+  static get CAPACITY_UTILISATION_WARNING() { return 2140; }
+  static get VACANCIES_WARNING() { return 2300; }
+  static get STARTERS_WARNING() { return 2310; }
+  static get LEAVERS_WARNING() { return 2320; }
 
+  static get REASONS_FOR_LEAVING_WARNING() { return 2360; }
 
-  static get ADDRESS_WARNING() { return 2150; }
-  static get REGTYPE_WARNING() { return 2160; }
-  static get PROV_ID_WARNING() { return 2170; }
-  static get LOCATION_ID_WARNING() { return 2180; }
-
-  static get HEADERS_ERROR() { return 1380; }
   get lineNumber() {
     return this._lineNumber;
   }
@@ -1667,7 +1664,7 @@ class Establishment {
 
         switch (thisProp) {
           case 'Capacity':
-            validationEr.errCode = Establishment.CAPACITY_UTILISATION_ERROR;
+            validationError.errCode = Establishment.CAPACITY_UTILISATION_ERROR;
             validationError.errType = 'CAPACITY_UTILISATION_ERROR';
             validationError.source  = `${this._currentLine.CAPACITY} - ${this._currentLine.UTILISATION}`;
             break;

--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -1447,6 +1447,7 @@ class Establishment {
   // add a duplicate validation error to the current set
   addDuplicate(originalLineNumber) {
     return {
+      origin: 'Establishments',
       lineNumber: this._lineNumber,
       errCode: Establishment.DUPLICATE_ERROR,
       errType: `DUPLICATE_ERROR`,
@@ -1556,7 +1557,14 @@ class Establishment {
   };
 
   get validationErrors() {
-    return this._validationErrors;
+        // include the "origin" of validation error
+        return this._validationErrors.map(thisValidation => {
+          return {
+            origin: 'Establishments',
+            ...thisValidation,
+          };
+        });
+    
   };
 
   // returns an API representation of this Establishment

--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -52,15 +52,14 @@ class Establishment {
   static get NAME_ERROR() { return 1030; }
   static get ADDRESS_ERROR() { return 1040; }
   static get ESTABLISHMENT_TYPE_ERROR() { return 1070; }
-  static get SHARE_WITH_CQC_ERROR() { return 1070; }
-  static get SHARE_WITH_LA_ERROR() { return 1080; }
+  static get SHARE_WITH_ERROR() { return 1070; }
   static get LOCAL_AUTHORITIES_ERROR() { return 1090; }
   static get REGTYPE_ERROR() { return 1100; }
   static get PROV_ID_ERROR() { return 1105; }
   static get LOCATION_ID_ERROR() { return 1110; }
   static get ALL_SERVICES_ERROR() { return 1120; }
   static get SERVICE_USERS_ERROR() { return 1130; }
-  static get CAPACITY_UTILISATION_USERS_ERROR() { return 1140; }
+  static get CAPACITY_UTILISATION_ERROR() { return 1140; }
 
   static get TOTAL_PERM_TEMP_ERROR() { return 1200; }
   static get ALL_JOBS_ERROR() { return 1280; }
@@ -69,7 +68,29 @@ class Establishment {
   static get LEAVERS_ERROR() { return 1320; }
 
   static get REASONS_FOR_LEAVING_ERROR() { return 1360; }
-  static get DESTINATIONS_ON_LEAVING_ERROR() { return 1370; }
+
+
+  static get NAME_WARNING() { return 2000; }
+  static get MAIN_SERVICE_WARNING() { return 2010; }
+  static get ESTABLISHMENT_TYPE_WARNING() { return 2020; }
+  static get SHARE_WITH_WARNING() { return 2030; }
+  static get TOTAL_PERM_TEMP_WARNING() { return 2040; }
+  static get LOCAL_AUTHORITIES_WARNING() { return 2050; }
+  static get REGTYPE_WARNING() { return 2060; }
+  static get PROV_ID_WARNING() { return 2070; }
+  static get LOCATION_ID_WARNING() { return 2080; }
+  static get ALL_SERVICES_WARNING() { return 2090; }
+  static get SERVICE_USERS_WARNING() { return 2100; }
+  static get CAPACITY_UTILISATION_WARNING() { return 2110; }
+  static get VACANCIES_WARNING() { return 2120; }
+  static get STARTERS_WARNING() { return 2130; }
+  static get LEAVERS_WARNING() { return 2140; }
+
+
+  static get ADDRESS_WARNING() { return 2150; }
+  static get REGTYPE_WARNING() { return 2160; }
+  static get PROV_ID_WARNING() { return 2170; }
+  static get LOCATION_ID_WARNING() { return 2180; }
 
   static get HEADERS_ERROR() { return 1380; }
   get lineNumber() {
@@ -411,8 +432,8 @@ class Establishment {
     if (Number.isNaN(myShareWithCqc)) {
       this._validationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.SHARE_WITH_CQC_ERROR,
-        errType: `SHARE_WITH_CQC_ERROR`,
+        errCode: Establishment.SHARE_WITH_ERROR,
+        errType: `SHARE_WITH_ERROR`,
         error: "Share with CQC (PERMCQC) must be an integer",
         source: this._currentLine.PERMCQC,
       });
@@ -420,8 +441,8 @@ class Establishment {
     } else if (!ALLOWED_VALUES.includes(myShareWithCqc)) {
       this._validationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.SHARE_WITH_CQC_ERROR,
-        errType: `SHARE_WITH_CQC_ERROR`,
+        errCode: Establishment.SHARE_WITH_ERROR,
+        errType: `SHARE_WITH_ERROR`,
         error: "Share with CQC (PERMCQC) must be 0 or 1",
         source: myShareWithCqc,
       });
@@ -438,8 +459,8 @@ class Establishment {
     if (Number.isNaN(myShareWithLa)) {
       this._validationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.SHARE_WITH_LA_ERROR,
-        errType: `SHARE_WITH_LA_ERROR`,
+        errCode: Establishment.SHARE_WITH_ERROR,
+        errType: `SHARE_WITH_ERROR`,
         error: "Share with LA (PERMLA) must be an integer",
         source: this._currentLine.PERMLA,
       });
@@ -447,8 +468,8 @@ class Establishment {
     } else if (!ALLOWED_VALUES.includes(myShareWithLa)) {
       this._validationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.SHARE_WITH_LA_ERROR,
-        errType: `SHARE_WITH_LA_ERROR`,
+        errCode: Establishment.SHARE_WITH_ERROR,
+        errType: `SHARE_WITH_ERROR`,
         error: "Share with LA (PERMLA) must be 0 or 1",
         source: myShareWithLa,
       });
@@ -748,8 +769,8 @@ class Establishment {
     if (listOfCapacities.length === 0) {
       localValidationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
-        errType: `CAPACITY_UTILISATION_USERS_ERROR`,
+        errCode: Establishment.CAPACITY_UTILISATION_ERROR,
+        errType: `CAPACITY_UTILISATION_ERROR`,
         error: "Capacities (CAPACITY) must be a semi-colon delimited list of integers",
         source: this._currentLine.CAPACITY,
       });
@@ -757,8 +778,8 @@ class Establishment {
     if (listOfUtilisations.length === 0) {
       localValidationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
-        errType: `CAPACITY_UTILISATION_USERS_ERROR`,
+        errCode: Establishment.CAPACITY_UTILISATION_ERROR,
+        errType: `CAPACITY_UTILISATION_ERROR`,
         error: "Utilisations (UTILISATION) must be a semi-colon delimited list of integers",
         source: this._currentLine.UTILISATION,
       });
@@ -766,8 +787,8 @@ class Establishment {
     if (listOfCapacities.length != listOfUtilisations.length) {
       localValidationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
-        errType: `CAPACITY_UTILISATION_USERS_ERROR`,
+        errCode: Establishment.CAPACITY_UTILISATION_ERROR,
+        errType: `CAPACITY_UTILISATION_ERROR`,
         error: "Number of Capacities (CAPACITY) and Utilisations (UTILISATION) must be equal",
         source: `${this._currentLine.CAPACITY} - ${this._currentLine.UTILISATION}`,
       });
@@ -777,8 +798,8 @@ class Establishment {
     if (listOfCapacities.length !== (this._allServices ? this._allServices.length : 0)) {
       localValidationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
-        errType: `CAPACITY_UTILISATION_USERS_ERROR`,
+        errCode: Establishment.CAPACITY_UTILISATION_ERROR,
+        errType: `CAPACITY_UTILISATION_ERROR`,
         error: "Number of Capacities/Utilisations (CAPACITY/UTILISATION) must equal the number of all services (ALLSERVICES)",
         source: `${this._currentLine.CAPACITY} - ${this._currentLine.UTILISATION} - ${this._currentLine.ALLSERVICES}`,
       });
@@ -794,8 +815,8 @@ class Establishment {
     if (!areCapacitiesValid) {
       localValidationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
-        errType: `CAPACITY_UTILISATION_USERS_ERROR`,
+        errCode: Establishment.CAPACITY_UTILISATION_ERROR,
+        errType: `CAPACITY_UTILISATION_ERROR`,
         error: `All capacities (CAPACITY) must be integers and less than ${MAX_CAP_UTIL}`,
         source: this._currentLine.CAPACITY,
       });
@@ -807,8 +828,8 @@ class Establishment {
     if (!areUtilisationsValid) {
       localValidationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
-        errType: `CAPACITY_UTILISATION_USERS_ERROR`,
+        errCode: Establishment.CAPACITY_UTILISATION_ERROR,
+        errType: `CAPACITY_UTILISATION_ERROR`,
         error: `All utilisations (UTILISATION) must be integers and less than ${MAX_CAP_UTIL}`,
         source: this._currentLine.UTILISATION,
       });
@@ -1247,8 +1268,8 @@ class Establishment {
           } else {
             this._validationErrors.push({
               lineNumber: this._lineNumber,
-              errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
-              errType: `CAPACITY_UTILISATION_USERS_ERROR`,
+              errCode: Establishment.CAPACITY_UTILISATION_ERROR,
+              errType: `CAPACITY_UTILISATION_ERROR`,
               error: `Capacities (CAPACITY): position ${index+1} is unexpected capacity (no expected capacity for given service: ${this._allServices[index]})`,
               source: this._currentLine.CAPACITY,
             });
@@ -1283,8 +1304,8 @@ class Establishment {
           } else {
             this._validationErrors.push({
               lineNumber: this._lineNumber,
-              errCode: Establishment.CAPACITY_UTILISATION_USERS_ERROR,
-              errType: `CAPACITY_UTILISATION_USERS_ERROR`,
+              errCode: Establishment.CAPACITY_UTILISATION_ERROR,
+              errType: `CAPACITY_UTILISATION_ERROR`,
               error: `Utilisations (UTILISATION): position ${index+1} is unknown utilisation`,
               source: this._currentLine.UTILISATION,
             });
@@ -1633,6 +1654,205 @@ class Establishment {
       ...fixedProperties,
       ...changeProperties,
     };
+  }
+
+  // maps Entity (API) validation messages to bulk upload specific messages (using Entity property name)
+  addAPIValidations(errors, warnings) {
+    errors.forEach(thisError => {
+
+console.log("WA DEBUG - this error: ", thisError)
+
+      thisError.properties ? thisError.properties.forEach(thisProp => {
+        const validationError = {
+          lineNumber: this._lineNumber,
+          error: thisError.message,
+        };
+
+        switch (thisProp) {
+          case 'Capacity':
+            validationEr.errCode = Establishment.CAPACITY_UTILISATION_ERROR;
+            validationError.errType = 'CAPACITY_UTILISATION_ERROR';
+            validationError.source  = `${this._currentLine.CAPACITY} - ${this._currentLine.UTILISATION}`;
+            break;
+          case 'EmployerType':
+            validationError.errCode = Establishment.ESTABLISHMENT_TYPE_ERROR;
+            validationError.errType = 'ESTABLISHMENT_TYPE_ERROR';
+            validationError.source  = `${this._currentLine.ESTTYPE}`;
+            break;
+          case 'Leavers':
+            validationError.errCode = Establishment.LEAVERS_ERROR;
+            validationError.errType = 'LEAVERS_ERROR';
+            validationError.source  = `${this._currentLine.LEAVERS}`;
+            break;
+          case 'Starters':
+            validationError.errCode = Establishment.STARTERS_ERROR;
+            validationError.errType = 'STARTERS_ERROR';
+            validationError.source  = `${this._currentLine.STARTERS}`;
+            break;
+          case 'Vacancies':
+            validationError.errCode = Establishment.VACANCIES_ERROR;
+            validationError.errType = 'VACANCIES_ERROR';
+            validationError.source  = `${this._currentLine.VACANCIES}`;
+            break;
+          case 'MainService':
+            validationError.errCode = Establishment.MAIN_SERVICE_ERROR;
+            validationError.errType = 'MAIN_SERVICE_ERROR';
+            validationError.source  = `${this._currentLine.MAINSERVICE}`;
+            break;
+          case 'Name':
+            validationError.errCode = Establishment.NAME_ERROR;
+            validationError.errType = 'NAME_ERROR';
+            validationError.source  = `${this._currentLine.ESTNAME}`;
+            break;
+          case 'Services':
+            validationError.errCode = Establishment.ALL_SERVICES_ERROR;
+            validationError.errType = 'ALL_SERVICES_ERROR';
+            validationError.source  = `${this._currentLine.ALLSERVICES} - ${this._currentLine.SERVICEDESC}`;
+            break;
+          case 'ServiceUsers':
+            validationError.errCode = Establishment.SERVICE_USERS_ERROR;
+            validationError.errType = 'SERVICE_USERS_ERROR';
+            validationError.source  = `${this._currentLine.SERVICEUSERS} - ${this._currentLine.OTHERUSERDESC}`;
+            break;
+          case 'ShareWithLA':
+            validationError.errCode = Establishment.LOCAL_AUTHORITIES_ERROR;
+            validationError.errType = 'LOCAL_AUTHORITIES_ERROR';
+            validationError.source  = `${this._currentLine.SHARELA}`;
+            break;
+          case 'ShareWith':
+            validationError.errCode = Establishment.SHARE_WITH;
+            validationError.errType = 'SHARE_WITH_ERROR';
+            validationError.source  = `${this._currentLine.PERMCQC} - ${this._currentLine.PERMLA}`;
+            break;
+          case 'Staff':
+            validationError.errCode = Establishment.TOTAL_PERM_TEMP_ERROR;
+            validationError.errType = 'TOTAL_PERM_TEMP_ERROR';
+            validationError.source  = `${this._currentLine.TOTALPERMTEMP}`;
+            break;
+          case 'Address':
+          case 'Postcode':
+            validationWarning.errCode = Establishment.ADDRESS_ERROR;
+            validationWarning.errType = 'ADDRESS_ERROR';
+            validationWarning.source  = `${this._currentLine.ADDRESS1},${this._currentLine.ADDRESS2},${this._currentLine.ADDRESS3},${this._currentLine.POSTTOWN},${this._currentLine.POSTCODE}`;
+            break;
+          case 'CQCRegistered':
+            validationWarning.errCode = Establishment.REGTYPE_ERROR;
+            validationWarning.errType = 'REGTYPE_ERROR';
+            validationWarning.source  = `${this._currentLine.REGTYPE}`;
+            break;
+          case 'LocationID':
+            validationWarning.errCode = Establishment.LOCATION_ID_ERROR;
+            validationWarning.errType = 'LOCATION_ID_ERROR';
+            validationWarning.source  = `${this._currentLine.LOCATIONID}`;
+            break;   
+          case 'NMDSID':
+              // where to map NMDSID error?????
+          default:
+            validationError.errCode = thisError.code;
+            validationError.errType = 'Undefined';
+            validationError.source  = thisProp;
+        }
+
+        this._validationErrors.push(validationError);
+      }) : true;
+    });
+  
+    warnings.forEach(thisWarning => {
+      thisWarning.properties ? thisWarning.properties.forEach(thisProp => {
+        const validationWarning = {
+          lineNumber: this._lineNumber,
+          warning: thisWarning.message,
+        };
+
+        switch (thisProp) {
+          case 'Capacity':
+            validationWarning.warnCode = Establishment.CAPACITY_UTILISATION_WARNING;
+            validationWarning.warnType = 'CAPACITY_UTILISATION_WARNING';
+            validationWarning.source  = `${this._currentLine.CAPACITY} - ${this._currentLine.UTILISATION}`;
+            break;
+          case 'EmployerType':
+            validationWarning.warnCode = Establishment.ESTABLISHMENT_TYPE_WARNING;
+            validationWarning.warnType = 'ESTABLISHMENT_TYPE_WARNING';
+            validationWarning.source  = `${this._currentLine.ESTTYPE}`;
+            break;
+          case 'Leavers':
+            validationWarning.warnCode = Establishment.LEAVERS_WARNING;
+            validationWarning.warnType = 'LEAVERS_WARNING';
+            validationWarning.source  = `${this._currentLine.LEAVERS}`;
+            break;
+          case 'Starters':
+            validationWarning.warnCode = Establishment.STARTERS_WARNING;
+            validationWarning.warnType = 'STARTERS_WARNING';
+            validationWarning.source  = `${this._currentLine.STARTERS}`;
+            break;
+          case 'Vacancies':
+            validationWarning.warnCode = Establishment.VACANCIES_WARNING;
+            validationWarning.warnType = 'VACANCIES_WARNING';
+            validationWarning.source  = `${this._currentLine.VACANCIES}`;
+            break;
+          case 'MainService':
+            validationWarning.warnCode = Establishment.MAIN_SERVICE_WARNING;
+            validationWarning.warnType = 'MAIN_SERVICE_WARNING';
+            validationWarning.source  = `${this._currentLine.MAINSERVICE}`;
+            break;
+          case 'Name':
+            validationWarning.warnCode = Establishment.NAME_WARNING;
+            validationWarning.warnType = 'NAME_WARNING';
+            validationWarning.source  = `${this._currentLine.ESTNAME}`;
+            break;
+          case 'Services':
+            validationWarning.warnCode = Establishment.ALL_SERVICES_WARNING;
+            validationWarning.warnType = 'ALL_SERVICES_WARNING';
+            validationWarning.source  = `${this._currentLine.ALLSERVICES} - ${this._currentLine.SERVICEDESC}`;
+            break;
+          case 'ServiceUsers':
+            validationWarning.warnCode = Establishment.SERVICE_USERS_WARNING;
+            validationWarning.warnType = 'SERVICE_USERS_WARNING';
+            validationWarning.source  = `${this._currentLine.SERVICEUSERS} - ${this._currentLine.OTHERUSERDESC}`;
+            break;
+          case 'ShareWithLA':
+            validationWarning.warnCode = Establishment.LOCAL_AUTHORITIES_WARNING;
+            validationWarning.warnType = 'LOCAL_AUTHORITIES_WARNING';
+            validationWarning.source  = `${this._currentLine.SHARELA}`;
+            break;
+          case 'ShareWith':
+            validationWarning.warnCode = Establishment.SHARE_WITH;
+            validationWarning.warnType = 'SHARE_WITH';
+            validationWarning.source  = `${this._currentLine.PERMCQC} - ${this._currentLine.PERMLA}`;
+            break;
+          case 'Staff':
+            validationWarning.warnCode = Establishment.TOTAL_PERM_TEMP_WARNING;
+            validationWarning.warnType = 'TOTAL_PERM_TEMP_WARNING';
+            validationWarning.source  = `${this._currentLine.TOTALPERMTEMP}`;
+            break;
+          case 'Address':
+          case 'Postcode':
+            validationWarning.warnCode = Establishment.ADDRESS_WARNING;
+            validationWarning.warnType = 'ADDRESS_WARNING';
+            validationWarning.source  = `${this._currentLine.ADDRESS1},${this._currentLine.ADDRESS2},${this._currentLine.ADDRESS3},${this._currentLine.POSTTOWN},${this._currentLine.POSTCODE}`;
+            break;
+          case 'CQCRegistered':
+            validationWarning.warnCode = Establishment.REGTYPE_WARNING;
+            validationWarning.warnType = 'REGTYPE_WARNING';
+            validationWarning.source  = `${this._currentLine.REGTYPE}`;
+            break;
+          case 'LocationID':
+            validationWarning.warnCode = Establishment.LOCATION_ID_WARNING;
+            validationWarning.warnType = 'LOCATION_ID_WARNING';
+            validationWarning.source  = `${this._currentLine.LOCATIONID}`;
+            break;   
+          case 'NMDSID':
+              // where to map NMDSID error?????
+          default:
+            validationWarning.warnCode = thisWarning.code;
+            validationWarning.warnType = 'Undefined';
+            validationWarning.source  = thisProp;
+        }
+
+        this._validationErrors.push(validationWarning);
+      }) : true;
+    });
+
   }
 };
 

--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -1659,9 +1659,6 @@ class Establishment {
   // maps Entity (API) validation messages to bulk upload specific messages (using Entity property name)
   addAPIValidations(errors, warnings) {
     errors.forEach(thisError => {
-
-console.log("WA DEBUG - this error: ", thisError)
-
       thisError.properties ? thisError.properties.forEach(thisProp => {
         const validationError = {
           lineNumber: this._lineNumber,

--- a/server/models/BulkImport/csv/training.js
+++ b/server/models/BulkImport/csv/training.js
@@ -336,6 +336,7 @@ class Training {
   // add unchecked establishment reference validation error
   uncheckedEstablishment() {
     return {
+      origin: 'Training',
       lineNumber: this._lineNumber,
       errCode: Training.UNCHECKED_ESTABLISHMENT_ERROR,
       errType: `UNCHECKED_ESTABLISHMENT_ERROR`,
@@ -347,6 +348,7 @@ class Training {
   // add unchecked establishment reference validation error
   uncheckedWorker() {
     return {
+      origin: 'Training',
       lineNumber: this._lineNumber,
       errCode: Training.UNCHECKED_WORKER_ERROR,
       errType: `UNCHECKED_WORKER_ERROR`,
@@ -409,7 +411,13 @@ class Training {
   };
 
   get validationErrors() {
-    return this._validationErrors;
+    // include the "origin" of validation error
+    return this._validationErrors.map(thisValidation => {
+      return {
+        origin: 'Training',
+        ...thisValidation,
+      };
+    });
   };
 
   // maps Entity (API) validation messages to bulk upload specific messages (using Entity property name)

--- a/server/models/BulkImport/csv/training.js
+++ b/server/models/BulkImport/csv/training.js
@@ -18,8 +18,9 @@ class Training {
     this._notes= null;
   };
 
-  static get UNCHECKED_WORKER_ERROR() { return 997; }
-  static get UNCHECKED_ESTABLISHMENT_ERROR() { return 998; }
+  static get UNCHECKED_WORKER_ERROR() { return 996; }
+  static get UNCHECKED_ESTABLISHMENT_ERROR() { return 997; }
+  static get HEADERS_ERROR() { return 999; }
   static get LOCALESTID_ERROR() { return 1000; }
   static get UNIQUE_WORKER_ID_ERROR() { return 1010; }
   static get DATE_COMPLETED_ERROR() { return 1020; }
@@ -28,7 +29,13 @@ class Training {
   static get CATEGORY_ERROR() { return 1050; }
   static get ACCREDITED_ERROR() { return 1060; }
   static get NOTES_ERROR() { return 1070; }
-  static get HEADERS_ERROR() { return 1080; }
+
+  static get DATE_COMPLETED_WARNING() { return 2020; }
+  static get EXPIRY_DATE_WARNING() { return 2030; }
+  static get DESCRIPTION_WARNING() { return 2040; }
+  static get CATEGORY_WARNING() { return 2050; }
+  static get ACCREDITED_WARNING() { return 2060; }
+  static get NOTES_WARNING() { return 2070; }
 
   get lineNumber() {
     return this._lineNumber;
@@ -404,6 +411,106 @@ class Training {
   get validationErrors() {
     return this._validationErrors;
   };
+
+  // maps Entity (API) validation messages to bulk upload specific messages (using Entity property name)
+  addAPIValidations(errors, warnings) {
+    errors.forEach(thisError => {
+      thisError.properties ? thisError.properties.forEach(thisProp => {
+        const validationError = {
+          lineNumber: this._lineNumber,
+          error: thisError.message,
+        };
+
+        switch (thisProp) {
+          case 'TrainingCategory':
+            validationError.errCode = Training.CATEGORY_ERROR;
+            validationError.errType = 'CATEGORY_ERROR';
+            validationError.source  = `${this._currentLine.CATEGORY}`;
+            break;
+          case 'Title':
+            validationError.errCode = Training.DESCRIPTION_ERROR;
+            validationError.errType = 'DESCRIPTION_ERROR';
+            validationError.source  = `${this._currentLine.DESCRIPTION}`;
+            break;
+          case 'Accredited':
+            validationError.errCode = Training.ACCREDITED_ERROR;
+            validationError.errType = 'ACCREDITED_ERROR';
+            validationError.source  = `${this._currentLine.ACCREDITED}`;
+            break;
+          case 'Completed':
+            validationError.errCode = Training.DATE_COMPLETED_ERROR;
+            validationError.errType = 'DATE_COMPLETED_ERROR';
+            validationError.source  = `${this._currentLine.DATECOMPLETED}`;
+            break;
+          case 'Expires':
+            validationError.errCode = Training.EXPIRY_DATE_ERROR;
+            validationError.errType = 'EXPIRY_DATE_ERROR';
+            validationError.source  = `${this._currentLine.EXPIRYDATE}`;
+            break;
+          case 'Notes':
+            validationError.errCode = Training.NOTES_ERROR;
+            validationError.errType = 'NOTES_ERROR';
+            validationError.source  = `${this._currentLine.NOTES}`;
+            break;
+          default:
+            validationError.errCode = thisError.code;
+            validationError.errType = 'Undefined';
+            validationError.source  = thisProp;
+        }
+        this._validationErrors.push(validationError);
+      }) : true;
+    });
+
+  
+    warnings.forEach(thisWarning => {
+      thisWarning.properties ? thisWarning.properties.forEach(thisProp => {
+        const validationWarning = {
+          lineNumber: this._lineNumber,
+          warning: thisWarning.message,
+        };
+
+        switch (thisProp) {
+          case 'TrainingCategory':
+            validationWarning.warnCode = Training.CATEGORY_WARNING;
+            validationWarning.warnType = 'CATEGORY_WARNING';
+            validationWarning.source  = `${this._currentLine.CATEGORY}`;
+            break;
+          case 'Title':
+            validationWarning.warnCode = Training.DESCRIPTION_WARNING;
+            validationWarning.warnType = 'DESCRIPTION_WARNING';
+            validationWarning.source  = `${this._currentLine.DESCRIPTION}`;
+            break;
+          case 'Accredited':
+            validationWarning.warnCode = Training.ACCREDITED_WARNING;
+            validationWarning.warnType = 'ACCREDITED_WARNING';
+            validationWarning.source  = `${this._currentLine.ACCREDITED}`;
+            break;
+          case 'Completed':
+            validationWarning.warnCode = Training.DATE_COMPLETED_WARNING;
+            validationWarning.warnType = 'DATE_COMPLETED_WARNING';
+            validationWarning.source  = `${this._currentLine.DATECOMPLETED}`;
+            break;
+          case 'Expires':
+            validationWarning.warnCode = Training.EXPIRY_DATE_WARNING;
+            validationWarning.warnType = 'EXPIRY_DATE_WARNING';
+            validationWarning.source  = `${this._currentLine.EXPIRYDATE}`;
+            break;
+          case 'Notes':
+            validationWarning.warnCode = Training.NOTES_WARNING;
+            validationWarning.warnType = 'NOTES_WARNING';
+            validationWarning.source  = `${this._currentLine.NOTES}`;
+            break;
+          default:
+            validationWarning.warnCode = thisWarning.code;
+            validationWarning.warnType = 'Undefined';
+            validationWarning.source  = thisProp;
+        }
+
+        this._validationErrors.push(validationWarning);
+      }) : true;
+    });
+  }
+
 };
 
 module.exports.Training = Training;

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -1887,8 +1887,6 @@ class Worker {
       this._qualifications.forEach(thisQualification => {
         const myValidatedQualification = BUDI.qualifications(BUDI.TO_ASC, thisQualification.id);
 
-        console.log("WA DBEUG - transformed qualification: ", thisQualification.id, myValidatedQualification)
-
         if (!myValidatedQualification) {
           this._validationErrors.push({
             lineNumber: this._lineNumber,
@@ -1912,6 +1910,7 @@ class Worker {
   // add a duplicate validation error to the current set
   addDuplicate(originalLineNumber) {
     return {
+      origin: 'Workers',
       lineNumber: this._lineNumber,
       errCode: Worker.DUPLICATE_ERROR,
       errType: `DUPLICATE_ERROR`,
@@ -1923,6 +1922,7 @@ class Worker {
   // add unchecked establishment reference validation error
   uncheckedEstablishment() {
     return {
+      origin: 'Workers',
       lineNumber: this._lineNumber,
       errCode: Worker.UNCHECKED_ESTABLISHMENT_ERROR,
       errType: `UNCHECKED_ESTABLISHMENT_ERROR`,
@@ -2298,7 +2298,15 @@ class Worker {
   }
 
   get validationErrors() {
-    return this._validationErrors;
+    // include the "origin" of validation error
+    return this._validationErrors.map(thisValidation => {
+console.log("WA DEBUG - this validation: ", thisValidation)
+
+      return {
+        origin: 'Workers',
+        ...thisValidation,
+      };
+    });
   };
 
   // maps Entity (API) validation messages to bulk upload specific messages (using Entity property name)

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -2300,8 +2300,6 @@ class Worker {
   get validationErrors() {
     // include the "origin" of validation error
     return this._validationErrors.map(thisValidation => {
-console.log("WA DEBUG - this validation: ", thisValidation)
-
       return {
         origin: 'Workers',
         ...thisValidation,

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -65,61 +65,104 @@ class Worker {
     this._amhp = null;
   };
 
-  //49 csv columns
-  static get DUPLICATE_ERROR() { return 999; }
-  static get UNCHECKED_ESTABLISHMENT_ERROR() { return 998; }
+  static get UNCHECKED_ESTABLISHMENT_ERROR() { return 997; }
+  static get DUPLICATE_ERROR() { return 998; }
+  static get HEADERS_ERROR() { return 999; }
+
   static get LOCAL_ID_ERROR() { return 1010; }
   static get UNIQUE_WORKER_ID_ERROR() { return 1020; }
   static get CHANGE_UNIQUE_WORKER_ID_ERROR() { return 1030; }
   static get STATUS_ERROR() { return 1040; }
+
   static get DISPLAY_ID_ERROR() { return 1050; }
   static get NINUMBER_ERROR() { return 1060; }
   static get POSTCODE_ERROR() { return 1070; }
   static get DOB_ERROR() { return 1080; }
   static get GENDER_ERROR() { return 1090; }
-  static get ETHNICITY_ERROR() { return 2000; }
-  static get NATIONALITY_ERROR() { return 2010; }
-  static get BRTITISH_CITIZENSHIP_ERROR() { return 2020; }
-  static get COUNTRY_OF_BIRTH_ERROR() { return 2030; }
-  static get YEAR_OF_ENTRY_ERROR() { return 2040; }
-  static get DISABLED_ERROR() { return 2050; }
-  static get CARE_CERT_ERROR() { return 2080; }
-  static get CARE_CERT_DATE_ERROR() { return 2090; }
-  static get RECSOURCE_ERROR() { return 3000; }
-  static get START_DATE_ERROR() { return 3010; }
-  static get START_INSECT_ERROR() { return 3020; }
-  static get APPRENCTICE_ERROR() { return 3030; }
-  static get CONTRACT_TYPE_ERROR() { return 3040; } //EMPL STATUS
-  static get ZERO_HRCONT_ERROR() { return 3060; }
-  static get DAYSICK_ERROR() { return 3070; }
-  static get SALARY_INT_ERROR() { return 3080; }
-  static get SALARY_ERROR() { return 3090; }
-  static get HOURLY_RATE_ERROR() { return 4000; }
-  static get MAIN_JOB_ROLE_ERROR() { return 4010; }
-  static get MAIN_JOB_DESC_ERROR() { return 4020; }
-  static get CONT_HOURS_ERROR() { return 4030; }
-  static get AVG_HOURS_ERROR() { return 4040; }
-  static get OTHER_JOB_ROLE_ERROR() { return 4050; }
-  static get OTHER_JR_DESC_ERROR() { return 4060; }
-  static get NMCREG_ERROR() { return 4070; }
-  static get NURSE_SPEC_ERROR() { return 4080; }
+  static get ETHNICITY_ERROR() { return 1100; }
+  static get NATIONALITY_ERROR() { return 1110; }
+  static get BRTITISH_CITIZENSHIP_ERROR() { return 1120; }
+  static get COUNTRY_OF_BIRTH_ERROR() { return 1230; }
+  static get YEAR_OF_ENTRY_ERROR() { return 1140; }
+  static get DISABLED_ERROR() { return 1150; }
+  static get CARE_CERT_ERROR() { return 1160; }
+  static get CARE_CERT_DATE_ERROR() { return 1170; }
+  static get RECSOURCE_ERROR() { return 1180; }
+  static get START_DATE_ERROR() { return 1190; }
+  static get START_INSECT_ERROR() { return 1200; }
+  static get APPRENCTICE_ERROR() { return 1210; }
+  static get CONTRACT_TYPE_ERROR() { return 1220; } //EMPL STATUS
+  static get ZERO_HRCONT_ERROR() { return 1230; }
+  static get DAYSICK_ERROR() { return 1240; }
+  static get SALARY_INT_ERROR() { return 1250; }
+  static get SALARY_ERROR() { return 1260; }
+  static get HOURLY_RATE_ERROR() { return 1270; }
+  static get MAIN_JOB_ROLE_ERROR() { return 1280; }
+  static get MAIN_JOB_DESC_ERROR() { return 1290; }
+  static get CONT_HOURS_ERROR() { return 1300; }
+  static get AVG_HOURS_ERROR() { return 1310; }
+  static get OTHER_JOB_ROLE_ERROR() { return 1320; }
+  static get OTHER_JR_DESC_ERROR() { return 1330; }
+  static get NMCREG_ERROR() { return 1340; }
+  static get NURSE_SPEC_ERROR() { return 1350; }
 
-  static get SOCIALCARE_QUAL_ERROR() { return 4090; }
-  static get NON_SOCIALCARE_QUAL_ERROR() { return 5000; }
+  static get SOCIALCARE_QUAL_ERROR() { return 1360; }
+  static get NON_SOCIALCARE_QUAL_ERROR() { return 1370; }
+
+  static get AMHP_ERROR() { return 1380; }
 
 
-  static get NO_QUAL_WT_ERROR() { return 5010; }
-  static get QUAL_WT_ERROR() { return 5020; }
-  static get QUAL_WT_NOTES_ERROR() { return 5030; }
-  static get QUAL_ACH_ERROR() { return 5035; }
-  static get QUAL_ACH01_ERROR() { return 5040; }
-  static get QUAL_ACH01_NOTES_ERROR() { return 5050; }
-  static get QUAL_ACH02_ERROR() { return 5060; }
-  static get QUAL_ACH02_NOTES_ERROR() { return 5070; }
-  static get QUAL_ACH03_ERROR() { return 5080; }
-  static get QUAL_ACH03_NOTES_ERROR() { return 5090; }
-  static get AMHP_ERROR() { return 6000; }
-  static get HEADERS_ERROR() { return 6010; }
+  static get UNIQUE_WORKER_ID_WARNING() { return 3020; }
+  static get DISPLAY_ID_WARNING() { return 3050; }
+  static get NINUMBER_WARNING() { return 3060; }
+  static get POSTCODE_WARNING() { return 3070; }
+  static get DOB_WARNING() { return 3080; }
+  static get GENDER_WARNING() { return 3090; }
+  static get ETHNICITY_WARNING() { return 3100; }
+  static get NATIONALITY_WARNING() { return 3110; }
+  static get BRTITISH_CITIZENSHIP_WARNING() { return 3120; }
+  static get COUNTRY_OF_BIRTH_WARNING() { return 3130; }
+  static get YEAR_OF_ENTRY_WARNING() { return 3140; }
+  static get DISABLED_WARNING() { return 3150; }
+  static get CARE_CERT_WARNING() { return 3160; }
+  static get CARE_CERT_DATE_WARNING() { return 3170; }
+  static get RECSOURCE_WARNING() { return 3180; }
+  static get START_DATE_WARNING() { return 3190; }
+  static get START_INSECT_WARNING() { return 3200; }
+  static get APPRENCTICE_WARNING() { return 3210; }
+  static get CONTRACT_TYPE_WARNING() { return 3220; } //EMPL STATUS
+  static get ZERO_HRCONT_WARNING() { return 3230; }
+  static get DAYSICK_WARNING() { return 3240; }
+  static get SALARY_INT_WARNING() { return 3250; }
+  static get SALARY_WARNING() { return 3260; }
+  static get HOURLY_RATE_WARNING() { return 3270; }
+  static get MAIN_JOB_ROLE_WARNING() { return 3280; }
+  static get MAIN_JOB_DESC_WARNING() { return 3290; }
+  static get CONT_HOURS_WARNING() { return 3300; }
+  static get AVG_HOURS_WARNING() { return 3310; }
+  static get OTHER_JOB_ROLE_WARNING() { return 3320; }
+  static get OTHER_JR_DESC_WARNING() { return 3330; }
+  static get NMCREG_WARNING() { return 3340; }
+  static get NURSE_SPEC_WARNING() { return 3350; }
+
+  static get SOCIALCARE_QUAL_ERROR() { return 3360; }
+  static get NON_SOCIALCARE_QUAL_ERROR() { return 3370; }
+
+  static get QUAL_ACH_ERROR() { return 5000; }
+  static get QUAL_ACH01_ERROR() { return 5010; }
+  static get QUAL_ACH01_NOTES_ERROR() { return 5020; }
+  static get QUAL_ACH02_ERROR() { return 5030; }
+  static get QUAL_ACH02_NOTES_ERROR() { return 5040; }
+  static get QUAL_ACH03_ERROR() { return 5050; }
+  static get QUAL_ACH03_NOTES_ERROR() { return 5060; }
+
+  static get QUAL_ACH_WARNING() { return 5500; }
+  static get QUAL_ACH01_WARNING() { return 5510; }
+  static get QUAL_ACH01_NOTES_WARNING() { return 5520; }
+  static get QUAL_ACH02_WARNING() { return 5530; }
+  static get QUAL_ACH02_NOTES_WARNING() { return 5540; }
+  static get QUAL_ACH03_WARNING() { return 5550; }
+  static get QUAL_ACH03_NOTES_WARNING() { return 5560; }
 
   get lineNumber() {
     return this._lineNumber;
@@ -2125,9 +2168,6 @@ class Worker {
 
     if (this._startInsect) {
       if (this._startInsect === 999) {
-
-console.log("WA DEBUG !!!!!!!!!!!!!! start in sector: ", this._startInsect)
-
         changeProperties.socialCareStartDate = {
           value : 'No'
         } 
@@ -2302,6 +2342,76 @@ console.log("WA DEBUG !!!!!!!!!!!!!! start in sector: ", this._startInsect)
   get validationErrors() {
     return this._validationErrors;
   };
+
+  // maps Entity (API) validation messages to bulk upload specific messages (using Entity property name)
+  addAPIValidations(errors, warnings) {
+    errors.forEach(thisError => {
+      thisError.properties ? thisError.properties.forEach(thisProp => {
+        const validationError = {
+          lineNumber: this._lineNumber,
+          error: thisError.message,
+        };
+
+        switch (thisProp) {
+          case 'NameOrId':
+            validationError.errCode = Worker.UNIQUE_WORKER_ID_ERROR;
+            validationError.errType = 'UNIQUE_WORKER_ID_ERROR';
+            validationError.source  = `${this._currentLine.UNIQUEWORKERID}`;
+            break;
+          case 'MainJob':
+            validationError.errCode = Worker.MAIN_JOB_ROLE_ERROR;
+            validationError.errType = 'MAIN_JOB_ROLE_ERROR';
+            validationError.source  = `${this._currentLine.MAINJOBROLE} - ${this._currentLine.MAINJRDESC}`;
+            break;
+          case 'Contract':
+            validationError.errCode = Worker.CONTRACT_TYPE_ERROR;
+            validationError.errType = 'CONTRACT_TYPE_ERROR';
+            validationError.source  = `${this._currentLine.EMPLSTATUS}`;
+            break;
+          default:
+            validationError.errCode = thisError.code;
+            validationError.errType = 'Undefined';
+            validationError.source  = thisProp;
+        }
+        this._validationErrors.push(validationError);
+      }) : true;
+    });
+
+  
+    warnings.forEach(thisWarning => {
+      thisWarning.properties ? thisWarning.properties.forEach(thisProp => {
+        const validationWarning = {
+          lineNumber: this._lineNumber,
+          warning: thisWarning.message,
+        };
+
+        switch (thisProp) {
+          case 'NameOrId':
+            validationWarning.warnCode = Worker.UNIQUE_WORKER_ID_WARNING;
+            validationWarning.warnType = 'UNIQUE_WORKER_ID_WARNING';
+            validationWarning.source  = `${this._currentLine.UNIQUEWORKERID}`;
+            break;
+          case 'MainJob':
+            validationWarning.warnCode = Worker.MAIN_JOB_ROLE_WARNING;
+            validationWarning.warnType = 'MAIN_JOB_ROLE_WARNING';
+            validationWarning.source  = `${this._currentLine.MAINJOBROLE} - ${this._currentLine.MAINJRDESC}`;
+            break;
+          case 'Contract':
+            validationWarning.warnCode = Worker.CONTRACT_TYPE_WARNING;
+            validationWarning.warnType = 'CONTRACT_TYPE_WARNING';
+            validationWarning.source  = `${this._currentLine.EMPLSTATUS}`;
+            break;
+          default:
+            validationWarning.warnCode = thisWarning.code;
+            validationWarning.warnType = 'Undefined';
+            validationWarning.source  = thisProp;
+        }
+
+        this._validationErrors.push(validationWarning);
+      }) : true;
+    });
+  }
+  
 };
 
 module.exports.Worker = Worker;

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -81,12 +81,11 @@ class Worker {
   static get GENDER_ERROR() { return 1090; }
   static get ETHNICITY_ERROR() { return 1100; }
   static get NATIONALITY_ERROR() { return 1110; }
-  static get BRTITISH_CITIZENSHIP_ERROR() { return 1120; }
+  static get BRITISH_CITIZENSHIP_ERROR() { return 1120; }
   static get COUNTRY_OF_BIRTH_ERROR() { return 1230; }
   static get YEAR_OF_ENTRY_ERROR() { return 1140; }
   static get DISABLED_ERROR() { return 1150; }
   static get CARE_CERT_ERROR() { return 1160; }
-  static get CARE_CERT_DATE_ERROR() { return 1170; }
   static get RECSOURCE_ERROR() { return 1180; }
   static get START_DATE_ERROR() { return 1190; }
   static get START_INSECT_ERROR() { return 1200; }
@@ -120,12 +119,11 @@ class Worker {
   static get GENDER_WARNING() { return 3090; }
   static get ETHNICITY_WARNING() { return 3100; }
   static get NATIONALITY_WARNING() { return 3110; }
-  static get BRTITISH_CITIZENSHIP_WARNING() { return 3120; }
+  static get BRITISH_CITIZENSHIP_WARNING() { return 3120; }
   static get COUNTRY_OF_BIRTH_WARNING() { return 3130; }
   static get YEAR_OF_ENTRY_WARNING() { return 3140; }
   static get DISABLED_WARNING() { return 3150; }
   static get CARE_CERT_WARNING() { return 3160; }
-  static get CARE_CERT_DATE_WARNING() { return 3170; }
   static get RECSOURCE_WARNING() { return 3180; }
   static get START_DATE_WARNING() { return 3190; }
   static get START_INSECT_WARNING() { return 3200; }
@@ -593,8 +591,8 @@ class Worker {
       if (isNaN(myBritishCitizenship)) {
         this._validationErrors.push({
           lineNumber: this._lineNumber,
-          errCode: Worker.BRTITISH_CITIZENSHIP_ERROR,
-          errType: 'BRTITISH_CITIZENSHIP_ERROR',
+          errCode: Worker.BRITISH_CITIZENSHIP_ERROR,
+          errType: 'BRITISH_CITIZENSHIP_ERROR',
           error: "CitizenShip (BRITISHCITIZENSHIP) must be an integer",
           source: this._currentLine.BRITISHCITIZENSHIP,
         });
@@ -602,8 +600,8 @@ class Worker {
       } else if (!BritishCitizenshipValues.includes(parseInt(myBritishCitizenship))) {
         this._validationErrors.push({
           lineNumber: this._lineNumber,
-          errCode: Worker.BRITISHCITIZENSHIP_ERROR,
-          errType: 'BRTITISH_CITIZENSHIP_ERROR',
+          errCode: Worker.BRITISH_CITIZENSHIP_ERROR,
+          errType: 'BRITISH_CITIZENSHIP_ERROR',
           error: "British Citizenship (BRITISHCITIZENSHIP) must have value 1(Yes) to 2(No),  999(Unknown) ",
           source: this._currentLine.BRITISHCITIZENSHIP,
         });
@@ -732,51 +730,6 @@ class Worker {
             this._careCert = 'Yes, in progress or partially completed';
             break;
         }
-        return true;
-      }
-    } else {
-      return true;
-    }
-  }
-
-  _validateCareCertDate() {
-    const myCareCertDate = this._currentLine.CARECERTDATE;
-    const dateRegex = /^([0-2][0-9]|(3)[0-1])(\/)(((0)[0-9])|((1)[0-2]))(\/)\d{4}$/;
-
-    if (this._currentLine.CARECERTDATE && this._currentLine.CARECERTDATE.length > 0) {
-      const today = moment(new Date());
-      const myCareCertRealDate = moment.utc(myCareCertDate, "DD/MM/YYYY");
-  
-      // optional
-      if (!dateRegex.test(this._currentLine.CARECERTDATE)) {
-        this._validationErrors.push({
-          lineNumber: this._lineNumber,
-          errCode: Worker.CARE_CERT_DATE_ERROR,
-          errType: 'CARECERTDATE_ERROR',
-          error: "Care Certificate Date (CARECERTDATE) should by in dd/mm/yyyy format",
-          source: this._currentLine.CARECERTDATE,
-        });
-        return false;
-      } else if (!myCareCertRealDate.isValid()) {
-        this._validationErrors.push({
-          lineNumber: this._lineNumber,
-          errCode: Worker.CARE_CERT_DATE_ERROR,
-          errType: 'CARE_CERT_DATE_ERROR',
-          error: "Care Certificate Date (CARECERTDATE)  is invalid date",
-          source: this._currentLine.STARTDATE,
-        });
-        return false;
-      } else if (myCareCertRealDate.isAfter(today)) {
-        this._validationErrors.push({
-          lineNumber: this._lineNumber,
-          errCode: Worker.CARE_CERT_DATE_ERROR,
-          errType: 'CARECERTDATE_ERROR',
-          error: "Care Certificate Date (CARECERTDATE) can not be in future",
-          source: this._currentLine.CARECERTDATE,
-        });
-        return false;
-      } else if (myCareCertDate) {
-        this._careCertDate = myCareCertRealDate;
         return true;
       }
     } else {
@@ -2358,20 +2311,146 @@ class Worker {
         };
 
         switch (thisProp) {
-          case 'NameOrId':
+          case 'WorkerNameOrId':
             validationError.errCode = Worker.UNIQUE_WORKER_ID_ERROR;
             validationError.errType = 'UNIQUE_WORKER_ID_ERROR';
             validationError.source  = `${this._currentLine.UNIQUEWORKERID}`;
             break;
-          case 'MainJob':
+          case 'WorkerMainJob':
             validationError.errCode = Worker.MAIN_JOB_ROLE_ERROR;
             validationError.errType = 'MAIN_JOB_ROLE_ERROR';
             validationError.source  = `${this._currentLine.MAINJOBROLE} - ${this._currentLine.MAINJRDESC}`;
             break;
-          case 'Contract':
+          case 'WorkerContract':
             validationError.errCode = Worker.CONTRACT_TYPE_ERROR;
             validationError.errType = 'CONTRACT_TYPE_ERROR';
             validationError.source  = `${this._currentLine.EMPLSTATUS}`;
+            break;
+          case 'WorkerAnnualHourlyPay':
+            // note - the Worker entity wraps the pay type (interval) and rate, with a single rate for hourly and annually
+            validationError.errCode = Worker.SALARY_INT_ERROR;
+            validationError.errType = 'SALARY_INT_ERROR';
+            validationError.source  = `${this._currentLine.SALARYINT} - ${this._currentLine.SALARY} - ${this._currentLine.HOURLYRATE}`;
+            break;
+          case 'WorkerApprenticeshipTraining':
+            validationError.errCode = Worker.APPRENCTICE_ERROR;
+            validationError.errType = 'APPRENCTICE_ERROR';
+            validationError.source  = `${this._currentLine.APPRENTICE}`;
+            break;
+          case 'WorkerApprovedMentalHealthWorker':
+            validationError.errCode = Worker.AMHP_ERROR;
+            validationError.errType = 'AMHP_ERROR';
+            validationError.source  = `${this._currentLine.AMHP}`;
+            break;
+          case 'WorkerBritishCitizenship':
+            validationError.errCode = Worker.BRITISH_CITIZENSHIP_ERROR;
+            validationError.errType = 'BRITISH_CITIZENSHIP_ERROR';
+            validationError.source  = `${this._currentLine.BRITISHCITIZENSHIP}`;
+            break;
+          case 'WorkerCareCertificate':
+            validationError.errCode = Worker.CARE_CERT_ERROR;
+            validationError.errType = 'CARE_CERT_ERROR';
+            validationError.source  = `${this._currentLine.CARECERT}`;
+            break;
+          case 'WorkerCountry':
+            validationError.errCode = Worker.COUNTRY_OF_BIRTH_ERROR;
+            validationError.errType = 'COUNTRY_OF_BIRTH_ERROR';
+            validationError.source  = `${this._currentLine.COUNTRYOFBIRTH}`;
+            break;
+          case 'WorkerDateOfBirth':
+            validationError.errCode = Worker.DOB_ERROR;
+            validationError.errType = 'DOB_ERROR';
+            validationError.source  = `${this._currentLine.DOB}`;
+            break;
+          case 'WorkerDaysSick':
+            validationError.errCode = Worker.DAYSICK_ERROR;
+            validationError.errType = 'DAYSICK_ERROR';
+            validationError.source  = `${this._currentLine.DAYSSICK}`;
+            break;
+          case 'WorkerDisability':
+            validationError.errCode = Worker.DISABLED_ERROR;
+            validationError.errType = 'DISABLED_ERROR';
+            validationError.source  = `${this._currentLine.DISABLED}`;
+            break;
+          case 'WorkerEthnicity':
+            validationError.errCode = Worker.ETHNICITY_ERROR;
+            validationError.errType = 'ETHNICITY_ERROR';
+            validationError.source  = `${this._currentLine.ETHNICITY}`;
+            break;
+          case 'WorkerGender':
+            validationError.errCode = Worker.GENDER_ERROR;
+            validationError.errType = 'GENDER_ERROR';
+            validationError.source  = `${this._currentLine.GENDER}`;
+            break;
+          // in Worker entity, we have separated the non-social care qualification type and level into separate properties
+          case 'WorkerOtherQualification':
+          case 'WorkerHighestQualification':
+            validationError.errCode = Worker.NON_SOCIALCARE_QUAL_ERROR;
+            validationError.errType = 'NON_SOCIALCARE_QUAL_ERROR';
+            validationError.source  = `${this._currentLine.NONSCQUAL}`;
+            break;
+          case 'WorkerMainJobStartDate':
+            validationError.errCode = Worker.START_DATE_ERROR;
+            validationError.errType = 'START_DATE_ERROR';
+            validationError.source  = `${this._currentLine.STARTDATE}`;
+            break;
+          case 'WorkerNationalInsuranceNumber':
+            validationError.errCode = Worker.NINUMBER_ERROR;
+            validationError.errType = 'NINUMBER_ERROR';
+            validationError.source  = `${this._currentLine.NINUMBER}`;
+            break;
+          case 'WorkerNationality':
+            validationError.errCode = Worker.NATIONALITY_ERROR;
+            validationError.errType = 'NATIONALITY_ERROR';
+            validationError.source  = `${this._currentLine.NATIONALITY}`;
+            break;
+          case 'WorkerOtherJobs':
+            // the Worker entity combines OTHERJOBROLE and OTHERJRDESC
+            validationError.errCode = Worker.OTHER_JOB_ROLE_ERROR;
+            validationError.errType = 'OTHER_JOB_ROLE_ERROR';
+            validationError.source  = `${this._currentLine.OTHERJOBROLE} - ${this._currentLine.OTHERJRDESC}`;
+            break;
+          case 'WorkerPostcode':
+            validationError.errCode = Worker.POSTCODE_ERROR;
+            validationError.errType = 'POSTCODE_ERROR';
+            validationError.source  = `${this._currentLine.POSTCODE}`;
+            break;
+          // in Worker entity, we have separated the social care qualification type and level into separate properties
+          case 'WorkerQualificationInSocialCare':
+          case 'WorkerSocialCareQualification':
+            validationError.errCode = Worker.SOCIALCARE_QUAL_ERROR;
+            validationError.errType = 'SOCIALCARE_QUAL_ERROR';
+            validationError.source  = `${this._currentLine.SCQUAL}`;
+            break;
+          case 'WorkerRecruitedFrom':
+            validationError.errCode = Worker.RECSOURCE_ERROR;
+            validationError.errType = 'RECSOURCE_ERROR';
+            validationError.source  = `${this._currentLine.RECSOURCE}`;
+            break;
+          case 'WorkerSocialCareStartDate':
+            validationError.errCode = Worker.START_INSECT_ERROR;
+            validationError.errType = 'START_INSECT_ERROR';
+            validationError.source  = `${this._currentLine.STARTINSECT}`;
+            break;
+          case `WorkerWeeklyHoursAverage`:
+            validationError.errCode = Worker.AVG_HOURS_ERROR;
+            validationError.errType = 'AVG_HOURS_ERROR';
+            validationError.source  = `${this._currentLine.AVGHOURS}`;
+            break;
+          case 'WorkerWeeklyHoursContracted':
+            validationError.errCode = Worker.CONT_HOURS_ERROR;
+            validationError.errType = 'CONT_HOURS_ERROR';
+            validationError.source  = `${this._currentLine.CONTHOURS}`;
+            break;
+          case 'WorkerYearArrived':
+            validationError.errCode = Worker.YEAR_OF_ENTRY_ERROR;
+            validationError.errType = 'YEAR_OF_ENTRY_ERROR';
+            validationError.source  = `${this._currentLine.YEAROFENTRY}`;
+            break;
+          case 'WorkerZeroContract':
+            validationError.errCode = Worker.ZERO_HRCONT_ERROR;
+            validationError.errType = 'ZERO_HRCONT_ERROR';
+            validationError.source  = `${this._currentLine.ZEROHRCONT}`;
             break;
           default:
             validationError.errCode = thisError.code;
@@ -2391,20 +2470,143 @@ class Worker {
         };
 
         switch (thisProp) {
-          case 'NameOrId':
+          case 'WorkerNameOrId':
             validationWarning.warnCode = Worker.UNIQUE_WORKER_ID_WARNING;
             validationWarning.warnType = 'UNIQUE_WORKER_ID_WARNING';
             validationWarning.source  = `${this._currentLine.UNIQUEWORKERID}`;
             break;
-          case 'MainJob':
+          case 'WorkerMainJob':
             validationWarning.warnCode = Worker.MAIN_JOB_ROLE_WARNING;
             validationWarning.warnType = 'MAIN_JOB_ROLE_WARNING';
             validationWarning.source  = `${this._currentLine.MAINJOBROLE} - ${this._currentLine.MAINJRDESC}`;
             break;
-          case 'Contract':
+          case 'WorkerContract':
             validationWarning.warnCode = Worker.CONTRACT_TYPE_WARNING;
             validationWarning.warnType = 'CONTRACT_TYPE_WARNING';
             validationWarning.source  = `${this._currentLine.EMPLSTATUS}`;
+            break;
+          case 'WorkerAnnualHourlyPay':
+            // note - the Worker entity wraps the pay type (interval) and rate, with a single rate for hourly and annually
+            validationWarning.warnCode = Worker.SALARY_INT_WARNING;
+            validationWarning.warnType = 'SALARY_INT_WARNING';
+            validationWarning.source  = `${this._currentLine.SALARYINT} - ${this._currentLine.SALARY} - ${this._currentLine.HOURLYRATE}`;
+            break;
+          case 'WorkerApprenticeshipTraining':
+            validationWarning.warnCode = Worker.APPRENCTICE_WARNING;
+            validationWarning.warnType = 'APPRENCTICE_WARNING';
+            validationWarning.source  = `${this._currentLine.APPRENTICE}`;
+            break;
+          case 'WorkerApprovedMentalHealthWorker':
+            validationWarning.warnCode = Worker.AMHP_WARNING;
+            validationWarning.warnType = 'AMHP_WARNING';
+            validationWarning.source  = `${this._currentLine.AMHP}`;
+            break;
+          case 'WorkerBritishCitizenship':
+            validationWarning.warnCode = Worker.BRITISH_CITIZENSHIP_WARNING;
+            validationWarning.warnType = 'BRITISH_CITIZENSHIP_ERROR';
+            validationWarning.source  = `${this._currentLine.BRITISHCITIZENSHIP}`;
+            break;
+          case 'WorkerCareCertificate':
+            validationWarning.warnCode = Worker.CARE_CERT_WARNING;
+            validationWarning.warnType = 'CARE_CERT_WARNING';
+            validationWarning.source  = `${this._currentLine.CARECERT}`;
+            break;
+          case 'WorkerCountry':
+            validationWarning.warnCode = Worker.COUNTRY_OF_BIRTH_WARNING;
+            validationWarning.warnType = 'COUNTRY_OF_BIRTH_ERROR';
+            validationWarning.source  = `${this._currentLine.COUNTRYOFBIRTH}`;
+            break;
+          case 'WorkerDateOfBirth':
+            validationWarning.warnCode = Worker.DOB_WARNING;
+            validationWarning.warnType = 'DOB_WARNING';
+            validationWarning.source  = `${this._currentLine.DOB}`;
+            break;
+          case 'WorkerDaysSick':
+            validationWarning.warnCode = Worker.DAYSICK_WARNING;
+            validationWarning.warnType = 'DAYSICK_WARNING';
+            validationWarning.source  = `${this._currentLine.DAYSSICK}`;
+            break;
+          case 'WorkerDisability':
+            validationWarning.warnCode = Worker.DISABLED_WARNING;
+            validationWarning.warnType = 'DISABLED_WARNING';
+            validationWarning.source  = `${this._currentLine.DISABLED}`;
+            break;
+          case 'WorkerEthnicity':
+            validationWarning.warnCode = Worker.ETHNICITY_WARNING;
+            validationWarning.warnType = 'ETHNICITY_WARNING';
+            validationWarning.source  = `${this._currentLine.ETHNICITY}`;
+            break;
+          case 'WorkerGender':
+            validationWarning.warnCode = Worker.GENDER_WARNING;
+            validationWarning.warnType = 'GENDER_WARNING';
+            validationWarning.source  = `${this._currentLine.GENDER}`;
+            break;
+          case 'WorkerHighestQualification':
+            validationWarning.warnCode = Worker.NON_SOCIALCARE_QUAL_WARNING;
+            validationWarning.warnType = 'NON_SOCIALCARE_QUAL_WARNING';
+            validationWarning.source  = `${this._currentLine.STARTDATE}`;
+            break;
+          case 'WorkerMainJobStartDate':
+            validationWarning.warnCode = Worker.START_DATE_WARNING;
+            validationWarning.warnType = 'START_DATE_WARNING';
+            validationWarning.source  = `${this._currentLine.STARTDATE}`;
+            break;
+          case 'WorkerNationalInsuranceNumber':
+            validationWarning.warnCode = Worker.NINUMBER_WARNING;
+            validationWarning.warnType = 'NINUMBER_WARNING';
+            validationWarning.source  = `${this._currentLine.NINUMBER}`;
+            break;
+          case 'WorkerNationality':
+            validationWarning.warnCode = Worker.NATIONALITY_WARNING;
+            validationWarning.warnType = 'NATIONALITY_WARNING';
+            validationWarning.source  = `${this._currentLine.NATIONALITY}`;
+            break;
+          case 'WorkerOtherJobs':
+            validationWarning.warnCode = Worker.OTHER_JOB_ROLE_WARNING;
+            validationWarning.warnType = 'OTHER_JOB_ROLE_WARNING';
+            validationWarning.source  = `${this._currentLine.OTHERJOBROLE} - ${this._currentLine.OTHERJRDESC}`;
+            break;
+          case 'WorkerPostcode':
+            validationWarning.warnCode = Worker.POSTCODE_ERROR;
+            validationWarning.warnType = 'POSTCODE_ERROR';
+            validationWarning.source  = `${this._currentLine.POSTCODE}`;
+            break;
+          // in Worker entity, we have separated the social care qualification type and level into separate properties
+          case 'WorkerQualificationInSocialCare':
+          case 'WorkerSocialCareQualification':
+            validationWarning.warnCode = Worker.SOCIALCARE_QUAL_WARNING;
+            validationWarning.warnType = 'SOCIALCARE_QUAL_WARNING';
+            validationWarning.source  = `${this._currentLine.SCQUAL}`;
+            break;
+          case 'WorkerRecruitedFrom':
+            validationWarning.warnCode = Worker.RECSOURCE_ERROR;
+            validationWarning.warnType = 'RECSOURCE_ERROR';
+            validationWarning.source  = `${this._currentLine.RECSOURCE}`;
+            break;
+          case 'WorkerSocialCareStartDate':
+            validationWarning.warnCode = Worker.START_INSECT_WARNING;
+            validationWarning.warnType = 'START_INSECT_WARNING';
+            validationWarning.source  = `${this._currentLine.STARTINSECT}`;
+            break;
+          case 'WorkerWeeklyHoursAverage':
+            validationWarning.warnCode = Worker.AVG_HOURS_WARNING;
+            validationWarning.warnType = 'AVG_HOURS_WARNING';
+            validationWarning.source  = `${this._currentLine.AVGHOURS}`;
+            break;
+          case 'WorkerWeeklyHoursContracted':
+            validationWarning.warnCode = Worker.CONT_HOURS_WARNING;
+            validationWarning.warnType = 'CONT_HOURS_WARNING';
+            validationWarning.source  = `${this._currentLine.CONTHOURS}`;
+            break;
+          case 'WorkerYearArrived':
+            validationWarning.warnCode = Worker.YEAR_OF_ENTRY_ERROR;
+            validationWarning.warnType = 'YEAR_OF_ENTRY_ERROR';
+            validationWarning.source  = `${this._currentLine.YEAROFENTRY}`;
+            break;
+          case 'WorkerZeroContract':
+            validationWarning.warnCode = Worker.ZERO_HRCONT_WARNING;
+            validationWarning.warnType = 'ZERO_HRCONT_WARNING';
+            validationWarning.source  = `${this._currentLine.ZEROHRCONT}`;
             break;
           default:
             validationWarning.warnCode = thisWarning.code;
@@ -2429,7 +2631,7 @@ class Worker {
 
         switch (thisProp) {
           case 'Qualification':
-            validationError.errCode = Worker[`QUAL_ACH${columnIndex}_ERROR`];
+            validationError.errCode = Worker[`QUAL_ACH${columnIndex}_WARNING`];
             validationError.errType = `QUAL_ACH${columnIndex}_ERROR`;
             validationError.source  = `${this._currentLine[`QUALACH${columnIndex}`]}`;
             break;

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -789,7 +789,7 @@ class Worker extends EntityValidator {
                 allExistAndValid = false;
                 this._validations.push(new ValidationMessage(
                     ValidationMessage.ERROR,
-                    102,
+                    103,
                     contractProperty ? 'Invalid' : 'Missing',
                     ['Contract']
                 ));

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -767,7 +767,7 @@ class Worker extends EntityValidator {
                     ValidationMessage.ERROR,
                     101,
                     nameIdProperty ? 'Invalid' : 'Missing',
-                    ['NameOrId']
+                    ['WorkerNameOrId']
                 ));
                 this._log(Worker.LOG_ERROR, 'Worker::hasMandatoryProperties - missing or invalid name or id property');
             }
@@ -779,7 +779,7 @@ class Worker extends EntityValidator {
                     ValidationMessage.ERROR,
                     102,
                     mainJobProperty ? 'Invalid' : 'Missing',
-                    ['MainJob']
+                    ['WorkerMainJob']
                 ));
                 this._log(Worker.LOG_ERROR, 'Worker::hasMandatoryProperties - missing or invalid main job property');
             }
@@ -791,7 +791,7 @@ class Worker extends EntityValidator {
                     ValidationMessage.ERROR,
                     103,
                     contractProperty ? 'Invalid' : 'Missing',
-                    ['Contract']
+                    ['WorkerContract']
                 ));
                 this._log(Worker.LOG_ERROR, 'Worker::hasMandatoryProperties - missing or invalid contract property');
             }

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -554,7 +554,8 @@ const _validateEstablishmentCsv = async (thisLine, currentLineNumber, csvEstabli
       const errors = thisApiEstablishment.errors;
       const warnings = thisApiEstablishment.warnings;
 
-      _appendApiErrorsAndWarnings(lineValidator, errors, warnings);
+      //_appendApiErrorsAndWarnings(lineValidator, errors, warnings);
+      lineValidator.addAPIValidations(errors, warnings);
 
       if (errors.length === 0) {
         //console.log("WA DEBUG - this establishment entity: ", JSON.stringify(thisApiEstablishment.toJSON(), null, 2));

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -581,7 +581,7 @@ const _validateEstablishmentCsv = async (thisLine, currentLineNumber, csvEstabli
 
 const _loadWorkerQualifications = async (lineValidator, thisQual, myAPIQualifications) => {
   const thisApiQualification = new QualificationEntity();
-  await thisApiQualification.load(thisQual);
+  await thisApiQualification.load(thisQual);      // ignores "column" attribute (being the CSV column index, e.g "03" from which the qualification is mapped)
   // console.log("WA DEBUG - this qualification entity: ", JSON.stringify(thisApiQualification.toJSON(), null, 2));
 
   const isValid = thisApiQualification.validate();
@@ -594,7 +594,7 @@ const _loadWorkerQualifications = async (lineValidator, thisQual, myAPIQualifica
     const errors = thisApiQualification.errors;
     const warnings = thisApiQualification.warnings;
 
-    _appendApiErrorsAndWarnings(lineValidator, errors, warnings);
+    lineValidator.addQualificationAPIValidation(thisQual.column, errors, warnings);
 
     if (errors.length === 0) {
       // console.log("WA DEBUG - this qualification entity: ", JSON.stringify(thisApiQualification.toJSON(), null, 2));
@@ -623,6 +623,16 @@ const _validateWorkerCsv = async (thisLine, currentLineNumber, csvWorkerSchemaEr
       // no validation errors in the entity itself, so add it ready for completion
       //console.log("WA DEBUG - this worker entity: ", JSON.stringify(thisApiWorker.toJSON(), null, 2));
       myAPIWorkers.push(thisApiWorker);
+
+      // construct Qualification entities (can be multiple of a single Worker record) - regardless of whether the
+      //  Worker is valid or not; we need to return as many errors/warnings in one go as possible
+      const thisQualificationAsAPI = lineValidator.toQualificationAPI();
+      await Promise.all(
+        thisQualificationAsAPI.map((thisQual) => {
+          return _loadWorkerQualifications(lineValidator, thisQual, myAPIQualifications);
+        }) 
+      );  
+
     } else {
       const errors = thisApiWorker.errors;
       const warnings = thisApiWorker.warnings;
@@ -634,15 +644,6 @@ const _validateWorkerCsv = async (thisLine, currentLineNumber, csvWorkerSchemaEr
         myAPIWorkers.push(thisApiWorker);
       }
     }
-
-    // construct Qualification entities (can be multiple of a single Worker record) - regardless of whether the
-    //  Worker is valid or not; we need to return as many errors/warnings in one go as possible
-    const thisQualificationAsAPI = lineValidator.toQualificationAPI();
-    await Promise.all(
-      thisQualificationAsAPI.map((thisQual) => {
-        return _loadWorkerQualifications(lineValidator, thisQual, myAPIQualifications);
-      }) 
-    );  
   } catch (err) {
     console.error("WA - localised validate workers error until validation card", err);
   }
@@ -732,8 +733,6 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, estab
         allEstablishmentsByKey[keyNoWhitespace] = thisEstablishment.lineNumber;
       }
     });
-    console.log("WA DEBUG - all known establishments: ", allEstablishmentsByKey)
-
   } else {
     console.info("API bulkupload - validateBulkUploadFiles: no establishment records");
     status = false;

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -554,7 +554,6 @@ const _validateEstablishmentCsv = async (thisLine, currentLineNumber, csvEstabli
       const errors = thisApiEstablishment.errors;
       const warnings = thisApiEstablishment.warnings;
 
-      //_appendApiErrorsAndWarnings(lineValidator, errors, warnings);
       lineValidator.addAPIValidations(errors, warnings);
 
       if (errors.length === 0) {
@@ -628,7 +627,7 @@ const _validateWorkerCsv = async (thisLine, currentLineNumber, csvWorkerSchemaEr
       const errors = thisApiWorker.errors;
       const warnings = thisApiWorker.warnings;
 
-      _appendApiErrorsAndWarnings(lineValidator, errors, warnings);
+      lineValidator.addAPIValidations(errors, warnings);
   
       if (errors.length === 0) {
         //console.log("WA DEBUG - this worker entity: ", JSON.stringify(thisApiWorker.toJSON(), null, 2));
@@ -679,7 +678,7 @@ const _validateTrainingCsv = async (thisLine, currentLineNumber, csvTrainingSche
       const errors = thisApiTraining.errors;
       const warnings = thisApiTraining.warnings;
 
-      _appendApiErrorsAndWarnings(lineValidator, errors, warnings);
+      lineValidator.addAPIValidations(errors, warnings);
   
       if (errors.length === 0) {
         // console.log("WA DEBUG - this training entity: ", JSON.stringify(thisApiTraining.toJSON(), null, 2));


### PR DESCRIPTION
https://trello.com/c/FUtQEhVR

Remapping each errors/validations raised within the entities Establishment, Worker, Qualification and Training to the original bulk upload validation error/warning.

With Qualifications this included having to maintain provenance of the column against which the entity was constructed from.

Re-sequenced all CSV errors/warning numbers now, given there is no dependency on them. Consistent numbers used across CSV types for duplicates, unchecked and headers. And all warnings have the same _final octet_ number as errors.

Fixed a BUDI code mapping - 101, resulting always in an entity error.