### PR TITLE
Accessibility | Removing incorrect use of title attribute

### DIFF
--- a/src/app/features/bulk-upload/download-data-files/download-data-files.component.html
+++ b/src/app/features/bulk-upload/download-data-files/download-data-files.component.html
@@ -19,7 +19,7 @@
     </a>
   </li>
 </ul>
-<app-details title="How to use the codes">
+<app-details [title]="'How to use the codes'">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <p>

--- a/src/app/features/dashboard/staff-records-tab/staff-records-tab.component.html
+++ b/src/app/features/dashboard/staff-records-tab/staff-records-tab.component.html
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-<app-status *ngIf="createStaffResponse" title="&#10003; Success.">
+<app-status *ngIf="createStaffResponse" [title]="'&#10003; Success.'">
   {{
     createStaffResponse
       | i18nPlural

--- a/src/app/features/reports/reports.component.html
+++ b/src/app/features/reports/reports.component.html
@@ -64,11 +64,11 @@
 </div>
 
 <app-tabs *ngIf="displayWDFReport" [displayWDFReport]="displayWDFReport">
-  <app-tab title="Workplace">
+  <app-tab [title]="'Workplace'">
     <app-workplace-tab [displayWDFReport]="displayWDFReport"></app-workplace-tab>
   </app-tab>
 
-  <app-tab title="Staff records">
+  <app-tab [title]="'Staff records'">
     <app-staff-records-tab [displayWDFReport]="displayWDFReport"></app-staff-records-tab>
   </app-tab>
 </app-tabs>

--- a/src/app/features/workers/basic-records-save-success/basic-records-save-success.component.html
+++ b/src/app/features/workers/basic-records-save-success/basic-records-save-success.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <app-panel title="&#10003; Success">
+    <app-panel [title]="'&#10003; Success'">
       {{ total }} basic staff records<br />
       have been saved
     </app-panel>

--- a/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.html
+++ b/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.html
@@ -8,7 +8,7 @@
       </label>
     </h1>
 
-    <app-details title="Help with qualification levels">
+    <app-details [title]="'Help with qualification levels'">
       <p>You can find more information about qualification levels here:</p>
       <p>
         <a

--- a/src/app/features/workers/social-care-qualification-level/social-care-qualification-level.component.html
+++ b/src/app/features/workers/social-care-qualification-level/social-care-qualification-level.component.html
@@ -8,7 +8,7 @@
       </label>
     </h1>
 
-    <app-details title="Help with qualification levels">
+    <app-details [title]="'Help with qualification levels'">
       <p>You can find more information about qualification levels here:</p>
       <p>
         <a

--- a/src/app/features/workers/staff-record/staff-record.component.html
+++ b/src/app/features/workers/staff-record/staff-record.component.html
@@ -45,7 +45,7 @@
   </div>
 
   <app-tabs>
-    <app-tab title="Staff Record">
+    <app-tab [title]="'Staff Record'">
       <app-basic-record [worker]="worker" [return]="returnToRecord" [reportDetails]="reportDetails"></app-basic-record>
       <app-personal-details
         [worker]="worker"
@@ -54,7 +54,7 @@
       ></app-personal-details>
       <app-employment [worker]="worker" [return]="returnToRecord" [reportDetails]="reportDetails"></app-employment>
     </app-tab>
-    <app-tab title="Qualifications and training">
+    [<app-tab [title]="'Qualifications and training'">
       <app-qualifications-and-training
         [worker]="worker"
         [return]="returnToQuals"

--- a/src/app/features/workers/worker-save-success/worker-save-success.component.html
+++ b/src/app/features/workers/worker-save-success/worker-save-success.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <app-panel title="&#10003; Success">
+    <app-panel [title]="'&#10003; Success'">
       The staff record has<br />
       been saved
     </app-panel>

--- a/src/app/features/workplace/data-sharing/data-sharing.component.html
+++ b/src/app/features/workplace/data-sharing/data-sharing.component.html
@@ -13,7 +13,7 @@
       Before we can do that, in order to comply with the Data Protection Act and The General Data Protection Regulations
       (GDPR) we need your consent.
     </p>
-    <app-details title="Why do we share your data?">
+    <app-details [title]="'Why do we share your data?'">
       <p>
         The Care Quality Commission use the data you provide as part of their overall suite of intelligence about adult
         social care providers and the wider sector. Local authorities use it to check compliance if the data for this
@@ -22,7 +22,7 @@
         with you.
       </p>
     </app-details>
-    <app-details title="What do we share with CQC?">
+    <app-details [title]="'What do we share with CQC?'">
       <p>We share all data, including individual worker records, with the exception of:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>Record ID</li>
@@ -38,7 +38,7 @@
       </ul>
       <p>CQC cannot identify workers through this process</p>
     </app-details>
-    <app-details title="What do we share with local authorities?">
+    <app-details [title]="'What do we share with local authorities?'">
       <p>We will share the following data with your local authority:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>Your unique workplace reference</li>

--- a/src/app/features/workplace/success/success.component.html
+++ b/src/app/features/workplace/success/success.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <app-panel title="&#10003; Success">
+    <app-panel [title]="'&#10003; Success'">
       You have saved your<br />
       workplace details
     </app-panel>


### PR DESCRIPTION
Binding custom directive `title` so HTML doesn't pick it up