### PR TITLE
Increase the request timeout for daily snasphot report to ten minutes

### DIFF
--- a/server/routes/reports/dailySnapshot/index.js
+++ b/server/routes/reports/dailySnapshot/index.js
@@ -45,6 +45,7 @@ const isAuthorised = (req, res , next) => {
 // optional parameter - "history" must equal "none" (default), "property", "timeline" or "full"
 router.use('/', isAuthorised);
 router.route('/').get(async (req, res) => {
+    req.setTimeout(10 * 60 * 1000);   // ten minutes
     try {
         // rather than define a sequelize model, instead, simply query directly upon a view
         // NOTE - the order of the records is defined by the view

--- a/server/routes/reports/dailySnapshot/index.js
+++ b/server/routes/reports/dailySnapshot/index.js
@@ -45,7 +45,7 @@ const isAuthorised = (req, res , next) => {
 // optional parameter - "history" must equal "none" (default), "property", "timeline" or "full"
 router.use('/', isAuthorised);
 router.route('/').get(async (req, res) => {
-    req.setTimeout(10 * 60 * 1000);   // ten minutes
+    req.setTimeout(15 * 60 * 1000);   // fifteen minutes
     try {
         // rather than define a sequelize model, instead, simply query directly upon a view
         // NOTE - the order of the records is defined by the view


### PR DESCRIPTION
No trello card for this one, but I tried to run the daily snapshot against the tribalDB remotely, and it timed out after 2 mins (express default).

This was a remote database connection, although I did expect the query/simple JSON presentation to return within that period - it's 640k records.

In preparation for the deployment to green, I want to be sure the daily snapshot completes, so adding this quick change to cover my bases.