### PR TITLE
Feature - bulk upload consume uploaded api for getting signed urls

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { PageNotFoundComponent } from '@core/components/error/page-not-found/page-not-found.component';
 import { ProblemWithTheServiceComponent } from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
 import { AuthGuard } from '@core/guards/auth/auth.guard';
+import { RoleGuard } from '@core/guards/role/role.guard';
 import { DashboardComponent } from '@features/dashboard/dashboard.component';
 import { ForgotYourPasswordComponent } from '@features/forgot-your-password/forgot-your-password.component';
 import { LoginComponent } from '@features/login/login.component';

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -77,7 +77,7 @@ const routes: Routes = [
   {
     path: 'bulk-upload',
     loadChildren: '@features/bulk-upload/bulk-upload.module#BulkUploadModule',
-    // canActivate: [AuthGuard, RoleGuard],
+    canActivate: [AuthGuard, RoleGuard],
     data: {
       roles: ['Edit'],
       title: 'Bulk Upload',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,15 +1,14 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { PageNotFoundComponent } from '@core/components/error/page-not-found/page-not-found.component';
+import { ProblemWithTheServiceComponent } from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
 import { AuthGuard } from '@core/guards/auth/auth.guard';
 import { DashboardComponent } from '@features/dashboard/dashboard.component';
 import { ForgotYourPasswordComponent } from '@features/forgot-your-password/forgot-your-password.component';
 import { LoginComponent } from '@features/login/login.component';
 import { LogoutComponent } from '@features/logout/logout.component';
-import { NgModule } from '@angular/core';
-import { PageNotFoundComponent } from '@core/components/error/page-not-found/page-not-found.component';
-import { ProblemWithTheServiceComponent } from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
 import { ReportsComponent } from '@features/reports/reports.component';
 import { ResetPasswordComponent } from '@features/reset-password/reset-password.component';
-import { RoleGuard } from '@core/guards/role/role.guard';
-import { RouterModule, Routes } from '@angular/router';
 
 const routes: Routes = [
   {
@@ -78,7 +77,7 @@ const routes: Routes = [
   {
     path: 'bulk-upload',
     loadChildren: '@features/bulk-upload/bulk-upload.module#BulkUploadModule',
-    canActivate: [AuthGuard, RoleGuard],
+    // canActivate: [AuthGuard, RoleGuard],
     data: {
       roles: ['Edit'],
       title: 'Bulk Upload',

--- a/src/app/core/model/bulk-upload.model.ts
+++ b/src/app/core/model/bulk-upload.model.ts
@@ -4,8 +4,21 @@ export enum FileValidateStatus {
   Pass = 'Pass',
 }
 
-export interface PresignedUrlResponse {
-  urls: string;
+export interface PresignedUrlRequestItem {
+  filename: string;
+}
+
+export interface PresignedUrlResponseItem extends PresignedUrlRequestItem {
+  signedUrl: string;
+}
+
+export interface PresignedUrlsRequest {
+  files: PresignedUrlRequestItem[];
+}
+
+export interface UploadFileRequestItem {
+  file: UploadFile;
+  signedUrl: string;
 }
 
 export interface UploadFile extends File {

--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -56,7 +56,7 @@ export class BulkUploadService {
           },
           {
             name: 'filecount',
-            message: 'Please select a total of 3 files.',
+            message: 'Please select between 2 and 3 files.',
           },
           {
             name: 'filesize',

--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -1,11 +1,10 @@
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { PresignedUrlResponse, UploadFile, ValidatedFilesResponse } from '@core/model/bulk-upload.model';
+import { PresignedUrlResponseItem, PresignedUrlsRequest, UploadFile, ValidatedFilesResponse } from '@core/model/bulk-upload.model';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -18,17 +17,11 @@ export class BulkUploadService {
 
   constructor(private http: HttpClient, private establishmentService: EstablishmentService) {}
 
-  public getPresignedUrl(filename: string): Observable<string> {
-    const params = new HttpParams().set('filename', filename);
-
-    return this.http
-      .get<PresignedUrlResponse>(
-        `/api/establishment/${this.establishmentService.establishmentId}/bulkupload/signedUrl`,
-        {
-          params,
-        }
-      )
-      .pipe(map((data: PresignedUrlResponse) => data.urls));
+  public getPresignedUrls(payload: PresignedUrlsRequest): Observable<PresignedUrlResponseItem[]> {
+    return this.http.post<PresignedUrlResponseItem[]>(
+      `/api/establishment/${this.establishmentService.establishmentId}/bulkupload/uploaded`,
+      payload
+    );
   }
 
   public uploadFile(file: UploadFile, signedURL: string): Observable<any> {

--- a/src/app/features/bulk-upload/files-upload/files-upload.component.ts
+++ b/src/app/features/bulk-upload/files-upload/files-upload.component.ts
@@ -91,7 +91,6 @@ export class FilesUploadComponent implements OnInit {
 
     if (this.form.valid) {
       this.getPresignedUrls();
-      // this.uploadFiles(this.selectedFiles);
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }

--- a/src/app/shared/validators/custom-form-validators.ts
+++ b/src/app/shared/validators/custom-form-validators.ts
@@ -61,7 +61,7 @@ export class CustomValidators extends Validators {
     const errors: ValidationErrors = {};
     const maxFileSize = 20971520;
 
-    if (files.length !== 3) {
+    if (files.length < 2 || files.length > 3) {
       errors[`filecount`] = true;
     }
 


### PR DESCRIPTION
- change `/api/establishment/:$establishmentId/bulkupload/signedUrl` to `/api/establishment/:$establishmentId/bulkupload/uploaded` in order to consume new api 
- create new interfaces
- allow 2 - 3 files selection