### PR TITLE
feature | bulk upload | references display grid

### DIFF
--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -29,7 +29,7 @@ TODO check if needed -->
       id="server-error"
     >
       <div
-        class="govuk__grid govuk__reference-grid-container govuk-!-padding-top-2 govuk-!-padding-bottom-2 govuk__align-items-center"
+        class="govuk__grid govuk__grid-container"
       >
         <p class="govuk-!-margin-bottom-0"><strong>{{ columnOneLabel }}</strong></p>
         <p class="govuk-!-margin-bottom-0">
@@ -38,7 +38,7 @@ TODO check if needed -->
       </div>
 
       <div
-        class="govuk-form-group govuk-!-margin-bottom-0 govuk__grid govuk__reference-grid-container govuk-!-padding-top-2 govuk-!-padding-bottom-2 govuk__align-items-center"
+        class="govuk-form-group govuk__grid govuk__grid-container"
         *ngFor="let reference of references"
         [class.govuk-form-group--error]="form.get('name-' + reference.uid).errors && submitted"
         [ngClass]="form.get('name-' + reference.uid).errors && submitted ? 'govuk__grid-two-rows' : 'govuk__grid-one-row'"

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -28,7 +28,9 @@ TODO check if needed -->
       [formGroup]="form"
       id="server-error"
     >
-      <div class="govuk__grid govuk__reference-grid-container govuk__align-items-center">
+      <div
+        class="govuk__grid govuk__reference-grid-container govuk-!-padding-top-2 govuk-!-padding-bottom-2 govuk__align-items-center"
+      >
         <p class="govuk-!-margin-bottom-0"><strong>{{ columnOneLabel }}</strong></p>
         <p class="govuk-!-margin-bottom-0">
           <strong>{{ columnTwoLabel }}</strong>
@@ -36,23 +38,21 @@ TODO check if needed -->
       </div>
 
       <div
-        class="govuk-form-group govuk-!-margin-bottom-0 govuk__grid govuk__reference-grid-container"
+        class="govuk-form-group govuk-!-margin-bottom-0 govuk__grid govuk__reference-grid-container govuk-!-padding-top-2 govuk-!-padding-bottom-2 govuk__align-items-center"
         *ngFor="let reference of references"
         [class.govuk-form-group--error]="form.get('name-' + reference.uid).errors && submitted"
-        [ngClass]="form.get('name-' + reference.uid).errors && submitted ? 'govuk__align-items-end' : 'govuk__align-items-center'"
+        [ngClass]="form.get('name-' + reference.uid).errors && submitted ? 'govuk__grid-two-rows' : 'govuk__grid-one-row'"
       >
-        <div class="govuk__grid" [class.govuk__reference-grid-has-error]="form.get('name-' + reference.uid).errors && submitted">
-          <label class="govuk-label govuk-!-margin-bottom-0" for="name-{{ reference.uid }}">
-            {{ reference.name }}
-          </label>
-          <span
-            id="name-{{ reference.uid }}-error"
-            class="govuk-error-message govuk__reference-grid-error-msg"
-            *ngIf="form.get('name-' + reference.uid).errors && submitted"
-          >
-            <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('name-' + reference.uid) }}
-          </span>
-        </div>
+        <label class="govuk-label govuk-!-margin-bottom-0" for="name-{{ reference.uid }}">
+          {{ reference.name }}
+        </label>
+        <span
+          id="name-{{ reference.uid }}-error"
+          class="govuk-error-message govuk__grid-row-start-1 govuk__reference-grid-error"
+          *ngIf="form.get('name-' + reference.uid).errors && submitted"
+        >
+          <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('name-' + reference.uid) }}
+        </span>
         <input
           class="govuk-input"
           [class.govuk-input--error]="form.get('name-' + reference.uid).errors && submitted"

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -2,10 +2,10 @@
 <button (click)="updateReferences()">Update References</button>
 
 <ng-container *ngIf="referencesUpdated">
-  <p>Settings updated</p>
-  <p>
-    <a [routerLink]="['/bulk-upload']">Go to Bulk Upload</a>
-  </p>
+ <p>Settings updated</p>
+ <p>
+   <a [routerLink]="['/bulk-upload']">Go to Bulk Upload</a>
+ </p>
 </ng-container>
 TODO check if needed -->
 
@@ -19,64 +19,70 @@ TODO check if needed -->
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full govuk-!-margin-top-6">
+  <div class="govuk-grid-column-full">
     <form
-      *ngIf="workplaces && workplaces.length"
+      class="govuk-!-margin-top-6"
+      *ngIf="references.length"
       novalidate
       (ngSubmit)="onSubmit()"
       [formGroup]="form"
       id="server-error"
     >
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            {{ columnOneLabel }}
-          </dt>
-          <dd class="govuk-summary-list__value govuk-!-width-one-third govuk-util__bold">
-            {{ columnTwoLabel }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row" *ngFor="let workplace of workplaces">
-          <dt
-            class="govuk-summary-list__key govuk-!-width-two-thirds govuk-util__normal"
-            [class.govuk-form-group--error]="form.get('name-' + workplace.uid).errors && submitted"
-          >
-            <span
-              id="name-{{ workplace.uid }}-error"
-              class="govuk-error-message"
-              *ngIf="form.get('name-' + workplace.uid).errors && submitted"
-            >
-              <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('name-' + workplace.uid) }}
-            </span>
-            {{ workplace.name }}
-          </dt>
-          <dd class="govuk-summary-list__value govuk-!-width-one-third govuk-util__normal govuk-!-padding-right-0">
-            <input
-              class="govuk-input"
-              [class.govuk-input--error]="form.get('name-' + workplace.uid).errors && submitted"
-              id="name-{{ workplace.uid }}"
-              name="name-{{ workplace.uid }}"
-              type="text"
-              formControlName="name-{{ workplace.uid }}"
-            />
-          </dd>
-        </div>
-      </dl>
-    </form>
-    <p *ngIf="workplaces && !workplaces.length">There are no workplaces.</p>
-  </div>
-</div>
+      <div class="govuk__grid govuk__reference-grid-container govuk__align-items-center">
+        <p class="govuk-!-margin-bottom-0"><strong>{{ columnOneLabel }}</strong></p>
+        <p class="govuk-!-margin-bottom-0">
+          <strong>{{ columnTwoLabel }}</strong>
+        </p>
+      </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="govuk-button-group">
-      <button type="button" class="govuk-button govuk-!-margin-right-8 govuk-!-margin-bottom-0" (click)="onSubmit()">
-        Save and continue
-      </button>
-      <span class="govuk-visually-hidden">or</span>
-      <button type="button" class="govuk-button govuk-button--link govuk-!-margin-bottom-0" (click)="onSubmit()">
-        Save and exit
-      </button>
+      <div
+        class="govuk-form-group govuk-!-margin-bottom-0 govuk__grid govuk__reference-grid-container"
+        *ngFor="let reference of references"
+        [class.govuk-form-group--error]="form.get('name-' + reference.uid).errors && submitted"
+        [ngClass]="form.get('name-' + reference.uid).errors && submitted ? 'govuk__align-items-end' : 'govuk__align-items-center'"
+      >
+        <div class="govuk__grid" [class.govuk__reference-grid-has-error]="form.get('name-' + reference.uid).errors && submitted">
+          <label class="govuk-label govuk-!-margin-bottom-0" for="name-{{ reference.uid }}">
+            {{ reference.name }}
+          </label>
+          <span
+            id="name-{{ reference.uid }}-error"
+            class="govuk-error-message govuk__reference-grid-error-msg"
+            *ngIf="form.get('name-' + reference.uid).errors && submitted"
+          >
+            <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('name-' + reference.uid) }}
+          </span>
+        </div>
+        <input
+          class="govuk-input"
+          [class.govuk-input--error]="form.get('name-' + reference.uid).errors && submitted"
+          id="name-{{ reference.uid }}"
+          name="name-{{ reference.uid }}"
+          type="text"
+          formControlName="name-{{ reference.uid }}"
+        />
+        <p class="govuk-!-margin-bottom-0 govuk__justify-self-end"><a href="">Staff references</a></p>
+      </div>
+    </form>
+
+    <p *ngIf="!references.length">There are no workplaces.</p>
+
+    <div class="govuk-grid-row" *ngIf="references.length">
+      <div class="govuk-grid-column-full">
+        <div class="govuk-button-group">
+          <button
+            type="button"
+            class="govuk-button govuk-!-margin-right-8 govuk-!-margin-bottom-0"
+            (click)="onSubmit()"
+          >
+            Save and continue
+          </button>
+          <span class="govuk-visually-hidden">or</span>
+          <button type="button" class="govuk-button govuk-button--link govuk-!-margin-bottom-0" (click)="onSubmit()">
+            Save and exit
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.scss
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.scss
@@ -1,0 +1,15 @@
+@import '~src/assets/scss/partials/colors';
+
+.govuk__reference-grid-container {
+  grid-template-columns: 40% 30% auto;
+  padding: 8px 0;
+  border-bottom: solid 1px $alto;
+}
+
+.govuk__reference-grid-error-msg {
+  grid-row-start: 1;
+}
+
+.govuk__reference-grid-has-error {
+  text-indent: 15px;
+}

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.scss
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.scss
@@ -2,14 +2,10 @@
 
 .govuk__reference-grid-container {
   grid-template-columns: 40% 30% auto;
-  padding: 8px 0;
   border-bottom: solid 1px $alto;
 }
 
-.govuk__reference-grid-error-msg {
-  grid-row-start: 1;
-}
-
-.govuk__reference-grid-has-error {
-  text-indent: 15px;
+.govuk__reference-grid-error {
+  grid-column-start: 1;
+  grid-column-end: 4;
 }

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.scss
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.scss
@@ -1,10 +1,5 @@
 @import '~src/assets/scss/partials/colors';
 
-.govuk__reference-grid-container {
-  grid-template-columns: 40% 30% auto;
-  border-bottom: solid 1px $alto;
-}
-
 .govuk__reference-grid-error {
   grid-column-start: 1;
   grid-column-end: 4;

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -18,41 +18,33 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
   public serverError: string;
   public serverErrorsMap: ErrorDefinition[] = [];
   public submitted = false;
-  public references: Workplace[] = [];
+  public references: Workplace[] = []; // TODO update to Workplace[] | StaffRecord[]
 
   constructor(
     protected authService: AuthService,
     protected router: Router,
     protected formBuilder: FormBuilder,
     protected errorSummaryService: ErrorSummaryService,
-    protected userService: UserService
+    protected userService: UserService,
   ) {}
 
   ngOnInit() {
     this.setupForm();
     this.getReferences();
+    this.setPrimaryEstablishmentName();
+  }
+
+  private setPrimaryEstablishmentName(): void {
+    this.primaryEstablishmentName = this.authService.establishment.name;
   }
 
   private setupForm(): void {
     this.form = this.formBuilder.group({});
   }
 
-  private getReferences(): void {
-    this.subscriptions.add(
-      this.userService.getEstablishments().subscribe((workplaces: GetWorkplacesResponse) => {
-        console.log(workplaces);
-        if (workplaces) {
-          this.primaryEstablishmentName = workplaces.primary ? workplaces.primary.name : null;
-          this.references = workplaces.subsidaries ? workplaces.subsidaries.establishments : [];
-          if (this.references.length) {
-            this.updateForm();
-          }
-        }
-      })
-    );
-  }
+  protected getReferences(): void {}
 
-  private updateForm(): void {
+  protected updateForm(): void {
     this.references.forEach((workplace: Workplace) => {
       this.form.addControl(`name-${workplace.uid}`, new FormControl(null, [Validators.required]));
 

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -18,7 +18,7 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
   public serverError: string;
   public serverErrorsMap: ErrorDefinition[] = [];
   public submitted = false;
-  public workplaces: Workplace[] = []; // TODO rename workplaces variable to something generic
+  public references: Workplace[] = [];
 
   constructor(
     protected authService: AuthService,
@@ -30,21 +30,21 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.setupForm();
-    this.getEstablishments();
+    this.getReferences();
   }
 
   private setupForm(): void {
     this.form = this.formBuilder.group({});
   }
 
-  private getEstablishments(): void {
+  private getReferences(): void {
     this.subscriptions.add(
       this.userService.getEstablishments().subscribe((workplaces: GetWorkplacesResponse) => {
         console.log(workplaces);
         if (workplaces) {
           this.primaryEstablishmentName = workplaces.primary ? workplaces.primary.name : null;
-          this.workplaces = workplaces.subsidaries ? workplaces.subsidaries.establishments : [];
-          if (this.workplaces.length) {
+          this.references = workplaces.subsidaries ? workplaces.subsidaries.establishments : [];
+          if (this.references.length) {
             this.updateForm();
           }
         }
@@ -53,7 +53,7 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
   }
 
   private updateForm(): void {
-    this.workplaces.forEach((workplace: Workplace) => {
+    this.references.forEach((workplace: Workplace) => {
       this.form.addControl(`name-${workplace.uid}`, new FormControl(null, [Validators.required]));
 
       this.formErrorsMap.push({

--- a/src/app/features/bulk-upload/check-workplace-references/check-workplace-references.component.html
+++ b/src/app/features/bulk-upload/check-workplace-references/check-workplace-references.component.html
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">Check your workplace references</h2>
 <p>Check your workplace and staff references to make sure they are the <br />same as the files you are uploading.</p>
+<p><a [routerLink]="['/bulk-upload/workplace-references']">View workplace references</a></p>
 <!--
   TODO uncomment once relevant sections have been developed
   <p *ngIf="***">Last updated on {{ lastUpdated | date: 'd MMMM y' }}</p>
-  <a [routerLink]="['/reports']">View workplace references</a>
 -->

--- a/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
+++ b/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
@@ -10,6 +10,7 @@ import { BulkUploadReferences } from '@features/bulk-upload/bulk-upload-referenc
 @Component({
   selector: 'app-workplace-references-page',
   templateUrl: '../bulk-upload-references/bulk-upload-references.html',
+  styleUrls: ['../bulk-upload-references/bulk-upload-references.scss'],
 })
 export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
   // TODO check if needed

--- a/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
+++ b/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BulkUploadFileType } from '@core/model/bulk-upload.model';
+import { GetWorkplacesResponse } from '@core/model/my-workplaces.model';
 import { AuthService } from '@core/services/auth.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { UserService } from '@core/services/user.service';
@@ -36,4 +37,17 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
     this.authService.isFirstBulkUpload = false;
   }
    **/
+
+  protected getReferences(): void {
+    this.subscriptions.add(
+      this.userService.getEstablishments().subscribe((workplaces: GetWorkplacesResponse) => {
+        if (workplaces) {
+          this.references = workplaces.subsidaries ? workplaces.subsidaries.establishments : [];
+          if (this.references.length) {
+            this.updateForm();
+          }
+        }
+      })
+    );
+  }
 }

--- a/src/assets/scss/components/_form-group.scss
+++ b/src/assets/scss/components/_form-group.scss
@@ -1,0 +1,4 @@
+.govuk-form-group--error.govuk__grid {
+  text-indent: 15px;
+  padding-left: 0;
+}

--- a/src/assets/scss/components/_grid.scss
+++ b/src/assets/scss/components/_grid.scss
@@ -1,0 +1,28 @@
+.govuk__grid {
+  display: grid;
+  column-gap: $govuk-gutter-half;
+}
+
+.govuk__grid-one-row {
+  grid-template-rows: auto;
+}
+
+.govuk__grid-row-start-1 {
+  grid-row-start: 1;
+}
+
+.govuk__grid-two-rows {
+  grid-template-rows: auto auto;
+}
+
+.govuk__align-items-center {
+  align-items: center;
+}
+
+.govuk__align-items-end {
+  align-items: end;
+}
+
+.govuk__justify-self-end {
+  justify-self: end;
+}

--- a/src/assets/scss/components/_grid.scss
+++ b/src/assets/scss/components/_grid.scss
@@ -3,6 +3,15 @@
   column-gap: $govuk-gutter-half;
 }
 
+.govuk__grid-container {
+  grid-template-columns: 40% 30% auto;
+  border-bottom: solid 1px govuk-colour("grey-1");
+  margin-bottom: 0;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  align-items: center;
+}
+
 .govuk__grid-one-row {
   grid-template-rows: auto;
 }

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -21,21 +21,23 @@ body {
 // Custom Components
 @import 'components/auto-suggest';
 @import 'components/buttons';
-@import 'components/doh-logo';
 @import 'components/checkboxes';
+@import 'components/doh-logo';
 @import 'components/fieldset';
 @import 'components/footer';
+@import 'components/form-group';
+@import 'components/grid';
 @import 'components/header';
 @import 'components/input';
 @import 'components/inset-text';
 @import 'components/panel';
 @import 'components/progress';
 @import 'components/radios';
-@import 'components/summary-list';
 @import 'components/select';
+@import 'components/summary-list';
+@import 'components/tables';
 @import 'components/tabs';
 @import 'components/tag';
-@import 'components/tables';
 
 // Removing focus outline used for skip functionality
 main:focus {

--- a/src/assets/scss/modules/_utils.scss
+++ b/src/assets/scss/modules/_utils.scss
@@ -49,3 +49,20 @@
 .govuk__flex {
   display: flex;
 }
+
+.govuk__grid {
+  display: grid;
+  column-gap: $govuk-gutter-half;
+}
+
+.govuk__align-items-center {
+  align-items: center;
+}
+
+.govuk__align-items-end {
+  align-items: end;
+}
+
+.govuk__justify-self-end {
+  justify-self: end;
+}

--- a/src/assets/scss/modules/_utils.scss
+++ b/src/assets/scss/modules/_utils.scss
@@ -49,20 +49,3 @@
 .govuk__flex {
   display: flex;
 }
-
-.govuk__grid {
-  display: grid;
-  column-gap: $govuk-gutter-half;
-}
-
-.govuk__align-items-center {
-  align-items: center;
-}
-
-.govuk__align-items-end {
-  align-items: end;
-}
-
-.govuk__justify-self-end {
-  justify-self: end;
-}


### PR DESCRIPTION
- made bulk upload references page ui conform to design using css grids whilst retaining accessible markup using the preferred GDS form-group's for holding form elements
- renamed `workplaces` > `references`, `getEstablishments()` > `getReferences()`
- added link to `workplace-references` route form bulk upload
- added new css grid helper classes to `utils.scss`