### PR TITLE
Fixing the predicate on sum of leavers to ignore when a single value of 999 (Don't know) is given.

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -35,7 +35,7 @@ class Establishment {
     this._utilisations = null;
 
     this._totalPermTemp = null;
-  
+
     this._alljobs = null;
     this._vacancies = null;
     this._starters = null;
@@ -209,7 +209,7 @@ class Establishment {
         error: `Local Identifier (LOCALESTID) must be no more than ${MAX_LENGTH} characters`,
         source: myLocalId,
       });
-      return false;      
+      return false;
     } else {
       this._localId = myLocalId;
       return true;
@@ -499,7 +499,7 @@ class Establishment {
         this._localAuthorities = listOfLAs.map(thisLA => parseInt(thisLA, 10));
         return true;
       }
-  
+
     } else {
       return true;
     }
@@ -598,11 +598,11 @@ class Establishment {
       return true;
     }
   }
-  
+
   _validateAllServices() {
     // all services must have at least one value (main service) or a semi colon delimited list of integers; treat consistently as a list of
     const myAllServices = this._currentLine.ALLSERVICES;
-    if (!myAllServices || myAllServices.length == 0) {    
+    if (!myAllServices || myAllServices.length == 0) {
       this._validationErrors.push({
         lineNumber: this._lineNumber,
         errCode: Establishment.ALL_SERVICES_ERROR,
@@ -834,7 +834,7 @@ class Establishment {
         source: this._currentLine.UTILISATION,
       });
     }
-    
+
     if (localValidationErrors.length > 0) {
       localValidationErrors.forEach(thisValidation => this._validationErrors.push(thisValidation));;
       return false;
@@ -1035,14 +1035,14 @@ class Establishment {
 
   _validateReasonsForLeaving() {
     // only if the sum of "LEAVERS" is greater than 0
-    const sumOfLeavers = this._leavers ? this._leavers.reduce((total, thisCount) => total+thisCount) : 0;
+    const sumOfLeavers = this._leavers && Array.isArray(this._leavers) && this._leavers[0] !== 999 ? this._leavers.reduce((total, thisCount) => total+thisCount) : 0;
 
     if (sumOfLeavers > 0) {
       const allReasons = this._currentLine.REASONS.split(';');
       const allReasonsCounts = this._currentLine.REASONNOS.split(';');
 
       const localValidationErrors = [];
-  
+
       if (!allReasons || allReasons.length==0) {
         localValidationErrors.push({
           lineNumber: this._lineNumber,
@@ -1052,7 +1052,7 @@ class Establishment {
           source: this._currentLine.REASONS,
         });
       }
-      if (!allReasons.every(thisCount => !Number.isNaN(parseInt(thisCount)) || parseInt(thisCount) < MIN_COUNT)) {
+      if (!allReasons.every(thisCount => !Number.isNaN(parseInt(thisCount)))) {
         localValidationErrors.push({
           lineNumber: this._lineNumber,
           errCode: Establishment.REASONS_FOR_LEAVING_ERROR,
@@ -1104,12 +1104,12 @@ class Establishment {
           source: `${this._currentLine.REASONNOS} (${sumOfReasonsCounts}) - ${this._currentLine.LEAVERS} (${sumOfLeavers})`,
         });
       }
-  
+
       if (localValidationErrors.length > 0) {
         localValidationErrors.forEach(thisValidation => this._validationErrors.push(thisValidation));;
         return false;
       }
-  
+
       this._reasonsForLeaving = allReasons.map((thisReason, index) => {
         return {
           id: parseInt(thisReason, 10),
@@ -1118,7 +1118,7 @@ class Establishment {
       });
 
       return true;
-  
+
     } else {
       return true;
     }
@@ -1238,7 +1238,7 @@ class Establishment {
             errType: `LOCAL_AUTHORITIES_ERROR`,
             error: `Local Authorities (SHARELA): ${thisLA} is unknown`,
             source: this._currentLine.SHARELA,
-          }); 
+          });
         }
       });
 
@@ -1274,7 +1274,7 @@ class Establishment {
               source: this._currentLine.CAPACITY,
             });
           }
-            
+
         }
       });
 
@@ -1353,7 +1353,7 @@ class Establishment {
   _transformAllVacanciesStartersLeavers() {
     // vacancies, starters and leavers is either an array of counts against positional indexes to _allJobs
     //  or a single value of 999
-    
+
     // if a single value of 999, then map to "Don't know"
     // if a full set of 0 (e.g. 0, or 0;0 or 0;0;0, ...), then map to "None"
     const DONT_KNOW=999;
@@ -1367,7 +1367,7 @@ class Establishment {
         .map((thisJob, index) => {
           return {
             jobId: this._alljobs[index],
-            total: thisJob  
+            total: thisJob
           };
         })
         .filter(thisJob => thisJob.total !== 0);
@@ -1382,7 +1382,7 @@ class Establishment {
         .map((thisJob, index) => {
           return {
             jobId: this._alljobs[index],
-            total: thisJob  
+            total: thisJob
           };
         })
         .filter(thisJob => thisJob.total !== 0);
@@ -1397,7 +1397,7 @@ class Establishment {
         .map((thisJob, index) => {
           return {
             jobId: this._alljobs[index],
-            total: thisJob  
+            total: thisJob
           };
         })
         .filter(thisJob => thisJob.total !== 0);
@@ -1519,7 +1519,7 @@ class Establishment {
     status = !this._validateJobRoleTotals() ? false : status;
 
     status = !this._validateReasonsForLeaving() ? false : status;
-    
+
     return status;
   }
 
@@ -1598,7 +1598,7 @@ class Establishment {
             ...thisValidation,
           };
         });
-    
+
   };
 
   // returns an API representation of this Establishment
@@ -1778,7 +1778,7 @@ class Establishment {
             validationError.errCode = Establishment.LOCATION_ID_ERROR;
             validationError.errType = 'LOCATION_ID_ERROR';
             validationError.source  = `${this._currentLine.LOCATIONID}`;
-            break;   
+            break;
           case 'NMDSID':
               // where to map NMDSID error?????
           default:
@@ -1790,7 +1790,7 @@ class Establishment {
         this._validationErrors.push(validationError);
       }) : true;
     });
-  
+
     warnings.forEach(thisWarning => {
       thisWarning.properties ? thisWarning.properties.forEach(thisProp => {
         const validationWarning = {
@@ -1874,7 +1874,7 @@ class Establishment {
             validationWarning.warnCode = Establishment.LOCATION_ID_WARNING;
             validationWarning.warnType = 'LOCATION_ID_WARNING';
             validationWarning.source  = `${this._currentLine.LOCATIONID}`;
-            break;   
+            break;
           case 'NMDSID':
               // where to map NMDSID error?????
           default:


### PR DESCRIPTION
Hey Andrew

https://trello.com/c/u4uhUDRK

This is a simple fix to account for recent introductions to the CSV upload files that allow a single value of `999` to be used to identify "Don't know" on vacancies, leavers and starters.

The sum of leavers is a predicate in validating "REASONS". That predicate needs to exclude single value of 999.

But the main reason this was caught is because I had an validation copy and paste error in that I was trying to report on MIN_COUNT  when parsing `REASONS`.