### PR TITLE
bugfix | redirect issue

### DIFF
--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -22,7 +22,7 @@
             <a routerLink="/account-management/your-account" class="govuk-header__link">Account</a>
           </li>
           <li class="govuk-header__navigation-item">
-            <a routerLink="/logged-out" class="govuk-header__link">Logout</a>
+            <a href="#" (click)="signOut($event)" class="govuk-header__link">Logout</a>
           </li>
         </ng-container>
       </ul>

--- a/src/app/core/guards/auth/auth.guard.ts
+++ b/src/app/core/guards/auth/auth.guard.ts
@@ -15,21 +15,22 @@ export class AuthGuard implements CanActivate, CanActivateChild {
   ) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    return this.checkLogin(route);
+    return this.checkLogin(state);
   }
 
   canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
     return this.canActivate(route, state);
   }
 
-  private checkLogin(route: ActivatedRouteSnapshot): boolean {
+  private checkLogin(state: RouterStateSnapshot): boolean {
+    if (this.establishmentService.isSameLoggedInUser) {
+      this.authService.redirect = state.url;
+    }
+
     if (this.authService.isLoggedIn) {
       return true;
     }
 
-    if (this.establishmentService.isSameLoggedInUser) {
-      this.authService.redirect = { url: route.url, fragment: route.fragment, queryParams: route.queryParams };
-    }
     this.router.navigate(['/login']);
     return false;
   }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -17,7 +17,7 @@ export class AuthService {
   private _session: LoggedInSession = null;
   private _token: string = null;
 
-  public redirect: { url: UrlSegment[]; fragment?: string; queryParams?: Params };
+  public redirect: string;
 
   // Observable login stream
   public auth$: Observable<LoggedInSession> = this._auth$.asObservable();
@@ -120,7 +120,7 @@ export class AuthService {
       localStorage.clear();
       this._session = null;
       this.token = null;
-      this.router.navigate(['/login']);
+      this.router.navigate(['/logged-out']);
     }
   }
 

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -151,14 +151,9 @@ export class LoginComponent implements OnInit, OnDestroy {
         () => {
           const redirect = this.authService.redirect;
 
-          if (redirect && redirect.url.length) {
-            const navExtras: NavigationExtras = {
-              queryParams: redirect.queryParams,
-              fragment: redirect.fragment,
-            };
-
+          if (redirect && redirect.length) {
+            this.router.navigateByUrl(redirect);
             this.authService.redirect = null;
-            this.router.navigate([redirect.url.toString()], navExtras);
           } else {
             this.router.navigate(['/dashboard']);
           }


### PR DESCRIPTION
- simplify and fix redirect to previous page if user logs in again

**Note:** This was the best solution I could come up without exposing the previous route in the browser address bar and also without touching the `window.location` object itself.

I also tried to use angular's `ActivatedRouteSnapshot` in the `AuthService` but angular throws injector errors, I then tried to use `ActivatedRoute` within `AuthService` but not all url segments were not exposed