### PR TITLE
Bulk upload complete create, update and delete establishments and workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Thumbs.db
 # localhost config variations
 /server/config/localhost.*.yaml
 /server/config/localhost-*.yaml
+
+// nodemon localisations
+nodemon.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -15151,6 +15151,11 @@
       "integrity": "sha1-AbcCR6bTwkZ/cMRXle9eoYzhkdU=",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
+    },
     "uglify-js": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "slack": "^11.0.1",
     "slugify": "^1.3.4",
     "swagger-stats": "^0.95.7",
+    "ua-parser-js": "^0.7.20",
     "url-parse": "^1.4.7",
     "util": "^0.11.1",
     "uuid": "^3.3.2",

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -2130,6 +2130,7 @@ class Worker {
           id: this._nursingSpecialist
         } : undefined,
       amhp: this._amhp ? this._amhp : undefined,
+      completed: true,                                    // on bulk upload, every Worker record is naturally completed!
     };
 
     if (this._startInsect) {

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -2191,14 +2191,15 @@ class Worker {
     }
 
     if (this._daysSick) {
-      if (Number.isInteger(this._daysSick)) {
+      // days sick is decimal
+      if (this._daysSick !== 'No') {
         changeProperties.daysSick = {
           value : 'Yes',
           days: this._daysSick,
         };
       } else {
         changeProperties.daysSick = {
-          value : this._daysSick,
+          value : 'No',
         };
       }
     }
@@ -2217,26 +2218,26 @@ class Worker {
     }
 
     if (this._contHours) {
-      if (Number.isInteger(this._contHours)) {
+      if (this._contHours !== 'No') {
         changeProperties.weeklyHoursContracted = {
           value: 'Yes',
           hours: this._contHours,
         };
       } else {
         changeProperties.weeklyHoursContracted = {
-          value: this._contHours,
+          value: 'No',
         };
       }
     }
     if (this._avgHours) {
-      if (Number.isInteger(this._avgHours)) {
+      if (this._avgHours !== 'No') {
         changeProperties.weeklyHoursAverage = {
           value: 'Yes',
           hours: this._avgHours,
         };
       } else {
         changeProperties.weeklyHoursAverage = {
-          value: this._avgHours,
+          value: 'No',
         };
       }
     }

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -125,6 +125,14 @@ class Worker extends EntityValidator {
         this._trainingEntities.push(training);    
     };
 
+    get establishmentId() {
+        return this._establishmentId;
+    }
+
+    set establishmentId(establishmentId) {
+        this._establishmentId = establishmentId;
+    }
+
     get nameOrId() {
         // returns the name or id property - if known
         if (this._properties.get('NameOrId') && this._properties.get('NameOrId').property) {

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -570,7 +570,7 @@ class Worker extends EntityValidator {
 
     // "deletes" this Worker by setting the Worker to archived - does not delete any data!
     // Can throw "WorkerDeleteException"
-    async archive(deletedBy) {
+    async archive(deletedBy, externalTransaction=null) {
         try {
             
             const updatedTimestamp = new Date();
@@ -578,6 +578,8 @@ class Worker extends EntityValidator {
             // need to update the existing Worker record and add an
             //  deleted audit event within a single transaction
             await models.sequelize.transaction(async t => {
+                const thisTransaction = externalTransaction ? externalTransaction : t;
+
                 // now append the extendable properties
                 const updateDocument = {
                     archived: true,
@@ -602,7 +604,7 @@ class Worker extends EntityValidator {
                                                     uid: this.uid
                                                 },
                                                 attributes: ['id', 'updated'],
-                                                transaction: t,
+                                                transaction: thisTransaction,
                                             });
 
                 if (updatedRecordCount === 1) {
@@ -617,7 +619,7 @@ class Worker extends EntityValidator {
                         username: deletedBy,
                         type: 'deleted'}];
                         // having updated the record, create the audit event
-                    await models.workerAudit.bulkCreate(allAuditEvents, {transaction: t});
+                    await models.workerAudit.bulkCreate(allAuditEvents, {transaction: thisTransaction});
 
                     this._log(Worker.LOG_INFO, `Archived Worker with uid (${this._uid}) and id (${this._id})`);
 

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -1450,7 +1450,7 @@ router.route('/complete').post(async (req, res) => {
 
             // current is already restored, so simply need to delete it
             if (foundCurrentEstablishment) {
-              updateEstablishmentPromises.push(foundCurrentEstablishment.delete(theLoggedInUser, t));
+              updateEstablishmentPromises.push(foundCurrentEstablishment.delete(theLoggedInUser, t, true));
             }
           });
 

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -6,6 +6,8 @@ const csv = require('csvtojson');
 const Stream = require('stream');
 const dbmodels = require('../../models');
 
+const UserAgentParser = require('ua-parser-js');
+
 const router = express.Router();
 const s3 = new AWS.S3({
   region: appConfig.get('bulkupload.region').toString(),
@@ -1268,7 +1270,13 @@ const validationDifferenceReport = (primaryEstablishmentId, onloadEntities, curr
 
 };
 
-router.route('/report').get(async (req, res) => {  
+router.route('/report').get(async (req, res) => {
+  // this report returns as plain text. The report line endings are dependent on not the
+  //  runtime platform, but on the requesting platform (99.9999% of the users will be on Windows)
+  const userAgent = UserAgentParser(req.headers['user-agent']);
+  const windowsTest = /windows/i;
+  const NEWLINE = windowsTest.test(userAgent.os.name) ? "\r\n" : "\n";
+
   try {
     const params = {
       Bucket: appConfig.get('bulkupload.bucketname').toString(), 
@@ -1297,33 +1305,33 @@ router.route('/report').get(async (req, res) => {
 
     const errorTitle = '* Errors (will cause file(s) to be rejected) *';
     const errorPadding = '*'.padStart(errorTitle.length, '*');
-    readable.push(`${errorPadding}\n${errorTitle}\n${errorPadding}\n\n`);
+    readable.push(`${errorPadding}${NEWLINE}${errorTitle}${NEWLINE}${errorPadding}${NEWLINE}${NEWLINE}`);
 
     errorsAndWarnings
       .reduce((acc, val) => acc.concat(val), [])
       .filter(msg => msg.errCode && msg.errType)
       .sort((a,b) => a.errCode - b.errCode)
-      .map(item => readable.push(`${item.origin} - ${item.error}, ${item.errCode} on line ${item.lineNumber}\n`));
+      .map(item => readable.push(`${item.origin} - ${item.error}, ${item.errCode} on line ${item.lineNumber}${NEWLINE}`));
     
     const warningTitle = '* Warnings (files will be accepted but data is incomplete or internally inconsistent) *';
     const warningPadding = '*'.padStart(warningTitle.length, '*');
-    readable.push(`\n${warningPadding}\n${warningTitle}\n${warningPadding}\n\n`);
+    readable.push(`${NEWLINE}${warningPadding}${NEWLINE}${warningTitle}${NEWLINE}${warningPadding}${NEWLINE}${NEWLINE}`);
     
     errorsAndWarnings
       .reduce((acc, val) => acc.concat(val), [])
       .filter(msg => msg.warnCode && msg.warnType)
       .sort((a,b) => a.warnCode - b.warnCode)
-      .map(item => readable.push(`${item.origin} - ${item.warning}, ${item.warnCode} on line ${item.lineNumber}\n`));
+      .map(item => readable.push(`${item.origin} - ${item.warning}, ${item.warnCode} on line ${item.lineNumber}${NEWLINE}`));
 
     const laTitle = '* You are sharing data with the following Local Authorities *';
     const laPadding = '*'.padStart(laTitle.length, '*');
-    readable.push(`\n${laPadding}\n${laTitle}\n${laPadding}\n\n`);
+    readable.push(`${NEWLINE}${laPadding}${NEWLINE}${laTitle}${NEWLINE}${laPadding}${NEWLINE}${NEWLINE}`);
 
     entities ? entities
       .map(en => en.localAuthorities !== undefined ? en.localAuthorities : [])
       .reduce((acc, val) => acc.concat(val), [])
       .sort((a,b) => a.name > b.name)
-      .map(item => readable.push(`${item.name}\n`)) : true;
+      .map(item => readable.push(`${item.name}${NEWLINE}`)) : true;
     
     readable.push(null);
 

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -945,7 +945,7 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, isPar
   if (Array.isArray(training.imported) && training.imported.length > 0 && training.trainingMetadata.fileType == "Training") {
     await Promise.all(
       training.imported.map((thisLine, currentLineNumber) => {
-        return _validateTrainingCsv(thisLine, currentLineNumber=2, csvTrainingSchemaErrors, myTrainings, myAPITrainings);
+        return _validateTrainingCsv(thisLine, currentLineNumber+2, csvTrainingSchemaErrors, myTrainings, myAPITrainings);
       }) 
     );
 

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -1466,9 +1466,9 @@ router.route('/complete').post(async (req, res) => {
           console.log("WA DEBUG - watiing for updates/deletes to finish 'loading'")
           await Promise.all(updateEstablishmentPromises);
 
-          // and now all saves for new, updated and deleted establishments
+          // and now all saves for new, updated and deleted establishments, including their associated entities
           console.log("WA DEBUG - waiting for saves to finish")
-          await Promise.all(updatedEstablishments.map(toSave => toSave.save(theLoggedInUser, true, 0, t)));
+          await Promise.all(updatedEstablishments.map(toSave => toSave.save(theLoggedInUser, true, 0, t, true)));
 
           console.log("WA DEBUG - saves have completed")
 

--- a/server/routes/establishments/qualification/index.js
+++ b/server/routes/establishments/qualification/index.js
@@ -83,7 +83,6 @@ router.route('/').post(async (req, res) => {
     const establishmentId = req.establishmentId;
     const workerUid = req.params.workerId;
 
-    console.log("WA DEBUG - POST qualification - establishment id/worker id",establishmentId, workerUid);
     const thisQualificationRecord = new Qualification(establishmentId, workerUid);
     
     try {


### PR DESCRIPTION
Hi Darren

This PR extends from the previous one which implemented basic create, update and delete on Establishments.

The PR builds on that, by making an Establishment create, update and delete associated Workers.

For new Establishments, it is simply a case of passing down the new establishment ID in the associate set of Workers to be able to create the foreign key between Worker/Establishment records.

For existing Establishments, it gets a little hard, in that when loading the Establishment, new Workers result in new associations, existing Workers are passed new content to load (update) and  existing associated Workers not in the new set, are marked ready for deletion upon save.

When deleting an Establishment, it is only good practice to delete all associated Workers too.

I've done a quick fix on the validation report to make it readable on a Windows platform.

And to the Workers CSV line validator fix three properties that are in fact decimal numbers not integers when trying to render the JSON for the API.