### PR TITLE
bugfix | bulk upload | api call cancelled on files selection

### DIFF
--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -19,6 +19,7 @@ import { map } from 'rxjs/operators';
 export class BulkUploadService {
   public exposeForm$: BehaviorSubject<FormGroup> = new BehaviorSubject(null);
   public preValidationError$: BehaviorSubject<boolean> = new BehaviorSubject(null);
+  public preValidateFiles$: BehaviorSubject<boolean> = new BehaviorSubject(null);
   public selectedFiles$: BehaviorSubject<File[]> = new BehaviorSubject(null);
   public serverError$: BehaviorSubject<string> = new BehaviorSubject(null);
   public uploadedFiles$: BehaviorSubject<ValidatedFile[]> = new BehaviorSubject(null);

--- a/src/app/features/bulk-upload/files-upload/files-upload.component.ts
+++ b/src/app/features/bulk-upload/files-upload/files-upload.component.ts
@@ -159,6 +159,7 @@ export class FilesUploadComponent implements OnInit {
         null,
         () => this.cancelUpload(),
         () => {
+          this.bulkUploadService.preValidateFiles$.next(true);
           this.filesUploading = false;
           this.filesUploaded = true;
         }

--- a/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.ts
+++ b/src/app/features/bulk-upload/uploaded-files-list/uploaded-files-list.component.ts
@@ -40,24 +40,24 @@ export class UploadedFilesListComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.checkForUploadedFiles();
-    this.checkForSelectedFiles();
+    this.getUploadedFiles();
+    this.preValidateFilesSubscription();
   }
 
-  private checkForUploadedFiles(): void {
+  private getUploadedFiles(): void {
     this.subscriptions.add(
       this.bulkUploadService.uploadedFiles$.subscribe((uploadedFiles: ValidatedFile[]) => {
         if (uploadedFiles) {
-          this.checkForMandatoryFiles(uploadedFiles);
+          this.uploadedFiles = uploadedFiles;
         }
       })
     );
   }
 
-  private checkForSelectedFiles(): void {
+  private preValidateFilesSubscription(): void {
     this.subscriptions.add(
-      this.bulkUploadService.selectedFiles$.subscribe((selectedFiles: File[]) => {
-        if (selectedFiles) {
+      this.bulkUploadService.preValidateFiles$.subscribe((preValidateFiles: boolean) => {
+        if (preValidateFiles) {
           this.preValidateFiles();
         }
       })
@@ -68,6 +68,7 @@ export class UploadedFilesListComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.bulkUploadService
         .preValidateFiles(this.establishmentService.establishmentId)
+        .pipe(take(1))
         .subscribe(
           (response: ValidatedFile[]) => this.checkForMandatoryFiles(response),
           (response: HttpErrorResponse) => this.bulkUploadService.serverError$.next(response.error.message)


### PR DESCRIPTION
- on successful file upload to s3, fire prevalidate observable event in order for the uploaded files component to go ahead and prevalidate the files. This fixes the bug where on files selection the prevalidate api was being called and cancelled immediately