### PR TITLE
Introducing "public/download" proxy to S3 buckets.

### DIFF
--- a/server.js
+++ b/server.js
@@ -61,7 +61,7 @@ app.use('/public/download', proxy(
     {
         proxyReqPathResolver: function (req) {
           const updatedPath = publicDownloadBaseUrl + req.url;
-          console.log("public/download proxy API request to: ", `${updatedPath}`)
+          //console.log("public/download proxy API request to: ", `${updatedPath}`)
           return updatedPath;
         }
     }

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
+var proxy = require('express-http-proxy');          // for service public/download content
 
 // app config
 var AppConfig = require('./server/config/appConfig');
@@ -52,7 +53,21 @@ var testOnly = require('./server/routes/testOnly');
 
 var app = express();
 
-/*  
+
+/* public/download - proxy interception */
+const publicDownloadBaseUrl = config.get('public.download.baseurl');
+app.use('/public/download', proxy(
+    publicDownloadBaseUrl,
+    {
+        proxyReqPathResolver: function (req) {
+          const updatedPath = publicDownloadBaseUrl + req.url;
+          console.log("public/download proxy API request to: ", `${updatedPath}`)
+          return updatedPath;
+        }
+    }
+));
+
+/*
  * security - incorproate helmet & xss-clean (de facto/good practice headers) across all endpoints
  */
 
@@ -93,7 +108,7 @@ app.use('/api', helmet({
 // encodes all URL parameters
 app.use(unless('/api', 'test', xssClean()));
 
-/*  
+/*
  * end security
  */
 
@@ -106,13 +121,13 @@ app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 
-/*  
+/*
  * security - removes unwanted HTML from data
  */
 
 app.use('/api/test', sanitizer());       // used as demonstration on test routes only
 
-/*  
+/*
  * end security
  */
 

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -136,7 +136,7 @@ const config = convict({
           doc: 'The server certificate (authority - ca)',
           format: String,
           default: 'TBC',
-        }  
+        }
       }
     },
     pool: {
@@ -272,6 +272,15 @@ const config = convict({
       doc: 'The duration in seconds for the upload signed URL to expire',
       format: 'int',
       default: 300,
+    },
+  },
+  public: {
+    download: {
+      baseurl: {
+        doc: 'The baseurl to S3 bucket where public download content will be stored',
+        format: '*',
+        default: 'https://sfc-public-dev.s3.eu-west-2.amazonaws.com/public/download',
+      },
     },
   },
 });

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -24,4 +24,8 @@ bulkupload:
     region: eu-west-2
     bucketname: sfc-bulkupload-dev
 
+public:
+    download:
+        baseurl: https://sfc-public-dev.s3.eu-west-2.amazonaws.com/public/download
+
 # no notify definition - not used in development

--- a/server/config/production.yaml
+++ b/server/config/production.yaml
@@ -29,3 +29,7 @@ notify:
 bulkupload:
     region: eu-west-2
     bucketname: sfc-bulkupload-prod
+
+public:
+    download:
+        baseurl: https://sfc-public-prod.s3.eu-west-2.amazonaws.com/public/download

--- a/server/config/test.yaml
+++ b/server/config/test.yaml
@@ -30,3 +30,7 @@ notify:
 bulkupload:
     region: eu-west-2
     bucketname: sfc-bulkupload-staging
+
+public:
+    download:
+        baseurl: https://sfc-public-staging.s3.eu-west-2.amazonaws.com/public/download


### PR DESCRIPTION
https://trello.com/c/LyVCfwYI

Hi Nasir

Requesting your review of this backend change, because the change is more about the application hosting environment than it is about code.

As per discussion yesterday, I'm introducing "npm proxy" to the `server.js` allowing me to proxy all requests to `public/download` to an S3 bucket. Using a new config property `public.download.baseurl` I am able to redirect to URL, but most significantly, control which of three S3 buckets to redirect to - config by environment specific URL.

I've introduced three new buckets allowing public access; one for each of dev, staging and production.

I've uploaded the current set of guidance doc PDFs and I've made them public.

Note, every time the PDFs are uploaded, they have to be make public again.