### PR TITLE
Introducting AWS secret configs for preprod.

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -12,7 +12,7 @@ const AppConfig = require('./appConfig');
 const config = convict({
   env: {
     doc: 'The application environment',
-    format: ['production', 'development', 'test', 'accessibility', 'localhost'],
+    format: ['production', 'preproduction', 'development', 'test', 'accessibility', 'localhost'],
     default: 'localhost',
     env: 'NODE_ENV'
   },

--- a/server/config/preproduction.yaml
+++ b/server/config/preproduction.yaml
@@ -1,0 +1,43 @@
+aws:
+    region: eu-west-1
+    secrets:
+        use: true
+        wallet: preprod/api
+    kinesis:
+      enabled: true
+      establishments: establishments.prod
+      workers: workers.prod
+      users: users.prod
+    sns:
+      enabled: true
+      registrations: arn:aws:sns:eu-west-1:364648107127:registrations-prod
+      feedback: arn:aws:sns:eu-west-1:364648107127:feedback-prod
+
+slack:
+    level : 3     # enables Slack notifications
+
+jwt:
+    iss: 'asc-wds.skillsforcare.org.uk'
+    ttl:
+        login: 5
+
+db:
+    pool: 15
+    ssl: true
+    client_ssl:
+        status: false
+        usingFiles: false
+
+notify:
+    replyTo: '44e98371-2e44-4c6b-ad76-235136be0f8a'
+    templates:
+        resetPassword: 'fd430f0d-6609-400a-b171-cf124453ec1c'
+        addUser: 'f20e9cbe-920d-4b1f-b05d-bac1ca8d5b54'
+
+bulkupload:
+    region: eu-west-2
+    bucketname: sfc-bulkupload-preprod
+
+public:
+    download:
+        baseurl: https://sfc-public-prod.s3.eu-west-2.amazonaws.com/public/download

--- a/server/config/preproduction.yaml
+++ b/server/config/preproduction.yaml
@@ -5,13 +5,13 @@ aws:
         wallet: preprod/api
     kinesis:
       enabled: true
-      establishments: establishments.prod
-      workers: workers.prod
-      users: users.prod
+      establishments: establishments.preprod
+      workers: workers.preprod
+      users: users.preprod
     sns:
       enabled: true
-      registrations: arn:aws:sns:eu-west-1:364648107127:registrations-prod
-      feedback: arn:aws:sns:eu-west-1:364648107127:feedback-prod
+      registrations: arn:aws:sns:eu-west-1:364648107127:registrations-preprod
+      feedback: arn:aws:sns:eu-west-1:364648107127:feedback-preprod
 
 slack:
     level : 3     # enables Slack notifications
@@ -29,10 +29,10 @@ db:
         usingFiles: false
 
 notify:
-    replyTo: '44e98371-2e44-4c6b-ad76-235136be0f8a'
+    replyTo: '73711295-a4da-4303-9127-65be2a409681'
     templates:
-        resetPassword: 'fd430f0d-6609-400a-b171-cf124453ec1c'
-        addUser: 'f20e9cbe-920d-4b1f-b05d-bac1ca8d5b54'
+        resetPassword: 'f2c43610-9ec9-4271-b9b1-dd55569b191c'
+        addUser: 'e581eea2-4206-4c90-8594-4357960e3e74'
 
 bulkupload:
     region: eu-west-2


### PR DESCRIPTION
Hi Warren,

Here is trello card for this request https://trello.com/c/EJxfSl0p

I have introduced preproduction.yml and have following changes

- point to preprod wallet (has its own api users and other policy) - Screen shot is in Trello ticket
- point to preprod bucket (only this has auto-delete policy)
- i have turn status = false for client_ssl (there are no ssl cert for preprod need)
- I have also remove the database name and user because it comes from gov paas 

Only i dont know sns and kenisis values postfix with .prod? do you have prepro for those?

Thanks
Nasir
