### PR TITLE
Bulk upload complete training and qualifications

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -5,7 +5,7 @@ aws:
         wallet: dev/api
 
 db:
-    pool: 5
+    pool: 15
     ssl: true
     username: sfcapp
     client_ssl:

--- a/server/config/localhost.yaml
+++ b/server/config/localhost.yaml
@@ -10,7 +10,7 @@ jwt:
     ttl:
         login: 60
 db:
-    pool: 5
+    pool: 15
     ssl: false
     username: sfcadmin
     client_ssl:

--- a/server/config/production.yaml
+++ b/server/config/production.yaml
@@ -13,7 +13,7 @@ jwt:
         login: 5
 
 db:
-    pool: 5
+    pool: 15
     ssl: true
     username: sfcapp
     client_ssl:

--- a/server/config/test.yaml
+++ b/server/config/test.yaml
@@ -5,7 +5,7 @@ aws:
         wallet: staging/api
 
 db:
-    pool: 5
+    pool: 15
     ssl: true
     username: sfcapp
     database: sfctstdb

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -248,7 +248,7 @@ class Establishment extends EntityValidator {
                         // check if we already have the Worker associated, before associating a new worker
                         if (this._workerEntities[workerKey]) {
                             // else we already have this worker, load changes against it
-                            promises.push(this._workerEntities[workerKey].load(thisWorker));
+                            promises.push(this._workerEntities[workerKey].load(thisWorker, true));
 
                         } else {
                             const newWorker = new Worker(null);
@@ -316,10 +316,10 @@ class Establishment extends EntityValidator {
                     return thisWorker;
                 });
     
-                await Promise.all(workersAsArray.map(thisWorkerToSave => thisWorkerToSave.save(savedBy, bulkUploaded, 0, externalTransaction)));
+                await Promise.all(workersAsArray.map(thisWorkerToSave => thisWorkerToSave.save(savedBy, bulkUploaded, 0, externalTransaction, true)));
 
                 // and now all the associated Workers marked for deletion
-                await Promise.all(this._readyForDeletionWorkers.map(thisWorkerToSave => thisWorkerToSave.archive(savedBy,externalTransaction)));
+                await Promise.all(this._readyForDeletionWorkers.map(thisWorkerToSave => thisWorkerToSave.archive(savedBy,externalTransaction, true)));
             } catch (err) {
                 console.error('Establishment::saveAssociatedEntities error: ', err);
                 // rethrow error to ensure the transaction is rolled back

--- a/server/models/classes/qualification.js
+++ b/server/models/classes/qualification.js
@@ -229,16 +229,6 @@ class Qualification extends EntityValidator {
                 this._log(Qualification.LOG_ERROR, `qualification failed validation: qualification.id (${document.qualification.id}) must be an integer`);
                 returnStatus = false;
             }
-            if (document.qualification.level && !Number.isInteger(document.qualification.level)) {
-                this._validations.push(new ValidationMessage(
-                    ValidationMessage.ERROR,
-                    103,
-                    `qualification.level (${document.qualification.level}) must be an integer`,
-                    ['Qualification']
-                ));
-                this._log(Qualification.LOG_ERROR, `qualification failed validation: qualification.level (${document.qualification.level}) must be an integer`);
-                returnStatus = false;
-            }
             let foundQualification = null;
             if (document.qualification.id) {
                 foundQualification = qualifications.find(thisQualification => thisQualification.id === document.qualification.id);
@@ -363,9 +353,6 @@ class Qualification extends EntityValidator {
         if (mustSave && this._isNew) {
             // create new Qualification Record
             try {
-                console.log("WA DEBUG - saving qualification: ", this._qualification)
-
-
                 // must validate the Worker record - to get the workerFk (integer)
                 let workerRecord = null;
 
@@ -399,9 +386,6 @@ class Qualification extends EntityValidator {
                         notes: this._notes,
                         attributes: ['uid', 'created', 'updated'],
                     };
-                    console.log("WA DEBUG - saving qualification found associated worker record: ", creationDocument)
-
-                    //console.log("WA DEBUG creation document: ", creationDocument)
     
                     // need to create the Training record only
                     //  in one transaction

--- a/server/models/classes/qualification.js
+++ b/server/models/classes/qualification.js
@@ -44,6 +44,7 @@ class Qualification extends EntityValidator {
 
         this._establishmentId = establishmentId;
         this._workerUid = workerUid;
+        this._workerId = null;
         this._id = null;
         this._uid = null;
         this._created = null;
@@ -93,6 +94,25 @@ class Qualification extends EntityValidator {
         if (this._logLevel >= level) {
             console.log(`TODO: (${level}) - Qualification class: `, msg);
         }
+    }
+
+    get workerId() {
+        return this._workerUid;
+    }
+    get workerUid() {
+        return this._workerUid;
+    }
+    get establishmentId() {
+        return this._establishmentId;
+    }
+    set workerId(newID) {
+        this._workerId = newID;
+    }
+    set workerUid(newUid) {
+        this._workerUid = newUid;
+    }
+    set establishmentId(newId) {
+        this._establishmentId = newId;
     }
 
     //
@@ -343,16 +363,27 @@ class Qualification extends EntityValidator {
         if (mustSave && this._isNew) {
             // create new Qualification Record
             try {
-                // must validate the Worker record - to get the workerFk (integer)
-                const workerRecord = await models.worker.findOne({
-                    where: {
-                        establishmentFk: this._establishmentId,
-                        uid: this._workerUid,
-                        archived: false
-                    },
-                    attributes: ['id']
-                });
+                console.log("WA DEBUG - saving qualification: ", this._qualification)
 
+
+                // must validate the Worker record - to get the workerFk (integer)
+                let workerRecord = null;
+
+                if (!this._workerId) {
+                    workerRecord = await models.worker.findOne({
+                        where: {
+                            establishmentFk: this._establishmentId,
+                            uid: this._workerUid,
+                            archived: false
+                        },
+                        attributes: ['id']
+                    });    
+                } else {
+                    workerRecord = {
+                        id: this._workerId
+                    };
+                }
+                
                 if (workerRecord && workerRecord.id) {
 
                     const now = new Date();
@@ -368,6 +399,7 @@ class Qualification extends EntityValidator {
                         notes: this._notes,
                         attributes: ['uid', 'created', 'updated'],
                     };
+                    console.log("WA DEBUG - saving qualification found associated worker record: ", creationDocument)
 
                     //console.log("WA DEBUG creation document: ", creationDocument)
     

--- a/server/models/classes/training.js
+++ b/server/models/classes/training.js
@@ -23,6 +23,7 @@ class Training extends EntityValidator {
         
         this._establishmentId = establishmentId;
         this._workerUid = workerUid;
+        this._workerId = null;
         this._id = null;
         this._uid = null;
         this._created = null;
@@ -75,6 +76,25 @@ class Training extends EntityValidator {
         if (this._logLevel >= level) {
             console.log(`TODO: (${level}) - Training class: `, msg);
         }
+    }
+
+    get workerId() {
+        return this._workerId;
+    }
+    get workerUid() {
+        return this._workerUid;
+    }
+    get establishmentId() {
+        return this._establishmentId;
+    }
+    set workerId(newID) {
+        this._workerId = newID;
+    }
+    set workerUid(newUid) {
+        this._workerUid = newUid;
+    }
+    set establishmentId(newId) {
+        this._establishmentId = newId;
     }
 
     //
@@ -431,15 +451,24 @@ class Training extends EntityValidator {
             // create new Training Record
             try {
                 // must validate the Worker record
-                const workerRecord = await models.worker.findOne({
-                    where: {
-                        establishmentFk: this._establishmentId,
-                        uid: this._workerUid,
-                        archived: false
-                    },
-                    attributes: ['id']
-                });
-
+                let workerRecord = null;
+                
+                
+                if (!this._workerId) {
+                    workerRecord = await models.worker.findOne({
+                        where: {
+                            establishmentFk: this._establishmentId,
+                            uid: this._workerUid,
+                            archived: false
+                        },
+                        attributes: ['id']
+                    });    
+                } else {
+                    workerRecord = {
+                        id: this._workerId
+                    };
+                }
+                
                 if (workerRecord && workerRecord.id) {
                     const now = new Date();
                     const creationDocument = {

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -246,6 +246,7 @@ class Worker extends EntityValidator {
 
                 // now create new training records
                 this._trainingEntities.forEach(currentTrainingRecord => {
+                    currentTrainingRecord.workerId = this._id;
                     currentTrainingRecord.workerUid = this._uid;
                     currentTrainingRecord.establishmentId = this._establishmentId;
                     newTrainingPromises.push(currentTrainingRecord.save(savedBy, bulkUploaded, 0, externalTransaction));

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -122,7 +122,7 @@ class Worker extends EntityValidator {
     // this method add this given training (entity) as an association to this worker entity - (bulk import)
     //  - note, no unique key for a training; just simply an array of
     associateTraining(training) {
-        this._trainingEntities.push(training);    
+        this._trainingEntities.push(training);
     };
 
     get establishmentId() {
@@ -159,7 +159,12 @@ class Worker extends EntityValidator {
             if (associatedEntities) {
                 const promises = [];
 
+                // training records and qualifications are no change managed
+                //  therefore, simply remove all existing associations
+                //  and create new ones
+
                 // first training records
+                this._trainingEntities = [];
                 if (document.training && Array.isArray(document.training)) {
                     document.training.forEach(thisTraining => {
                         const newTrainingRecord = new Training(null, null);
@@ -170,6 +175,7 @@ class Worker extends EntityValidator {
                 }
 
                 // and qualifications records
+                this._qualificationsEntities = [];
                 if (document.qualifications && Array.isArray(document.qualifications)) {
                     document.qualifications.forEach(thisQualificationRecord => {
                         const newQualificationRecord = new Qualification(null, null);
@@ -177,11 +183,12 @@ class Worker extends EntityValidator {
                         this.associateQualification(newQualificationRecord);
                         promises.push(newQualificationRecord.load(thisQualificationRecord));
                     });
-                }                
+                }
 
                 // wait for loading of all training and qualification records
                 await Promise.all(promises);
             }
+
         } catch (err) {
             this._log(Worker.LOG_ERROR, `Woker::load - failed: ${err}`);
             throw new WorkerExceptions.WorkerJsonException(
@@ -221,9 +228,65 @@ class Worker extends EntityValidator {
         }
     }
 
+    async saveAssociatedEntities(savedBy, bulkUploaded=false, externalTransaction)  {
+        const newQualificationsPromises = [];
+        const newTrainingPromises = [];
+
+        try {
+            // there is no change audit on training; simply delete all that is there and recreate
+            if (this._trainingEntities && this._trainingEntities.length > 0) {
+                // delete all existing training records for this worker
+                await models.workerTraining.destroy(
+                    {
+                        where: {
+                            workerFk: this._id
+                        },
+                        transaction: externalTransaction,
+                    });
+
+                // now create new training records
+                this._trainingEntities.forEach(currentTrainingRecord => {
+                    currentTrainingRecord.workerUid = this._uid;
+                    currentTrainingRecord.establishmentId = this._establishmentId;
+                    newTrainingPromises.push(currentTrainingRecord.save(savedBy, bulkUploaded, 0, externalTransaction));
+                })
+            }
+
+            /*
+            // there is no change audit on qualifications; simply delete all that is there and recreate
+            if (this._qualificationsEntities && this._qualificationsEntities.length > 0) {
+                // delete all existing training records for this worker
+                await models.workerQualifications.destroy(
+                    {
+                        where: {
+                            workerFk: this._id
+                        },
+                        transaction: externalTransaction,
+                    });
+
+                // now create new training records
+                this._qualificationsEntities.forEach(currentQualificationRecord => {
+                    currentQualificationRecord.workerId = this._id;
+                    currentQualificationRecord.workerUid = this._uid;
+                    currentQualificationRecord.establishmentId = this._establishmentId;
+                    newQualificationsPromises.push(currentQualificationRecord.save(savedBy, bulkUploaded, 0, externalTransaction));
+                })
+            }
+            */
+
+            await Promise.all(newTrainingPromises);
+            await Promise.all(newQualificationsPromises);
+        } catch (err) {
+            console.error('Worker::saveAssociatedEntities error: ', err);
+            // rethrow error to ensure the transaction is rolled back
+            throw err;
+        }
+
+    }
+
     // saves the Worker to DB. Returns true if saved; false is not.
     // Throws "WorkerSaveException" on error
-    async save(savedBy, bulkUploaded=false, ttl=0, externalTransaction=null) {
+    async save(savedBy, bulkUploaded=false, ttl=0, externalTransaction=null, associatedEntities=false) {
         let mustSave = this._initialise();
 
         if (!this.uid) {
@@ -285,6 +348,13 @@ class Worker extends EntityValidator {
                             };
                         }));
                     await models.workerAudit.bulkCreate(allAuditEvents, {transaction: thisTransaction});
+
+
+                    console.log("WA DEBUG - saving worker: ", this.nameOrId, associatedEntities)
+
+                    if (associatedEntities) {
+                        await this.saveAssociatedEntities(savedBy, bulkUploaded, thisTransaction);
+                    }
 
                     this._log(Worker.LOG_INFO, `Created Worker with uid (${this._uid}) and id (${this._id})`);
                 });
@@ -409,6 +479,10 @@ class Worker extends EntityValidator {
                         const completedProperty = this._properties.get('Completed');
                         if (completedProperty && completedProperty.modified) {
                             await WdfCalculator.calculate(savedBy.toLowerCase(), this._establishmentId, null, thisTransaction);
+                        }
+
+                        if (associatedEntities) {
+                            await this.saveAssociatedEntities(savedBy, bulkUploaded, thisTransaction);
                         }
 
                         this._log(Worker.LOG_INFO, `Updated Worker with uid (${this._uid}) and id (${this._id})`);
@@ -570,7 +644,7 @@ class Worker extends EntityValidator {
 
     // "deletes" this Worker by setting the Worker to archived - does not delete any data!
     // Can throw "WorkerDeleteException"
-    async archive(deletedBy, externalTransaction=null) {
+    async archive(deletedBy, externalTransaction=null, associatedEntities=false) {
         try {
             
             const updatedTimestamp = new Date();
@@ -620,6 +694,11 @@ class Worker extends EntityValidator {
                         type: 'deleted'}];
                         // having updated the record, create the audit event
                     await models.workerAudit.bulkCreate(allAuditEvents, {transaction: thisTransaction});
+
+                    // delete all training and qualifications for this user??
+                    if (associatedEntities) {
+                        // TODO - to be confirmed
+                    }
 
                     this._log(Worker.LOG_INFO, `Archived Worker with uid (${this._uid}) and id (${this._id})`);
 

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -253,7 +253,6 @@ class Worker extends EntityValidator {
                 })
             }
 
-            /*
             // there is no change audit on qualifications; simply delete all that is there and recreate
             if (this._qualificationsEntities && this._qualificationsEntities.length > 0) {
                 // delete all existing training records for this worker
@@ -273,7 +272,6 @@ class Worker extends EntityValidator {
                     newQualificationsPromises.push(currentQualificationRecord.save(savedBy, bulkUploaded, 0, externalTransaction));
                 })
             }
-            */
 
             await Promise.all(newTrainingPromises);
             await Promise.all(newQualificationsPromises);


### PR DESCRIPTION
Hey Darren

https://trello.com/c/QAzbzesV

Well this should have been easier than I had expected, but it pretty much done.

This PR includes updating associated qualifications and training records when a Worker entity is saved. As there is no change audit on training or qualifications, its a simple case of delete all such records, then create new records with the data as given on bulk upload last Worker records.

To allow for that, I had to introduce setters on the Training/Qualification entities to set the associated establishment and worker id, necessary to create the foreign keys in database. I also took the opportunity for a quick optimisation in each of `Qualification::save` and `Training::save` so if the `WorkerID` is known (it would be on bulk upload through the associations) then no need to look up using the Worker UID (as required when called upon from frontend).

There is one known defect - that associated with creating the qualification records; for some reason, the onload qualifications are missing the `qualification.id` - I've raised a defect for that whilst commenting out the code, because I want to get this card moved into test and ready for the demo.