### PR TITLE
prevent self delete

### DIFF
--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -582,6 +582,10 @@ router.route('/establishment/:id/:userid').delete(async (req, res) => {
 
     try {
         if (await thisUser.restore(userId, null, false)) {
+            if(thisUser.username && thisUser.username == req.username){
+                return res.status(400).send('Cannot delete own user account');
+            }
+
             console.log('restored about to delete');
             await thisUser.delete(req.username);
             return res.status(204).send();


### PR DESCRIPTION
Check implemented to prevent a user from deleting their own account 

As per:

https://trello.com/c/bMEfsdSV/202-user-accounts-block-delete-own-account