### PR TITLE
Accessibility | Close Dialog Improvements

### DIFF
--- a/src/app/core/components/dialog.component.ts
+++ b/src/app/core/components/dialog.component.ts
@@ -1,0 +1,12 @@
+import { HostListener, Inject } from '@angular/core';
+import { Dialog, DIALOG_DATA } from '@core/services/dialog.service';
+
+export class DialogComponent {
+  constructor(@Inject(DIALOG_DATA) public data: any, public dialog: Dialog<any>) {}
+
+  @HostListener('document:keydown', ['$event']) onKeydownHandler(event: KeyboardEvent) {
+    if (['Escape', 'Esc'].includes(event.key)) {
+      this.dialog.close();
+    }
+  }
+}

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -32,11 +32,20 @@ export class Dialog<T, R = any> {
     const customInjector = this.createInjector(this.data);
 
     this.overlayRef = this.overlay.create(config);
+
+    const sub = this.overlayRef.backdropClick().subscribe(() => {
+      this.close();
+      sub.unsubscribe();
+    });
+
     const componentPortal = new ComponentPortal(this.componentType, null, customInjector);
 
     this.overlayRef.attach(componentPortal);
     this.focusTrap = this.focusTrapFactory.create(this.overlayRef.overlayElement);
     this.overlayRef.overlayElement.setAttribute('tabindex', '-1');
+    this.overlayRef.overlayElement.setAttribute('aria-modal', 'true');
+    this.overlayRef.overlayElement.setAttribute('aria-labelledby', 'dialogHeading');
+    this.overlayRef.overlayElement.setAttribute('role', 'dialog');
     this.overlayRef.overlayElement.focus();
   }
 

--- a/src/app/features/bulk-upload/upload-warning-dialog/upload-warning-dialog.component.html
+++ b/src/app/features/bulk-upload/upload-warning-dialog/upload-warning-dialog.component.html
@@ -1,4 +1,6 @@
-<h1 class="govuk-panel--warning-prompt">Uploading the files will permanently delete all the following information:</h1>
+<h1 id="dialogHeading" class="govuk-panel--warning-prompt">
+  Uploading the files will permanently delete all the following information:
+</h1>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/src/app/features/bulk-upload/upload-warning-dialog/upload-warning-dialog.component.ts
+++ b/src/app/features/bulk-upload/upload-warning-dialog/upload-warning-dialog.component.ts
@@ -1,4 +1,5 @@
 import { Component, Inject } from '@angular/core';
+import { DialogComponent } from '@core/components/dialog.component';
 import { ValidatedFile } from '@core/model/bulk-upload.model';
 import { Dialog, DIALOG_DATA } from '@core/services/dialog.service';
 
@@ -6,11 +7,13 @@ import { Dialog, DIALOG_DATA } from '@core/services/dialog.service';
   selector: 'app-upload-warning-dialog',
   templateUrl: './upload-warning-dialog.component.html',
 })
-export class UploadWarningDialogComponent {
+export class UploadWarningDialogComponent extends DialogComponent {
   constructor(
     @Inject(DIALOG_DATA) public data: { establishmentsFile: ValidatedFile; workersFile: ValidatedFile },
     public dialog: Dialog<UploadWarningDialogComponent>
-  ) {}
+  ) {
+    super(data, dialog);
+  }
 
   public close(continueUpload: boolean) {
     this.dialog.close(continueUpload);

--- a/src/app/features/workers/delete-qualification-dialog/delete-qualification-dialog.component.html
+++ b/src/app/features/workers/delete-qualification-dialog/delete-qualification-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l">You are about to delete the following qualification.</h1>
+<h1 id="dialogHeading" class="govuk-heading-l">You are about to delete the following qualification.</h1>
 
 <dl class="govuk-summary-list govuk-summary-list--no-border">
   <div class="govuk-summary-list__row">

--- a/src/app/features/workers/delete-qualification-dialog/delete-qualification-dialog.component.ts
+++ b/src/app/features/workers/delete-qualification-dialog/delete-qualification-dialog.component.ts
@@ -1,12 +1,15 @@
 import { Component, Inject } from '@angular/core';
+import { DialogComponent } from '@core/components/dialog.component';
 import { Dialog, DIALOG_DATA } from '@core/services/dialog.service';
 
 @Component({
   selector: 'app-delete-qualification-dialog',
   templateUrl: './delete-qualification-dialog.component.html',
 })
-export class DeleteQualificationDialogComponent {
-  constructor(@Inject(DIALOG_DATA) public data, public dialog: Dialog<DeleteQualificationDialogComponent>) {}
+export class DeleteQualificationDialogComponent extends DialogComponent {
+  constructor(@Inject(DIALOG_DATA) public data, public dialog: Dialog<DeleteQualificationDialogComponent>) {
+    super(data, dialog);
+  }
 
   close(confirm: boolean) {
     this.dialog.close(confirm);

--- a/src/app/features/workers/delete-training-dialog/delete-training-dialog.component.html
+++ b/src/app/features/workers/delete-training-dialog/delete-training-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l">You are about to delete the following training record.</h1>
+<h1 id="dialogHeading" class="govuk-heading-l">You are about to delete the following training record.</h1>
 
 <dl class="govuk-summary-list govuk-summary-list--no-border">
   <div class="govuk-summary-list__row">

--- a/src/app/features/workers/delete-training-dialog/delete-training-dialog.component.ts
+++ b/src/app/features/workers/delete-training-dialog/delete-training-dialog.component.ts
@@ -1,12 +1,15 @@
 import { Component, Inject } from '@angular/core';
+import { DialogComponent } from '@core/components/dialog.component';
 import { Dialog, DIALOG_DATA } from '@core/services/dialog.service';
 
 @Component({
   selector: 'app-delete-training-dialog',
   templateUrl: './delete-training-dialog.component.html',
 })
-export class DeleteTrainingDialogComponent {
-  constructor(@Inject(DIALOG_DATA) public data, public dialog: Dialog<DeleteTrainingDialogComponent>) {}
+export class DeleteTrainingDialogComponent extends DialogComponent {
+  constructor(@Inject(DIALOG_DATA) public data, public dialog: Dialog<DeleteTrainingDialogComponent>) {
+    super(data, dialog);
+  }
 
   close(confirm: boolean) {
     this.dialog.close(confirm);

--- a/src/app/features/workers/delete-worker-dialog/delete-worker-dialog.component.html
+++ b/src/app/features/workers/delete-worker-dialog/delete-worker-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l">You are about to delete this staff record.</h1>
+<h1 id="dialogHeading" class="govuk-heading-l">You are about to delete this staff record.</h1>
 <p>Once deleted you will not be able to access it again.</p>
 <h2 class="govuk-heading-m">Why are you removing this staff record?</h2>
 <form novalidate (ngSubmit)="onSubmit()" [formGroup]="form">

--- a/src/app/features/workers/delete-worker-dialog/delete-worker-dialog.component.ts
+++ b/src/app/features/workers/delete-worker-dialog/delete-worker-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
+import { DialogComponent } from '@core/components/dialog.component';
 import { ErrorDetails } from '@core/model/errorSummary.model';
 import { Worker } from '@core/model/worker.model';
 import { Dialog, DIALOG_DATA } from '@core/services/dialog.service';
@@ -12,7 +13,7 @@ import { Subscription } from 'rxjs';
   selector: 'app-delete-worker-dialog',
   templateUrl: './delete-worker-dialog.component.html',
 })
-export class DeleteWorkerDialogComponent implements OnInit, OnDestroy {
+export class DeleteWorkerDialogComponent extends DialogComponent implements OnInit, OnDestroy {
   public reasons: Reason[];
   public maxLength = 500;
   public form: FormGroup;
@@ -28,6 +29,8 @@ export class DeleteWorkerDialogComponent implements OnInit, OnDestroy {
     private errorSummaryService: ErrorSummaryService,
     private workerService: WorkerService
   ) {
+    super(worker, dialog);
+
     this.form = this.formBuilder.group({
       reason: null,
       details: [null, [Validators.maxLength(this.maxLength)]],


### PR DESCRIPTION
Dialogs can now be closed by pressing the Escape key, or clicking outside of the Dialog area.
Updated Dialog with ARIA labels
Dialog `h1`'s must contain the `dialogHeading` id