### PR TITLE
Bulk upload validation report config hotfix

### DIFF
--- a/server/config/test.yaml
+++ b/server/config/test.yaml
@@ -8,7 +8,6 @@ db:
     pool: 5
     ssl: true
     username: sfcapp
-    database: sfctstdb
     client_ssl:
         status: true
         usingFiles: false
@@ -29,4 +28,4 @@ notify:
 
 bulkupload:
     region: eu-west-2
-bucketname: sfc-bulkupload-staging
+    bucketname: sfc-bulkupload-staging

--- a/server/config/test.yaml
+++ b/server/config/test.yaml
@@ -8,6 +8,7 @@ db:
     pool: 5
     ssl: true
     username: sfcapp
+    database: sfctstdb
     client_ssl:
         status: true
         usingFiles: false

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -876,7 +876,7 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, estab
 router.route('/report').get(async (req, res) => {  
   try {
     const params = {
-      Bucket: appConfig.get('bulkuploaduser.bucketname').toString(), 
+      Bucket: appConfig.get('bulkupload.bucketname').toString(), 
       Prefix: `${req.establishmentId}/validation/`
     };
   


### PR DESCRIPTION
Hi Nasir

With the introduction of AWS Secrets Manager, I rejigged the config.js schema which include renaming the `bulkupload` root name.

At the time, I didn't have your validation report endpoint.

This PR fixes the report endpoint to use the new config name.

Also included in this PR are changes to `test.yaml` we had to do to get the deployment to staging working.

Thanks