### PR TITLE
Feature/extend account details component so its reused on account creation flow

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -87,6 +87,12 @@ const routes: Routes = [
     },
   },
   {
+    path: 'create-account',
+    loadChildren: '@features/create-account/create-account.module#CreateAccountModule',
+    // canActivate: [AuthGuard],
+    data: { title: 'Create account' },
+  },
+  {
     path: '',
     redirectTo: 'dashboard',
     pathMatch: 'full',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -89,7 +89,7 @@ const routes: Routes = [
   {
     path: 'create-account',
     loadChildren: '@features/create-account/create-account.module#CreateAccountModule',
-    // canActivate: [AuthGuard],
+    canActivate: [AuthGuard],
     data: { title: 'Create account' },
   },
   {

--- a/src/app/core/services/create-account/create-account.service.spec.ts
+++ b/src/app/core/services/create-account/create-account.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CreateAccountService } from './create-account.service';
+
+describe('CreateAccountService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: CreateAccountService = TestBed.get(CreateAccountService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/create-account/create-account.service.ts
+++ b/src/app/core/services/create-account/create-account.service.ts
@@ -1,0 +1,10 @@
+import { BehaviorSubject } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { UserDetails } from '@core/model/userDetails.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CreateAccountService {
+  public accountDetails$: BehaviorSubject<UserDetails> = new BehaviorSubject(null);
+}

--- a/src/app/features/account-management/change-your-details/change-your-details.component.ts
+++ b/src/app/features/account-management/change-your-details/change-your-details.component.ts
@@ -25,7 +25,7 @@ export class ChangeYourDetailsComponent extends AccountDetails {
     protected router: Router,
     protected userService: UserService,
   ) {
-    super(backService, errorSummaryService, fb, router, userService);
+    super(backService, errorSummaryService, fb, router);
   }
 
   protected init() {

--- a/src/app/features/account/account-details/account-details.ts
+++ b/src/app/features/account/account-details/account-details.ts
@@ -6,7 +6,6 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { UserDetails } from '@core/model/userDetails.model';
-import { UserService } from '@core/services/user.service';
 
 export class AccountDetails implements OnInit, OnDestroy {
   protected formErrorsMap: Array<ErrorDetails>;
@@ -41,7 +40,6 @@ export class AccountDetails implements OnInit, OnDestroy {
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
     protected router: Router,
-    protected userService: UserService
   ) {}
 
   ngOnInit() {

--- a/src/app/features/create-account/create-account-routing.module.ts
+++ b/src/app/features/create-account/create-account-routing.module.ts
@@ -6,7 +6,6 @@ const routes: Routes = [
   {
     path: '',
     component: CreateAccountComponent,
-    data: { title: 'Home' },
   },
 ];
 

--- a/src/app/features/create-account/create-account-routing.module.ts
+++ b/src/app/features/create-account/create-account-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { CreateAccountComponent } from '@features/create-account/create-account/create-account.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: CreateAccountComponent,
+    data: { title: 'Home' },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class CreateAccountRoutingModule {}

--- a/src/app/features/create-account/create-account.module.ts
+++ b/src/app/features/create-account/create-account.module.ts
@@ -1,0 +1,14 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { CreateAccountRoutingModule } from '@features/create-account/create-account-routing.module';
+import { SharedModule } from '@shared/shared.module';
+import { CreateAccountComponent } from './create-account/create-account.component';
+
+@NgModule({
+  imports: [
+    CommonModule, ReactiveFormsModule, SharedModule, CreateAccountRoutingModule
+  ],
+  declarations: [CreateAccountComponent]
+})
+export class CreateAccountModule { }

--- a/src/app/features/create-account/create-account/create-account.component.html
+++ b/src/app/features/create-account/create-account/create-account.component.html
@@ -1,0 +1,3 @@
+<p>
+  create-account works!
+</p>

--- a/src/app/features/create-account/create-account/create-account.component.html
+++ b/src/app/features/create-account/create-account/create-account.component.html
@@ -37,60 +37,70 @@
         </ng-container>
       </fieldset>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          <h2 class="govuk-fieldset__heading">
-            Permissions
-          </h2>
-        </legend>
+      <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('permissions').errors">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h2 class="govuk-fieldset__heading">
+              Permissions
+            </h2>
+          </legend>
 
-        <div class="govuk-radios govuk-radios--conditional">
-          <div class="govuk-radios__item">
-            <input
-              class="govuk-radios__input"
-              [formControlName]="'permissions'"
-              id="permissions-conditional-1"
-              name="permissions"
-              type="radio"
-              data-aria-controls="conditional-permissions-conditional-1"
-            />
-            <label class="govuk-label govuk-radios__label" for="permissions-conditional-1">
-              Edit
-            </label>
-          </div>
-          <div
-            class="govuk-radios__conditional"
-            [class.govuk-radios__conditional--hidden]="form.get('permissions').value !== 'Edit'"
-            id="conditional-permissions-conditional-1"
-          >
-            <div class="govuk-form-group">
-              <label class="govuk-label" for="primaryUser">
-                Make this user a primary user
-              </label>
+          <span *ngIf="submitted && form.get('permissions').errors" id="permissions-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('permissions') }}
+          </span>
+          <div class="govuk-radios govuk-radios--conditional">
+            <div class="govuk-radios__item">
               <input
-                class="govuk-input govuk-input--width-4"
-                [formControlName]="'primaryUser'"
-                id="primaryUser"
-                name="primaryUser"
-                type="checkbox"
+                class="govuk-radios__input"
+                [class.govuk-input--error]="submitted && form.get('permissions').errors"
+                [formControlName]="'permissions'"
+                id="permissions-conditional-1"
+                name="permissions"
+                value="edit"
+                type="radio"
+                data-aria-controls="conditional-permissions-conditional-1"
               />
+              <label class="govuk-label govuk-radios__label" for="permissions-conditional-1">
+                Edit
+              </label>
+            </div>
+            <div
+              class="govuk-radios__conditional"
+              [class.govuk-radios__conditional--hidden]="form.get('permissions').value !== 'edit'"
+              id="conditional-permissions-conditional-1"
+            >
+              <div class="govuk-checkboxes">
+                <div class="govuk-checkboxes__item">
+                  <input
+                    class="govuk-checkboxes__input"
+                    [formControlName]="'primaryUser'"
+                    id="primaryUser"
+                    name="primaryUser"
+                    type="checkbox"
+                  />
+                  <label class="govuk-label govuk-checkboxes__label" for="primaryUser">
+                    Make this user a primary user
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                [formControlName]="'permissions'"
+                id="permissions-2"
+                name="permissions"
+                value="read"
+                type="radio"
+              />
+              <label class="govuk-label govuk-radios__label" for="permissions-2">
+                Read-only
+              </label>
             </div>
           </div>
-
-          <div class="govuk-radios__item">
-            <input
-              class="govuk-radios__input"
-              [formControlName]="'permissions'"
-              id="permissions-2"
-              name="permissions"
-              type="radio"
-            />
-            <label class="govuk-label govuk-radios__label" for="permissions-2">
-              Read-only
-            </label>
-          </div>
-        </div>
-      </fieldset>
+        </fieldset>
+      </div>
 
       <div class="govuk-button-group">
         <button class="govuk-button govuk-!-margin-right-8 govuk-!-margin-bottom-0" type="submit">

--- a/src/app/features/create-account/create-account/create-account.component.html
+++ b/src/app/features/create-account/create-account/create-account.component.html
@@ -37,6 +37,61 @@
         </ng-container>
       </fieldset>
 
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h2 class="govuk-fieldset__heading">
+            Permissions
+          </h2>
+        </legend>
+
+        <div class="govuk-radios govuk-radios--conditional">
+          <div class="govuk-radios__item">
+            <input
+              class="govuk-radios__input"
+              [formControlName]="'permissions'"
+              id="permissions-conditional-1"
+              name="permissions"
+              type="radio"
+              data-aria-controls="conditional-permissions-conditional-1"
+            />
+            <label class="govuk-label govuk-radios__label" for="permissions-conditional-1">
+              Edit
+            </label>
+          </div>
+          <div
+            class="govuk-radios__conditional"
+            [class.govuk-radios__conditional--hidden]="form.get('permissions').value !== 'Edit'"
+            id="conditional-permissions-conditional-1"
+          >
+            <div class="govuk-form-group">
+              <label class="govuk-label" for="primaryUser">
+                Make this user a primary user
+              </label>
+              <input
+                class="govuk-input govuk-input--width-4"
+                [formControlName]="'primaryUser'"
+                id="primaryUser"
+                name="primaryUser"
+                type="checkbox"
+              />
+            </div>
+          </div>
+
+          <div class="govuk-radios__item">
+            <input
+              class="govuk-radios__input"
+              [formControlName]="'permissions'"
+              id="permissions-2"
+              name="permissions"
+              type="radio"
+            />
+            <label class="govuk-label govuk-radios__label" for="permissions-2">
+              Read-only
+            </label>
+          </div>
+        </div>
+      </fieldset>
+
       <div class="govuk-button-group">
         <button class="govuk-button govuk-!-margin-right-8 govuk-!-margin-bottom-0" type="submit">
           {{ callToActionLabel }}

--- a/src/app/features/create-account/create-account/create-account.component.html
+++ b/src/app/features/create-account/create-account/create-account.component.html
@@ -1,3 +1,51 @@
-<p>
-  create-account works!
-</p>
+<app-error-summary
+  *ngIf="submitted && form.invalid"
+  [formErrorsMap]="formErrorsMap"
+  [form]="form"
+  [serverError]="serverError"
+>
+</app-error-summary>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <form novalidate (ngSubmit)="onSubmit()" [formGroup]="form" id="server-error">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <span class="govuk-caption-l">User account</span>
+          <h1 class="govuk-fieldset__heading">
+            Add user account
+          </h1>
+        </legend>
+
+        <ng-container *ngFor="let item of formControlsMap">
+          <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get(item.name).errors">
+            <label class="govuk-label" for="{{ item.name }}">
+              {{ item.label }}
+            </label>
+            <span *ngIf="submitted && form.get(item.name).errors" id="fullName-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage(item.name) }}
+            </span>
+            <input
+              class="govuk-input govuk-input--width-20"
+              [formControlName]="item.name"
+              id="{{ item.name }}"
+              name="{{ item.name }}"
+              [class.govuk-input--error]="submitted && form.get(item.name).errors"
+              type="text"
+            />
+          </div>
+        </ng-container>
+      </fieldset>
+
+      <div class="govuk-button-group">
+        <button class="govuk-button govuk-!-margin-right-8 govuk-!-margin-bottom-0" type="submit">
+          {{ callToActionLabel }}
+        </button>
+        <span class="govuk-visually-hidden">or</span>
+        <a role="button" class="govuk-button govuk-button--link govuk-!-margin-bottom-0" [routerLink]="['/dashboard']">
+          Cancel
+        </a>
+      </div>
+    </form>
+  </div>
+</div>

--- a/src/app/features/create-account/create-account/create-account.component.spec.ts
+++ b/src/app/features/create-account/create-account/create-account.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateAccountComponent } from './create-account.component';
+
+describe('CreateAccountComponent', () => {
+  let component: CreateAccountComponent;
+  let fixture: ComponentFixture<CreateAccountComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CreateAccountComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/create-account/create-account/create-account.component.ts
+++ b/src/app/features/create-account/create-account/create-account.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
+import { FormBuilder, FormControl, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BackService } from '@core/services/back.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
@@ -21,6 +21,25 @@ export class CreateAccountComponent extends AccountDetails {
     private createAccountService: CreateAccountService
   ) {
     super(backService, errorSummaryService, fb, router);
+  }
+
+  protected init(): void {
+    this.addFormControls();
+  }
+
+  private addFormControls(): void {
+    this.form.addControl('permissions', new FormControl(null, Validators.required));
+    this.form.addControl('primaryUser', new FormControl(null));
+
+    this.formErrorsMap.push({
+      item: 'permissions',
+      type: [
+        {
+          name: 'required',
+          message: 'Please specify permissions for the new account.',
+        }
+      ],
+    });
   }
 
   protected save() {

--- a/src/app/features/create-account/create-account/create-account.component.ts
+++ b/src/app/features/create-account/create-account/create-account.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-create-account',
+  templateUrl: './create-account.component.html',
+})
+export class CreateAccountComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/src/app/features/create-account/create-account/create-account.component.ts
+++ b/src/app/features/create-account/create-account/create-account.component.ts
@@ -1,11 +1,30 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { Router } from '@angular/router';
+import { BackService } from '@core/services/back.service';
+import { CreateAccountService } from '@core/services/create-account/create-account.service';
+import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { AccountDetails } from '@features/account/account-details/account-details';
 
 @Component({
   selector: 'app-create-account',
   templateUrl: './create-account.component.html',
 })
-export class CreateAccountComponent implements OnInit {
-  constructor() {}
+export class CreateAccountComponent extends AccountDetails {
+  public callToActionLabel = 'Save user account';
 
-  ngOnInit() {}
+  constructor(
+    protected backService: BackService,
+    protected errorSummaryService: ErrorSummaryService,
+    protected fb: FormBuilder,
+    protected router: Router,
+    private createAccountService: CreateAccountService
+  ) {
+    super(backService, errorSummaryService, fb, router);
+  }
+
+  protected save() {
+    this.createAccountService.accountDetails$.next(this.setUserDetails());
+    this.router.navigate(['/create-account/create-username']); // TODO will build in seperate pr
+  }
 }

--- a/src/app/features/registration/change-your-details/change-your-details.component.ts
+++ b/src/app/features/registration/change-your-details/change-your-details.component.ts
@@ -15,13 +15,13 @@ export class ChangeYourDetailsComponent extends AccountDetails {
   public callToActionLabel = 'Save and return';
 
   constructor(
+    private userService: UserService,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
     protected router: Router,
-    protected userService: UserService,
   ) {
-    super(backService, errorSummaryService, fb, router, userService);
+    super(backService, errorSummaryService, fb, router);
   }
 
   protected init() {

--- a/src/app/features/registration/your-details/your-details.component.ts
+++ b/src/app/features/registration/your-details/your-details.component.ts
@@ -12,13 +12,13 @@ import { AccountDetails } from '@features/account/account-details/account-detail
 })
 export class YourDetailsComponent extends AccountDetails {
   constructor(
+    private userService: UserService,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
     protected router: Router,
-    protected userService: UserService
   ) {
-    super(backService, errorSummaryService, fb, router, userService);
+    super(backService, errorSummaryService, fb, router);
   }
 
   protected save() {


### PR DESCRIPTION
- Extend `account-details` component so its reused on account creation flow
- add new field/s to `account-details` component permissions on account creation flow