### PR TITLE
Bugfix/account activation missing exit cta

### DIFF
--- a/src/app/features/account/account-details/account-details.ts
+++ b/src/app/features/account/account-details/account-details.ts
@@ -154,16 +154,23 @@ export class AccountDetails implements OnInit, OnDestroy {
     return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
   }
 
-  public onSubmit(): void {
+  public onSubmit(payload: { action: string; save: boolean }) {
+    if (!payload.save) {
+      return this.navigateToNextRoute();
+    }
+
     this.submitted = true;
     this.errorSummaryService.syncFormErrorsEvent.next(true);
 
     if (this.form.valid) {
       this.save();
+      this.navigateToNextRoute();
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }
   }
+
+  protected navigateToNextRoute(): void {}
 
   protected onError(response: HttpErrorResponse): void {
     if (response.status === 400) {

--- a/src/app/features/account/account-details/account-details.ts
+++ b/src/app/features/account/account-details/account-details.ts
@@ -154,7 +154,7 @@ export class AccountDetails implements OnInit, OnDestroy {
     return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
   }
 
-  public onSubmit(payload: { action: string; save: boolean }) {
+  public onSubmit(payload: { action: string; save: boolean } = { action: 'continue', save: true }) {
     if (!payload.save) {
       return this.navigateToNextRoute();
     }
@@ -164,7 +164,6 @@ export class AccountDetails implements OnInit, OnDestroy {
 
     if (this.form.valid) {
       this.save();
-      this.navigateToNextRoute();
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }

--- a/src/app/features/activate-user-account/change-your-details/change-your-details.component.html
+++ b/src/app/features/activate-user-account/change-your-details/change-your-details.component.html
@@ -38,14 +38,8 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third-from-desktop">
-    <div class="govuk-button-group">
-      <button class="govuk-button" type="button" (click)="onSubmit()">{{ callToActionLabel }}</button>
-      <span class="govuk-visually-hidden">or</span>
-      <button class="govuk-button govuk-button--link govuk-util__float-right" type="button" (click)="onSubmit()">
-        Exit
-      </button>
-    </div>
-  </div>
-</div>
+<app-submit-button
+  [return]="true"
+  (clicked)="onSubmit($event)"
+  [callToActionLabel]="callToActionLabel"
+></app-submit-button>

--- a/src/app/features/activate-user-account/change-your-details/change-your-details.component.ts
+++ b/src/app/features/activate-user-account/change-your-details/change-your-details.component.ts
@@ -57,6 +57,9 @@ export class ChangeYourDetailsComponent extends AccountDetails {
 
   protected save(): void {
     this.createAccountService.userDetails$.next(this.setUserDetails());
+  }
+
+  protected navigateToNextRoute(): void {
     this.router.navigate(this.previousAndReturnRoute);
   }
 

--- a/src/app/features/activate-user-account/change-your-details/change-your-details.component.ts
+++ b/src/app/features/activate-user-account/change-your-details/change-your-details.component.ts
@@ -57,6 +57,7 @@ export class ChangeYourDetailsComponent extends AccountDetails {
 
   protected save(): void {
     this.createAccountService.userDetails$.next(this.setUserDetails());
+    this.navigateToNextRoute();
   }
 
   protected navigateToNextRoute(): void {

--- a/src/app/features/workplace/create-user-account/create-user-account.component.html
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.html
@@ -69,21 +69,12 @@
           </div>
         </fieldset>
       </div>
-
-      <div class="govuk-button-group">
-        <button class="govuk-button govuk-!-margin-right-8 govuk-!-margin-bottom-0" type="submit">
-          {{ callToActionLabel }}
-        </button>
-        <span class="govuk-visually-hidden">or</span>
-        <a
-          role="button"
-          draggable="false"
-          class="govuk-button govuk-button--link govuk-!-margin-bottom-0"
-          [routerLink]="['/dashboard']"
-        >
-          Cancel
-        </a>
-      </div>
     </form>
   </div>
 </div>
+
+<app-submit-button
+  [return]="true"
+  (clicked)="onSubmit($event)"
+  [callToActionLabel]="callToActionLabel"
+></app-submit-button>

--- a/src/app/features/workplace/create-user-account/create-user-account.component.ts
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.ts
@@ -65,9 +65,13 @@ export class CreateUserAccountComponent extends AccountDetails {
       this.createAccountService
         .createAccount(this.establishmentUid, this.form.value)
         .subscribe(
-          () => this.router.navigate(['/workplace', this.establishmentUid, 'user', 'saved']),
+          () => this.navigateToNextRoute(),
           (error: HttpErrorResponse) => this.onError(error)
         )
     );
+  }
+
+  protected navigateToNextRoute(): void {
+    this.router.navigate(['/workplace', this.establishmentUid, 'user', 'saved']);
   }
 }

--- a/src/app/shared/components/submit-button/submit-button.component.html
+++ b/src/app/shared/components/submit-button/submit-button.component.html
@@ -10,8 +10,11 @@
     </button>
   </ng-container>
   <ng-template #summary>
-    <button type="button" class="govuk-button" (click)="onClick('return', true)">Save and return</button>
+    <button type="button" class="govuk-button" (click)="onClick('return', true)">
+      {{ callToActionLabel || 'Save and return' }}
+    </button>
   </ng-template>
+  <span class="govuk-visually-hidden">or</span>
   <button
     type="button"
     class="govuk-button govuk-button--link govuk-util__float-right"

--- a/src/app/shared/components/submit-button/submit-button.component.ts
+++ b/src/app/shared/components/submit-button/submit-button.component.ts
@@ -7,6 +7,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 export class SubmitButtonComponent {
   @Input() return: boolean;
   @Input() saveCallback: any;
+  @Input() public callToActionLabel?: string;
   @Output() clicked = new EventEmitter<{ action: string; save: boolean }>();
 
   onClick(action: string, save: boolean) {


### PR DESCRIPTION
- ensure missing Exit CTA button is present [when required] on screens that extend from `AccountDetails` base class
- tweak and reuse shared `app-submit-button` component
- more similar baby pr's to follow