### PR TITLE
setup

### DIFF
--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -291,7 +291,7 @@ class User {
 
     // saves the User to DB. Returns true if saved; false if not.
     // Throws "UserSaveException" on error
-    async save(savedBy, ttl=0, externalTransaction=null) {
+    async save(savedBy, ttl=0, externalTransaction=null, firstSave=false) {
         let mustSave = this._initialise();
 
         if (!this.uid) {
@@ -444,11 +444,7 @@ class User {
                     const thisTransaction = externalTransaction ? externalTransaction : t;
 
                     // Is this the intial update setup
-                    let loginCount = await models.login.count({ where: {
-                            registrationId: this._id
-                    }});
-                    
-                    if(loginCount == 0){
+                    if(firstSave){
 
                         const passwordHash = await bcrypt.hashSync(this._password, bcrypt.genSaltSync(10), null);
                         await models.login.create(

--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -688,7 +688,7 @@ router.route('/add').post(async (req, res) => {
                     // this is a part user (register user) - so no audit
                     // Also, because this is a part user (register user) - must send a registration email which means adding
                     //  user tracking
-                    await thisUser.save(trackingResponse.by);
+                    await thisUser.save(trackingResponse.by,0,null,true);
 
                     return res.status(200).json(thisUser.toJSON(false, false, false, true));
                 } else {


### PR DESCRIPTION
https://trello.com/c/jP2FroEU/205-account-confirmation-is-creating-a-second-user-record

This is another issue that came up regarding the registration making duplicate accounts.

When the restore adding in before the load. It meant that the code in the "create new" section of the save method was no longer running and instead an update running. This mean the initial setup code in create such as making the login entry, removing token etc was not running. 

I have now added these into the update section of the code - if there is no existing login. This may not be ideal as perhaps there are circumstances where a user is updated which has no login? - however with my limited knowledge for now I have determined this to be a means of checking if it is a new account

