### PR TITLE
bugfix | unable to choose files after validate step

### DIFF
--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -70,6 +70,7 @@ export class BulkUploadService {
   }
 
   public resetBulkUpload(): void {
+    this.uploadedFiles$.next(null);
     this.validationErrors$.next(null);
     this.serverError$.next(null);
   }

--- a/src/app/features/bulk-upload/files-upload/files-upload.component.ts
+++ b/src/app/features/bulk-upload/files-upload/files-upload.component.ts
@@ -159,6 +159,7 @@ export class FilesUploadComponent implements OnInit {
         null,
         () => this.cancelUpload(),
         () => {
+          this.resetFileInputElement();
           this.bulkUploadService.preValidateFiles$.next(true);
           this.filesUploading = false;
           this.filesUploaded = true;
@@ -166,8 +167,12 @@ export class FilesUploadComponent implements OnInit {
       );
   }
 
-  public removeFiles(): void {
+  private resetFileInputElement(): void {
     this.renderer.selectRootElement('#fileUpload').value = '';
+  }
+
+  public removeFiles(): void {
+    this.resetFileInputElement();
     this.fileUpload.setValidators(Validators.required);
     this.form.reset();
     this.submitted = false;


### PR DESCRIPTION
- ensure that upon successful files upload to s3 the file input dom element is cleared. Otherwise once files are validated, and in the scenario where the exact same files with the same files names are chosen the observable doesnt fire as technically the data stream hasn't changed