### PR TITLE
Bulk upload complete validate difference report

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -45,6 +45,9 @@ class Establishment {
     //console.log(`WA DEBUG - current establishment (${this._lineNumber}:`, this._currentLine);
   };
 
+  static get EXPECT_JUST_ONE_ERROR() { return 950; }
+  static get MISSING_PRIMARY_ERROR() { return 955; }
+
   static get DUPLICATE_ERROR() { return 998; }
   static get HEADERS_ERROR() { return 999; }
   static get MAIN_SERVICE_ERROR() { return 1000; }
@@ -1453,6 +1456,29 @@ class Establishment {
       errType: `DUPLICATE_ERROR`,
       error: `Duplicate of line ${originalLineNumber}`,
       source: this._currentLine.LOCALESTID,
+    };
+  }
+
+  static justOneEstablishmentError() {
+    return {
+      origin: 'Establishments',
+      lineNumber: 1,
+      errCode: Establishment.EXPECT_JUST_ONE_ERROR,
+      errType: `EXPECT_JUST_ONE_ERROR`,
+      error: 'Expect just one establishment',
+      source: '',
+    };
+  }
+
+  static missingPrimaryEstablishmentError(name) {
+    // TODO - this should be an error, but raising it as a warning for now
+    return {
+      origin: 'Establishments',
+      lineNumber: 1,
+      warnCode: Establishment.MISSING_PRIMARY_ERROR,
+      warnCode: `MISSING_PRIMARY_ERROR`,
+      error: `Missing the primary establishment: ${name}`,
+      source: '',
     };
   }
 

--- a/server/models/BulkImport/csv/metaData.js
+++ b/server/models/BulkImport/csv/metaData.js
@@ -7,6 +7,7 @@ class MetaData {
     this._warnings = null;
     this._errors = null;
     this._records = null;
+    this._deleted = null;
   };
 
   get userName() {
@@ -29,6 +30,9 @@ class MetaData {
   }
   get records() {
     return this._records;
+  }
+  get deleted() {
+    return this._deleted;
   }
 
   set userName(userName) {
@@ -58,6 +62,10 @@ class MetaData {
   set records(records) {
     return this._records = records;
   }
+
+  set deleted(deleted) {
+    return this._deleted = deleted;
+  }
   
   toJSON() {
     return {
@@ -66,7 +74,8 @@ class MetaData {
       fileType: this._fileType ? this._fileType : null,
       records: this._records ? this._records : 0,
       errors: this._errors ? this._errors : 0,
-      warnings: this._warnings ? this._warnings : 0
+      warnings: this._warnings ? this._warnings : 0,
+      deleted: this._deleted ? this._deleted : undefined,
     }
   }
 };

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -217,6 +217,15 @@ class Establishment extends EntityValidator {
         }
     };
 
+    // returns just the set of keys of the associated workers
+    get associatedWorkers() {
+        if (this._workerEntities) {
+            return Object.keys(this._workerEntities);
+        } else {
+            return [];
+        }
+    }
+
     // takes the given JSON document and creates an Establishment's set of extendable properties
     // Returns true if the resulting Establishment is valid; otherwise false
     async load(document, associatedEntities=false) {

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -266,7 +266,8 @@ class Establishment extends EntityValidator {
         if (this._properties.isValid === true) {
             return true;
         } else {
-            if (thisEstablishmentIsValid && Array.isArray(thisEstablishmentIsValid)) {
+            // only add validations if not already existing
+            if (thisEstablishmentIsValid && Array.isArray(thisEstablishmentIsValid) && this._validations.length == 0) {
                 const propertySuffixLength = 'Property'.length * -1;
                 thisEstablishmentIsValid.forEach(thisInvalidProp => {
                     this._validations.push(new ValidationMessage(

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -195,7 +195,8 @@ class Worker extends EntityValidator {
         if (thisWorkerIsValid === true && unmanagedPropertiesValid ) {
             return true;
         } else {
-            if (thisWorkerIsValid && Array.isArray(thisWorkerIsValid)) {
+            // only add validations if not already existing
+            if (thisWorkerIsValid && Array.isArray(thisWorkerIsValid) && this._validations.length == 0) {
                 const propertySuffixLength = 'Property'.length * -1;
                 thisWorkerIsValid.forEach(thisInvalidProp => {
                     this._validations.push(new ValidationMessage(

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -266,9 +266,6 @@ router.route('/validate').put(async (req, res) => {
     
     await Promise.all(createModelPromises).then(function(values){
        values.forEach(myfile=>{
-
-console.log("WA DEBUG - why is establishments metadata null: ", myfile.data.substring(0,50))
-
           if (establishmentRegex.test(myfile.data.substring(0,50))) {
             myDownloads.establishments = myfile.data;
             establishmentMetadata.filename = myfile.filename;
@@ -290,9 +287,6 @@ console.log("WA DEBUG - why is establishments metadata null: ", myfile.data.subs
         console.error("NM: validate.put", err);
     }) ;
 
-    console.log("WA DEBUG - why is establishments metadata null: ", establishmentMetadata)
-    
-  
     const importedEstablishments = myDownloads.establishments ? await csv().fromString(myDownloads.establishments) : null;
     const importedWorkers = myDownloads.workers ? await csv().fromString(myDownloads.workers) :  null;
     const importedTraining = myDownloads.trainings ? await csv().fromString(myDownloads.trainings) : null;
@@ -304,7 +298,7 @@ console.log("WA DEBUG - why is establishments metadata null: ", myfile.data.subs
       isParent,
       { imported: importedEstablishments, establishmentMetadata: establishmentMetadata  },
       { imported: importedWorkers, workerMetadata: workerMetadata },
-      { imported: importedTraining, trainingMetadata: trainingMetadata })
+      { imported: importedTraining, trainingMetadata: trainingMetadata });
 
       // handle parsing errors
       if (!validationResponse.status) {
@@ -681,9 +675,6 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, isPar
   const allEstablishmentsByKey = {}; const allWorkersByKey = {};
 
   // parse and process Establishments CSV
-console.log("WA DEBUG - validateBulkUploadFiles - estabishment metadata: ", establishments.establishmentMetadata)
-
-
   if (Array.isArray(establishments.imported) && establishments.imported.length > 0 && establishments.establishmentMetadata.fileType == "Establishment") {
     await Promise.all(
       establishments.imported.map((thisLine, currentLineNumber) => {
@@ -981,8 +972,6 @@ const validationDifferenceReport = (primaryEstablishmentId, onloadEntities, curr
       const currentWorkers = foundCurrentEstablishment.associatedWorkers;
       const onloadWorkers = thisOnloadEstablishment.associatedWorkers;
       const newWorkers = [], updatedWorkers = [], deletedWorkers = [];
-
-      console.log("WA DEBUG - onload workers: ". onloadWorkers)
 
       // find new/updated/deleted workers
       onloadWorkers.forEach(thisOnloadWorker => {

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -843,7 +843,7 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, isPar
   let notPrimary = true;
   if (primaryEstablishment) {
     const primaryEstablishmentKey = primaryEstablishment.name.replace(/\s/g, "");
-    const onloadedPrimaryEstablishment = myAPIEstablishments[primaryEstablishmentKey];
+    const onloadedPrimaryEstablishment = myAPIEstablishments[allEstablishmentsByKey[primaryEstablishmentKey]];
     if (!onloadedPrimaryEstablishment) {
       csvEstablishmentSchemaErrors.push(CsvEstablishmentValidator.missingPrimaryEstablishmentError(primaryEstablishment.name));
     }


### PR DESCRIPTION
Hi Darren

This is the validation difference report, which needs to load all current known establishments and their workers, and compare against the constructed set of establishments and workers identifying new, updated and deleted.

The difference report is uploaded to S3; I will consume it on the "complete" (the last I have to do to create, update and delete establishments and workers).

The difference report is then used to count the number of deleted establishments and deleted workers, which will be used by the frontend to display a popup modal as a warning.

Note - we cannot delete the primary establishment (the establishment of the logged in user). I do need to raise an error validation message. I'll have a look at doing that whilst you review this puppy.

Additionally, thus PR includes https://trello.com/c/F9jYfkhS; a fixed for a defect that was duplicate entity validation messages.

Thanks