### PR TITLE
Bulk Upload and Main Job "Other" Fixes

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -1481,12 +1481,11 @@ class Establishment {
   }
 
   static missingPrimaryEstablishmentError(name) {
-    // TODO - this should be an error, but raising it as a warning for now
     return {
       origin: 'Establishments',
       lineNumber: 1,
-      warnCode: Establishment.MISSING_PRIMARY_ERROR,
-      warnCode: `MISSING_PRIMARY_ERROR`,
+      errCode: Establishment.MISSING_PRIMARY_ERROR,
+      errType: `MISSING_PRIMARY_ERROR`,
       error: `Missing the primary establishment: ${name}`,
       source: '',
     };

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -294,12 +294,15 @@ class Establishment extends EntityValidator {
             if (thisEstablishmentIsValid && Array.isArray(thisEstablishmentIsValid) && this._validations.length == 0) {
                 const propertySuffixLength = 'Property'.length * -1;
                 thisEstablishmentIsValid.forEach(thisInvalidProp => {
-                    this._validations.push(new ValidationMessage(
-                        ValidationMessage.WARNING,
-                        111111111,
-                        'Invalid',
-                        [thisInvalidProp.slice(0,propertySuffixLength)],
-                    ));
+                    // temporarily quashing Services and Capacity property invalid warnings (whilst cache is being worked on)
+                    if (!(thisInvalidProp === 'ServicesProperty' || thisInvalidProp === 'CapacityProperty')) {
+                        this._validations.push(new ValidationMessage(
+                            ValidationMessage.WARNING,
+                            111111111,
+                            'Invalid',
+                            [thisInvalidProp.slice(0,propertySuffixLength)],
+                        ));
+                    }
                 });
             }
 

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -741,7 +741,7 @@ class Worker extends EntityValidator {
                         attributes: ['id', 'title']
                         }
                 ],
-                attributes: ['uid', 'NameOrIdValue', 'ContractValue', "CompletedValue", 'lastWdfEligibility', "created", "updated", "updatedBy"],
+                attributes: ['uid', 'NameOrIdValue', 'ContractValue', "CompletedValue", 'MainJobFkOther', 'lastWdfEligibility', "created", "updated", "updatedBy"],
                 order: [
                     ['updated', 'DESC']
                 ]
@@ -759,7 +759,8 @@ class Worker extends EntityValidator {
                         contract: thisWorker.ContractValue,
                         mainJob: {
                             jobId: thisWorker.mainJob.id,
-                            title: thisWorker.mainJob.title
+                            title: thisWorker.mainJob.title,
+                            other: thisWorker.MainJobFkOther ? thisWorker.MainJobFkOther : undefined,
                         },
                         completed: thisWorker.CompletedValue,
                         created:  thisWorker.created.toJSON(),

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -884,8 +884,6 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, isPar
     status = false;
   }
   establishments.establishmentMetadata.records = myEstablishments.length;
-  establishments.establishmentMetadata.errors = csvEstablishmentSchemaErrors.filter(thisError => 'errCode' in thisError).length;
-  establishments.establishmentMetadata.warnings = csvEstablishmentSchemaErrors.filter(thisError => 'warnCode' in thisError).length;
 
   // parse and process Workers CSV
   if (Array.isArray(workers.imported) && workers.imported.length > 0 && workers.workerMetadata.fileType == "Worker") {
@@ -938,8 +936,6 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, isPar
     status = false;
   }
   workers.workerMetadata.records = myWorkers.length;
-  workers.workerMetadata.errors = csvWorkerSchemaErrors.filter(thisError => 'errCode' in thisError).length;
-  workers.workerMetadata.warnings = csvWorkerSchemaErrors.filter(thisError => 'warnCode' in thisError).length;
 
   // parse and process Training CSV
   if (Array.isArray(training.imported) && training.imported.length > 0 && training.trainingMetadata.fileType == "Training") {
@@ -990,8 +986,6 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, isPar
       status = false;
   }
   training.trainingMetadata.records = myTrainings.length;
-  training.trainingMetadata.errors = csvTrainingSchemaErrors.filter(thisError => 'errCode' in thisError).length;
-  training.trainingMetadata.warnings = csvTrainingSchemaErrors.filter(thisError => 'warnCode' in thisError).length;
 
   // prepare entities ready for upload/return
   const establishmentsAsArray = Object.values(myAPIEstablishments);
@@ -1032,6 +1026,14 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, isPar
   } else {
     console.error(("Seriously, if seeing this then something has truely gone wrong - the primary establishment should always be in the set of current establishments!"));
   }
+
+  // update CSV metadata error/warning counts
+  establishments.establishmentMetadata.errors = csvEstablishmentSchemaErrors.filter(thisError => 'errCode' in thisError).length;
+  establishments.establishmentMetadata.warnings = csvEstablishmentSchemaErrors.filter(thisError => 'warnCode' in thisError).length;
+  workers.workerMetadata.errors = csvWorkerSchemaErrors.filter(thisError => 'errCode' in thisError).length;
+  workers.workerMetadata.warnings = csvWorkerSchemaErrors.filter(thisError => 'warnCode' in thisError).length;
+  training.trainingMetadata.errors = csvTrainingSchemaErrors.filter(thisError => 'errCode' in thisError).length;
+  training.trainingMetadata.warnings = csvTrainingSchemaErrors.filter(thisError => 'warnCode' in thisError).length;
 
   // create the difference report, which includes trapping for deleting of primary establishment
   const report = validationDifferenceReport(establishmentId, establishmentsAsArray, myCurrentEstablishments);


### PR DESCRIPTION
* Includes https://trello.com/c/fqa2hTrd - "other" main job description. Reusing bulk upload branch because it's a quick fix.

* For the purpose of the demo, suppressing the services/capacities warning in the validation report.

* An observation made during demo was that on successful completion, the uploaded files should have been  deleted.

* https://trello.com/c/CcwKfzlP - defect raised by Ann on standalone bulk uploads which may have been contributing to the contradictory validation errors for a parent upload too.