### PR TITLE
Adding a redirect (301) on /admin - redirecting to a convict setting …

### DIFF
--- a/server.js
+++ b/server.js
@@ -67,6 +67,11 @@ app.use('/public/download', proxy(
     }
 ));
 
+// redirect the admin application
+app.use('/admin', (req, res) => {
+  res.redirect(301, config.get('admin.url'));
+});
+
 /*
  * security - incorproate helmet & xss-clean (de facto/good practice headers) across all endpoints
  */

--- a/server/aws/secrets.js
+++ b/server/aws/secrets.js
@@ -13,11 +13,11 @@ const initialiseSecrets = async (region, wallet) => {
     const mySecretsValue = await secrets.getSecretValue({SecretId: wallet}).promise();
     if (typeof mySecretsValue.SecretString !== 'undefined') {
       const mySecrets = JSON.parse(mySecretsValue.SecretString);
-  
+
       if (typeof mySecrets == 'undefined') {
         throw new Error(`Unexpected parsing of secrets wallet: ${wallet}`);
       }
-  
+
       myLocalSecrets = {
         SLACK_URL: mySecrets.SLACK_URL,
         DB_HOST: mySecrets.DB_HOST,
@@ -27,6 +27,7 @@ const initialiseSecrets = async (region, wallet) => {
         DB_ROOT_CRT: mySecrets.DB_ROOT_CRT,
         DB_APP_USER_KEY: mySecrets.DB_APP_USER_KEY,
         DB_APP_USER_CERT: mySecrets.DB_APP_USER_CERT,
+        ADMIN_URL: mySecrets.ADMIN_URL,
       };
     }
 
@@ -99,6 +100,18 @@ const  govNotify = () => {
   }
 }
 
+const  adminUrl = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.ADMIN_URL) {
+      throw new Error('Unknown ADMIN_URL secret');
+    } else {
+      return myLocalSecrets.ADMIN_URL;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+}
+
 const dbAppUserKey = () => {
   if (myLocalSecrets !== null) {
     if (!myLocalSecrets.DB_APP_USER_KEY) {
@@ -143,3 +156,4 @@ module.exports.govNotify = govNotify;
 module.exports.dbAppUserKey = dbAppUserKey;
 module.exports.dbAppUserCertificate = dbAppUserCertificate;
 module.exports.dbAppRootCertificate = dbAppRootCertificate;
+module.exports.adminUrl = adminUrl;

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -283,6 +283,14 @@ const config = convict({
       },
     },
   },
+  admin: {
+    url: {
+      doc: 'The URL to redirect users to the admin application',
+      format: 'url',
+      default: 'https://unknown.com',
+      env: 'ADMIN_URL',
+    }
+  }
 });
 
 // Load environment dependent configuration
@@ -316,6 +324,7 @@ if (config.get('aws.secrets.use')) {
     // external APIs
     config.set('slack.url', AWSSecrets.slackUrl());
     config.set('notify.key', AWSSecrets.govNotify());
+    config.set('admin.url', AWSSecrets.adminUrl());
 
     AppConfig.ready = true;
     AppConfig.emit(AppConfig.READY_EVENT);


### PR DESCRIPTION
…of admin.url which is retrieved from env var ADMIN_URL or from ADMIN_URL in AWS Secrets Manager waller.