### PR TITLE
Bulk upload statuses - validations

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -1,9 +1,12 @@
 const BUDI = require('../BUDI').BUDI;
 
 class Establishment {
-  constructor(currentLine, lineNumber) {
+  constructor(currentLine, lineNumber, allCurrentEstablishments) {
     this._currentLine = currentLine;
     this._lineNumber = lineNumber;
+    this._allCurrentEstablishments = allCurrentEstablishments;
+
+
     this._validationErrors = [];
     this._headers_v1 = ["LOCALESTID","STATUS","ESTNAME","ADDRESS1","ADDRESS2","ADDRESS3","POSTTOWN","POSTCODE","ESTTYPE","OTHERTYPE","PERMCQC","PERMLA","SHARELA","REGTYPE","PROVNUM","LOCATIONID","MAINSERVICE","ALLSERVICES","CAPACITY","UTILISATION","SERVICEDESC","SERVICEUSERS","OTHERUSERDESC","TOTALPERMTEMP","ALLJOBROLES","STARTERS","LEAVERS","VACANCIES","REASONS","REASONNOS"];
 
@@ -11,6 +14,7 @@ class Establishment {
     // CSV properties
     this._localId = null;
     this._status = null;
+    this._key = null;
     this._name = null;
     this._address1 = null;
     this._address2 = null;
@@ -57,6 +61,7 @@ class Establishment {
   static get MAIN_SERVICE_ERROR() { return 1000; }
   static get LOCAL_ID_ERROR() { return 1010; }
   static get STATUS_ERROR() { return 1020; }
+  static get STATUS_WARNING() { return 1025; }
   static get NAME_ERROR() { return 1030; }
   static get ADDRESS_ERROR() { return 1040; }
   static get ESTABLISHMENT_TYPE_ERROR() { return 1070; }
@@ -76,7 +81,6 @@ class Establishment {
   static get LEAVERS_ERROR() { return 1320; }
 
   static get REASONS_FOR_LEAVING_ERROR() { return 1360; }
-
 
   static get MAIN_SERVICE_WARNING() { return 2000; }
   static get NAME_WARNING() { return 2030; }
@@ -114,6 +118,9 @@ class Establishment {
 
   get localId() {
     return this._localId;
+  }
+  get key() {
+    return this._key;
   }
   get status() {
     return this._status;
@@ -223,6 +230,7 @@ class Establishment {
       return false;
     } else {
       this._localId = myLocalId;
+      this._key = myLocalId.replace(/\s/g, "");
       return true;
     }
   }
@@ -244,6 +252,76 @@ class Establishment {
       });
       return false;
     } else {
+      // helper which returns true if the given LOCALESTID
+      const thisEstablishmentExists = (key) => {
+        const foundEstablishment = this._allCurrentEstablishments.find(currentEstablishment => {
+          return currentEstablishment.key === key;
+        });
+        return foundEstablishment ? true : false;
+      };
+
+      // we have a known status - now validate the status against the known set of all current establishments
+      switch (myStatus) {
+        case 'NEW':
+          if (thisEstablishmentExists(this._key)) {
+            this._validationErrors.push({
+              name: this._currentLine.LOCALESTID,
+              lineNumber: this._lineNumber,
+              errCode: Establishment.STATUS_ERROR,
+              errType: `STATUS_ERROR`,
+              error: `STATUS is NEW but establishment already exists`,
+              source: myStatus,
+            });
+          }
+          break;
+        case 'DELETE':
+          if (!thisEstablishmentExists(this._key)) {
+            this._validationErrors.push({
+              name: this._currentLine.LOCALESTID,
+              lineNumber: this._lineNumber,
+              errCode: Establishment.STATUS_ERROR,
+              errType: `STATUS_ERROR`,
+              error: `STATUS is DELETE but establishment does not exist`,
+              source: myStatus,
+            });
+          }
+          break;
+        case 'UNCHECKED':
+          this._validationErrors.push({
+            name: this._currentLine.LOCALESTID,
+            lineNumber: this._lineNumber,
+            warnCode: Establishment.STATUS_WARNING,
+            warnType: `STATUS_WARNING`,
+            warning: `STATUS is UNCHECKED and will be ignored`,
+            source: myStatus,
+          });
+          break;
+        case 'NOCHANGE':
+          if (!thisEstablishmentExists(this._key)) {
+            this._validationErrors.push({
+              name: this._currentLine.LOCALESTID,
+              lineNumber: this._lineNumber,
+              errCode: Establishment.STATUS_ERROR,
+              errType: `STATUS_ERROR`,
+              error: `STATUS is NOCHANGE but establishment does not exist`,
+              source: myStatus,
+            });
+          }
+          break;
+        case 'UPDATE':
+          if (!thisEstablishmentExists(this._key)) {
+            this._validationErrors.push({
+              name: this._currentLine.LOCALESTID,
+              lineNumber: this._lineNumber,
+              errCode: Establishment.STATUS_ERROR,
+              errType: `STATUS_ERROR`,
+              error: `STATUS is UPDATE but establishment does not exist`,
+              source: myStatus,
+            });
+          }
+          break;
+      }
+
       this._status = myStatus;
       return true;
     }
@@ -1587,52 +1665,62 @@ class Establishment {
 
     status = !this._validateLocalisedId() ? false : status;
     status = !this._validateStatus() ? false : status;
-    status = !this._validateEstablishmentName() ? false : status;
-    status = !this._validateAddress() ? false : status;
-    status = !this._validateEstablishmentType() ? false : status;
 
-    status = !this._validateShareWithCQC() ? false : status;
-    status = !this._validateShareWithLA() ? false : status;
-    status = !this._validateLocalAuthorities() ? false : status;
+    // if the status is unchecked, then don't continue validation
+    if (this._status !== 'UNCHECKED') {
+      status = !this._validateEstablishmentName() ? false : status;
+      status = !this._validateAddress() ? false : status;
+      status = !this._validateEstablishmentType() ? false : status;
 
-    status = !this._validateRegType() ? false : status;
-    status = !this._validateProvID() ? false : status;
-    status = !this._validateLocationID() ? false : status;
+      status = !this._validateShareWithCQC() ? false : status;
+      status = !this._validateShareWithLA() ? false : status;
+      status = !this._validateLocalAuthorities() ? false : status;
 
-    status = !this._validateMainService() ? false : status;
-    status = !this._validateAllServices() ? false : status;
-    status = !this._validateServiceUsers() ? false : status;
-    status = !this._validateCapacitiesAndUtilisations() ? false : status;
+      status = !this._validateRegType() ? false : status;
+      status = !this._validateProvID() ? false : status;
+      status = !this._validateLocationID() ? false : status;
 
-    status = !this._validateTotalPermTemp() ? false : status;
-    status = !this._validateAllJobs() ? false : status;
-    status = !this._validateJobRoleTotals() ? false : status;
+      status = !this._validateMainService() ? false : status;
+      status = !this._validateAllServices() ? false : status;
+      status = !this._validateServiceUsers() ? false : status;
+      status = !this._validateCapacitiesAndUtilisations() ? false : status;
 
-    status = !this._validateReasonsForLeaving() ? false : status;
+      status = !this._validateTotalPermTemp() ? false : status;
+      status = !this._validateAllJobs() ? false : status;
+      status = !this._validateJobRoleTotals() ? false : status;
+
+      status = !this._validateReasonsForLeaving() ? false : status;
+    }
 
     return status;
   }
 
   // returns true on success, false is any attribute of Establishment fails
   transform() {
-    let status = true;
+    // if this Worker is unchecked, skip all transformations
+    if (this._status !== 'UNCHECKED') {
+      let status = true;
 
-    status = !this._transformMainService() ? false : status;
-    status = !this._transformEstablishmentType() ? false : status;
-    status = !this._transformLocalAuthorities() ? false : status;
-    status = !this._transformAllServices() ? false : status;
-    status = !this._transformServiceUsers() ? false : status;
-    status = !this._transformAllJobs() ? false : status;
-    //status = !this._transformReasonsForLeaving() ? false : status;        // interim solution - not transforming reasons for leaving
-    status = !this._transformAllCapacities() ? false : status;
-    status = !this._transformAllUtilisation() ? false : status;
-    status = !this._transformAllVacanciesStartersLeavers() ? false : status;
+      status = !this._transformMainService() ? false : status;
+      status = !this._transformEstablishmentType() ? false : status;
+      status = !this._transformLocalAuthorities() ? false : status;
+      status = !this._transformAllServices() ? false : status;
+      status = !this._transformServiceUsers() ? false : status;
+      status = !this._transformAllJobs() ? false : status;
+      //status = !this._transformReasonsForLeaving() ? false : status;        // interim solution - not transforming reasons for leaving
+      status = !this._transformAllCapacities() ? false : status;
+      status = !this._transformAllUtilisation() ? false : status;
+      status = !this._transformAllVacanciesStartersLeavers() ? false : status;
 
-    return status;
+      return status;
+    } else {
+      return true;
+    }
   }
 
   toJSON() {
     return {
+      status: this._status,
       name: this._name,
       address1: this._address1,
       address2: this._address2,
@@ -1717,6 +1805,7 @@ class Establishment {
     }
 
     const changeProperties = {
+      status: this._status,
       name: this._name,
       localIdentifier: this._localId,
       isRegulated: this._regType === 2 ? true : false,

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -414,18 +414,13 @@ class Worker {
     } else {
       // helper which returns true if the given LOCALESTID
       const thisWorkerExists = (establishmentKey, workerKey) => {
-        console.log("WA DEBUG - thisWorkerExists - looking for: ", establishmentKey, workerKey)
         const foundEstablishment = this._allCurrentEstablishments.find(currentEstablishment => {
           return currentEstablishment.key === establishmentKey;
         });
 
         // having found the establishment, find the worker within the establishment
         if (foundEstablishment) {
-          console.log("WA DEBUG - thisWorkerExists - found establishment - LOCALSTID/establishment", this._localId, foundEstablishment.name)
           const foundWorker = foundEstablishment.theWorker(workerKey);
-
-          foundWorker ? console.log("WA DEBUG - thisWorkerExists - found worker - UNIQUEWORKERID/worker", this._uniqueWorkerId, foundWorker.nameOrId) : true;
-
           return foundWorker ? true : false;
         } else {
           return false;

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -2,9 +2,11 @@ const BUDI = require('../BUDI').BUDI;
 const moment = require('moment');
 
 class Worker {
-  constructor(currentLine, lineNumber) {
+  constructor(currentLine, lineNumber, allCurrentEstablishments) {
     this._currentLine = currentLine;
     this._lineNumber = lineNumber;
+    this._allCurrentEstablishments = allCurrentEstablishments;
+
     this._validationErrors = [];
     this._headers_v1 = ["LOCALESTID","UNIQUEWORKERID","CHGUNIQUEWRKID","STATUS","DISPLAYID","NINUMBER","POSTCODE","DOB","GENDER","ETHNICITY","NATIONALITY","BRITISHCITIZENSHIP","COUNTRYOFBIRTH","YEAROFENTRY","DISABLED","CARECERT","RECSOURCE","STARTDATE","STARTINSECT","APPRENTICE","EMPLSTATUS","ZEROHRCONT","DAYSSICK","SALARYINT","SALARY","HOURLYRATE","MAINJOBROLE","MAINJRDESC","CONTHOURS","AVGHOURS","OTHERJOBROLE","OTHERJRDESC","NMCREG","NURSESPEC","AMHP","SCQUAL","NONSCQUAL","QUALACH01","QUALACH01NOTES","QUALACH02","QUALACH02NOTES","QUALACH03","QUALACH03NOTES"];
     this._headers_v1_without_chgUnique = ["LOCALESTID","UNIQUEWORKERID","STATUS","DISPLAYID","NINUMBER","POSTCODE","DOB","GENDER","ETHNICITY","NATIONALITY","BRITISHCITIZENSHIP","COUNTRYOFBIRTH","YEAROFENTRY","DISABLED","CARECERT","RECSOURCE","STARTDATE","STARTINSECT","APPRENTICE","EMPLSTATUS","ZEROHRCONT","DAYSSICK","SALARYINT","SALARY","HOURLYRATE","MAINJOBROLE","MAINJRDESC","CONTHOURS","AVGHOURS","OTHERJOBROLE","OTHERJRDESC","NMCREG","NURSESPEC","AMHP","SCQUAL","NONSCQUAL","QUALACH01","QUALACH01NOTES","QUALACH02","QUALACH02NOTES","QUALACH03","QUALACH03NOTES"];
@@ -13,6 +15,9 @@ class Worker {
     this._localId = null;
     this._workerLocalID = null;
     this._changeUniqueWorkerId = null;
+    this._status = null;
+    this._key = null;
+    this._establishmentKey = null;
 
     this._NINumber = null;
     this._postCode = null;
@@ -74,6 +79,7 @@ class Worker {
   static get UNIQUE_WORKER_ID_ERROR() { return 1020; }
   static get CHANGE_UNIQUE_WORKER_ID_ERROR() { return 1030; }
   static get STATUS_ERROR() { return 1040; }
+  static get STATUS_WARNING() { return 1045; }
 
   static get DISPLAY_ID_ERROR() { return 1050; }
   static get NINUMBER_ERROR() { return 1060; }
@@ -198,6 +204,12 @@ class Worker {
   get status() {
     return this._status;
   }
+  get key() {
+    return this._key;
+  }
+  get establishmentKey() {
+    return this._establishmentKey;
+  }
   get dislpayID() {
     return this._displayId;
   }
@@ -318,6 +330,7 @@ class Worker {
       return false;
     } else {
       this._localId = myLocalId;
+      this._establishmentKey = myLocalId.replace(/\s/g, "");
       return true;
     }
 
@@ -353,6 +366,7 @@ class Worker {
       return false;
     } else {
       this._uniqueWorkerId = myUniqueWorkerId;
+      this._key = myUniqueWorkerId.replace(/\s/g, "");
       return true;
     }
   }
@@ -385,18 +399,7 @@ class Worker {
     const statusValues = ['DELETE', 'UPDATE', 'UNCHECKED', 'NOCHANGE', 'NEW','CHGSUB'];
     const myStatus = this._currentLine.STATUS ? this._currentLine.STATUS.toUpperCase() : this._currentLine.STATUS;
 
-    if (myStatus.length === 0) {
-      this._validationErrors.push({
-        worker: this._currentLine.UNIQUEWORKERID,
-        name: this._currentLine.LOCALESTID,
-        lineNumber: this._lineNumber,
-        errCode: Worker.STATUS_ERROR,
-        errType: `STATUS_ERROR`,
-        error: `You have not supplied a correct status`,
-        source: this._currentLine.STATUS,
-      });
-      return false;
-    } else if (!statusValues.includes(myStatus)) {
+   if (!statusValues.includes(myStatus)) {
       // must be present and must be one of the preset values (case insensitive)
       this._validationErrors.push({
         worker: this._currentLine.UNIQUEWORKERID,
@@ -409,6 +412,107 @@ class Worker {
       });
       return false;
     } else {
+      // helper which returns true if the given LOCALESTID
+      const thisWorkerExists = (establishmentKey, workerKey) => {
+        console.log("WA DEBUG - thisWorkerExists - looking for: ", establishmentKey, workerKey)
+        const foundEstablishment = this._allCurrentEstablishments.find(currentEstablishment => {
+          return currentEstablishment.key === establishmentKey;
+        });
+
+        // having found the establishment, find the worker within the establishment
+        if (foundEstablishment) {
+          console.log("WA DEBUG - thisWorkerExists - found establishment - LOCALSTID/establishment", this._localId, foundEstablishment.name)
+          const foundWorker = foundEstablishment.theWorker(workerKey);
+
+          foundWorker ? console.log("WA DEBUG - thisWorkerExists - found worker - UNIQUEWORKERID/worker", this._uniqueWorkerId, foundWorker.nameOrId) : true;
+
+          return foundWorker ? true : false;
+        } else {
+          return false;
+        }
+      };
+
+      switch (myStatus) {
+        case 'NEW':
+          if (thisWorkerExists(this._establishmentKey, this._key)) {
+            this._validationErrors.push({
+              name: this._currentLine.LOCALESTID,
+              worker: this._currentLine.UNIQUEWORKERID,
+              lineNumber: this._lineNumber,
+              errCode: Worker.STATUS_ERROR,
+              errType: `STATUS_ERROR`,
+              error: `STATUS is NEW but worker already exists`,
+              source: myStatus,
+            });
+          }
+          break;
+        case 'DELETE':
+          if (!thisWorkerExists(this._establishmentKey, this._key)) {
+            this._validationErrors.push({
+              name: this._currentLine.LOCALESTID,
+              worker: this._currentLine.UNIQUEWORKERID,
+              lineNumber: this._lineNumber,
+              errCode: Worker.STATUS_ERROR,
+              errType: `STATUS_ERROR`,
+              error: `STATUS is DELETE but worker does not exist`,
+              source: myStatus,
+            });
+          }
+          break;
+        case 'UNCHECKED':
+          this._validationErrors.push({
+            name: this._currentLine.LOCALESTID,
+            worker: this._currentLine.UNIQUEWORKERID,
+            lineNumber: this._lineNumber,
+            warnCode: Worker.STATUS_WARNING,
+            warnType: `STATUS_WARNING`,
+            warning: `STATUS is UNCHECKED and will be ignored`,
+            source: myStatus,
+          });
+          break;
+        case 'NOCHANGE':
+          if (!thisWorkerExists(this._establishmentKey, this._key)) {
+            this._validationErrors.push({
+              name: this._currentLine.LOCALESTID,
+              worker: this._currentLine.UNIQUEWORKERID,
+              lineNumber: this._lineNumber,
+              errCode: Worker.STATUS_ERROR,
+              errType: `STATUS_ERROR`,
+              error: `STATUS is NOCHANGE but worker does not exist`,
+              source: myStatus,
+            });
+          }
+          break;
+        case 'UPDATE':
+          if (!thisWorkerExists(this._establishmentKey, this._key)) {
+            this._validationErrors.push({
+              name: this._currentLine.LOCALESTID,
+              worker: this._currentLine.UNIQUEWORKERID,
+              lineNumber: this._lineNumber,
+              errCode: Worker.STATUS_ERROR,
+              errType: `STATUS_ERROR`,
+              error: `STATUS is UPDATE but worker does not exist`,
+              source: myStatus,
+            });
+          }
+          break;
+        case 'CHGSUB':
+          // note - the LOCALESTID here is that of the target sub - not the current sub
+          if (thisWorkerExists(this._establishmentKey, this._key)) {
+            this._validationErrors.push({
+              name: this._currentLine.LOCALESTID,
+              worker: this._currentLine.UNIQUEWORKERID,
+              lineNumber: this._lineNumber,
+              errCode: Worker.STATUS_ERROR,
+              errType: `STATUS_ERROR`,
+              error: `STATUS is CHGSUB but worker already exists in target Establishment`,
+              source: myStatus,
+            });
+          }
+          break;
+      }
+
+
       this._status = myStatus;
       return true;
     }
@@ -2351,67 +2455,78 @@ class Worker {
     status = !this._validateUniqueWorkerId() ? false : status;
     status = !this._validateChangeUniqueWorkerId() ? false : status;
     status = !this._validateStatus() ? false : status;
-    status = !this._validateDisplayId() ? false : status;
-    status = !this._validateNINumber() ? false : status;
-    status = !this._validatePostCode() ? false : status;
-    status = !this._validateDOB() ? false : status;
-    status = !this._validateGender() ? false : status;
-    status = !this._validateEthnicity() ? false : status;
-    status = !this._validateNationality() ? false : status;
-    status = !this._validateCitizenShip() ? false : status;
-    status = !this._validateCountryOfBirth() ? false : status;
-    status = !this._validateYearOfEntry() ? false : status;
-    status = !this._validateDisabled() ? false : status;
-    status = !this._validateCareCert() ? false : status;
-    status = !this._validateRecSource() ? false : status;
-    status = !this._validateStartDate() ? false : status;
-    status = !this._validateStartInsect() ? false : status;
-    status = !this._validateApprentice() ? false : status;
-    status = !this._validateZeroHourContract() ? false : status;
-    status = !this._validateDaysSick() ? false : status;
-    status = !this._validateSalaryInt() ? false : status;
-    status = !this._validateSalary() ? false : status;
-    status = !this._validateHourlyRate() ? false : status;
-    status = !this._validateMainJobRole() ? false : status;
-    status = !this._validateMainJobDesc() ? false : status;
-    status = !this._validateContHours() ? false : status;
-    status = !this._validateAvgHours() ? false : status;
-    status = !this._validateOtherJobs() ? false : status;
-    status = !this._validateRegisteredNurse() ? false : status;
-    status = !this._validateNursingSpecialist() ? false : status;
-    status = !this._validationQualificationRecords() ? false : status;
-    status = !this._validateSocialCareQualification() ? false : status;
-    status = !this._validateNonSocialCareQualification() ? false : status;
-    status = !this._validateAmhp() ? false : status;
+
+    // only continue to process validation, if the status is UNCHECKED
+    if (this._status !== 'UNCHECKED') {
+      status = !this._validateDisplayId() ? false : status;
+      status = !this._validateNINumber() ? false : status;
+      status = !this._validatePostCode() ? false : status;
+      status = !this._validateDOB() ? false : status;
+      status = !this._validateGender() ? false : status;
+      status = !this._validateEthnicity() ? false : status;
+      status = !this._validateNationality() ? false : status;
+      status = !this._validateCitizenShip() ? false : status;
+      status = !this._validateCountryOfBirth() ? false : status;
+      status = !this._validateYearOfEntry() ? false : status;
+      status = !this._validateDisabled() ? false : status;
+      status = !this._validateCareCert() ? false : status;
+      status = !this._validateRecSource() ? false : status;
+      status = !this._validateStartDate() ? false : status;
+      status = !this._validateStartInsect() ? false : status;
+      status = !this._validateApprentice() ? false : status;
+      status = !this._validateZeroHourContract() ? false : status;
+      status = !this._validateDaysSick() ? false : status;
+      status = !this._validateSalaryInt() ? false : status;
+      status = !this._validateSalary() ? false : status;
+      status = !this._validateHourlyRate() ? false : status;
+      status = !this._validateMainJobRole() ? false : status;
+      status = !this._validateMainJobDesc() ? false : status;
+      status = !this._validateContHours() ? false : status;
+      status = !this._validateAvgHours() ? false : status;
+      status = !this._validateOtherJobs() ? false : status;
+      status = !this._validateRegisteredNurse() ? false : status;
+      status = !this._validateNursingSpecialist() ? false : status;
+      status = !this._validationQualificationRecords() ? false : status;
+      status = !this._validateSocialCareQualification() ? false : status;
+      status = !this._validateNonSocialCareQualification() ? false : status;
+      status = !this._validateAmhp() ? false : status;
+    }
 
     return status;
   };
 
   // returns true on success, false is any attribute of Worker fails
   transform() {
-    let status = true;
+    // if this Worker is unchecked, skip all transformations
+    if (this._status !== 'UNCHECKED') {
+      let status = true;
 
-    // status = !this._transformMainService() ? false : status;
-    status = !this._transformContractType() ? false : status;
-    status = !this._transformEthnicity() ? false : status;
-    status = !this._transformRecruitment() ? false : status;
-    status = !this._transformMainJobRole() ? false : status;
-    status = !this._transformOtherJobRoles() ? false : status;
-    status = !this._transformRegisteredNurse() ? false : status;
-    status = !this._transformNursingSpecialist() ? false : status;
-    status = !this._transformNationality() ? false : status;
-    status = !this._transformCountryOfBirth() ? false : status;
-    status = !this._transformSocialCareQualificationLevel() ? false : status;
-    status = !this._transformNonSocialCareQualificationLevel() ? false : status;
-    status = !this._transformQualificationRecords() ? false : status;
+      // status = !this._transformMainService() ? false : status;
+      status = !this._transformContractType() ? false : status;
+      status = !this._transformEthnicity() ? false : status;
+      status = !this._transformRecruitment() ? false : status;
+      status = !this._transformMainJobRole() ? false : status;
+      status = !this._transformOtherJobRoles() ? false : status;
+      status = !this._transformRegisteredNurse() ? false : status;
+      status = !this._transformNursingSpecialist() ? false : status;
+      status = !this._transformNationality() ? false : status;
+      status = !this._transformCountryOfBirth() ? false : status;
+      status = !this._transformSocialCareQualificationLevel() ? false : status;
+      status = !this._transformNonSocialCareQualificationLevel() ? false : status;
+      status = !this._transformQualificationRecords() ? false : status;
 
-    return status;
+      return status;
+
+    } else {
+      return true;
+    }
   };
 
   toJSON() {
     // force to undefined if not set, because 'undefined' when JSON stingified is not rendered
     return {
       localId: this._localId,
+      status: this._status,
       uniqueWorkerId: this._uniqueWorkerId,
       changeUniqueWorker: this._changeUniqueWorkerId ? this._changeUniqueWorkerId : undefined,
       status: this._status,
@@ -2483,6 +2598,7 @@ class Worker {
     const changeProperties = {
     // the minimum to create a new worker
       localIdentifier: this._uniqueWorkerId,
+      status: this._status,
       nameOrId : this._displayId,
       contract : this._contractType,
       mainJob : {

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -109,6 +109,9 @@ class Establishment extends EntityValidator {
         this._workerEntities = {};
         this._readyForDeletionWorkers = null;
 
+        // bulk upload status - this is never stored in database
+        this._status = null;
+
         // default logging level - errors only
         // TODO: INFO logging on User; change to LOG_ERROR only
         this._logLevel = Establishment.LOG_INFO;
@@ -390,6 +393,11 @@ class Establishment extends EntityValidator {
               this._reasonsForLeaving = document.reasonsForLeaving;
             }
 
+            // bulk upload status
+            if (document.status) {
+              this._status = document.status;
+            }
+
             // allow for deep restoration of entities (associations - namely Worker here)
             if (associatedEntities) {
                 const promises = [];
@@ -444,6 +452,8 @@ class Establishment extends EntityValidator {
 
     // returns true if Establishment is valid, otherwise false
     isValid() {
+      // in bulk upload, an establishment entity, if UNCHECKED, will be nothing more than a status and a local identifier
+      if (this._status === null || this._status !== 'UNCHECKED' ) {
         const thisEstablishmentIsValid = this._properties.isValid;
         if (this._properties.isValid === true) {
             return true;
@@ -464,6 +474,9 @@ class Establishment extends EntityValidator {
             this._log(Establishment.LOG_ERROR, `Establishment invalid properties: ${thisEstablishmentIsValid.toString()}`);
             return false;
         }
+      } else {
+        return true;
+      }
     }
 
     async saveAssociatedEntities(savedBy, bulkUploaded=false, externalTransaction)  {
@@ -1341,6 +1354,11 @@ class Establishment extends EntityValidator {
                 myDefaultJSON.reasonsForLeaving = this.reasonsForLeaving;
             }
 
+            // bulk upload status
+            if (this._status) {
+              myDefaultJSON.status = this._status;
+            }
+
             myDefaultJSON.created = this.created ? this.created.toJSON() : null;
             myDefaultJSON.updated = this.updated ? this.updated.toJSON() : null;
             myDefaultJSON.updatedBy = this.updatedBy ? this.updatedBy : null;
@@ -1377,104 +1395,107 @@ class Establishment extends EntityValidator {
 
     // returns true if all mandatory properties for an Establishment exist and are valid
     get hasMandatoryProperties() {
-        let allExistAndValid = true;    // assume all exist until proven otherwise
+      let allExistAndValid = true;    // assume all exist until proven otherwise
 
-       try {
-            const nmdsIdRegex = /^[A-Z]1[\d]{6}$/i;
-            if (this._uid !== null && !(this._nmdsId && nmdsIdRegex.test(this._nmdsId))) {
-                allExistAndValid = false;
-                this._validations.push(new ValidationMessage(
-                    ValidationMessage.ERROR,
-                    101,
-                    this._nmdsId ? `Invalid: ${this._nmdsId}` : 'Missing',
-                    ['NMDSID']
-                ));
-                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid NMDS ID');
-            }
+      // in bulk upload, an establishment entity, if UNCHECKED, will be nothing more than a status and a local identifier
+      if (this._status === null || this._status !== 'UNCHECKED' ) {
+        try {
+          const nmdsIdRegex = /^[A-Z]1[\d]{6}$/i;
+          if (this._uid !== null && !(this._nmdsId && nmdsIdRegex.test(this._nmdsId))) {
+              allExistAndValid = false;
+              this._validations.push(new ValidationMessage(
+                  ValidationMessage.ERROR,
+                  101,
+                  this._nmdsId ? `Invalid: ${this._nmdsId}` : 'Missing',
+                  ['NMDSID']
+              ));
+              this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid NMDS ID');
+          }
 
-            if (!(this.name)) {
-                allExistAndValid = false;
-                this._validations.push(new ValidationMessage(
-                    ValidationMessage.ERROR,
-                    102,
-                    this.name ? `Invalid: ${this.name}` : 'Missing',
-                    ['Name']
-                ));
-                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid name');
-            }
+          if (!(this.name)) {
+              allExistAndValid = false;
+              this._validations.push(new ValidationMessage(
+                  ValidationMessage.ERROR,
+                  102,
+                  this.name ? `Invalid: ${this.name}` : 'Missing',
+                  ['Name']
+              ));
+              this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid name');
+          }
 
-            if (!(this.mainService)) {
-                allExistAndValid = false;
-                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid main service');
-            }
+          if (!(this.mainService)) {
+              allExistAndValid = false;
+              this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid main service');
+          }
 
-            // must at least have the first line of address
-            if (!(this._address1)) {
-                allExistAndValid = false;
-                this._validations.push(new ValidationMessage(
-                    ValidationMessage.ERROR,
-                    103,
-                    this._address ? `Invalid: ${this._address}` : 'Missing',
-                    ['Address']
-                ));
-                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid first line of address');
-            }
+          // must at least have the first line of address
+          if (!(this._address1)) {
+              allExistAndValid = false;
+              this._validations.push(new ValidationMessage(
+                  ValidationMessage.ERROR,
+                  103,
+                  this._address ? `Invalid: ${this._address}` : 'Missing',
+                  ['Address']
+              ));
+              this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid first line of address');
+          }
 
-            if (!(this._postcode)) {
-                allExistAndValid = false;
-                this._validations.push(new ValidationMessage(
-                    ValidationMessage.ERROR,
-                    104,
-                    this._postcode ? `Invalid: ${_postcode}` : 'Missing',
-                    ['Postcode']
-                ));
-                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid postcode');
-            }
+          if (!(this._postcode)) {
+              allExistAndValid = false;
+              this._validations.push(new ValidationMessage(
+                  ValidationMessage.ERROR,
+                  104,
+                  this._postcode ? `Invalid: ${_postcode}` : 'Missing',
+                  ['Postcode']
+              ));
+              this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid postcode');
+          }
 
-            if (this._isRegulated === null) {
-                allExistAndValid = false;
-                this._validations.push(new ValidationMessage(
-                    ValidationMessage.ERROR,
-                    105,
-                    'Missing',
-                    ['CQCRegistered']
-                ));
-                this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing regulated flag');
-            }
+          if (this._isRegulated === null) {
+              allExistAndValid = false;
+              this._validations.push(new ValidationMessage(
+                  ValidationMessage.ERROR,
+                  105,
+                  'Missing',
+                  ['CQCRegistered']
+              ));
+              this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing regulated flag');
+          }
 
-            // location id can be null for a Non-CQC site
-            // if a CQC site, and main service is head office (ID=16)
-            const MAIN_SERVICE_HEAD_OFFICE_ID=16;
-            if (this._isRegulated) {
-                if (this.mainService.id !== MAIN_SERVICE_HEAD_OFFICE_ID && this._locationId === null)  {
-                    allExistAndValid = false;
-                    this._validations.push(new ValidationMessage(
-                        ValidationMessage.ERROR,
-                        106,
-                        'Missing (mandatory) for a CQC Registered site',
-                        ['LocationID']
-                    ));
-                    this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid Location ID for a (CQC) Regulated workspace');
-                }
-            }
+          // location id can be null for a Non-CQC site
+          // if a CQC site, and main service is head office (ID=16)
+          const MAIN_SERVICE_HEAD_OFFICE_ID=16;
+          if (this._isRegulated) {
+              if (this.mainService.id !== MAIN_SERVICE_HEAD_OFFICE_ID && this._locationId === null)  {
+                  allExistAndValid = false;
+                  this._validations.push(new ValidationMessage(
+                      ValidationMessage.ERROR,
+                      106,
+                      'Missing (mandatory) for a CQC Registered site',
+                      ['LocationID']
+                  ));
+                  this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid Location ID for a (CQC) Regulated workspace');
+              }
+          }
 
-            // prov id can be null for a Non-CQC site - CANNOT IMPOSE THIS PROPERTY AS IT IS NOT YET COMING FROM REGISTRATION
-            // if (this._isRegulated && this._provId === null) {
-            //   allExistAndValid = false;
-            //   this._validations.push(new ValidationMessage(
-            //       ValidationMessage.ERROR,
-            //       106,
-            //       'Missing (mandatory) for a CQC Registered site',
-            //       ['ProvID']
-            //   ));
-            //   this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid Prov ID for a (CQC) Regulated workspace');
-            // }
+          // prov id can be null for a Non-CQC site - CANNOT IMPOSE THIS PROPERTY AS IT IS NOT YET COMING FROM REGISTRATION
+          // if (this._isRegulated && this._provId === null) {
+          //   allExistAndValid = false;
+          //   this._validations.push(new ValidationMessage(
+          //       ValidationMessage.ERROR,
+          //       106,
+          //       'Missing (mandatory) for a CQC Registered site',
+          //       ['ProvID']
+          //   ));
+          //   this._log(Establishment.LOG_ERROR, 'Establishment::hasMandatoryProperties - missing or invalid Prov ID for a (CQC) Regulated workspace');
+          // }
 
         } catch (err) {
             console.error(err)
         }
+      }
 
-        return allExistAndValid;
+      return allExistAndValid;
     }
 
     // returns true if this establishment is WDF eligible as referenced from the

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -716,9 +716,6 @@ const _validateEstablishmentCsv = async (thisLine, currentLineNumber, csvEstabli
   lineValidator.transform();
 
   const thisEstablishmentAsAPI = lineValidator.toAPI();
-
-  console.log("WA DEBUG - establishment toAPI: ", thisEstablishmentAsAPI)
-
   const thisApiEstablishment = new EstablishmentEntity();
 
   try {


### PR DESCRIPTION
https://trello.com/c/1pTd8zzJ

This first cut of code covers just the validation of the statuses for both establishments and workers, cross checking for existing or missing establishments/workers of the current state.

It also includes the creation of skeletal establishment and worker entities by updating the entities' `hasMandatoryProperties` and `isValid` to short cicuit if status is "UNCHECKED".

I've doubled checked the intermediatry `all.entities.json`, all establishments and their associated workers are accurately represented including holding the original "status", which will be required for subsequent processing.

I've also double checked the validation `difference.report.json`, and this is still showing the correct set of new, updated and deleted establishments and workers.