### PR TITLE
feature | bulk upload | cleanup interfaces

### DIFF
--- a/src/app/core/model/bulk-upload.model.ts
+++ b/src/app/core/model/bulk-upload.model.ts
@@ -17,13 +17,13 @@ export interface PresignedUrlsRequest {
 }
 
 export interface UploadFileRequestItem {
-  file: UploadFile;
+  file: File;
   signedUrl: string;
 }
 
-export interface UploadFile extends File {
+export interface UploadedFile {
+  name: string;
   errors?: number;
-  extension: string;
   fileType?: string;
   records?: number;
   status?: FileValidateStatus;
@@ -39,7 +39,7 @@ export interface ValidatedFilesResponse {
 export interface ValidatedFile {
   errors: number;
   filename: string;
-  fileType?: string;
+  fileType: string;
   records: number;
   warnings: number;
 }

--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { PresignedUrlResponseItem, PresignedUrlsRequest, UploadFile, ValidatedFilesResponse } from '@core/model/bulk-upload.model';
+import { PresignedUrlResponseItem, PresignedUrlsRequest, ValidatedFilesResponse } from '@core/model/bulk-upload.model';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { BehaviorSubject, Observable } from 'rxjs';
@@ -11,8 +11,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 })
 export class BulkUploadService {
   public exposeForm$: BehaviorSubject<FormGroup> = new BehaviorSubject(null);
-  public selectedFiles$: BehaviorSubject<Array<UploadFile>> = new BehaviorSubject(null);
-  public uploadedFiles$: BehaviorSubject<Array<UploadFile>> = new BehaviorSubject(null);
+  public selectedFiles$: BehaviorSubject<File[]> = new BehaviorSubject(null);
   public validationErrors$: BehaviorSubject<Array<ErrorDefinition>> = new BehaviorSubject(null);
 
   constructor(private http: HttpClient, private establishmentService: EstablishmentService) {}
@@ -24,7 +23,7 @@ export class BulkUploadService {
     );
   }
 
-  public uploadFile(file: UploadFile, signedURL: string): Observable<any> {
+  public uploadFile(file: File, signedURL: string): Observable<any> {
     const headers = new HttpHeaders({ 'Content-Type': file.type });
     return this.http.put(signedURL, file, { headers, reportProgress: true, observe: 'events' });
   }

--- a/src/app/features/bulk-upload/files-upload/files-upload.component.ts
+++ b/src/app/features/bulk-upload/files-upload/files-upload.component.ts
@@ -4,7 +4,6 @@ import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/fo
 import {
   PresignedUrlResponseItem,
   PresignedUrlsRequest,
-  UploadFile,
   UploadFileRequestItem,
 } from '@core/model/bulk-upload.model';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
@@ -23,7 +22,7 @@ export class FilesUploadComponent implements OnInit {
   public filesUploading = false;
   public filesUploaded = false;
   public submitted = false;
-  private selectedFiles: Array<UploadFile>;
+  private selectedFiles: File[];
   private bytesTotal = 0;
   private bytesUploaded: number[] = [];
   private presignedUrlsSubcription$: Subscription = new Subscription();
@@ -58,8 +57,6 @@ export class FilesUploadComponent implements OnInit {
   public onFilesSelection($event: Event): void {
     const target = $event.target || $event.srcElement;
     this.selectedFiles = Array.from(target['files']);
-    this.selectedFiles.map((file: UploadFile) => (file.extension = this.bulkUploadService.getFileType(file.name)));
-
     this.fileUpload.setValidators(CustomValidators.checkFiles(this.fileUpload, this.selectedFiles));
     this.bulkUploadService.selectedFiles$.next(this.selectedFiles);
 
@@ -70,7 +67,7 @@ export class FilesUploadComponent implements OnInit {
 
   private getPresignedUrlsRequest(): PresignedUrlsRequest {
     const request: PresignedUrlsRequest = { files: [] };
-    this.selectedFiles.forEach((file: UploadFile) => {
+    this.selectedFiles.forEach((file: File) => {
       request.files.push({ filename: file.name });
     });
 
@@ -100,7 +97,7 @@ export class FilesUploadComponent implements OnInit {
     this.bytesUploaded = [];
     const request: UploadFileRequestItem[] = [];
 
-    this.selectedFiles.forEach((file: UploadFile) => {
+    this.selectedFiles.forEach((file: File) => {
       this.bytesTotal += file.size;
       this.bytesUploaded.push(0);
 
@@ -135,7 +132,6 @@ export class FilesUploadComponent implements OnInit {
         null,
         () => this.cancelUpload(),
         () => {
-          this.bulkUploadService.uploadedFiles$.next(this.selectedFiles);
           this.filesUploading = false;
           this.filesUploaded = true;
         }

--- a/src/app/features/bulk-upload/selected-files-list/selected-files-list.component.html
+++ b/src/app/features/bulk-upload/selected-files-list/selected-files-list.component.html
@@ -9,7 +9,7 @@
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row" *ngFor="let file of selectedFiles">
       <td class="govuk-table__cell" scope="row">{{ file.name }}</td>
-      <td class="govuk-table__cell">{{ file.extension }}</td>
+      <td class="govuk-table__cell">{{ getFileType(file.name) }}</td>
       <td class="govuk-table__cell">{{ transformFileSize(file.size) }}</td>
     </tr>
   </tbody>

--- a/src/app/features/bulk-upload/selected-files-list/selected-files-list.component.ts
+++ b/src/app/features/bulk-upload/selected-files-list/selected-files-list.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { UploadFile } from '@core/model/bulk-upload.model';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { Subscription } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
@@ -9,7 +8,7 @@ import { distinctUntilChanged } from 'rxjs/operators';
   templateUrl: './selected-files-list.component.html',
 })
 export class SelectedFilesListComponent implements OnInit, OnDestroy {
-  public selectedFiles: Array<UploadFile>;
+  public selectedFiles: File[];
   private subscriptions: Subscription = new Subscription();
 
   constructor(private bulkUploadService: BulkUploadService) {}
@@ -18,7 +17,7 @@ export class SelectedFilesListComponent implements OnInit, OnDestroy {
     this.setupSubscription();
   }
 
-  private transformFileSize(fileSize: number): string {
+  public transformFileSize(fileSize: number): string {
     const fileSizeInKB: number = Math.round(fileSize / 1000);
 
     if (fileSizeInKB < 1) {
@@ -32,11 +31,15 @@ export class SelectedFilesListComponent implements OnInit, OnDestroy {
     }
   }
 
+  public getFileType(fileName: string): string {
+    return this.bulkUploadService.getFileType(fileName);
+  }
+
   private setupSubscription(): void {
     this.subscriptions.add(
       this.bulkUploadService.selectedFiles$
         .pipe(distinctUntilChanged())
-        .subscribe((selectedFiles: Array<UploadFile>) => {
+        .subscribe((selectedFiles: File[]) => {
           if (selectedFiles) {
             this.selectedFiles = selectedFiles;
           }
@@ -46,11 +49,8 @@ export class SelectedFilesListComponent implements OnInit, OnDestroy {
 
   /**
    * Unsubscribe to ensure no memory leaks
-   * And set selected files to none otherwise
-   * on route revisit the selected files are cached
    */
   ngOnDestroy() {
-    this.bulkUploadService.selectedFiles$.next(null);
     this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.html
+++ b/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.html
@@ -39,7 +39,7 @@
           </p>
         </td>
         <td class="govuk-table__cell" [class.govuk-error-table__cell]="file.errors">
-          {{ file.fileType ? file.fileType : file.extension }}
+          {{ file.fileType ? file.fileType : getFileType(file.name) }}
         </td>
         <td class="govuk-table__cell" [class.govuk-error-table__cell]="file.errors">
           {{ file.records ? file.records : '-' }}

--- a/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.ts
+++ b/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.ts
@@ -8,7 +8,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { saveAs } from 'file-saver';
 import { filter } from 'lodash';
 import { Subscription } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-uploaded-files-list',
@@ -16,7 +16,7 @@ import { take } from 'rxjs/operators';
   providers: [I18nPluralPipe],
 })
 export class UploadedFilesListComponent implements OnInit, OnDestroy {
-  public uploadedFiles: Array<UploadedFile>;
+  public uploadedFiles: UploadedFile[];
   public validationComplete = false;
   public totalWarnings = 0;
   public totalErrors = 0;
@@ -34,14 +34,11 @@ export class UploadedFilesListComponent implements OnInit, OnDestroy {
 
   public setupSubscription(): void {
     this.subscriptions.add(
-      this.bulkUploadService.selectedFiles$.subscribe((selectedFiles: File[]) => {
-        if (selectedFiles) {
-          this.uploadedFiles = [];
-          selectedFiles.forEach((selectedFile: File) => {
-            this.uploadedFiles.push({ name: selectedFile.name });
-          });
-        }
-      })
+      this.bulkUploadService.selectedFiles$
+        .pipe(
+          map((selectedFiles: File[]) => selectedFiles.map((file: File) => ({ name: file.name })))
+        )
+        .subscribe((uploadedFiles: UploadedFile[]) => this.uploadedFiles = uploadedFiles)
     );
   }
 

--- a/src/app/shared/validators/custom-form-validators.ts
+++ b/src/app/shared/validators/custom-form-validators.ts
@@ -1,6 +1,5 @@
 import { AbstractControl, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { FILE_UPLOAD_TYPES } from '@core/constants/constants';
-import { UploadFile } from '@core/model/bulk-upload.model';
 
 export class CustomValidators extends Validators {
   static maxWords(limit: number): ValidatorFn {
@@ -57,7 +56,7 @@ export class CustomValidators extends Validators {
     }
   }
 
-  static checkFiles(fileUpload, files: Array<UploadFile>): ValidatorFn {
+  static checkFiles(fileUpload, files: File[]): ValidatorFn {
     const errors: ValidationErrors = {};
     const maxFileSize = 20971520;
 
@@ -65,15 +64,18 @@ export class CustomValidators extends Validators {
       errors[`filecount`] = true;
     }
 
-    files.forEach((file: UploadFile) => {
+    files.forEach((file: File) => {
       if (file.size > maxFileSize) {
         errors['filesize'] = true;
         return;
       }
     });
 
-    files.forEach((file: UploadFile) => {
-      if (!FILE_UPLOAD_TYPES.includes(file.extension)) {
+    files.forEach((file: File) => {
+      const parts: Array<string> = file.name.split('.');
+      const fileExtension: string = parts[parts.length - 1].toUpperCase();
+
+      if (!FILE_UPLOAD_TYPES.includes(fileExtension)) {
         errors['filetype'] = true;
         return;
       }


### PR DESCRIPTION
- renamed `UploadFile` interface to `UploadedFile` and ensure its not extending `File`
- made `selectedFiles$` observable to type `File[]` and removed unnecessary `uploadedFiles$` observable