### PR TITLE
rework

### DIFF
--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -706,6 +706,18 @@ class User {
                     transaction: thisTransaction
                     });     
 
+                    await models.addUserTracking.update(
+                        {
+                            completed: new Date(),
+                        },
+                        {
+                            transaction: thisTransaction,
+                            where : {
+                                userFk: this._id
+                            },
+                        }
+                    );
+
                     const auditEvent = {
                         userFk: this._id,
                         username: deletedBy,

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -660,14 +660,90 @@ class User {
         }
     };
 
-    // deletes this User from DB
-    // Can throw "UserDeleteException"
-    async delete() {
-      // this is an async method - don't wait for it to return
-      AWSKinesis.userPump(AWSKinesis.DELETED, this.toJSON());
+    async delete(deletedBy, externalTransaction=null, associatedEntities=false) {
+    
+        try {
+            const updatedTimestamp = new Date();
 
-      throw new Error('Not implemented');
+            await models.sequelize.transaction(async t => {
+
+                const thisTransaction = externalTransaction ? externalTransaction : t;
+                let randomNewUsername = uuid.v4();
+                let oldUsername = this._username;
+
+                const updateDocument = {
+                    updated: updatedTimestamp,
+                    updatedBy: deletedBy,
+                    archived: true,
+                    FullNameValue: false,
+                    isPrimary: false,
+                    Username: randomNewUsername,
+                    EmailValue: '',
+                    PhoneValue: '',
+                    JobTitle: '',
+                    SecurityQuestionValue: '',
+                    SecurityQuestionAnswerValue: ''
+                };
+
+                let [updatedRecordCount, updatedRows] = await models.user.update(updateDocument,
+                                            {
+                                                returning: true,
+                                                where: {
+                                                    uid: this.uid
+                                                },
+                                                attributes: ['id', 'updated'],
+                                                transaction: thisTransaction,
+                                            });
+
+                if (updatedRecordCount === 1) {
+
+                    await models.login.update({
+                        isActive: false
+                    },{
+                    where: {
+                        registrationId: this._id
+                    },
+                    transaction: thisTransaction
+                    });     
+
+                    const auditEvent = {
+                        userFk: this._id,
+                        username: deletedBy,
+                        type: 'delete',
+                        property: 'isActive',
+                        event: {}
+                    };
+                    await models.userAudit.create(auditEvent, {transaction: thisTransaction});
+        
+                    await models.sequelize.query('UPDATE  cqc."EstablishmentAudit" SET "Username" = :usernameNew WHERE "Username" = :username', { replacements: { username: oldUsername, usernameNew: randomNewUsername },type: models.sequelize.QueryTypes.UPDATE, transaction: thisTransaction });
+                    await models.sequelize.query('UPDATE cqc."UserAudit" SET "Username" = :usernameNew WHERE "Username" = :username', { replacements: { username: oldUsername, usernameNew: randomNewUsername }, type: models.sequelize.QueryTypes.UPDATE, transaction: thisTransaction });
+                    await models.sequelize.query('UPDATE cqc."WorkerAudit" SET "Username" = :usernameNew WHERE "Username" = :username', { replacements: { username: oldUsername, usernameNew: randomNewUsername }, type: models.sequelize.QueryTypes.UPDATE, transaction: thisTransaction });
+    
+                    AWSKinesis.userPump(AWSKinesis.DELETED, this.toJSON());
+
+                    this._log(User.LOG_INFO, `Archived User with uid (${this._uid}) and id (${this._id})`);
+
+                } else {
+                    const nameId = this._properties.get('NameOrId');
+                    throw new UserExceptions.UserDeleteException(null,
+                                                                        this.uid,
+                                                                        null,
+                                                                        err,
+                                                                        `Failed to update (archive) user record with uid: ${this._uid}`);
+                }
+
+            });
+        } catch (err) {
+            console.log('throwing error');
+            console.log(err);
+            throw new UserExceptions.UserDeleteException(null,
+                this.uid,
+                null,
+                err,
+                `Failed to update (archive) user record with uid: ${this._uid}`);
+        }
     };
+
 
     static async fetchUserTypeCounts(establishmentId){
         const results = await models.user.findAll({

--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -569,8 +569,7 @@ router.route('/validateAddUser').post(async (req, res) => {
     }
 });
 
-
-router.use('/add/establishment/:id', Authorization.hasAuthorisedEstablishment);
+router.use('/establishment/:id/:userid', Authorization.hasAuthorisedEstablishment);
 router.route('/establishment/:id/:userid').delete(async (req, res) => {
     const userId = req.params.userid;
 

--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -493,9 +493,6 @@ router.route('/:uid/resend-activation').post(async (req, res) => {
     }
 });
 
-router.route('/:username').delete(async (req, res) => {
-    return res.status(200).send();
-});
 
 // validates (part add) a new user - not authentication middleware
 router.route('/validateAddUser').post(async (req, res) => {
@@ -572,92 +569,39 @@ router.route('/validateAddUser').post(async (req, res) => {
     }
 });
 
-router.use('/:username', Authorization.isAuthorised);
-router.route('/:username').delete(async (req, res) => {
-   try {
-        const login = await models.login.findOne({
-            where: {
-                username: {
-                    [models.Sequelize.Op.iLike] : req.params.username
-                },
-                isActive: true
-            },
-            include: [
-                {
-                    model: models.user,
-                    attributes: ['id', 'FullNameValue'],
-                    where: {
-                        establishmentId: req.establishmentId
-                    }
-                }
-            ]
-        });
 
-        if (login && login.user.id) {
-            await models.sequelize.transaction(async t => {
+router.use('/add/establishment/:id', Authorization.hasAuthorisedEstablishment);
+router.route('/establishment/:id/:userid').delete(async (req, res) => {
+    const userId = req.params.userid;
 
-                // If the deleted user is the primary, make us the primary
-                if(login.user.isPrimary){
-                    await models.user.update({
-                            isPrimary: true,
-                            updated: new Date(),
-                            updatedBy: req.username.toLowerCase()
-                        },{
-                        where: {
-                            username: req.username
-                        },
-                        transaction: t,
-                        attributes: ['id', 'updated'],
-                    });                    
-                }
+    const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/;
+    if (!uuidRegex.test(userId.toUpperCase())) {
+        return res.status(503).send('Invalid request');
+    }
 
-                // Set the login to not active
-                login.update({
-                    isActive: false
-                },
-                {transaction: t});
+    const thisUser = new User.User(userId);
 
-                // Create audit log entry
-                const auditEvent = {
-                    userFk: login.user.id,
-                    username: req.username,
-                    type: 'delete',
-                    property: 'isActive',
-                    event: {}
-                };
-                await models.userAudit.create(auditEvent, {transaction: t});
-
-                let randomNewUsername = uuid.v4();
-
-                login.user.update({
-                    Archived: true,
-                    FullNameValue: false,
-                    isPrimary: false,
-                    Username: randomNewUsername,
-                    EmailValue: '',
-                    PhoneValue: '',
-                    JobTitle: '',
-                    SecurityQuestionValue: '',
-                    SecurityQuestionAnswerValue: ''
-                },
-                {transaction: t});
-
-                await models.sequelize.query('UPDATE  cqc."EstablishmentAudit" SET "Username" = :usernameNew WHERE "Username" = :username', { replacements: { username: login.username, usernameNew: randomNewUsername },type: models.sequelize.QueryTypes.UPDATE, transaction: t });
-                await models.sequelize.query('UPDATE cqc."UserAudit" SET "Username" = :usernameNew WHERE "Username" = :username', { replacements: { username: login.username, usernameNew: randomNewUsername }, type: models.sequelize.QueryTypes.UPDATE, transaction: t });
-                await models.sequelize.query('UPDATE cqc."WorkerAudit" SET "Username" = :usernameNew WHERE "Username" = :username', { replacements: { username: login.username, usernameNew: randomNewUsername }, type: models.sequelize.QueryTypes.UPDATE, transaction: t });
-
-            });
-
-            return res.status(200).send(`User deleted`);
+    try {
+        if (await thisUser.restore(userId, null, false)) {
+            console.log('restored about to delete');
+            await thisUser.delete(req.username);
+            return res.status(204).send();
         } else {
-            return res.status(404).send(`User not found`);
+            console.log('404 not found that user')
+            return res.status(404).send('Not Found');            
         }
+    } catch (err) {
+        const thisError = new User.UserExceptions.UserRestoreException(
+            thisUser.id,
+            thisUser.uid,
+            null,
+            err,
+            null,
+            `Failed to delete User with id/uid: ${userId}`);
 
-  } catch (err) {
-    console.error('User delete failed', err);
-    return res.status(503).send();
-  }
-
+        console.error('User::DELETE - failed', thisError.message);
+        return res.status(503).send(thisError.safe);
+    }
 });
 
 // registers (full add) a new user - authentication middleware is specific to add user token


### PR DESCRIPTION
This is a reworking of the delete given the issues raised today. Delete moved into the Property Class system.

Delete now takes place using userid. With the change in middleware it should also now allow for deleting users within a sub establishment.

The isPrimary code which makes the deleter into the primary if the person deleted is the primary has been removed as I am unsure how to approach this. I will be raising this with Maria.

https://trello.com/c/7cUmofEk/151-6-user-accounts-delete-user-accounts