### PR TITLE
Feature/bulk upload references update establishments

### DIFF
--- a/src/app/core/model/establishment.model.ts
+++ b/src/app/core/model/establishment.model.ts
@@ -113,3 +113,7 @@ export enum jobOptionsEnum {
   DONT_KNOW = "Don't know",
   NONE = 'None',
 }
+
+export interface LocalIdentifierRequest {
+  localIdentifier: string;
+}

--- a/src/app/core/model/my-workplaces.model.ts
+++ b/src/app/core/model/my-workplaces.model.ts
@@ -8,6 +8,9 @@ export interface GetWorkplacesResponse {
 
 export interface Workplace {
   dataOwner: WorkplaceDataOwner;
+  dataOwnerPermissions: string;
+  isParent: boolean;
+  localIdentifier: string;
   mainService: string;
   name: string;
   parentPermissions: ParentPermissions;

--- a/src/app/core/model/my-workplaces.model.ts
+++ b/src/app/core/model/my-workplaces.model.ts
@@ -27,3 +27,8 @@ export enum ParentPermissions {
   Workplace = 'Workplace',
   WorkplaceAndStaff = 'Workplace and Staff',
 }
+
+export interface WorkPlaceReference {
+  name: string;
+  uid: string;
+}

--- a/src/app/core/model/worker.model.ts
+++ b/src/app/core/model/worker.model.ts
@@ -6,6 +6,7 @@ export interface Worker {
   nameOrId: string;
   contract: Contracts;
   mainJob: JobRole;
+  localIdentifier: string;
   approvedMentalHealthWorker?: string;
   otherJobs?: JobRole[];
   mainJobStartDate?: string;

--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -11,6 +11,7 @@ import {
   ValidatedFilesResponse,
 } from '@core/model/bulk-upload.model';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
+import { WorkPlaceReference } from '@core/model/my-workplaces.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -26,6 +27,7 @@ export class BulkUploadService {
   public serverError$: BehaviorSubject<string> = new BehaviorSubject(null);
   public uploadedFiles$: BehaviorSubject<ValidatedFile[]> = new BehaviorSubject(null);
   public validationErrors$: BehaviorSubject<Array<ErrorDefinition>> = new BehaviorSubject(null);
+  public workPlaceReferences$: BehaviorSubject<WorkPlaceReference[]> = new BehaviorSubject(null);
 
   constructor(private http: HttpClient, private establishmentService: EstablishmentService) {}
 

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, isDevMode } from '@angular/core';
-import { Establishment, UpdateJobsRequest } from '@core/model/establishment.model';
+import { Establishment, LocalIdentifierRequest, UpdateJobsRequest } from '@core/model/establishment.model';
 import { AllServicesResponse, ServiceGroup } from '@core/model/services.model';
 import { URLStructure } from '@core/model/url.model';
 import { BehaviorSubject, Observable } from 'rxjs';
@@ -156,5 +156,9 @@ export class EstablishmentService {
 
   updateJobs(establishmentId, data: UpdateJobsRequest): Observable<Establishment> {
     return this.http.post<Establishment>(`/api/establishment/${establishmentId}/jobs`, data);
+  }
+
+  public updateLocalIdentifier(establishmentUid: string, localIdentifier: LocalIdentifierRequest): Observable<any> {
+    return this.http.post<any>(`/api/establishment/${establishmentUid}/localIdentifier`, localIdentifier);
   }
 }

--- a/src/app/core/services/worker.service.ts
+++ b/src/app/core/services/worker.service.ts
@@ -97,7 +97,13 @@ export class WorkerService {
     return this.http.get<Worker>(`/api/establishment/${this.establishmentService.establishmentId}/worker/${workerId}`);
   }
 
-  getAllWorkers() {
+  public getAllWorkersByUid(uid: string): Observable<Worker[]> {
+    return this.http
+      .get<WorkersResponse>(`/api/establishment/${uid}/worker`)
+      .pipe(map(w => w.workers));
+  }
+
+  public getAllWorkers(): Observable<Worker[]> {
     return this.http
       .get<WorkersResponse>(`/api/establishment/${this.establishmentService.establishmentId}/worker`)
       .pipe(map(w => w.workers));

--- a/src/app/core/services/worker.service.ts
+++ b/src/app/core/services/worker.service.ts
@@ -97,9 +97,9 @@ export class WorkerService {
     return this.http.get<Worker>(`/api/establishment/${this.establishmentService.establishmentId}/worker/${workerId}`);
   }
 
-  public getAllWorkersByUid(uid: string): Observable<Worker[]> {
+  public getAllWorkersByUid(establishmentUid: string): Observable<Worker[]> {
     return this.http
-      .get<WorkersResponse>(`/api/establishment/${uid}/worker`)
+      .get<WorkersResponse>(`/api/establishment/${establishmentUid}/worker`)
       .pipe(map(w => w.workers));
   }
 

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -51,26 +51,26 @@ TODO check if needed -->
       <div
         class="govuk-form-group govuk__grid govuk__grid-container"
         *ngFor="let reference of references"
-        [class.govuk-form-group--error]="form.get('name-' + reference.uid).errors && submitted"
-        [ngClass]="form.get('name-' + reference.uid).errors && submitted ? 'govuk__grid-two-rows' : 'govuk__grid-one-row'"
+        [class.govuk-form-group--error]="form.get(reference.uid).errors && submitted"
+        [ngClass]="form.get(reference.uid).errors && submitted ? 'govuk__grid-two-rows' : 'govuk__grid-one-row'"
       >
-        <label class="govuk-label govuk-!-margin-bottom-0" for="name-{{ reference.uid }}">
+        <label class="govuk-label govuk-!-margin-bottom-0" for="{{ reference.uid }}">
           {{ reference.name ? reference.name : reference.nameOrId }}
         </label>
         <span
-          id="name-{{ reference.uid }}-error"
+          id="{{ reference.uid }}-error"
           class="govuk-error-message govuk__grid-row-start-1 govuk__reference-grid-error"
-          *ngIf="form.get('name-' + reference.uid).errors && submitted"
+          *ngIf="form.get(reference.uid).errors && submitted"
         >
-          <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('name-' + reference.uid) }}
+          <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage(reference.uid) }}
         </span>
         <input
           class="govuk-input"
-          [class.govuk-input--error]="form.get('name-' + reference.uid).errors && submitted"
-          id="name-{{ reference.uid }}"
-          name="name-{{ reference.uid }}"
+          [class.govuk-input--error]="form.get(reference.uid).errors && submitted"
+          id="{{ reference.uid }}"
+          name="{{ reference.uid }}"
           type="text"
-          formControlName="name-{{ reference.uid }}"
+          formControlName="{{ reference.uid }}"
           [value]="reference.localIdentifier"
         />
         <p

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -36,7 +36,7 @@ TODO check if needed -->
       id="server-error"
     >
       <div class="govuk__grid govuk__grid-container">
-        <ng-container *ngIf="referenceType === referenceTypeEnum.Worker">
+        <ng-container *ngIf="referenceType === referenceTypeEnum.Worker && establishmentName">
           <h2 class="govuk-heading-m govuk__reference-subsidiary-name">{{ establishmentName }}</h2>
           <p class="govuk-!-margin-0 govuk__justify-self-end">
             <strong>{{ remainingEstablishments }}</strong> workplaces remaining

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -10,7 +10,7 @@
 TODO check if needed -->
 
 <app-error-summary
-  *ngIf="submitted && (form.invalid || serverError)"
+  *ngIf="(submitted && form.invalid) || serverError"
   [serverError]="serverError"
   [formErrorsMap]="formErrorsMap"
   [form]="form"
@@ -31,7 +31,7 @@ TODO check if needed -->
       class="govuk-!-margin-top-6"
       *ngIf="references.length"
       novalidate
-      (ngSubmit)="onSubmit()"
+      (ngSubmit)="onSubmit(true)"
       [formGroup]="form"
       id="server-error"
     >
@@ -71,6 +71,7 @@ TODO check if needed -->
           name="name-{{ reference.uid }}"
           type="text"
           formControlName="name-{{ reference.uid }}"
+          [value]="reference.localIdentifier"
         />
         <p class="govuk-!-margin-bottom-0 govuk__justify-self-end"><a href="">Staff references</a></p>
       </div>
@@ -84,12 +85,12 @@ TODO check if needed -->
           <button
             type="button"
             class="govuk-button govuk-!-margin-right-8 govuk-!-margin-bottom-0"
-            (click)="onSubmit()"
+            (click)="onSubmit(true)"
           >
             Save and continue
           </button>
           <span class="govuk-visually-hidden">or</span>
-          <button type="button" class="govuk-button govuk-button--link govuk-!-margin-bottom-0" (click)="onSubmit()">
+          <button type="button" class="govuk-button govuk-button--link govuk-!-margin-bottom-0" (click)="onSubmit(false)">
             Save and exit
           </button>
         </div>

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -75,7 +75,7 @@ TODO check if needed -->
         />
         <p
           class="govuk-!-margin-bottom-0 govuk__justify-self-end"
-          *ngIf="referenceType === referenceTypeEnum.Establishment"
+          *ngIf="referenceType === referenceTypeEnum.Establishment && reference.localIdentifier"
         >
           <a [routerLink]="['/bulk-upload/staff-references', reference.uid]">Staff references</a>
         </p>

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -38,10 +38,10 @@ TODO check if needed -->
       <div
         class="govuk__grid govuk__grid-container"
       >
-        <!-- TODO remove hardcoded sub name once BE updates api -->
-        <h2 class="govuk-heading-m govuk__reference-subsidiary-name">Collingwood Grange</h2>
-        <!-- TODO remove hardcoded count once BE updates api -->
-        <p class="govuk-!-margin-0 govuk__justify-self-end"><strong>8</strong> workplaces remaining</p>
+        <ng-container *ngIf="referenceType === referenceTypeEnum.Worker">
+          <h2 class="govuk-heading-m govuk__reference-subsidiary-name">Collingwood Grange</h2>
+          <p class="govuk-!-margin-0 govuk__justify-self-end"><strong>8</strong> workplaces remaining</p>
+        </ng-container>
         <p class="govuk-!-margin-bottom-0"><strong>{{ columnOneLabel }}</strong></p>
         <p class="govuk-!-margin-bottom-0">
           <strong>{{ columnTwoLabel }}</strong>
@@ -73,7 +73,9 @@ TODO check if needed -->
           formControlName="name-{{ reference.uid }}"
           [value]="reference.localIdentifier"
         />
-        <p class="govuk-!-margin-bottom-0 govuk__justify-self-end"><a href="">Staff references</a></p>
+        <p class="govuk-!-margin-bottom-0 govuk__justify-self-end">
+          <a [routerLink]="['/bulk-upload/staff-references', reference.uid]">Staff references</a>
+        </p>
       </div>
     </form>
 

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -39,8 +39,10 @@ TODO check if needed -->
         class="govuk__grid govuk__grid-container"
       >
         <ng-container *ngIf="referenceType === referenceTypeEnum.Worker">
-          <h2 class="govuk-heading-m govuk__reference-subsidiary-name">Collingwood Grange</h2>
-          <p class="govuk-!-margin-0 govuk__justify-self-end"><strong>8</strong> workplaces remaining</p>
+          <h2 class="govuk-heading-m govuk__reference-subsidiary-name">{{ establishmentName }}</h2>
+          <p class="govuk-!-margin-0 govuk__justify-self-end">
+            <strong>{{ remainingEstablishments }}</strong> workplaces remaining
+          </p>
         </ng-container>
         <p class="govuk-!-margin-bottom-0"><strong>{{ columnOneLabel }}</strong></p>
         <p class="govuk-!-margin-bottom-0">

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -1,14 +1,3 @@
-<!-- TODO check if needed
-<button (click)="updateReferences()">Update References</button>
-
-<ng-container *ngIf="referencesUpdated">
- <p>Settings updated</p>
- <p>
-   <a [routerLink]="['/bulk-upload']">Go to Bulk Upload</a>
- </p>
-</ng-container>
-TODO check if needed -->
-
 <app-error-summary
   *ngIf="(submitted && form.invalid) || serverError"
   [serverError]="serverError"

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -60,7 +60,6 @@
           name="{{ reference.uid }}"
           type="text"
           formControlName="{{ reference.uid }}"
-          [value]="reference.localIdentifier"
         />
         <p
           class="govuk-!-margin-bottom-0 govuk__justify-self-end"

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.html
@@ -35,9 +35,7 @@ TODO check if needed -->
       [formGroup]="form"
       id="server-error"
     >
-      <div
-        class="govuk__grid govuk__grid-container"
-      >
+      <div class="govuk__grid govuk__grid-container">
         <ng-container *ngIf="referenceType === referenceTypeEnum.Worker">
           <h2 class="govuk-heading-m govuk__reference-subsidiary-name">{{ establishmentName }}</h2>
           <p class="govuk-!-margin-0 govuk__justify-self-end">
@@ -75,7 +73,10 @@ TODO check if needed -->
           formControlName="name-{{ reference.uid }}"
           [value]="reference.localIdentifier"
         />
-        <p class="govuk-!-margin-bottom-0 govuk__justify-self-end">
+        <p
+          class="govuk-!-margin-bottom-0 govuk__justify-self-end"
+          *ngIf="referenceType === referenceTypeEnum.Establishment"
+        >
           <a [routerLink]="['/bulk-upload/staff-references', reference.uid]">Staff references</a>
         </p>
       </div>
@@ -94,7 +95,11 @@ TODO check if needed -->
             Save and continue
           </button>
           <span class="govuk-visually-hidden">or</span>
-          <button type="button" class="govuk-button govuk-button--link govuk-!-margin-bottom-0" (click)="onSubmit(false)">
+          <button
+            type="button"
+            class="govuk-button govuk-button--link govuk-!-margin-bottom-0"
+            (click)="onSubmit(false)"
+          >
             Save and exit
           </button>
         </div>

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -2,6 +2,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { OnDestroy, OnInit } from '@angular/core';
 import { AbstractControl, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
+import { BulkUploadFileType } from '@core/model/bulk-upload.model';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { Workplace } from '@core/model/my-workplaces.model';
 import { URLStructure } from '@core/model/url.model';
@@ -13,10 +14,11 @@ import { Subscription } from 'rxjs';
 export class BulkUploadReferences implements OnInit, OnDestroy {
   protected subscriptions: Subscription = new Subscription();
   public form: FormGroup;
-  public formErrorsMap: ErrorDetails[] = []; // TODO look at generic error messages
+  public formErrorsMap: ErrorDetails[] = [];
   public primaryEstablishmentName: string;
   public references: Array<Workplace | Worker> = [];
   public referenceType: string;
+  public referenceTypeEnum = BulkUploadFileType;
   public return: URLStructure;
   public serverError: string;
   public serverErrorsMap: ErrorDefinition[] = [];
@@ -32,7 +34,6 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
   ngOnInit() {
     this.init();
     this.setupForm();
-    this.getReferences();
     this.setPrimaryEstablishmentName();
     this.setServerErrors();
   }
@@ -40,14 +41,14 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
   protected init() {}
 
   private setPrimaryEstablishmentName(): void {
-    this.primaryEstablishmentName = this.authService.establishment.name;
+    this.primaryEstablishmentName = this.authService.establishment ? this.authService.establishment.name : null;
   }
 
   private setupForm(): void {
     this.form = this.formBuilder.group({});
   }
 
-  protected getReferences(): void {}
+  protected getReferences(establishmentUid?: string): void {}
 
   protected updateForm(): void {
     this.references.forEach((reference: Workplace | Worker) => {

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -81,6 +81,10 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
         name: 503,
         message: 'Service unavailable.',
       },
+      {
+        name: 404,
+        message: `Unable to update ${this.referenceType.toLowerCase()} references.`,
+      },
     ];
   }
 

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -1,15 +1,16 @@
+import { AbstractControl, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { AuthService } from '@core/services/auth.service';
+import { BulkUploadFileType } from '@core/model/bulk-upload.model';
+import { BulkUploadService } from '@core/services/bulk-upload.service';
+import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
+import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { OnDestroy, OnInit } from '@angular/core';
-import { AbstractControl, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
-import { BulkUploadFileType } from '@core/model/bulk-upload.model';
-import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
-import { Workplace } from '@core/model/my-workplaces.model';
+import { Subscription } from 'rxjs';
 import { URLStructure } from '@core/model/url.model';
 import { Worker } from '@core/model/worker.model';
-import { AuthService } from '@core/services/auth.service';
-import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { Subscription } from 'rxjs';
+import { Workplace } from '@core/model/my-workplaces.model';
 
 export class BulkUploadReferences implements OnInit, OnDestroy {
   protected subscriptions: Subscription = new Subscription();
@@ -23,12 +24,15 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
   public serverError: string;
   public serverErrorsMap: ErrorDefinition[] = [];
   public submitted = false;
+  public establishmentName: string;
+  public remainingEstablishments: number;
 
   constructor(
     protected authService: AuthService,
     protected router: Router,
     protected formBuilder: FormBuilder,
     protected errorSummaryService: ErrorSummaryService,
+    protected bulkUploadService: BulkUploadService,
   ) {}
 
   ngOnInit() {

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -1,7 +1,6 @@
 import { AbstractControl, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { AuthService } from '@core/services/auth.service';
 import { BulkUploadFileType } from '@core/model/bulk-upload.model';
-import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -32,7 +31,6 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
     protected router: Router,
     protected formBuilder: FormBuilder,
     protected errorSummaryService: ErrorSummaryService,
-    protected bulkUploadService: BulkUploadService,
   ) {}
 
   ngOnInit() {
@@ -102,19 +100,14 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
     return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
   }
 
-  protected saveAndContinue(): void {}
-  protected saveAndExit(): void {}
+  protected save(saveAndContinue: boolean): void {}
 
   public onSubmit(saveAndContinue: boolean): void {
     this.submitted = true;
     this.errorSummaryService.syncFormErrorsEvent.next(true);
 
     if (this.form.valid) {
-      if (saveAndContinue) {
-        this.saveAndContinue();
-      } else {
-        this.saveAndExit();
-      }
+      this.save(saveAndContinue);
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -82,7 +82,7 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
         message: 'Service unavailable.',
       },
       {
-        name: 404,
+        name: 400,
         message: `Unable to update ${this.referenceType.toLowerCase()} references.`,
       },
     ];

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -12,25 +12,26 @@ import { Worker } from '@core/model/worker.model';
 import { Workplace } from '@core/model/my-workplaces.model';
 
 export class BulkUploadReferences implements OnInit, OnDestroy {
+  protected maxLength = 120;
   protected subscriptions: Subscription = new Subscription();
+  public establishmentName: string;
   public form: FormGroup;
   public formErrorsMap: ErrorDetails[] = [];
   public primaryEstablishmentName: string;
   public references: Array<Workplace | Worker> = [];
   public referenceType: string;
   public referenceTypeEnum = BulkUploadFileType;
+  public remainingEstablishments: number;
   public return: URLStructure;
   public serverError: string;
   public serverErrorsMap: ErrorDefinition[] = [];
   public submitted = false;
-  public establishmentName: string;
-  public remainingEstablishments: number;
 
   constructor(
     protected authService: AuthService,
     protected router: Router,
     protected formBuilder: FormBuilder,
-    protected errorSummaryService: ErrorSummaryService,
+    protected errorSummaryService: ErrorSummaryService
   ) {}
 
   ngOnInit() {
@@ -56,7 +57,11 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
     this.references.forEach((reference: Workplace | Worker) => {
       this.form.addControl(
         reference.uid,
-        new FormControl(null, [Validators.required, this.uniqueValidator.bind(this)])
+        new FormControl(reference.localIdentifier, [
+          Validators.required,
+          Validators.maxLength(this.maxLength),
+          this.uniqueValidator.bind(this),
+        ])
       );
 
       this.formErrorsMap.push({
@@ -65,6 +70,10 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
           {
             name: 'required',
             message: `Enter the missing ${this.referenceType.toLowerCase()} reference.`,
+          },
+          {
+            name: 'maxlength',
+            message: `The reference must be ${this.maxLength} characters or less.`,
           },
           {
             name: 'unique',
@@ -93,7 +102,7 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
     this.errorSummaryService.scrollToErrorSummary();
   }
 
-  protected uniqueValidator(control: AbstractControl): { [key: string]: boolean } | null  {
+  protected uniqueValidator(control: AbstractControl): { [key: string]: boolean } | null {
     const formValues: string[] = Object.values(this.form.value);
     const isDuplicate: boolean = formValues.includes(control.value);
     return isDuplicate ? { unique: true } : null;

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -57,12 +57,12 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
   protected updateForm(): void {
     this.references.forEach((reference: Workplace | Worker) => {
       this.form.addControl(
-        `name-${reference.uid}`,
+        reference.uid,
         new FormControl(null, [Validators.required, this.uniqueValidator.bind(this)])
       );
 
       this.formErrorsMap.push({
-        item: `name-${reference.uid}`,
+        item: reference.uid,
         type: [
           {
             name: 'required',

--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -97,12 +97,19 @@ export class BulkUploadReferences implements OnInit, OnDestroy {
     return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
   }
 
-  public onSubmit(): void {
+  protected saveAndContinue(): void {}
+  protected saveAndExit(): void {}
+
+  public onSubmit(saveAndContinue: boolean): void {
     this.submitted = true;
     this.errorSummaryService.syncFormErrorsEvent.next(true);
 
     if (this.form.valid) {
-      console.log('form valid');
+      if (saveAndContinue) {
+        this.saveAndContinue();
+      } else {
+        this.saveAndExit();
+      }
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }

--- a/src/app/features/bulk-upload/bulk-upload-routing.module.ts
+++ b/src/app/features/bulk-upload/bulk-upload-routing.module.ts
@@ -13,18 +13,22 @@ const routes: Routes = [
     path: '',
     component: BulkUploadPageComponent,
     canActivate: [BulkUploadGuard],
+    data: { title: 'Home' },
   },
   {
     path: 'start',
     component: BulkUploadStartPageComponent,
+    data: { title: 'Start' },
   },
   {
     path: 'workplace-references',
     component: WorkplaceReferencesPageComponent,
+    data: { title: 'Workplace references' },
   },
   {
-    path: 'staff-references',
+    path: 'staff-references/:uid',
     component: StaffReferencesPageComponent,
+    data: { title: 'Staff references' },
   },
 ];
 

--- a/src/app/features/bulk-upload/staff-references-page/staff-references-page.component.ts
+++ b/src/app/features/bulk-upload/staff-references-page/staff-references-page.component.ts
@@ -28,15 +28,15 @@ export class StaffReferencesPageComponent extends BulkUploadReferences {
   private establishmentUid: string;
 
   constructor(
+    private activatedRoute: ActivatedRoute,
+    private bulkUploadService: BulkUploadService,
     protected authService: AuthService,
-    protected router: Router,
-    protected formBuilder: FormBuilder,
     protected errorSummaryService: ErrorSummaryService,
+    protected formBuilder: FormBuilder,
+    protected router: Router,
     protected workerService: WorkerService,
-    protected bulkUploadService: BulkUploadService,
-    private activatedRoute: ActivatedRoute
   ) {
-    super(authService, router, formBuilder, errorSummaryService, bulkUploadService);
+    super(authService, router, formBuilder, errorSummaryService);
   }
 
   /** TODO check if needed

--- a/src/app/features/bulk-upload/staff-references-page/staff-references-page.component.ts
+++ b/src/app/features/bulk-upload/staff-references-page/staff-references-page.component.ts
@@ -1,13 +1,14 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BulkUploadFileType } from '@core/model/bulk-upload.model';
 import { Worker } from '@core/model/worker.model';
 import { AuthService } from '@core/services/auth.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { WorkerService } from '@core/services/worker.service';
 import { BulkUploadReferences } from '@features/bulk-upload/bulk-upload-references/bulk-upload-references';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-workplace-references-page',
@@ -27,7 +28,8 @@ export class StaffReferencesPageComponent extends BulkUploadReferences {
     protected router: Router,
     protected formBuilder: FormBuilder,
     protected errorSummaryService: ErrorSummaryService,
-    protected workerService: WorkerService
+    protected workerService: WorkerService,
+    private activatedRoute: ActivatedRoute
   ) {
     super(authService, router, formBuilder, errorSummaryService);
   }
@@ -39,9 +41,15 @@ export class StaffReferencesPageComponent extends BulkUploadReferences {
   }
    **/
 
-  protected getReferences(): void {
+  protected init(): void {
     this.subscriptions.add(
-      this.workerService.getAllWorkers().subscribe(
+      this.activatedRoute.params.pipe(take(1)).subscribe(params => this.getReferences(params.uid))
+    );
+  }
+
+  protected getReferences(establishmentUid: string): void {
+    this.subscriptions.add(
+      this.workerService.getAllWorkersByUid(establishmentUid).subscribe(
         (references: Worker[]) => {
           if (references) {
             this.references = references;

--- a/src/app/features/bulk-upload/staff-references-page/staff-references-page.component.ts
+++ b/src/app/features/bulk-upload/staff-references-page/staff-references-page.component.ts
@@ -19,8 +19,6 @@ import { filter, findIndex } from 'lodash';
   styleUrls: ['../bulk-upload-references/bulk-upload-references.scss'],
 })
 export class StaffReferencesPageComponent extends BulkUploadReferences {
-  // TODO check if needed
-  public referencesUpdated = false;
   public referenceType = BulkUploadFileType.Worker;
   public referenceTypeInfo = 'You must create unique references for each member of staff.';
   public columnOneLabel = 'Name';
@@ -38,13 +36,6 @@ export class StaffReferencesPageComponent extends BulkUploadReferences {
   ) {
     super(authService, router, formBuilder, errorSummaryService);
   }
-
-  /** TODO check if needed
-   public updateReferences() {
-    this.referencesUpdated = true;
-    this.authService.isFirstBulkUpload = false;
-  }
-   **/
 
   protected init(): void {
     this.subscriptions.add(

--- a/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
+++ b/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
@@ -28,15 +28,15 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
   private workPlaceReferences: WorkPlaceReference[] = [];
 
   constructor(
-    protected authService: AuthService,
-    protected router: Router,
-    protected formBuilder: FormBuilder,
-    protected errorSummaryService: ErrorSummaryService,
-    protected bulkUploadService: BulkUploadService,
+    private bulkUploadService: BulkUploadService,
+    private establishmentService: EstablishmentService,
     private userService: UserService,
-    private establishmentService: EstablishmentService
+    protected authService: AuthService,
+    protected errorSummaryService: ErrorSummaryService,
+    protected formBuilder: FormBuilder,
+    protected router: Router,
   ) {
-    super(authService, router, formBuilder, errorSummaryService, bulkUploadService);
+    super(authService, router, formBuilder, errorSummaryService);
   }
 
   /** TODO check if needed
@@ -77,7 +77,7 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
     );
   }
 
-  protected saveAndContinue(): void {
+  protected save(saveAndContinue: boolean): void {
     const requests = [];
     const payloads = Object.keys(this.form.value).map(key => ({
       uid: key,
@@ -89,7 +89,13 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
     this.subscriptions.add(
       forkJoin(...requests)
         .pipe(take(1))
-        .subscribe()
+        .subscribe(() => {
+          if (saveAndContinue) {
+            this.router.navigate(['/bulk-upload/staff-references', this.workPlaceReferences[0].uid]);
+          } else {
+            this.router.navigate(['/dashboard']);
+          }
+        })
     );
   }
 }

--- a/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
+++ b/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
@@ -39,6 +39,10 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
   }
    **/
 
+  protected init(): void {
+    this.getReferences();
+  }
+
   protected getReferences(): void {
     this.subscriptions.add(
       this.userService.getEstablishments().subscribe(

--- a/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
+++ b/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
@@ -19,8 +19,6 @@ import { take } from 'rxjs/operators';
   styleUrls: ['../bulk-upload-references/bulk-upload-references.scss'],
 })
 export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
-  // TODO check if needed
-  public referencesUpdated = false;
   public referenceType = BulkUploadFileType.Establishment;
   public referenceTypeInfo = 'You must create unique references for each workplace.';
   public columnOneLabel = 'Workplace';
@@ -38,13 +36,6 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
   ) {
     super(authService, router, formBuilder, errorSummaryService);
   }
-
-  /** TODO check if needed
-   public updateReferences() {
-    this.referencesUpdated = true;
-    this.authService.isFirstBulkUpload = false;
-  }
-   **/
 
   protected init(): void {
     this.getReferences();

--- a/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
+++ b/src/app/features/bulk-upload/workplace-references-page/workplace-references-page.component.ts
@@ -32,7 +32,7 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
     protected authService: AuthService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
-    protected router: Router,
+    protected router: Router
   ) {
     super(authService, router, formBuilder, errorSummaryService);
   }
@@ -80,13 +80,16 @@ export class WorkplaceReferencesPageComponent extends BulkUploadReferences {
     this.subscriptions.add(
       forkJoin(...requests)
         .pipe(take(1))
-        .subscribe(() => {
-          if (saveAndContinue) {
-            this.router.navigate(['/bulk-upload/staff-references', this.workPlaceReferences[0].uid]);
-          } else {
-            this.router.navigate(['/dashboard']);
-          }
-        })
+        .subscribe(
+          () => {
+            if (saveAndContinue) {
+              this.router.navigate(['/bulk-upload/staff-references', this.workPlaceReferences[0].uid]);
+            } else {
+              this.router.navigate(['/dashboard']);
+            }
+          },
+          (error: HttpErrorResponse) => this.onError(error)
+        )
     );
   }
 }


### PR DESCRIPTION
this pr completes `https://trello.com/c/AscBN35F` and due to the stateless nature of the BE means the FE has to make x amount of api calls in order to update all establishments.

- added `WorkPlaceReference`, `LocalIdentifierRequest` models, update `Workplace` model
- store `workPlaceReferences$` in an observable in order to get establishment name as this is not exposed on the get all workers api
- added new `updateLocalIdentifier` and `getAllWorkersByUid` methods on there appropriate services
- added missing seo page titles for bulk upload screens