### PR TITLE
new "admin" user role on login

### DIFF
--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -301,7 +301,6 @@ class User {
                     uid: this.uid,
                     updatedBy: savedBy.toLowerCase(),
                     isPrimary: this._isPrimary,
-                    isAdmin: false,
                     archived: false,
                     attributes: ['id', 'created', 'updated'],
                 };
@@ -549,7 +548,6 @@ class User {
                 // fetch by username
                 fetchQuery = {
                     where: {
-                        establishmentId: this._establishmentId,
                         archived: false,
                     },
                     include: [
@@ -566,7 +564,6 @@ class User {
                 // fetch by username
                 fetchQuery = {
                     where: {
-                        establishmentId: this._establishmentId,
                         uid: uid,
                         archived: false,
                     },
@@ -579,8 +576,11 @@ class User {
                 };
             }
 
+            console.log("WA DEBUG - restoring user: ", fetchQuery)
+
             const fetchResults = await models.user.findOne(fetchQuery);
             if (fetchResults && fetchResults.id && Number.isInteger(fetchResults.id)) {
+              console.log("WA DEBUG - restored User")
                 // update self - don't use setters because they modify the change state
                 this._isNew = false;
                 this._id = fetchResults.id;
@@ -906,8 +906,9 @@ class User {
 
             // now, if the primary establishment is a parent
             //  and if the user's role against their primary parent is Edit
-            //  fetch all other establishments associated with this parnet
-            if (myRole === 'Edit' && isParent) {
+            //  fetch all other establishments associated with this parent
+            console.log("WA DEBUG - my role: ", myRole)
+            if ((myRole === 'Edit' || myRole === 'Admin') && isParent) {
                 // get all subsidaries associated with this parent
                 allSubResults = await models.establishment.findAll({
                     attributes: ['uid', 'isParent', 'dataOwner', 'parentUid', 'LocalIdentifierValue', 'parentPermissions', 'NameValue', 'updated'],

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -576,11 +576,8 @@ class User {
                 };
             }
 
-            console.log("WA DEBUG - restoring user: ", fetchQuery)
-
             const fetchResults = await models.user.findOne(fetchQuery);
             if (fetchResults && fetchResults.id && Number.isInteger(fetchResults.id)) {
-              console.log("WA DEBUG - restored User")
                 // update self - don't use setters because they modify the change state
                 this._isNew = false;
                 this._id = fetchResults.id;
@@ -907,7 +904,6 @@ class User {
             // now, if the primary establishment is a parent
             //  and if the user's role against their primary parent is Edit
             //  fetch all other establishments associated with this parent
-            console.log("WA DEBUG - my role: ", myRole)
             if ((myRole === 'Edit' || myRole === 'Admin') && isParent) {
                 // get all subsidaries associated with this parent
                 allSubResults = await models.establishment.findAll({

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -17,7 +17,7 @@ module.exports = function(sequelize, DataTypes) {
     },
     establishmentId: {
       type: DataTypes.INTEGER,
-      allowNull: false,
+      allowNull: true,
       field: '"EstablishmentID"'
     },
     archived: {
@@ -186,7 +186,7 @@ module.exports = function(sequelize, DataTypes) {
     UserRoleValue: {
       type: DataTypes.ENUM,
       allowNull: false,
-      values: ['Read', 'Edit'],
+      values: ['Read', 'Edit', 'Admin'],
       default: 'Edit',
       field: '"UserRoleValue"'
     },
@@ -209,12 +209,6 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.TEXT,
       allowNull: true,
       field: '"UserRoleChangedBy"'
-    },
-    isAdmin: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      default: false,
-      field: '"AdminUser"'
     },
     tribalId: {
       type: DataTypes.INTEGER,

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -29,181 +29,233 @@ const tribalHashCompare = (password, salt, expectedHash) => {
   }
 };
 
-router.post('/',async function(req, res) {
-   Login
-      .findOne({
+router.post('/', async (req, res) => {
+  const givenUsername = req.body.username.toLowerCase();
+  const givenPassword = req.body.password;
+  const givenEstablishmentUid = req.body.establishment && req.body.establishment.uid ? req.body.establishment.uid : null;
+
+  try {
+    let establishmentUser = givenEstablishmentUid === null ? await models.login.findOne({
+      where: {
+        username: givenUsername,
+        isActive:true
+      },
+      attributes: ['id', 'username', 'isActive', 'invalidAttempt', 'registrationId', 'firstLogin', 'Hash', 'lastLogin', 'tribalHash', 'tribalSalt'],
+      include: [ {
+        model: models.user,
+        attributes: ['id', 'FullNameValue', 'EmailValue', 'isPrimary', 'establishmentId', "UserRoleValue", 'tribalId'],
+        include: [{
+          model: models.establishment,
+          attributes: ['id', 'uid', 'NameValue', 'isRegulated', 'nmdsId', 'isParent', 'parentUid', 'parentId'],
+          include: [{
+            model: models.services,
+            as: 'mainService',
+            attributes: ['id', 'name']
+          }]
+        }]
+      }]
+    }) : null;
+
+    if (!establishmentUser || !establishmentUser.user) {
+      // before returning error, check to see if this is a superadmin user with a given establishment UID, to be assumed as their "logged in session" primary establishment
+      establishmentUser = await models.login.findOne({
         where: {
-          username: {
-            [models.Sequelize.Op.iLike] : req.body.username.toLowerCase()
-          },
-          isActive:true
+          username: givenUsername,
+          isActive:true,
         },
         attributes: ['id', 'username', 'isActive', 'invalidAttempt', 'registrationId', 'firstLogin', 'Hash', 'lastLogin', 'tribalHash', 'tribalSalt'],
         include: [ {
           model: models.user,
-          attributes: ['id', 'FullNameValue', 'EmailValue', 'isAdmin', 'isPrimary', 'establishmentId', "UserRoleValue", 'tribalId'],
-          include: [{
-            model: models.establishment,
-            attributes: ['id', 'uid', 'NameValue', 'isRegulated', 'nmdsId', 'isParent', 'parentUid', 'parentId'],
-            include: [{
-              model: models.services,
-              as: 'mainService',
-              attributes: ['id', 'name']
-            }]
-          }]
+          attributes: ['id', 'FullNameValue', 'EmailValue', 'isPrimary', 'establishmentId', "UserRoleValue", 'tribalId'],
+          where: {
+            UserRoleValue: 'Admin',
+          }
         }]
-      
-      })
-      .then((login) => {
+      });
 
-        if (!login || !login.user) {
-          console.error(`Failed to find user account associated with: ${req.body.username} - `, login);
+      if (establishmentUser && establishmentUser.user && establishmentUser.user.id) {
+        if (!givenEstablishmentUid) {
+          console.error('This is an admin user; expect establishment.uid');
+          return res.status(400).send({});
+        }
+
+        // this is an admin user, find the given establishment
+        establishmentUser.user.establishment = await models.establishment.findOne({
+          attributes: ['id', 'uid', 'NameValue', 'isRegulated', 'nmdsId', 'isParent', 'parentUid', 'parentId'],
+          include: [{
+            model: models.services,
+            as: 'mainService',
+            attributes: ['id', 'name']
+          }],
+          where: {
+            uid: givenEstablishmentUid
+          }
+        });
+
+        if (establishmentUser.user.establishment && establishmentUser.user.establishment.id) {
+          console.log(`Found admin user (${givenUsername}) and establishment (${givenEstablishmentUid})`);
+        } else {
+          console.error('POST .../login failed: on finding the given establishment');
           return res.status(401).send({
             message: 'Authentication failed.',
           });
         }
+      } else {
+        console.error(`Failed to find user account associated with: ${givenUsername}`);
+        return res.status(401).send({
+          message: 'Authentication failed.',
+        });
+      }
+    }
 
-        // if this found login account is a migrated tribal account, and there is no current hash, then
-        //  we need to first validate password using tribal hashing
-        let tribalErr = null;
-        let tribalHashValidated = false;
-        if (login.user.tribalId !== null && login.Hash === null) {
-          tribalHashValidated = true;
-          const tribalHashCompareReset = tribalHashCompare(req.body.password, login.tribalSalt, login.tribalHash);
+    // if this found login account is a migrated tribal account, and there is no current hash, then
+    //  we need to first validate password using tribal hashing
+    let tribalErr = null;
+    let tribalHashValidated = false;
+    if (establishmentUser.user.tribalId !== null && login.Hash === null) {
+      tribalHashValidated = true;
+      const tribalHashCompareReset = tribalHashCompare(givenPassword, login.tribalSalt, login.tribalHash);
 
-          if (tribalHashCompareReset === false) {
-            tribalErr = 'Failed to authenticate using tribal hash';
+      if (tribalHashCompareReset === false) {
+        tribalErr = 'Failed to authenticate using tribal hash';
+      }
+    }
+
+    establishmentUser.comparePassword(escape(givenPassword), tribalErr, tribalHashValidated, async (err, isMatch, rehashTribal) => {
+      if (isMatch && !err) {
+        const loginTokenTTL = config.get('jwt.ttl.login');
+
+        const token = generateJWT.loginJWT(loginTokenTTL, establishmentUser.user.establishment.id, establishmentUser.user.establishment.uid, establishmentUser.user.establishment.isParent, givenUsername, establishmentUser.user.UserRoleValue);
+        var date = new Date().getTime();
+        date += (loginTokenTTL * 60  * 1000);
+
+
+        // dereference the parent establishment's name
+        if (Number.isInteger(establishmentUser.user.establishment.parentId)) {
+          const parentEstablishment = await models.establishment.findOne({
+            attributes: ['NameValue'],
+            where: {
+              id: establishmentUser.user.establishment.parentId
+            }
+          });
+
+          if (parentEstablishment.NameValue) {
+            establishmentUser.user.establishment.parentName = parentEstablishment.NameValue;
           }
         }
 
-        login.comparePassword(escape(req.body.password), tribalErr, tribalHashValidated, async (err, isMatch, rehashTribal) => {
-          if (isMatch && !err) {
-            const loginTokenTTL = config.get('jwt.ttl.login');
+        const response = formatSuccessulLoginResponse(
+          establishmentUser.user.FullNameValue,
+          establishmentUser.firstLogin,
+          establishmentUser.user.isPrimary,
+          establishmentUser.lastLogin,
+          establishmentUser.user.UserRoleValue,
+          establishmentUser.user.establishment,
+          establishmentUser.user.establishment.mainService,
+          new Date(date).toISOString()
+        );
 
-            const token = generateJWT.loginJWT(loginTokenTTL, login.user.establishment.id, login.user.establishment.uid, login.user.establishment.isParent, req.body.username.toLowerCase(), login.user.UserRoleValue);
-            var date = new Date().getTime();
-            date += (loginTokenTTL * 60  * 1000);
+        await models.sequelize.transaction(async t => {
+          // check if this is the first time logged in and if so, update the "FirstLogin" timestamp
+          // reset the number of failed attempts on any successful login
+          const loginUpdate = {
+            invalidAttempt: 0,
+            lastLogin: new Date(),
+          };
 
-
-            // dereference the parent establishment's name
-            if (Number.isInteger(login.user.establishment.parentId)) {
-              const parentEstablishment = await models.establishment.findOne({
-                attributes: ['NameValue'],
-                where: {
-                  id: login.user.establishment.parentId
-                }
-              });
-
-              if (parentEstablishment.NameValue) {
-                login.user.establishment.parentName = parentEstablishment.NameValue;
-              }
-            }
-   
-            const response = formatSuccessulLoginResponse(
-              login.user.FullNameValue,
-              login.firstLogin,
-              login.user.isPrimary,
-              login.lastLogin,
-              login.user.UserRoleValue,
-              login.user.establishment,
-              login.user.establishment.mainService,
-              new Date(date).toISOString()
-            );
-
-            await models.sequelize.transaction(async t => {
-              // check if this is the first time logged in and if so, update the "FirstLogin" timestamp
-              // reset the number of failed attempts on any successful login
-              const loginUpdate = {
-                invalidAttempt: 0,
-                lastLogin: new Date(),
-              };
-
-              // if this is a migrated tribal user's first login, and consequently, the compare is successful
-              //   but they still have no "Hash", we need to create a hash and store it.
-              if (rehashTribal) {
-                loginUpdate.Hash =  await bcrypt.hashSync(req.body.password, bcrypt.genSaltSync(10), null)
-              }
-
-
-              if (!login.firstLogin) {
-                loginUpdate.firstLogin = new Date();
-              }
-              login.update(loginUpdate, {transaction: t});
-
-              // add an audit record
-              const auditEvent = {
-                userFk: login.user.id,
-                username: login.username,
-                type: 'loginSuccess',
-                property: 'password',
-                event: {}
-              };
-              await models.userAudit.create(auditEvent, {transaction: t});
-            });
-
-            // TODO: ultimately remove "Bearer" from the response; this should be added by client
-            return res.set({'Authorization': 'Bearer ' + token}).status(200).json(response);
-
-          } else {
-            await models.sequelize.transaction(async t => {
-              const maxNumberOfFailedAttempts = 10;
-
-              // increment the number of failed attempts by one
-              const loginUpdate = {
-                invalidAttempt: login.invalidAttempt + 1
-              };
-              login.update(loginUpdate, {transaction: t});
-
-              if (login.invalidAttempt === (maxNumberOfFailedAttempts+1)) {
-                // send reset password email
-                const expiresTTLms = 60*24*1000; // 24 hours
-
-                const requestUuid = uuid.v4();
-                const now = new Date();
-                const expiresIn = new Date(now.getTime() + expiresTTLms);
-          
-                await models.passwordTracking.create({
-                  userFk: login.user.id,
-                  created: now.toISOString(),
-                  expires: expiresIn.toISOString(),
-                  uuid: requestUuid
-                }, {transaction: t});
-          
-                const resetLink = `${req.protocol}://${req.get('host')}/api/registration/validateResetPassword?reset=${requestUuid}`;
-
-                // send email to recipient with the reset UUID
-                try {
-                  await sendMail(login.user.EmailValue, login.user.FullNameValue, requestUuid);
-                } catch (err) {
-                  console.error(err);
-                }
-              }
-
-              // TODO - could implement both https://www.npmjs.com/package/request-ip & https://www.npmjs.com/package/iplocation 
-              //        to resolve the client's IP address on login failure, thus being able to audit the source of where the failed
-              //        login came from
-
-              // add an audit record
-              const auditEvent = {
-                userFk: login.user.id,
-                username: login.username,
-                type: login.invalidAttempt >= (maxNumberOfFailedAttempts+1) ? 'loginWhileLocked' : 'loginFailed',
-                property: 'password',
-                event: {}
-              };
-              await models.userAudit.create(auditEvent, {transaction: t});
-            });
-
-            return res.status(401).send({
-              message: 'Authentication failed.',
-            });
+          // if this is a migrated tribal user's first login, and consequently, the compare is successful
+          //   but they still have no "Hash", we need to create a hash and store it.
+          if (rehashTribal) {
+            loginUpdate.Hash =  await bcrypt.hashSync(givenPassword, bcrypt.genSaltSync(10), null)
           }
-        })
-      })
-      .catch((error) => {
-        console.error(error);
-        return res.status(503).send();
-      });
+
+
+          if (!establishmentUser.firstLogin) {
+            loginUpdate.firstLogin = new Date();
+          }
+          establishmentUser.update(loginUpdate, {transaction: t});
+
+          // add an audit record
+          const auditEvent = {
+            userFk: establishmentUser.user.id,
+            username: establishmentUser.username,
+            type: 'loginSuccess',
+            property: 'password',
+            event: {}
+          };
+          await models.userAudit.create(auditEvent, {transaction: t});
+        });
+
+        // TODO: ultimately remove "Bearer" from the response; this should be added by client
+        return res.set({'Authorization': 'Bearer ' + token}).status(200).json(response);
+
+      } else {
+        await models.sequelize.transaction(async t => {
+          const maxNumberOfFailedAttempts = 10;
+
+          // increment the number of failed attempts by one
+          const loginUpdate = {
+            invalidAttempt: establishmentUser.invalidAttempt + 1
+          };
+          await establishmentUser.update(loginUpdate, {transaction: t});
+
+          if (establishmentUser.invalidAttempt === (maxNumberOfFailedAttempts+1)) {
+            // lock the account
+            const loginUpdate = {
+              isActive: false
+            };
+            await establishmentUser.update(loginUpdate, {transaction: t});
+
+            // send reset password email
+            const expiresTTLms = 60*24*1000; // 24 hours
+
+            const requestUuid = uuid.v4();
+            const now = new Date();
+            const expiresIn = new Date(now.getTime() + expiresTTLms);
+
+            await models.passwordTracking.create({
+              userFk: establishmentUser.user.id,
+              created: now.toISOString(),
+              expires: expiresIn.toISOString(),
+              uuid: requestUuid
+            }, {transaction: t});
+
+            const resetLink = `${req.protocol}://${req.get('host')}/api/registration/validateResetPassword?reset=${requestUuid}`;
+
+            // send email to recipient with the reset UUID
+            try {
+              await sendMail(establishmentUser.user.EmailValue, establishmentUser.user.FullNameValue, requestUuid);
+            } catch (err) {
+              console.error(err);
+            }
+          }
+
+          // TODO - could implement both https://www.npmjs.com/package/request-ip & https://www.npmjs.com/package/iplocation
+          //        to resolve the client's IP address on login failure, thus being able to audit the source of where the failed
+          //        login came from
+
+          // add an audit record
+          const auditEvent = {
+            userFk: establishmentUser.user.id,
+            username: establishmentUser.username,
+            type: establishmentUser.invalidAttempt >= (maxNumberOfFailedAttempts+1) ? 'loginWhileLocked' : 'loginFailed',
+            property: 'password',
+            event: {}
+          };
+          await models.userAudit.create(auditEvent, {transaction: t});
+        });
+
+        return res.status(401).send({
+          message: 'Authentication failed.',
+        });
+      }
+    });
+
+
+  } catch (err) {
+    console.error("POST .../login failed: ", err);
+    return res.status(503).send({});
+  }
 });
 
 // TODO: enforce JSON schema
@@ -249,7 +301,7 @@ router.get('/refresh', async function(req, res) {
   return res.set({'Authorization': 'Bearer ' + token}).status(200).json({
     expiryDate: new Date(expiryDate).toISOString()
   });
-  
+
 });
 
 module.exports = router;


### PR DESCRIPTION
Adding support for an Admin user role, allowing for both known primary establishment, but also a given establishment to then assume as primary establishment.

Effectively, once logged in (authenticated) the JWT should support all user, establishment and worker/training/qualifications endpoint activity.

Removing the defunct "AdminUser" property on "User".