### PR TITLE
Bulk upload defects 20170717

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -728,8 +728,6 @@ class Establishment {
     const listOfServiceUsers = this._currentLine.SERVICEUSERS.split(';');
     const listOfServiceUsersDescriptions = this._currentLine.OTHERUSERDESC.split(';');
 
-    console.log("WA DEBUG - Number of service users - ", listOfServiceUsers.length, this._currentLine.SERVICEUSERS.length)
-
     const localValidationErrors = [];
     const isValid = this._currentLine.SERVICEUSERS.length ? listOfServiceUsers.every(thisService => !Number.isNaN(parseInt(thisService))) : true;
     if (!isValid) {

--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -87,6 +87,8 @@ class Establishment {
   static get ALL_SERVICES_WARNING() { return 2120; }
   static get SERVICE_USERS_WARNING() { return 2130; }
   static get CAPACITY_UTILISATION_WARNING() { return 2140; }
+  static get ALL_JOBS_WARNING() { return 2180; }
+
   static get VACANCIES_WARNING() { return 2300; }
   static get STARTERS_WARNING() { return 2310; }
   static get LEAVERS_WARNING() { return 2320; }
@@ -939,33 +941,21 @@ class Establishment {
   }
 
   _validateAllJobs() {
-    // mandatory
+    // optional
     const allJobs = this._currentLine.ALLJOBROLES.split(';');
-
     const localValidationErrors = [];
 
     // allJobs can only be empty, if TOTALPERMTEMP is 0
-    if (this._totalPermTemp > 0 && this._currentLine.ALLJOBROLES.length === 0) {
+    if (!this._currentLine.ALLJOBROLES || this._currentLine.ALLJOBROLES.length === 0) {
       localValidationErrors.push({
         lineNumber: this._lineNumber,
-        errCode: Establishment.ALL_JOBS_ERROR,
-        errType: `ALL_JOBS_ERROR`,
-        error: "All Job Roles (ALLJOBROLES) must be defined",
+        warnCode: Establishment.ALL_JOBS_WARNING,
+        warnType: `ALL_JOBS_WARNING`,
+        warning: "All Job Roles (ALLJOBROLES) missing",
         source: this._currentLine.ALLJOBROLES,
         name: this._currentLine.LOCALESTID,
       });
-    } else if (this._totalPermTemp > 0) {
-      // must have at least one job role
-      if (allJobs.length < 1) {
-        localValidationErrors.push({
-          lineNumber: this._lineNumber,
-          errCode: Establishment.ALL_JOBS_ERROR,
-          errType: `ALL_JOBS_ERROR`,
-          error: "All Job Roles (ALLJOBROLES) must be defined",
-          source: this._currentLine.ALLJOBROLES,
-          name: this._currentLine.LOCALESTID,
-        });
-      }
+    } else if (this._currentLine.ALLJOBROLES && this._currentLine.ALLJOBROLES.length > 0) {
       // all jobs are integers
       const isValid = allJobs.every(thisJob => !Number.isNaN(parseInt(thisJob)));
       if (!isValid) {
@@ -2079,6 +2069,7 @@ class Establishment {
     columns.push(entity.numberOfStaff ? entity.numberOfStaff : 0);
 
     // all job roles, starters, leavers and vacancies
+
     const allJobs = [];
     if (entity.starters && Array.isArray(entity.starters)) {
       entity.starters.forEach(thisStarter => allJobs.push(thisStarter));
@@ -2090,54 +2081,69 @@ class Establishment {
       entity.vacancies.forEach(thisVacancy => allJobs.push(thisVacancy));
     }
 
-    columns.push(allJobs.map(thisJob => BUDI.jobRoles(BUDI.FROM_ASC, thisJob.jobId)).join(';'));
-    if (entity.starters && !Array.isArray(entity.starters)) {
-      if (entity.starters === 'None') {
-        columns.push(allJobs.map(thisJob => 0).join(';'));
-      } else {
-        columns.push(999);
+    // all jobs needs to be a set of unique ids (which across starters, leavers and vacancies may be repeated)
+    const uniqueJobs = [];
+    allJobs.forEach(thisAllJob => {
+      if (!uniqueJobs.includes(thisAllJob.jobId)) {
+        uniqueJobs.push(thisAllJob.jobId);
       }
-    } else {
-      columns.push(allJobs.map(thisJob => {
-        const isThisJobAStarterJob = entity.starters.find(myStarter => myStarter.id === thisJob.id);
-        if (isThisJobAStarterJob) {
-          return isThisJobAStarterJob.total;
+    });
+
+    columns.push(uniqueJobs.map(thisJob => BUDI.jobRoles(BUDI.FROM_ASC, thisJob)).join(';'));
+    if (uniqueJobs.length > 0) {
+      if (entity.starters && !Array.isArray(entity.starters)) {
+        if (entity.starters === 'None') {
+          columns.push(uniqueJobs.map(x => 0).join(';'));
         } else {
-          return 0;
+          columns.push(999);
         }
-      }).join(';'));
-    }
-    if (entity.leavers && !Array.isArray(entity.leavers)) {
-      if (entity.leavers === 'None') {
-        columns.push(allJobs.map(thisJob => 0).join(';'));
       } else {
-        columns.push(999);
+        columns.push(uniqueJobs.map(thisJob => {
+          const isThisJobAStarterJob = entity.starters.find(myStarter => myStarter.jobId === thisJob);
+          if (isThisJobAStarterJob) {
+            return isThisJobAStarterJob.total;
+          } else {
+            return 0;
+          }
+        }).join(';'));
       }
-    } else {
-      columns.push(allJobs.map(thisJob => {
-        const isThisJobALeaverJob = entity.leavers.find(myLeaver => myLeaver.id === thisJob.id);
-        if (isThisJobALeaverJob) {
-          return isThisJobALeaverJob.total;
-        } else {
-          return 0;
+      if (entity.leavers && !Array.isArray(entity.leavers)) {
+        if (entity.leavers === 'None') {
+          columns.push(uniqueJobs.map(x => 0).join(';'));
+        } else  {
+          columns.push(999);
         }
-      }).join(';'));
-    }
-    if (entity.vacancies && !Array.isArray(entity.vacancies)) {
-      if (entity.vacancies === 'None') {
-        columns.push(allJobs.map(thisJob => 0).join(';'));
       } else {
-        columns.push(999);
+        columns.push(uniqueJobs.map(thisJob => {
+          const isThisJobALeaverJob = entity.leavers.find(myLeaver => myLeaver.jobId === thisJob);
+          if (isThisJobALeaverJob) {
+            return isThisJobALeaverJob.total;
+          } else {
+            return 0;
+          }
+        }).join(';'));
       }
-    } else {
-      columns.push(allJobs.map(thisJob => {
-        const isThisJobAVacancyJob = entity.vacancies.find(myVacancy => myVacancy.id === thisJob.id);
-        if (isThisJobAVacancyJob) {
-          return isThisJobAVacancyJob.total;
+      if (entity.vacancies && !Array.isArray(entity.vacancies)) {
+        if (entity.vacancies === 'None') {
+          columns.push(uniqueJobs.map(x => 0).join(';'));
         } else {
-          return 0;
+          columns.push(999);
         }
-      }).join(';'));
+      } else {
+        columns.push(uniqueJobs.map(thisJob => {
+          const isThisJobAVacancyJob = entity.vacancies.find(myVacancy => myVacancy.jobId === thisJob);
+          if (isThisJobAVacancyJob) {
+            return isThisJobAVacancyJob.total;
+          } else {
+            return 0;
+          }
+        }).join(';'));
+      }
+
+    } else {
+      columns.push('');
+      columns.push('');
+      columns.push('');
     }
 
     // reasons for leaving - currently can't be mapped

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -1227,7 +1227,10 @@ class Worker {
   _validateMainJobRole() {
     const myMainJobRole = parseInt(this._currentLine.MAINJOBROLE, 10);
 
-    if (myMainJobRole !== 0 && (!myMainJobRole || isNaN(myMainJobRole))) {
+    console.log("WA DEBUG - myMainJobRole", myMainJobRole)
+
+    // note - optional in bulk import spec, but mandatory in ASC WDS frontend and backend
+    if (!this._currentLine.MAINJOBROLE || this._currentLine.MAINJOBROLE.length == 0 || !myMainJobRole || isNaN(myMainJobRole) || myMainJobRole === 0) {
       this._validationErrors.push({
         worker: this._currentLine.UNIQUEWORKERID,
         name: this._currentLine.LOCALESTID,
@@ -2014,10 +2017,24 @@ class Worker {
   };
 
   _transformMainJobRole() {
-    if (this._mainJobRole || this._mainJobRole === 0) {
+    console.log("WA DBEUG - _transformMainJobRole - this._mainJobRole: ", this._mainJobRole)
+    // main job is mandatory
+    if (this._mainJobRole === null) {
+      this._validationErrors.push({
+        worker: this._currentLine.UNIQUEWORKERID,
+        name: this._currentLine.LOCALESTID,
+        lineNumber: this._lineNumber,
+        errCode: Worker.MAIN_JOB_ROLE_ERROR,
+        errType: `MAIN_JOB_ROLE_ERROR`,
+        error: `The code you have entered for MAINJOBROLE is incorrect`,
+        source: this._currentLine.MAINJOBROLE,
+      });
+    } else if (this._mainJobRole || this._mainJobRole === 0) {
       const myValidatedJobRole = BUDI.jobRoles(BUDI.TO_ASC, this._mainJobRole);
+      console.log("WA DBEUG - _transformMainJobRole - myValidatedJobRole: ", myValidatedJobRole)
 
       if (!myValidatedJobRole) {
+        console.log("WA DBEUG - _transformMainJobRole - failed BUDI mapping raising error: ", myValidatedJobRole)
         this._validationErrors.push({
           worker: this._currentLine.UNIQUEWORKERID,
           name: this._currentLine.LOCALESTID,
@@ -2027,10 +2044,14 @@ class Worker {
           error: `The code you have entered for MAINJOBROLE is incorrect`,
           source: this._currentLine.MAINJOBROLE,
         });
+
+        console.log("WA DEBUG - transformMainJoBrole - validation errors: ", this._validationErrors)
       } else {
         this._mainJobRole = myValidatedJobRole;
       }
     }
+
+    console.log("WA DEBUG - main job role after transformation - ", this._mainJobRole, this._validationErrors)
   };
 
   _transformOtherJobRoles() {

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -2039,8 +2039,6 @@ class Worker {
           error: `The code you have entered for MAINJOBROLE is incorrect`,
           source: this._currentLine.MAINJOBROLE,
         });
-
-        console.log("WA DEBUG - transformMainJoBrole - validation errors: ", this._validationErrors)
       } else {
         this._mainJobRole = myValidatedJobRole;
       }

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -2050,8 +2050,6 @@ class Worker {
         this._mainJobRole = myValidatedJobRole;
       }
     }
-
-    console.log("WA DEBUG - main job role after transformation - ", this._mainJobRole, this._validationErrors)
   };
 
   _transformOtherJobRoles() {

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -1227,8 +1227,6 @@ class Worker {
   _validateMainJobRole() {
     const myMainJobRole = parseInt(this._currentLine.MAINJOBROLE, 10);
 
-    console.log("WA DEBUG - myMainJobRole", myMainJobRole)
-
     // note - optional in bulk import spec, but mandatory in ASC WDS frontend and backend
     if (!this._currentLine.MAINJOBROLE || this._currentLine.MAINJOBROLE.length == 0 || !myMainJobRole || isNaN(myMainJobRole) || myMainJobRole === 0) {
       this._validationErrors.push({
@@ -2017,7 +2015,6 @@ class Worker {
   };
 
   _transformMainJobRole() {
-    console.log("WA DBEUG - _transformMainJobRole - this._mainJobRole: ", this._mainJobRole)
     // main job is mandatory
     if (this._mainJobRole === null) {
       this._validationErrors.push({
@@ -2031,10 +2028,8 @@ class Worker {
       });
     } else if (this._mainJobRole || this._mainJobRole === 0) {
       const myValidatedJobRole = BUDI.jobRoles(BUDI.TO_ASC, this._mainJobRole);
-      console.log("WA DBEUG - _transformMainJobRole - myValidatedJobRole: ", myValidatedJobRole)
 
       if (!myValidatedJobRole) {
-        console.log("WA DBEUG - _transformMainJobRole - failed BUDI mapping raising error: ", myValidatedJobRole)
         this._validationErrors.push({
           worker: this._currentLine.UNIQUEWORKERID,
           name: this._currentLine.LOCALESTID,

--- a/server/models/cache/singletons/capacities.js
+++ b/server/models/cache/singletons/capacities.js
@@ -29,8 +29,21 @@ class CapacitiesCache {
 
   static allMyCapacities(allAssociatedServiceIndices) {
     if (allAssociatedServiceIndices && Array.isArray(allAssociatedServiceIndices)) {
+      // DO NOT RETURN REFERENCES TO THE ORIGINAL CACHE VALUES - BECAUSE CAPACITY PROPERTIES MODIFIES THE OBJECTS
       return ALL_CAPACITIES
-        .filter(x => allAssociatedServiceIndices && allAssociatedServiceIndices.length > 0 && allAssociatedServiceIndices.indexOf(x.service.id) > -1);
+        .filter(x => allAssociatedServiceIndices && allAssociatedServiceIndices.length > 0 && allAssociatedServiceIndices.indexOf(x.service.id) > -1)
+        .map(thisCap => {
+          return {
+            id: thisCap.id,
+            seq: thisCap.seq,
+            question: thisCap.question,
+            service: {
+              id: thisCap.service.id,
+              category: thisCap.service.category,
+              name: thisCap.service.name
+            }
+          };
+        });
     } else {
       // no given set of services - return empty set of capacities
       return [];

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -286,7 +286,8 @@ class Establishment extends EntityValidator {
             this.resetValidations();
 
             // inject all services against this establishment
-            document.allMyServices = ServiceCache.allMyServices(document.IsCQCRegulated);
+            const isRegulated = document.IsCQCRegulated || document.isRegulated;
+            document.allMyServices = ServiceCache.allMyServices(isRegulated);
 
             // inject all capacities against this establishment - note, "other services" can be represented by the JSON document attribute "services" or "otherServices"
             const allAssociatedServiceIndices = [];

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -295,7 +295,15 @@ class Establishment extends EntityValidator {
                 allAssociatedServiceIndices.push(document.mainService.id);
             }
             if (document && document.otherServices && Array.isArray(document.otherServices)) {
-                document.otherServices.forEach(thisService => allAssociatedServiceIndices.push(thisService.id));
+                document.otherServices.forEach(thisService => {
+                  if (thisService.id) {
+                    allAssociatedServiceIndices.push(thisService.id);
+                  } else if (thisService.services && Array.isArray(thisService.services)) {
+                    thisService.services.forEach(innerService => {
+                      allAssociatedServiceIndices.push(innerService.id)
+                    });
+                  }
+                });
             }
             if (document && document.services && Array.isArray(document.services)) {
                 document.services.forEach(thisService => allAssociatedServiceIndices.push(thisService.id));

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -982,7 +982,7 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, isPar
           const workerKeyNoWhitespace = (thisWorker._currentLine.LOCALESTID + thisWorker._currentLine.UNIQUEWORKERID).replace(/\s/g, "");
           workersKeyed[workerKeyNoWhitespace] = thisWorker._currentLine;
 
-          if (knownEstablishment) {
+          if (knownEstablishment && myAPIWorkers[thisWorker.lineNumber]) {
             knownEstablishment.associateWorker(myAPIWorkers[thisWorker.lineNumber].key, myAPIWorkers[thisWorker.lineNumber]);
           } else {
             // this should never happen


### PR DESCRIPTION
Includes:

https://trello.com/c/VsaLkn07 - fixes for ALLJOBROLES output on dedup'd job ids, which also impacts the formating of STARTERS, LEAVERS, and VACANCIES, and allowing for the fact that ALLJOBROLES could be empty.

https://trello.com/c/kfsOldCN - relaxing validation on import for empty ALLJOBROLES.

No trello card, bu t I fixed an issue with empty main job role (null). It was bombing on 503.

https://trello.com/c/sI1R6XCy - correctlng mapping CQC other services on bulk upload completion - onload entities restored from `all.entities.json`.

https://trello.com/c/8PqGW9jf - and this a proper headcase of first Capacity caching returning bizarre results owing to returning object references. And then, mismapped "otherServices" on entity load from JSON to get list of services to get associated capacity questions.