### PR TITLE
Bulk upload parent subs permissions

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -51,6 +51,7 @@ class Establishment {
   static get EXPECT_JUST_ONE_ERROR() { return 950; }
   static get MISSING_PRIMARY_ERROR() { return 955; }
 
+  static get NOT_OWNER_ERROR() { return 997; }
   static get DUPLICATE_ERROR() { return 998; }
   static get HEADERS_ERROR() { return 999; }
   static get MAIN_SERVICE_ERROR() { return 1000; }
@@ -1529,6 +1530,19 @@ class Establishment {
     };
   }
 
+  // add a duplicate validation error to the current set
+  addNotOwner() {
+    return {
+      origin: 'Establishments',
+      lineNumber: this._lineNumber,
+      errCode: Establishment.NOT_OWNER_ERROR,
+      errType: `NOT_OWNER_ERROR`,
+      error: `Not the owner`,
+      source: this._currentLine.LOCALESTID,
+      name: this._currentLine.LOCALESTID,
+    };
+  }
+
   static justOneEstablishmentError() {
     return {
       origin: 'Establishments',
@@ -1994,26 +2008,31 @@ class Establishment {
     columns.push(this._csvQuote(entity.town));
     columns.push(entity.postcode);
 
-    switch (entity.employerType.value) {
-      case 'Private Sector':
-        columns.push(6);
-        break;
-      case 'Voluntary / Charity':
-        columns.push(7);
-        break;
-      case 'Other':
-        columns.push(8);
-        break;
-      case 'Local Authority (generic/other)':
-        columns.push(3);
-        break;
-      case 'Local Authority (adult services)':
-        columns.push(1);
-        break;
-    }
-    if (entity.employerType.other) {
-      columns.push(this._csvQuote(entity.employerType.other))
+    if (entity.employerType) {
+      switch (entity.employerType.value) {
+        case 'Private Sector':
+          columns.push(6);
+          break;
+        case 'Voluntary / Charity':
+          columns.push(7);
+          break;
+        case 'Other':
+          columns.push(8);
+          break;
+        case 'Local Authority (generic/other)':
+          columns.push(3);
+          break;
+        case 'Local Authority (adult services)':
+          columns.push(1);
+          break;
+      }
+      if (entity.employerType.other) {
+        columns.push(this._csvQuote(entity.employerType.other))
+      } else {
+        columns.push('');
+      }
     } else {
+      columns.push('');
       columns.push('');
     }
 
@@ -2070,7 +2089,7 @@ class Establishment {
     columns.push(otherServices.map(thisService => thisService.other && thisService.other.length > 0 ? thisService.other : '').join(';'));
 
     // service users and their 'other' descriptions
-    const serviceUsers = entity.serviceUsers;
+    const serviceUsers = entity.serviceUsers ? entity.serviceUsers : [];
     columns.push(serviceUsers.map(thisUser => BUDI.serviceUsers(BUDI.FROM_ASC, thisUser.id)).join(';'));
     columns.push(serviceUsers.map(thisUser => thisUser.other && thisUser.other.length > 0 ? thisUser.other : '').join(';'));
 

--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -101,10 +101,18 @@ exports.hasAuthorisedEstablishment = async (req, res, next) => {
             // this is a known subsidairy of this given parent establishment
 
             // but, to be able to access the subsidary, then the permissions must not be null
-            if (referencedEstablishment.dataOwmer === 'Workplace' && referencedEstablishment.parentPermissions === null) {
-              console.error(`Found subsidiary establishment (${req.params.id}) for this known parent (${claim.EstblishmentId}/${claim.EstablishmentUID}), but access has not been given`);
-              // failed to find establishment by UUID - being a subsidairy of this known parent
-              return res.status(403).send(`Not permitted to access Establishment with id: ${req.params.id}`);
+            if (referencedEstablishment.dataOwner === 'Workplace') {
+              if (referencedEstablishment.parentPermissions === null) {
+                console.error(`Found subsidiary establishment (${req.params.id}) for this known parent (${claim.EstblishmentId}/${claim.EstablishmentUID}), but access has not been given`);
+                // failed to find establishment by UUID - being a subsidairy of this known parent
+                return res.status(403).send({message: `Parent not permitted to access Establishment with id: ${req.params.id}`});
+              }
+
+              // parent permissions must be either null (no access), "Workplace" or "Workplace and staff" - if not null, then have access to the establishment
+              // but only read access (GET)
+              if (req.method !== 'GET') {
+                return res.status(403).send({message: `Parent not permitted to update Establishment with id: ${req.params.id}`});
+              }
             }
 
             req.establishmentId = referencedEstablishment.id;


### PR DESCRIPTION
https://trello.com/c/LtgGtQho

Introduces authorisation to bulk upload (BU), as defined by the parent/sub owner/parent permissions.

BU can only work on subs it owns.

On BU Download, simply filters out those establishments it is does not owner.

But on BU upload, a validation error is required if trying to upload against a sub not owned.

Whilst implementing this I noticed some dodgy handling of null data on establishments - atypical of a newly created establishment with no properties - `entity.employerType` and `entity.serviceUsers` - fixed.

Also, whilst adding this new error, I've used "unshift" to put it to the top of all errors, and have updated accordingly missing primary and expect just one establishment validation errors too.

And whilst updating the Worker authentication, I noticed that the `workerId` was not coming through - doh. Need to add the middleware explicitly with workerId `router.use('/:workerId', validateWorker);` before adding it on "/".