### PR TITLE
feature | bulk upload | references | get workers

### DIFF
--- a/src/app/core/model/worker.model.ts
+++ b/src/app/core/model/worker.model.ts
@@ -85,3 +85,11 @@ export interface Worker {
   updated?: string;
   completed?: boolean;
 }
+
+export interface WorkersResponse {
+  workers: Worker[];
+}
+
+export interface WorkerEditResponse {
+  uid: string;
+}

--- a/src/app/core/services/worker.service.ts
+++ b/src/app/core/services/worker.service.ts
@@ -13,12 +13,8 @@ import { URLStructure } from '@core/model/url.model';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { Worker } from '../model/worker.model';
+import { Worker, WorkerEditResponse, WorkersResponse } from '../model/worker.model';
 import { EstablishmentService } from './establishment.service';
-
-interface WorkersResponse {
-  workers: Array<Worker>;
-}
 
 export interface Reason {
   id: number;
@@ -27,10 +23,6 @@ export interface Reason {
 
 interface LeaveReasonsResponse {
   reasons: Array<Reason>;
-}
-
-export interface WorkerEditResponse {
-  uid: string;
 }
 
 @Injectable({

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -38,6 +38,8 @@ TODO check if needed -->
       <div
         class="govuk__grid govuk__grid-container"
       >
+        <h2 class="govuk-heading-m govuk__reference-subsidiary-name">Collingwood Grange</h2>
+        <p class="govuk-!-margin-0 govuk__justify-self-end"><strong>8</strong> workplaces remaining</p>
         <p class="govuk-!-margin-bottom-0"><strong>{{ columnOneLabel }}</strong></p>
         <p class="govuk-!-margin-bottom-0">
           <strong>{{ columnTwoLabel }}</strong>
@@ -51,7 +53,7 @@ TODO check if needed -->
         [ngClass]="form.get('name-' + reference.uid).errors && submitted ? 'govuk__grid-two-rows' : 'govuk__grid-one-row'"
       >
         <label class="govuk-label govuk-!-margin-bottom-0" for="name-{{ reference.uid }}">
-          {{ reference.name }}
+          {{ reference.name ? reference.name : reference.nameOrId }}
         </label>
         <span
           id="name-{{ reference.uid }}-error"

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -38,7 +38,9 @@ TODO check if needed -->
       <div
         class="govuk__grid govuk__grid-container"
       >
+        <!-- TODO remove hardcoded sub name once BE updates api -->
         <h2 class="govuk-heading-m govuk__reference-subsidiary-name">Collingwood Grange</h2>
+        <!-- TODO remove hardcoded count once BE updates api -->
         <p class="govuk-!-margin-0 govuk__justify-self-end"><strong>8</strong> workplaces remaining</p>
         <p class="govuk-!-margin-bottom-0"><strong>{{ columnOneLabel }}</strong></p>
         <p class="govuk-!-margin-bottom-0">

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.scss
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.scss
@@ -4,3 +4,8 @@
   grid-column-start: 1;
   grid-column-end: 4;
 }
+
+.govuk__reference-subsidiary-name {
+  grid-column-start: 1;
+  grid-column-end: 3;
+}

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -5,9 +5,9 @@ import { Router } from '@angular/router';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { Workplace } from '@core/model/my-workplaces.model';
 import { URLStructure } from '@core/model/url.model';
+import { Worker } from '@core/model/worker.model';
 import { AuthService } from '@core/services/auth.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { UserService } from '@core/services/user.service';
 import { Subscription } from 'rxjs';
 
 export class BulkUploadReferences implements OnInit, OnDestroy {
@@ -15,7 +15,7 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
   public form: FormGroup;
   public formErrorsMap: ErrorDetails[] = []; // TODO look at generic error messages
   public primaryEstablishmentName: string;
-  public references: Workplace[] = []; // TODO update to Workplace[] | StaffRecord[]
+  public references: Array<Workplace | Worker> = [];
   public referenceType: string;
   public return: URLStructure;
   public serverError: string;
@@ -27,7 +27,6 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
     protected router: Router,
     protected formBuilder: FormBuilder,
     protected errorSummaryService: ErrorSummaryService,
-    protected userService: UserService
   ) {}
 
   ngOnInit() {
@@ -35,6 +34,7 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
     this.setupForm();
     this.getReferences();
     this.setPrimaryEstablishmentName();
+    this.setServerErrors();
   }
 
   protected init() {}
@@ -50,7 +50,7 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
   protected getReferences(): void {}
 
   protected updateForm(): void {
-    this.references.forEach((reference: Workplace) => {
+    this.references.forEach((reference: Workplace | Worker) => {
       this.form.addControl(
         `name-${reference.uid}`,
         new FormControl(null, [Validators.required, this.uniqueValidator.bind(this)])
@@ -70,6 +70,15 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
         ],
       });
     });
+  }
+
+  private setServerErrors() {
+    this.serverErrorsMap = [
+      {
+        name: 503,
+        message: 'Service unavailable.',
+      },
+    ];
   }
 
   protected onError(error: HttpErrorResponse): void {

--- a/src/app/features/bulk-upload/staff-references-page/staff-references-page.component.ts
+++ b/src/app/features/bulk-upload/staff-references-page/staff-references-page.component.ts
@@ -1,15 +1,18 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BulkUploadFileType } from '@core/model/bulk-upload.model';
+import { Worker } from '@core/model/worker.model';
 import { AuthService } from '@core/services/auth.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { UserService } from '@core/services/user.service';
+import { WorkerService } from '@core/services/worker.service';
 import { BulkUploadReferences } from '@features/bulk-upload/bulk-upload-references/bulk-upload-references';
 
 @Component({
   selector: 'app-workplace-references-page',
   templateUrl: '../bulk-upload-references/bulk-upload-references.html',
+  styleUrls: ['../bulk-upload-references/bulk-upload-references.scss'],
 })
 export class StaffReferencesPageComponent extends BulkUploadReferences {
   // TODO check if needed
@@ -24,9 +27,9 @@ export class StaffReferencesPageComponent extends BulkUploadReferences {
     protected router: Router,
     protected formBuilder: FormBuilder,
     protected errorSummaryService: ErrorSummaryService,
-    protected userService: UserService
+    protected workerService: WorkerService
   ) {
-    super(authService, router, formBuilder, errorSummaryService, userService);
+    super(authService, router, formBuilder, errorSummaryService);
   }
 
   /** TODO check if needed
@@ -35,4 +38,20 @@ export class StaffReferencesPageComponent extends BulkUploadReferences {
     this.authService.isFirstBulkUpload = false;
   }
    **/
+
+  protected getReferences(): void {
+    this.subscriptions.add(
+      this.workerService.getAllWorkers().subscribe(
+        (references: Worker[]) => {
+          if (references) {
+            this.references = references;
+            if (this.references.length) {
+              this.updateForm();
+            }
+          }
+        },
+        (error: HttpErrorResponse) => this.onError(error)
+      )
+    );
+  }
 }

--- a/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
+++ b/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
@@ -27,9 +27,9 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
     protected router: Router,
     protected formBuilder: FormBuilder,
     protected errorSummaryService: ErrorSummaryService,
-    protected userService: UserService
+    private userService: UserService
   ) {
-    super(authService, router, formBuilder, errorSummaryService, userService);
+    super(authService, router, formBuilder, errorSummaryService);
   }
 
   /** TODO check if needed
@@ -39,21 +39,12 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
   }
    **/
 
-  protected init() {
-    this.serverErrorsMap = [
-      {
-        name: 503,
-        message: 'Service unavailable.',
-      },
-    ];
-  }
-
   protected getReferences(): void {
     this.subscriptions.add(
       this.userService.getEstablishments().subscribe(
-        (workplaces: GetWorkplacesResponse) => {
-          if (workplaces) {
-            this.references = workplaces.subsidaries ? workplaces.subsidaries.establishments : [];
+        (references: GetWorkplacesResponse) => {
+          if (references) {
+            this.references = references.subsidaries ? references.subsidaries.establishments : [];
             if (this.references.length) {
               this.updateForm();
             }

--- a/src/assets/scss/components/_grid.scss
+++ b/src/assets/scss/components/_grid.scss
@@ -4,7 +4,7 @@
 }
 
 .govuk__grid-container {
-  grid-template-columns: 40% 30% auto;
+  grid-template-columns: 33.33% 33.33% auto;
   border-bottom: solid 1px govuk-colour("grey-1");
   margin-bottom: 0;
   padding-top: govuk-spacing(2);


### PR DESCRIPTION
- invoke `getAllWorkers` api call and update ui
- display subsidiary name and enter temporary workplaces remaining count copy
- conditionally display name or nameOrId property on label
- relocated `WorkersResponse` and `WorkerEditResponse` to model file so they can be reused
- moved common 503 error code to base class
- removed/relocated userService from base class as only one child class needed it
- adjust cols width as per design