### PR TITLE
bugfix | workplace references caching

### DIFF
--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -41,9 +41,6 @@ export class BulkUploadService {
   ) {}
 
   public get workPlaceReferences$() {
-    if (this._workPlaceReferences$.value !== null) {
-      return this._workPlaceReferences$.asObservable();
-    }
     return this.userService.getEstablishments().pipe(
       map(response => {
         const references = [];


### PR DESCRIPTION
remove caching block as if user logs out and a different user signs in > the previous data is cached and returned