### PR TITLE
Merge Accessibility config changese into Develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,6 @@ deploy:
     space: sandbox
     manifest: manifest.featureGDS.yml
     on:
-        branch: feature/integrate-govuk-frontend
+        branch: develop_accessibility_demo
 notifications:
     slack: skills-for-care:Co9S4WS4ZitevGOyBrEb6yEL

--- a/server/config/accessibility.yaml
+++ b/server/config/accessibility.yaml
@@ -1,6 +1,35 @@
+aws:
+    region: eu-west-1
+    secrets:
+        use: true
+        wallet: demo/api
+db:
+    pool: 15
+    ssl: true
+    username: sfcdemoadmin
+    database: sfcdemodb
+    client_ssl:
+        status: true
+        usingFiles: false
+
 slack:
     level : 3     # enables Slack notifications
+
 jwt:
     iss: 'sfcaccessibility.cloudapps.digital'
     ttl:
         login: 10
+
+notify:
+    replyTo: '73711295-a4da-4303-9127-65be2a409681'
+    templates:
+        resetPassword: 'f2c43610-9ec9-4271-b9b1-dd55569b191c'
+        addUser: 'e581eea2-4206-4c90-8594-4357960e3e74'
+
+bulkupload:
+    region: eu-west-2
+    bucketname: sfc-bulkupload-staging
+
+public:
+    download:
+        baseurl: https://sfc-public-staging.s3.eu-west-2.amazonaws.com/public/download

--- a/server/config/accessibility.yaml
+++ b/server/config/accessibility.yaml
@@ -28,7 +28,7 @@ notify:
 
 bulkupload:
     region: eu-west-2
-    bucketname: sfc-bulkupload-staging
+    bucketname: sfc-bulkupload-demo
 
 public:
     download:


### PR DESCRIPTION
Hello, 

As part of client specfic environment, i have reuse the existing accessibility config file and copied all test config in it except the database name and user which points to accessibility related database. The AWS secret has also changed and point to demo/api.

In summary
- URL is sfcaccessbility
- DB is NEW and separate from dev/staging
- Application config file is accessibility.config
- AWS Secret (user, policy etc) new and separate  dev/staging

Thanks