### PR TITLE
bugfix | dont call prevalidate api on fetched uploaded-files

### DIFF
--- a/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.ts
+++ b/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.ts
@@ -41,7 +41,7 @@ export class UploadedFilesListComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.bulkUploadService.uploadedFiles$.subscribe((uploadedFiles: ValidatedFile[]) => {
         if (uploadedFiles) {
-          this.preValidateFiles();
+          this.checkForMandatoryFiles(uploadedFiles);
         }
       })
     );


### PR DESCRIPTION
- no need to invoke the prevalidate files again as this step is immediately done once files are uploaded to s3