### PR TITLE
Bug Fix | User Accounts Issues

### DIFF
--- a/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.html
+++ b/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.html
@@ -1,4 +1,8 @@
-<app-error-summary *ngIf="submitted && form.invalid" [form]="form"></app-error-summary>
+<app-error-summary
+  *ngIf="submitted && (form.invalid || serverError)"
+  [form]="form"
+  [serverError]="serverError"
+></app-error-summary>
 
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
   <div class="govuk-grid-row">

--- a/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
+++ b/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
@@ -40,6 +40,7 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
     },
   ];
   public return: URLStructure;
+  public submitted = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -97,6 +98,8 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
     if (!payload.save) {
       return this.router.navigate(['/workplace', this.workplace.uid], { fragment: 'user-accounts' });
     }
+
+    this.submitted = true;
 
     const { role, primary } = this.form.value;
     const updatedPrimary = role === Roles.Read ? false : primary;

--- a/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
+++ b/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
@@ -58,6 +58,7 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.setupServerErrorsMap();
     this.breadcrumbService.show();
 
     this.form = this.formBuilder.group({
@@ -68,6 +69,15 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.subscriptions.unsubscribe();
+  }
+
+  public setupServerErrorsMap(): void {
+    this.serverErrorsMap = [
+      {
+        name: 400,
+        message: 'Cannot update user permissions as too many of that role already exist.',
+      },
+    ];
   }
 
   public changePrimary() {

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -22,6 +22,7 @@ import { take, withLatestFrom } from 'rxjs/operators';
 export class UserAccountViewComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
   public loginInfo: SummaryList[];
+  public loggedInUser: UserDetails;
   public securityInfo: SummaryList[];
   public establishment: Establishment;
   public user: UserDetails;
@@ -55,6 +56,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
           withLatestFrom(this.userService.loggedInUser$)
         )
         .subscribe(([users, loggedInUser]) => {
+          this.loggedInUser = loggedInUser;
           this.setPermissions(users, loggedInUser);
         })
     );
@@ -100,6 +102,14 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
   }
 
   private deleteUser() {
+    if (this.user.isPrimary) {
+      this.subscriptions.add(
+        this.userService
+          .updateUserDetails(this.loggedInUser.uid, { ...this.loggedInUser, ...{ isPrimary: true } })
+          .subscribe(data => (this.userService.loggedInUser = data))
+      );
+    }
+
     this.subscriptions.add(
       this.userService.deleteUser(this.establishment.uid, this.user.uid).subscribe(
         () => {

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -157,14 +157,10 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
   private setPermissions(users: Array<UserDetails>, loggedInUser: UserDetails) {
     const canEdit = loggedInUser.role === Roles.Edit;
     const isPending = this.user.username === null;
-    const isPrimary = this.user.isPrimary;
     const editUsersList = users.filter(user => user.role === Roles.Edit);
 
     this.canDeleteUser =
-      canEdit &&
-      (editUsersList.length > 1 || this.user.role === Roles.Read) &&
-      !isPrimary &&
-      loggedInUser.uid !== this.user.uid;
+      canEdit && (editUsersList.length > 1 || this.user.role === Roles.Read) && loggedInUser.uid !== this.user.uid;
     this.canResendActivationLink = canEdit && isPending;
     this.canEdit = canEdit && users.length > 1;
   }


### PR DESCRIPTION
Users can now delete primary users
When a primary user is deleted the logged in user then becomes primary
Users get an error when they try to change a users permissions to a role that is already maxed out 