### PR TITLE
Prevent deletion of primary on BE

### DIFF
--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -615,6 +615,10 @@ router.route('/establishment/:id/:userid').delete(async (req, res) => {
                 return res.status(400).send('Cannot delete own user account');
             }
 
+            if(thisUser._isPrimary){
+                return res.status(400).send('Cannot delete primary account');
+            }
+
             console.log('restored about to delete');
             await thisUser.delete(req.username);
             return res.status(204).send();


### PR DESCRIPTION
Added in a check to prevent the deletion of the primary as requested in:

https://trello.com/c/bkIXF7MI/214-delete-user-accounts-primary-should-not-be-allowed-to-be-deleted