### PR TITLE
Feature/extend confirm account details component so its reused on account creation flow

### DIFF
--- a/src/app/core/model/account-details.model.ts
+++ b/src/app/core/model/account-details.model.ts
@@ -1,5 +1,0 @@
-export interface AccountDetails {
-  label: string;
-  data: string;
-  route: string;
-}

--- a/src/app/core/model/account.model.ts
+++ b/src/app/core/model/account.model.ts
@@ -1,0 +1,13 @@
+export interface AccountDetails {
+  label: string;
+  data: string;
+  route: string;
+}
+
+export interface CreateAccountRequest {
+  email: string;
+  fullname: string;
+  jobTitle: string;
+  phone: string;
+  role: string;
+}

--- a/src/app/core/model/roles.enum.ts
+++ b/src/app/core/model/roles.enum.ts
@@ -1,3 +1,4 @@
 export enum Roles {
   Edit = 'Edit',
+  Read = 'Read'
 }

--- a/src/app/core/services/create-account/create-account.service.ts
+++ b/src/app/core/services/create-account/create-account.service.ts
@@ -1,7 +1,6 @@
-import { HttpClient } from '@angular/common/http';
-import { CreateAccountRequest } from '@core/model/account.model';
-import { EstablishmentService } from '@core/services/establishment.service';
 import { BehaviorSubject } from 'rxjs';
+import { CreateAccountRequest } from '@core/model/account.model';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { LoginCredentials } from '@core/model/login-credentials.model';
 import { SecurityDetails } from '@core/model/security-details.model';
@@ -13,9 +12,9 @@ export class CreateAccountService {
   public loginCredentials$: BehaviorSubject<LoginCredentials> = new BehaviorSubject(null);
   public securityDetails$: BehaviorSubject<SecurityDetails> = new BehaviorSubject(null);
 
-  constructor(private http: HttpClient, private establishmentService: EstablishmentService) {}
+  constructor(private http: HttpClient) {}
 
-  public createAccount(requestPayload: CreateAccountRequest) {
-    return this.http.post(`/api/user/add/establishment/${this.establishmentService.establishmentId}`, requestPayload);
+  public createAccount(establishmentUid: string, requestPayload: CreateAccountRequest) {
+    return this.http.post(`/api/user/add/establishment/${establishmentUid}`, requestPayload);
   }
 }

--- a/src/app/core/services/create-account/create-account.service.ts
+++ b/src/app/core/services/create-account/create-account.service.ts
@@ -1,14 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { CreateAccountRequest } from '@core/model/account.model';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { BehaviorSubject } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { LoginCredentials } from '@core/model/login-credentials.model';
 import { SecurityDetails } from '@core/model/security-details.model';
-import { UserDetails } from '@core/model/userDetails.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class CreateAccountService {
-  public accountDetails$: BehaviorSubject<UserDetails> = new BehaviorSubject(null);
   public loginCredentials$: BehaviorSubject<LoginCredentials> = new BehaviorSubject(null);
   public securityDetails$: BehaviorSubject<SecurityDetails> = new BehaviorSubject(null);
+
+  constructor(private http: HttpClient, private establishmentService: EstablishmentService) {}
+
+  public createAccount(requestPayload: CreateAccountRequest) {
+    return this.http.post(`/api/user/add/establishment/${this.establishmentService.establishmentId}`, requestPayload);
+  }
 }

--- a/src/app/features/account-management/change-your-details/change-your-details.component.ts
+++ b/src/app/features/account-management/change-your-details/change-your-details.component.ts
@@ -74,9 +74,7 @@ export class ChangeYourDetailsComponent extends AccountDetails {
     this.subscriptions.add(
       this.userService.updateUserDetails(username, userDetails).subscribe(
         () => this.router.navigate(['/account-management']),
-        (error: HttpErrorResponse) => {
-          this.serverError = this.errorSummaryService.getServerErrorMessage(error.status, this.serverErrorsMap);
-        }
+        (error: HttpErrorResponse) => this.onError(error)
       )
     );
   }

--- a/src/app/features/account/account-details/account-details.ts
+++ b/src/app/features/account/account-details/account-details.ts
@@ -18,7 +18,7 @@ export class AccountDetails implements OnInit, OnDestroy {
   public formControlsMap: any[] = [
     {
       label: 'Your full name',
-      name: 'fullName'
+      name: 'fullname'
     },
     {
       label: 'Your job title',
@@ -44,7 +44,7 @@ export class AccountDetails implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.form = this.fb.group({
-      fullName: ['', [Validators.required, Validators.maxLength(120)]],
+      fullname: ['', [Validators.required, Validators.maxLength(120)]],
       jobTitle: ['', [Validators.required, Validators.maxLength(120)]],
       email: [
         '',
@@ -77,7 +77,7 @@ export class AccountDetails implements OnInit, OnDestroy {
   public setupFormErrorsMap(): void {
     this.formErrorsMap = [
       {
-        item: 'fullName',
+        item: 'fullname',
         type: [
           {
             name: 'required',
@@ -140,6 +140,10 @@ export class AccountDetails implements OnInit, OnDestroy {
       {
         name: 404,
         message: 'User not found or does not belong to the given establishment.',
+      },
+      {
+        name: 400,
+        message: 'Unable to create user.',
       },
     ];
   }

--- a/src/app/features/account/account-details/account-details.ts
+++ b/src/app/features/account/account-details/account-details.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { BackService } from '@core/services/back.service';
 import { OnDestroy, OnInit } from '@angular/core';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
@@ -162,6 +163,11 @@ export class AccountDetails implements OnInit, OnDestroy {
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }
+  }
+
+  protected onError(error: HttpErrorResponse): void {
+    this.serverError = this.errorSummaryService.getServerErrorMessage(error.status, this.serverErrorsMap);
+    this.errorSummaryService.scrollToErrorSummary();
   }
 
   protected save(): void {}

--- a/src/app/features/account/confirm-account-details/confirm-account-details.ts
+++ b/src/app/features/account/confirm-account-details/confirm-account-details.ts
@@ -2,6 +2,7 @@ import { AccountDetails } from '@core/model/account-details.model';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
 import { LocationAddress } from '@core/model/location.model';
 import { LoginCredentials } from '@core/model/login-credentials.model';
 import { OnDestroy, OnInit } from '@angular/core';
@@ -87,6 +88,11 @@ export class ConfirmAccountDetails implements OnInit, OnDestroy {
   public getFirstErrorMessage(item: string): string {
     const errorType = Object.keys(this.form.get(item).errors)[0];
     return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
+  }
+
+  protected onError(error: HttpErrorResponse): void {
+    this.serverError = this.errorSummaryService.getServerErrorMessage(error.status, this.serverErrorsMap);
+    this.errorSummaryService.scrollToErrorSummary();
   }
 
   /**

--- a/src/app/features/account/confirm-account-details/confirm-account-details.ts
+++ b/src/app/features/account/confirm-account-details/confirm-account-details.ts
@@ -1,4 +1,4 @@
-import { AccountDetails } from '@core/model/account-details.model';
+import { AccountDetails } from '@core/model/account.model';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';

--- a/src/app/features/create-account/account-saved/account-saved.component.html
+++ b/src/app/features/create-account/account-saved/account-saved.component.html
@@ -1,0 +1,3 @@
+<p>
+  account-saved works!
+</p>

--- a/src/app/features/create-account/account-saved/account-saved.component.html
+++ b/src/app/features/create-account/account-saved/account-saved.component.html
@@ -1,3 +1,19 @@
-<p>
-  account-saved works!
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">User account saved</h1>
+    <p>
+      An email has been sent to the address provided containing a link to complete the set up of the account.
+    </p>
+    <div class="govuk-button-group">
+      <a
+        role="button"
+        draggable="false"
+        class="govuk-button"
+        [routerLink]="['/dashboard']"
+        [fragment]="'user-accounts'"
+      >
+        Return to user accounts
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/app/features/create-account/account-saved/account-saved.component.spec.ts
+++ b/src/app/features/create-account/account-saved/account-saved.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccountSavedComponent } from './account-saved.component';
+
+describe('AccountSavedComponent', () => {
+  let component: AccountSavedComponent;
+  let fixture: ComponentFixture<AccountSavedComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AccountSavedComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AccountSavedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/create-account/account-saved/account-saved.component.ts
+++ b/src/app/features/create-account/account-saved/account-saved.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-account-saved',
+  templateUrl: './account-saved.component.html',
+  styles: []
+})
+export class AccountSavedComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/features/create-account/account-saved/account-saved.component.ts
+++ b/src/app/features/create-account/account-saved/account-saved.component.ts
@@ -1,15 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-account-saved',
   templateUrl: './account-saved.component.html',
-  styles: []
 })
-export class AccountSavedComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-}
+export class AccountSavedComponent {}

--- a/src/app/features/create-account/confirm-account-details/confirm-account-details.component.html
+++ b/src/app/features/create-account/confirm-account-details/confirm-account-details.component.html
@@ -1,0 +1,3 @@
+<p>
+  confirm-account-details works!
+</p>

--- a/src/app/features/create-account/confirm-account-details/confirm-account-details.component.spec.ts
+++ b/src/app/features/create-account/confirm-account-details/confirm-account-details.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmAccountDetailsComponent } from './confirm-account-details.component';
+
+describe('ConfirmAccountDetailsComponent', () => {
+  let component: ConfirmAccountDetailsComponent;
+  let fixture: ComponentFixture<ConfirmAccountDetailsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ConfirmAccountDetailsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmAccountDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/create-account/confirm-account-details/confirm-account-details.component.ts
+++ b/src/app/features/create-account/confirm-account-details/confirm-account-details.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-confirm-account-details',
+  templateUrl: './confirm-account-details.component.html',
+})
+export class ConfirmAccountDetailsComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/src/app/features/create-account/create-account-routing.module.ts
+++ b/src/app/features/create-account/create-account-routing.module.ts
@@ -1,3 +1,4 @@
+import { AccountSavedComponent } from '@features/create-account/account-saved/account-saved.component';
 import { ConfirmAccountDetailsComponent } from '@features/create-account/confirm-account-details/confirm-account-details.component';
 import { CreateAccountComponent } from '@features/create-account/create-account/create-account.component';
 import { CreateUsernameComponent } from '@features/create-account/create-username/create-username.component';
@@ -14,6 +15,11 @@ const routes: Routes = [
     path: 'create-username',
     component: CreateUsernameComponent,
     data: { title: 'Create Username' },
+  },
+  {
+    path: 'saved',
+    component: AccountSavedComponent,
+    data: { title: 'Account saved' },
   },
   {
     path: 'security-question',

--- a/src/app/features/create-account/create-account-routing.module.ts
+++ b/src/app/features/create-account/create-account-routing.module.ts
@@ -1,7 +1,8 @@
-import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
+import { ConfirmAccountDetailsComponent } from '@features/create-account/confirm-account-details/confirm-account-details.component';
 import { CreateAccountComponent } from '@features/create-account/create-account/create-account.component';
 import { CreateUsernameComponent } from '@features/create-account/create-username/create-username.component';
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
 import { SecurityQuestionComponent } from '@features/create-account/security-question/security-question.component';
 
 const routes: Routes = [
@@ -18,6 +19,11 @@ const routes: Routes = [
     path: 'security-question',
     component: SecurityQuestionComponent,
     data: { title: 'Security Question' },
+  },
+  {
+    path: 'confirm-account-details',
+    component: ConfirmAccountDetailsComponent,
+    data: { title: 'Confirm Account Details' },
   },
 ];
 

--- a/src/app/features/create-account/create-account-routing.module.ts
+++ b/src/app/features/create-account/create-account-routing.module.ts
@@ -12,7 +12,7 @@ const routes: Routes = [
     component: CreateAccountComponent,
   },
   {
-    path: 'create-username',
+    path: 'create-username/:establishmentUid',
     component: CreateUsernameComponent,
     data: { title: 'Create Username' },
   },

--- a/src/app/features/create-account/create-account.module.ts
+++ b/src/app/features/create-account/create-account.module.ts
@@ -7,6 +7,7 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { SecurityQuestionComponent } from './security-question/security-question.component';
 import { SharedModule } from '@shared/shared.module';
+import { AccountSavedComponent } from './account-saved/account-saved.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, CreateAccountRoutingModule],
@@ -15,6 +16,7 @@ import { SharedModule } from '@shared/shared.module';
     CreateAccountComponent,
     CreateUsernameComponent,
     SecurityQuestionComponent,
+    AccountSavedComponent,
   ],
 })
 export class CreateAccountModule {}

--- a/src/app/features/create-account/create-account.module.ts
+++ b/src/app/features/create-account/create-account.module.ts
@@ -1,14 +1,20 @@
 import { CommonModule } from '@angular/common';
+import { ConfirmAccountDetailsComponent } from './confirm-account-details/confirm-account-details.component';
+import { CreateAccountComponent } from './create-account/create-account.component';
+import { CreateAccountRoutingModule } from '@features/create-account/create-account-routing.module';
+import { CreateUsernameComponent } from './create-username/create-username.component';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { CreateAccountRoutingModule } from '@features/create-account/create-account-routing.module';
-import { SharedModule } from '@shared/shared.module';
-import { CreateAccountComponent } from './create-account/create-account.component';
-import { CreateUsernameComponent } from './create-username/create-username.component';
 import { SecurityQuestionComponent } from './security-question/security-question.component';
+import { SharedModule } from '@shared/shared.module';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, CreateAccountRoutingModule],
-  declarations: [CreateAccountComponent, CreateUsernameComponent, SecurityQuestionComponent],
+  declarations: [
+    ConfirmAccountDetailsComponent,
+    CreateAccountComponent,
+    CreateUsernameComponent,
+    SecurityQuestionComponent,
+  ],
 })
 export class CreateAccountModule {}

--- a/src/app/features/create-account/create-account/create-account.component.html
+++ b/src/app/features/create-account/create-account/create-account.component.html
@@ -41,7 +41,7 @@
         </ng-container>
       </fieldset>
 
-      <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('permissions').errors">
+      <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('role').errors">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
             <h2 class="govuk-fieldset__heading">
@@ -49,20 +49,20 @@
             </h2>
           </legend>
 
-          <span *ngIf="submitted && form.get('permissions').errors" id="permissions-error" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('permissions') }}
+          <span *ngIf="submitted && form.get('role').errors" id="role-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('role') }}
           </span>
           <div class="govuk-radios">
-            <div class="govuk-radios__item" *ngFor="let item of permissionsRadios; let i = index">
+            <div class="govuk-radios__item" *ngFor="let item of roleRadios; let i = index">
               <input
                 class="govuk-radios__input"
-                [formControlName]="'permissions'"
-                id="permissions-{{ i }}"
-                name="permissions"
+                [formControlName]="'role'"
+                id="role-{{ i }}"
+                name="role"
                 value="{{ item.value }}"
                 type="radio"
               />
-              <label class="govuk-label govuk-radios__label" for="permissions-{{ i }}">
+              <label class="govuk-label govuk-radios__label" for="role-{{ i }}">
                 {{ item.label }}
               </label>
             </div>

--- a/src/app/features/create-account/create-account/create-account.component.ts
+++ b/src/app/features/create-account/create-account/create-account.component.ts
@@ -7,7 +7,7 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { FormBuilder, FormControl, Validators } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { RadioFieldData } from '@core/model/form-controls.model';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-create-account',
@@ -15,6 +15,7 @@ import { Router } from '@angular/router';
 })
 export class CreateAccountComponent extends AccountDetails {
   public callToActionLabel = 'Save user account';
+  public establishmentUid: string;
   public roleRadios: RadioFieldData[] = [
     {
       value: 'Edit',
@@ -29,6 +30,7 @@ export class CreateAccountComponent extends AccountDetails {
   constructor(
     private breadcrumbService: BreadcrumbService,
     private createAccountService: CreateAccountService,
+    private route: ActivatedRoute,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
@@ -40,6 +42,7 @@ export class CreateAccountComponent extends AccountDetails {
   protected init(): void {
     this.breadcrumbService.show();
     this.addFormControls();
+    this.establishmentUid = this.route.snapshot.params.establishmentUid;
   }
 
   private addFormControls(): void {
@@ -59,7 +62,7 @@ export class CreateAccountComponent extends AccountDetails {
   protected save() {
     this.subscriptions.add(
       this.createAccountService
-        .createAccount(this.form.value)
+        .createAccount(this.establishmentUid, this.form.value)
         .subscribe(
           () => this.router.navigate(['/create-account/saved']),
           (error: HttpErrorResponse) => this.onError(error)

--- a/src/app/features/create-account/create-account/create-account.component.ts
+++ b/src/app/features/create-account/create-account/create-account.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormControl, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RadioFieldData } from '@core/model/form-controls.model';
 import { BackService } from '@core/services/back.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { AccountDetails } from '@features/account/account-details/account-details';
@@ -13,47 +14,52 @@ import { AccountDetails } from '@features/account/account-details/account-detail
 })
 export class CreateAccountComponent extends AccountDetails {
   public callToActionLabel = 'Save user account';
-  public permissionsRadios: RadioFieldData[] = [
+  public roleRadios: RadioFieldData[] = [
     {
-      value: 'edit',
-      label: 'Edit'
+      value: 'Edit',
+      label: 'Edit',
     },
     {
-      value: 'read',
-      label: 'Read-only'
+      value: 'Read',
+      label: 'Read-only',
     },
   ];
 
   constructor(
+    private breadcrumbService: BreadcrumbService,
+    private createAccountService: CreateAccountService,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
-    protected router: Router,
-    private createAccountService: CreateAccountService
+    protected router: Router
   ) {
     super(backService, errorSummaryService, fb, router);
   }
 
   protected init(): void {
+    this.breadcrumbService.show();
     this.addFormControls();
   }
 
   private addFormControls(): void {
-    this.form.addControl('permissions', new FormControl(null, Validators.required));
+    this.form.addControl('role', new FormControl(null, Validators.required));
 
     this.formErrorsMap.push({
-      item: 'permissions',
+      item: 'role',
       type: [
         {
           name: 'required',
           message: 'Please specify permissions for the new account.',
-        }
+        },
       ],
     });
   }
 
   protected save() {
-    this.createAccountService.accountDetails$.next(this.setUserDetails());
-    this.router.navigate(['/create-account/create-username']);
+    this.subscriptions.add(
+      this.createAccountService.createAccount(this.form.value).subscribe(() => {
+        this.router.navigate(['/create-account/saved']);
+      })
+    );
   }
 }

--- a/src/app/features/create-account/create-account/create-account.component.ts
+++ b/src/app/features/create-account/create-account/create-account.component.ts
@@ -1,4 +1,5 @@
 import { AccountDetails } from '@features/account/account-details/account-details';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BackService } from '@core/services/back.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { Component } from '@angular/core';
@@ -7,7 +8,7 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { FormBuilder, FormControl, Validators } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { RadioFieldData } from '@core/model/form-controls.model';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Roles } from '@core/model/roles.enum';
 
 @Component({
   selector: 'app-create-account',
@@ -18,11 +19,11 @@ export class CreateAccountComponent extends AccountDetails {
   public establishmentUid: string;
   public roleRadios: RadioFieldData[] = [
     {
-      value: 'Edit',
+      value: Roles.Edit,
       label: 'Edit',
     },
     {
-      value: 'Read',
+      value: Roles.Read,
       label: 'Read-only',
     },
   ];

--- a/src/app/features/create-account/create-account/create-account.component.ts
+++ b/src/app/features/create-account/create-account/create-account.component.ts
@@ -1,12 +1,13 @@
-import { Component } from '@angular/core';
-import { FormBuilder, FormControl, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
-import { RadioFieldData } from '@core/model/form-controls.model';
+import { AccountDetails } from '@features/account/account-details/account-details';
 import { BackService } from '@core/services/back.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { Component } from '@angular/core';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { AccountDetails } from '@features/account/account-details/account-details';
+import { FormBuilder, FormControl, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+import { RadioFieldData } from '@core/model/form-controls.model';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-create-account',
@@ -57,9 +58,12 @@ export class CreateAccountComponent extends AccountDetails {
 
   protected save() {
     this.subscriptions.add(
-      this.createAccountService.createAccount(this.form.value).subscribe(() => {
-        this.router.navigate(['/create-account/saved']);
-      })
+      this.createAccountService
+        .createAccount(this.form.value)
+        .subscribe(
+          () => this.router.navigate(['/create-account/saved']),
+          (error: HttpErrorResponse) => this.onError(error)
+        )
     );
   }
 }

--- a/src/app/features/registration/confirm-account-details/confirm-account-details.component.ts
+++ b/src/app/features/registration/confirm-account-details/confirm-account-details.component.ts
@@ -112,10 +112,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
     this.subscriptions.add(
       this.registrationService.postRegistration(this.generatePayload()).subscribe(
         () => this.router.navigate(['/registration/complete']),
-        (error: HttpErrorResponse) => {
-          this.serverError = this.errorSummaryService.getServerErrorMessage(error.status, this.serverErrorsMap);
-          this.errorSummaryService.scrollToErrorSummary();
-        }
+        (error: HttpErrorResponse) => this.onError(error)
       )
     );
   }


### PR DESCRIPTION
- created user account saved route, component and updated module
- create new user account method, interface
- make api call to BE for creating account and cater for api error handling
- created skeleton wip confirm account details skeleton component
- renamed `permissions` to `role` & `fullName` to `fullname` in order to align with BE model