### PR TITLE
Bulk upload use local identifiers

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -295,15 +295,17 @@ class Establishment {
         errCode: Establishment.ADDRESS_ERROR,
         errType: `ADDRESS_ERROR`,
         error: 'First line of address (ADDRESS1) must be defined',
-        source: myAddress1,
         name: this._currentLine.LOCALESTID,
       });
     } else if (myAddress1.length > MAX_LENGTH) {
       localValidationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.ADDRESS_ERROR,
-        errType: `ADDRESS_ERROR`,
-        error: `First line of address (ADDRESS1) must be no more than ${MAX_LENGTH} characters`,
+        // errCode: Establishment.ADDRESS_ERROR,
+        // errType: `ADDRESS_ERROR`,
+        // error: `First line of address (ADDRESS1) must be no more than ${MAX_LENGTH} characters`,
+        warnCode: Establishment.ADDRESS_ERROR,
+        warnType: `ADDRESS_ERROR`,
+        warning: `First line of address (ADDRESS1) must be no more than ${MAX_LENGTH} characters`,
         source: myAddress1,
         name: this._currentLine.LOCALESTID,
       });
@@ -557,9 +559,12 @@ class Establishment {
     if (this._regType && this._regType == 2 && (!myprovID || myprovID.length==0)) {
       this._validationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.PROV_ID_ERROR,
-        errType: `PROV_ID_ERROR`,
-        error: "Prov ID (PROVNUM) must be given as this workplace is CQC regulated",
+        // errCode: Establishment.PROV_ID_ERROR,
+        // errType: `PROV_ID_ERROR`,
+        // error: "Prov ID (PROVNUM) must be given as this workplace is CQC regulated",
+        warnCode: Establishment.PROV_ID_ERROR,
+        warnType: `PROV_ID_ERROR`,
+        warning: "Prov ID (PROVNUM) must be given as this workplace is CQC regulated",
         source: myprovID,
         name: this._currentLine.LOCALESTID,
       });
@@ -568,9 +573,12 @@ class Establishment {
     else if (this._regType  && this._regType == 2 && !provIDRegex.test(myprovID)) {
       this._validationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.PROV_ID_ERROR,
-        errType: `PROV_ID_ERROR`,
-        error: "Prov ID (PROVNUM) must be in the format 'n-nnnnnnnnn'",
+        // errCode: Establishment.PROV_ID_ERROR,
+        // errType: `PROV_ID_ERROR`,
+        // error: "Prov ID (PROVNUM) must be in the format 'n-nnnnnnnnn'",
+        warnCode: Establishment.PROV_ID_ERROR,
+        warnType: `PROV_ID_ERROR`,
+        warning: "Prov ID (PROVNUM) must be in the format 'n-nnnnnnnnn'",
         source: myprovID,
         name: this._currentLine.LOCALESTID,
       });
@@ -1646,8 +1654,8 @@ class Establishment {
       capacities: this._capacities,
       utilisations: this._utilisations,
       totalPermTemp: this._totalPermTemp,
-      
-      
+
+
       allJobs: this._alljobs,
       counts: {
         vacancies: this._vacancies,
@@ -1840,9 +1848,10 @@ class Establishment {
             break;
           case 'Address':
           case 'Postcode':
-            validationError.errCode = Establishment.ADDRESS_ERROR;
-            validationError.errType = 'ADDRESS_ERROR';
-            validationError.source  = `${this._currentLine.ADDRESS1},${this._currentLine.ADDRESS2},${this._currentLine.ADDRESS3},${this._currentLine.POSTTOWN},${this._currentLine.POSTCODE}`;
+            // validationError.errCode = Establishment.ADDRESS_ERROR;
+            // validationError.errType = 'ADDRESS_ERROR';
+            // validationError.source  = `${this._currentLine.ADDRESS1},${this._currentLine.ADDRESS2},${this._currentLine.ADDRESS3},${this._currentLine.POSTTOWN},${this._currentLine.POSTCODE}`;
+            validationError.errCode = null; // ignore
             break;
           case 'CQCRegistered':
             validationError.errCode = Establishment.REGTYPE_ERROR;
@@ -1862,7 +1871,7 @@ class Establishment {
             validationError.source  = thisProp;
         }
 
-        this._validationErrors.push(validationError);
+        validationError.errCode ? this._validationErrors.push(validationError) : true;
       }) : true;
     });
 
@@ -1959,7 +1968,7 @@ class Establishment {
             validationWarning.source  = thisProp;
         }
 
-        this._validationErrors.push(validationWarning);
+        validationWarning.warnCode ? this._validationErrors.push(validationWarning) : true;
       }) : true;
     });
 

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -1091,10 +1091,10 @@ class Worker {
       const MAX_VALUE = 366.0;
       const DONT_KNOW_VALUE = 999;
 
-      const containsHalfDay = this._currentLine.DAYSSICK.indexOf('.') > 0 ?
-        this._currentLine.DAYSSICK.split(".")[1] : 5;
+      const containsHalfDay = this._currentLine.DAYSSICK.indexOf('.') > 0 ? parseInt(this._currentLine.DAYSSICK.split(".")[1], 10) : 5;
 
-      if (isNaN(myDaysSick) || containsHalfDay !== 5 || myDaysSick < 0 || myDaysSick > MAX_VALUE && myDaysSick != DONT_KNOW_VALUE) {
+      if (myDaysSick != DONT_KNOW_VALUE && (isNaN(myDaysSick) || containsHalfDay !== 5 || myDaysSick < 0 || myDaysSick > MAX_VALUE)) {
+
         this._validationErrors.push({
           worker: this._currentLine.UNIQUEWORKERID,
           name: this._currentLine.LOCALESTID,
@@ -2443,7 +2443,8 @@ class Worker {
   toAPI() {
     const changeProperties = {
     // the minimum to create a new worker
-      nameOrId : this._uniqueWorkerId,
+      localIdentifier: this._uniqueWorkerId,
+      nameOrId : this._displayId,
       contract : this._contractType,
       mainJob : {
         jobId: this._mainJobRole,

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -160,7 +160,7 @@ class Worker extends EntityValidator {
     }
 
     get key(){
-        return ((this._properties.get('LocalIdentifier') && this._properties.get('LocalIdentifier').property) ? this._properties.get('LocalIdentifier').property : this.nameOrId).replace(/\s/g, "");
+        return ((this._properties.get('LocalIdentifier') && this._properties.get('LocalIdentifier').property) ? this.localIdentifier.replace(/\s/g, "") : this.nameOrId).replace(/\s/g, "");
     }
 
     get contract() {
@@ -840,6 +840,7 @@ class Worker extends EntityValidator {
                 // now append the extendable properties
                 const updateDocument = {
                     archived: true,
+                    LocalIdentifierValue: null,
                     updated: updatedTimestamp,
                     updatedBy: deletedBy
                 };


### PR DESCRIPTION
Predominantly, this is all about effecting use upon local identifiers replacing previous dependency on Establishment::name and Worker::nameOrId for uniqueness.

I didn't realise how many occurrences would be impacted.

But I have done full testing here on upload and downloads, on new, updated and deleted establishments, or new, updated and deleted workers.

I've changed Local Identifiers and checked download and impact on upload. I've changed Local Idenitifier in the bulk upload CSV for worker and establishment, and confirmed the results of the upload.

All is looking good and repeatable.

Note - although I tried to include CHANGEWORKID in the scope of these changes, alas, rather than updating the worker, the worker is deleted. I've moved the associated card back to backend development.

Other fixed also included because they were stopping the import:

1. I've downgraded PRVID and ADDRESS1 errors to warnings; there are cards in the backlog to rectify these.
2. I've corrected OTHERJOBS validation errors and also allowed for it to be optional.
3. I've fixed type mismatch comparison on sick days.