### PR TITLE
BU local identifiers - optimisations

### DIFF
--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -1803,7 +1803,7 @@ class Establishment extends EntityValidator {
     //   - can only update the local identifier on subs "owned" by this given primary establishment
     //  - When updating the local identifier, the local identifier property itself is audited, but the establishment's own
     //    "updated" status is not updated
-    async bulkUpdateLocalIdentifier(username, givenLocalIdentifiers) {
+    async bulkUpdateLocalIdentifiers(username, givenLocalIdentifiers) {
       try {
 
         const myEstablishments = await Establishment.fetchMyEstablishments(this.isParent, this.id);
@@ -1862,7 +1862,7 @@ class Establishment extends EntityValidator {
         return updatedUids;
 
       } catch (err) {
-        console.error('Establishment::bulkUpdateLocalIdentifier error: ', err);
+        console.error('Establishment::bulkUpdateLocalIdentifiers error: ', err);
         throw err;
       }
 

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -1650,6 +1650,223 @@ class Establishment extends EntityValidator {
         this._log(Establishment.LOG_ERROR, `bulkUploadSuccess - failed: ${err}`);
       }
     }
+
+
+    // encapsulated method to fetch a list of all establishments (primary and any subs if a parent) for the given primary establishment
+    static async fetchMyEstablishments(isParent, primaryEstablishmentId) {
+        // for each establishment, need:
+        //  1. Name
+        //  2. Main Service (by title)
+        //  3. Data Owner
+        //  4. Data Owner Permissions
+        //  5. Updated
+        //  6. UID (significantly to be able to navigate to the specific establishment)
+        //  7. ParentUID
+        let allSubResults = null;
+        let primaryEstablishmentRecord = null;
+
+        // first - get the user's primary establishment (every user will have a primary establishment)
+        const fetchResults = await models.establishment.findOne({
+            attributes: ['uid', 'isParent', 'parentUid', 'dataOwner', 'LocalIdentifierValue', 'parentPermissions', 'NameValue', 'updated'],
+            include: [
+                {
+                    model: models.services,
+                    as: 'mainService',
+                    attributes: ['id', 'name']
+                }
+            ],
+            where: {
+                "id": primaryEstablishmentId
+            }
+        });
+
+        if (fetchResults) {
+            // this is the primary establishemnt
+            primaryEstablishmentRecord = fetchResults;
+
+            // now, if the primary establishment is a parent
+            //  and if the user's role against their primary parent is Edit
+            //  fetch all other establishments associated with this parent
+            if (isParent) {
+                // get all subsidaries associated with this parent
+                allSubResults = await models.establishment.findAll({
+                    attributes: ['uid', 'isParent', 'dataOwner', 'parentUid', 'LocalIdentifierValue', 'parentPermissions', 'NameValue', 'updated'],
+                    include: [
+                        {
+                            model: models.services,
+                            as: 'mainService',
+                            attributes: ['id', 'name']
+                        }
+                    ],
+                    where: {
+                        "parentUid": primaryEstablishmentRecord.uid
+                    },
+                    order: [
+                        ['updated','DESC']
+                    ]
+                });
+
+                // note - there is no error is there are no subs; an establishment can exist as a parent but with no subs
+            }
+            // else - do nothing - there is no error
+
+            // before returning, need to format the response
+            // explicit casting of local identifier to null if not yet set
+            const myEstablishments = {
+              primary: {
+                  uid: primaryEstablishmentRecord.uid,
+                  updated: primaryEstablishmentRecord.updated,
+                  isParent: primaryEstablishmentRecord.isParent,
+                  parentUid: primaryEstablishmentRecord.parentUid,
+                  name: primaryEstablishmentRecord.NameValue,
+                  localIdentifier: primaryEstablishmentRecord.LocalIdentifierValue ? primaryEstablishmentRecord.LocalIdentifierValue : null,
+                  mainService: primaryEstablishmentRecord.mainService.name,
+                  dataOwner: primaryEstablishmentRecord.dataOwner,
+                  parentPermissions: isParent ? undefined : primaryEstablishmentRecord.parentPermissions,
+              }
+            };
+
+            if (allSubResults && allSubResults.length > 0) {
+              myEstablishments.subsidaries = {
+                count: allSubResults.length,
+                establishments: allSubResults.map(thisSub => {
+                  return {
+                      uid: thisSub.uid,
+                      updated: thisSub.updated,
+                      parentUid: thisSub.parentUid,
+                      name: thisSub.NameValue,
+                      localIdentifier: thisSub.LocalIdentifierValue ? thisSub.LocalIdentifierValue : null,
+                      mainService: thisSub.mainService.name,
+                      dataOwner: thisSub.dataOwner,
+                      parentPermissions: thisSub.parentPermissions,
+                  };
+                })
+              };
+            }
+
+            return myEstablishments;
+
+
+        } else {
+            return false;
+        }
+    }
+
+    // a helper function that updates the establishment and adds the necessary audit events
+    //  https://trello.com/c/Z93EZqyB - requires that when updating local identifier, the
+    //                                  establishment's own `updated` timestamp is not is to
+    //                                  be updated
+    async _updateLocalIdOnEstablishment(thisGivenEstablishment, transaction, updatedTimestamp, username, allAuditEvents) {
+
+      const updatedEstablishment = await models.establishment.update(
+        {
+          LocalIdentifierValue: thisGivenEstablishment.value,
+          LocalIdentifierSavedBy: username,
+          LocalIdentifierChangedBy: username,
+          LocalIdentifierSavedAt: updatedTimestamp,
+          LocalIdentifierChangedAt: updatedTimestamp,
+        },
+        {
+          returning: true,
+          where: {
+              uid: thisGivenEstablishment.uid
+          },
+          attributes: ['id', 'updated'],
+          transaction,
+        }
+      );
+
+      if (updatedEstablishment[0] === 1) {
+        const updatedRecord = updatedEstablishment[1][0].get({plain: true});
+
+        // two for the LocalIdentifier property (saved and changed)
+        allAuditEvents.push({
+          establishmentFk: updatedRecord.EstablishmentID,
+          username,
+          type: 'saved',
+          property: 'LocalIdentifier',
+        });
+        allAuditEvents.push({
+          establishmentFk: updatedRecord.EstablishmentID,
+          username,
+          type: 'changed',
+          property: 'LocalIdentifier',
+          event: {
+            new: thisGivenEstablishment.value
+          }
+        });
+      }
+    };
+
+
+    // update the local identifiers across multiple establishments; this establishment being the primary with 0 or more subs
+    //   - can only update the local identifier on subs "owned" by this given primary establishment
+    //  - When updating the local identifier, the local identifier property itself is audited, but the establishment's own
+    //    "updated" status is not updated
+    async bulkUpdateLocalIdentifier(username, givenLocalIdentifiers) {
+      try {
+
+        const myEstablishments = await Establishment.fetchMyEstablishments(this.isParent, this.id);
+
+        // create a list of those establishment UIDs - the user will only be able to update the local identifier for which they own
+        const myEstablishmentUIDs = [];
+        myEstablishmentUIDs.push({
+          uid: myEstablishments.primary.uid,
+          localIdentifier: myEstablishments.primary.localIdentifier,
+        });
+
+        if (myEstablishments.subsidaries) {
+          myEstablishments.subsidaries.establishments.forEach(thisEst => {
+            // only those subs "owned" by this parent
+            thisEst.dataOwner === 'Parent' ? myEstablishmentUIDs.push({
+              uid: thisEst.uid,
+              localIdentifier: thisEst.localIdentifier,
+            }) : true;
+          });
+        }
+
+
+        // within one transaction
+        const updatedTimestamp = new Date();
+        const updatedUids = [];
+
+        // now note - there is no such thing as a bulk update (except when joing data between two tables on the database)
+        //   so when iterating through the local identifiers, check if the local identifier has changed before issuing
+        //   any update!
+
+        await models.sequelize.transaction(async t => {
+          const dbUpdatePromises = [];
+          const allAuditEvents = [];
+          givenLocalIdentifiers.forEach(thisGivenEstablishment => {
+            if (thisGivenEstablishment && thisGivenEstablishment.uid) {
+              const foundEstablishment = myEstablishmentUIDs.find(thisEst => thisEst.uid === thisGivenEstablishment.uid);
+
+              // only if the found and given local identifiers are not equal, then update the record
+              if (foundEstablishment && foundEstablishment.localIdentifier !== thisGivenEstablishment.value) {
+                const updateThisEstablishment = this._updateLocalIdOnEstablishment(thisGivenEstablishment, t, updatedTimestamp, username, allAuditEvents);
+                dbUpdatePromises.push(updateThisEstablishment);
+                updatedUids.push(thisGivenEstablishment);
+              } else if (foundEstablishment) {
+                updatedUids.push(thisGivenEstablishment);
+              } else {
+                // no found - just silently ignore
+              }
+            }
+          });
+
+          // wait for all updates to finish
+          await Promise.all(dbUpdatePromises);
+          await models.establishmentAudit.bulkCreate(allAuditEvents, {transaction: t});
+        });
+
+        return updatedUids;
+
+      } catch (err) {
+        console.error('Establishment::bulkUpdateLocalIdentifier error: ', err);
+        throw err;
+      }
+
+    };
 };
 
 module.exports.Establishment = Establishment;

--- a/server/models/classes/user.js
+++ b/server/models/classes/user.js
@@ -26,6 +26,9 @@ const SEQUELIZE_DOCUMENT_TYPE = require('./user/userProperties').SEQUELIZE_DOCUM
 const bcrypt = require('bcrypt-nodejs');
 const passwordValidator = require('../../utils/security/passwordValidation').isPasswordValid;
 
+// establishment entity
+const Establishment = require('./establishment').Establishment;
+
 class User {
     constructor(establishmentId, trackingUUID=null) {
         this._establishmentId = establishmentId;           // NOTE - a User has a direct link to an Establishment; this is likely to change with parent/sub
@@ -434,7 +437,7 @@ class User {
             // we are updating an existing User
             try {
                 const updatedTimestamp = new Date();
-                
+
                 // need to update the existing User record and add an
                 //  updated audit event within a single transaction
                 await models.sequelize.transaction(async t => {
@@ -705,7 +708,7 @@ class User {
     };
 
     async delete(deletedBy, externalTransaction=null, associatedEntities=false) {
-    
+
         try {
             const updatedTimestamp = new Date();
 
@@ -748,7 +751,7 @@ class User {
                         registrationId: this._id
                     },
                     transaction: thisTransaction
-                    });     
+                    });
 
                     await models.addUserTracking.update(
                         {
@@ -770,11 +773,11 @@ class User {
                         event: {}
                     };
                     await models.userAudit.create(auditEvent, {transaction: thisTransaction});
-        
+
                     await models.sequelize.query('UPDATE  cqc."EstablishmentAudit" SET "Username" = :usernameNew WHERE "Username" = :username', { replacements: { username: oldUsername, usernameNew: randomNewUsername },type: models.sequelize.QueryTypes.UPDATE, transaction: thisTransaction });
                     await models.sequelize.query('UPDATE cqc."UserAudit" SET "Username" = :usernameNew WHERE "Username" = :username', { replacements: { username: oldUsername, usernameNew: randomNewUsername }, type: models.sequelize.QueryTypes.UPDATE, transaction: thisTransaction });
                     await models.sequelize.query('UPDATE cqc."WorkerAudit" SET "Username" = :usernameNew WHERE "Username" = :username', { replacements: { username: oldUsername, usernameNew: randomNewUsername }, type: models.sequelize.QueryTypes.UPDATE, transaction: thisTransaction });
-    
+
                     AWSKinesis.userPump(AWSKinesis.DELETED, this.toJSON());
 
                     this._log(User.LOG_INFO, `Archived User with uid (${this._uid}) and id (${this._id})`);
@@ -835,7 +838,7 @@ class User {
                 {
                     model: models.login,
                     attributes: ['username', 'lastLogin']
-                } 
+                }
             ],
             attributes: ['uid', 'FullNameValue', 'EmailValue', 'UserRoleValue', 'created', 'updated', 'updatedBy','isPrimary'],
             order: [
@@ -862,9 +865,9 @@ class User {
             allUsers = allUsers.map((user) => {
                 return Object.assign(user, { status: user.username == null ? 'Pending' : 'Active'});
             });
-            
-            allUsers.sort((a, b) => { 
-                if((a.status > b.status)) return -1; 
+
+            allUsers.sort((a, b) => {
+                if((a.status > b.status)) return -1;
                 return (new Date(b.updated) - new Date(a.updated))
             });
         }
@@ -1072,104 +1075,8 @@ class User {
         if (filters) throw new Error("Filters not implemented");
 
         const primaryEstablishmentId = this._establishmentId;
-        //const myRole =  this._properties.get('UserRole');
-        const myRole = this._properties.get('UserRole') ? this._properties.get('UserRole').property : null;
 
-        // for each establishment, need:
-        //  1. Name
-        //  2. Main Service (by title)
-        //  3. Data Owner
-        //  4. Data Owner Permissions
-        //  5. Updated
-        //  6. UID (significantly to be able to navigate to the specific establishment)
-        //  7. ParentUID
-        let allSubResults = null;
-        let primaryEstablishmentRecord = null;
-
-        // first - get the user's primary establishment (every user will have a primary establishment)
-        const fetchResults = await models.establishment.findOne({
-            attributes: ['uid', 'isParent', 'parentUid', 'dataOwner', 'LocalIdentifierValue', 'parentPermissions', 'NameValue', 'updated'],
-            include: [
-                {
-                    model: models.services,
-                    as: 'mainService',
-                    attributes: ['id', 'name']
-                }
-            ],
-            where: {
-                "id": primaryEstablishmentId
-            }
-        });
-
-        if (fetchResults) {
-            // this is the primary establishemnt
-            primaryEstablishmentRecord = fetchResults;
-
-            // now, if the primary establishment is a parent
-            //  and if the user's role against their primary parent is Edit
-            //  fetch all other establishments associated with this parent
-            if (isParent) {
-                // get all subsidaries associated with this parent
-                allSubResults = await models.establishment.findAll({
-                    attributes: ['uid', 'isParent', 'dataOwner', 'parentUid', 'LocalIdentifierValue', 'parentPermissions', 'NameValue', 'updated'],
-                    include: [
-                        {
-                            model: models.services,
-                            as: 'mainService',
-                            attributes: ['id', 'name']
-                        }
-                    ],
-                    where: {
-                        "parentUid": primaryEstablishmentRecord.uid
-                    },
-                    order: [
-                        ['updated','DESC']
-                    ]
-                });
-
-                // note - there is no error is there are no subs; an establishment can exist as a parent but with no subs
-            }
-            // else - do nothing - there is no error
-
-        } else {
-            return false;
-        }
-
-        // before returning, need to format the response
-        // explicit casting of local identifier to null if not yet set
-        const myEstablishments = {
-            primary: {
-                uid: primaryEstablishmentRecord.uid,
-                updated: primaryEstablishmentRecord.updated,
-                isParent: primaryEstablishmentRecord.isParent,
-                parentUid: primaryEstablishmentRecord.parentUid,
-                name: primaryEstablishmentRecord.NameValue,
-                localIdentifier: primaryEstablishmentRecord.LocalIdentifierValue ? primaryEstablishmentRecord.LocalIdentifierValue : null,
-                mainService: primaryEstablishmentRecord.mainService.name,
-                dataOwner: primaryEstablishmentRecord.dataOwner,
-                parentPermissions: isParent ? undefined : primaryEstablishmentRecord.parentPermissions,
-            }
-        };
-
-        if (allSubResults && allSubResults.length > 0) {
-            myEstablishments.subsidaries = {
-                count: allSubResults.length,
-                establishments: allSubResults.map(thisSub => {
-                    return {
-                        uid: thisSub.uid,
-                        updated: thisSub.updated,
-                        parentUid: thisSub.parentUid,
-                        name: thisSub.NameValue,
-                        localIdentifier: thisSub.LocalIdentifierValue ? thisSub.LocalIdentifierValue : null,
-                        mainService: thisSub.mainService.name,
-                        dataOwner: thisSub.dataOwner,
-                        parentPermissions: thisSub.parentPermissions,
-                    };
-                })
-            };
-        }
-
-        return myEstablishments;
+        return await Establishment.fetchMyEstablishments(isParent, primaryEstablishmentId);
     };
 
 };

--- a/server/routes/establishments/localIdentifier.js
+++ b/server/routes/establishments/localIdentifier.js
@@ -98,7 +98,7 @@ router.route('/').put(async (req, res) => {
   try {
     // as a minimum for security purposes, we restore the user's primary establishment
     if (await thisEstablishment.restore(establishmentId)) {
-      const updatedUids = await thisEstablishment.bulkUpdateLocalIdentifier(username, givenLocalIdentifiers);
+      const updatedUids = await thisEstablishment.bulkUpdateLocalIdentifiers(username, givenLocalIdentifiers);
 
       const updatedTimestamp = new Date();
       return res.status(200).json({

--- a/server/routes/establishments/localIdentifier.js
+++ b/server/routes/establishments/localIdentifier.js
@@ -81,59 +81,6 @@ router.route('/').post(async (req, res) => {
   }
 });
 
-
-// a helper function that updates the establishment and adds the necessary audit events
-const updateLocalIdOnEstablishment = async (thisGivenEstablishment, transaction, updatedTimestamp, username, allAuditEvents) => {
-
-  const updatedEstablishment = await models.establishment.update(
-    {
-      LocalIdentifierValue: thisGivenEstablishment.value,
-      LocalIdentifierSavedBy: username,
-      LocalIdentifierChangedBy: username,
-      LocalIdentifierSavedAt: updatedTimestamp,
-      LocalIdentifierChangedAt: updatedTimestamp,
-      updated: updatedTimestamp,
-      updatedBy: username,
-    },
-    {
-      returning: true,
-      where: {
-          uid: thisGivenEstablishment.uid
-      },
-      attributes: ['id', 'updated'],
-      transaction,
-    }
-  );
-
-  if (updatedEstablishment[0] === 1) {
-    const updatedRecord = updatedEstablishment[1][0].get({plain: true});
-    // and now the audit events - one for the establishment entity
-    allAuditEvents.push({
-      establishmentFk: updatedRecord.EstablishmentID,
-      username,
-      type: 'updated'
-    });
-
-    // and two for the LocalIdentifier property (saved and changed)
-    allAuditEvents.push({
-      establishmentFk: updatedRecord.EstablishmentID,
-      username,
-      type: 'saved',
-      property: 'LocalIdentifier',
-    });
-    allAuditEvents.push({
-      establishmentFk: updatedRecord.EstablishmentID,
-      username,
-      type: 'changed',
-      property: 'LocalIdentifier',
-      event: {
-        new: thisGivenEstablishment.value
-      }
-    });
-  }
-
-}
-
 // a workaround to allow updating all local identifiers for all given establishments in one transaction
 router.route('/').put(async (req, res) => {
   const establishmentId = req.establishmentId;
@@ -151,43 +98,9 @@ router.route('/').put(async (req, res) => {
   try {
     // as a minimum for security purposes, we restore the user's primary establishment
     if (await thisEstablishment.restore(establishmentId)) {
+      const updatedUids = await thisEstablishment.bulkUpdateLocalIdentifier(username, givenLocalIdentifiers);
 
-      // having restored their primary establishment and hence authenticated, we also fetch a list the user's current set of establishments
-      const thisUser = new User(establishmentId);
-      await thisUser.restore(null, username,false);
-      const myEstablishments = await thisUser.myEstablishments(isParent);
-
-      // create a list of those establishment UIDs - the user will only be able to update the local identifier for which they own
-      const myEstablishmentUIDs = [];
-      myEstablishmentUIDs.push(myEstablishments.primary.uid);
-
-      if (myEstablishments.subsidaries) {
-        myEstablishments.subsidaries.establishments.forEach(thisEst => {
-          myEstablishmentUIDs.push(thisEst.uid);
-        });
-      }
-
-      // within one transaction
       const updatedTimestamp = new Date();
-      const updatedUids = [];
-      await models.sequelize.transaction(async t => {
-        const dbUpdatePromises = [];
-        const allAuditEvents = [];
-        givenLocalIdentifiers.forEach(thisGivenEstablishment => {
-          if (thisGivenEstablishment && thisGivenEstablishment.uid && myEstablishmentUIDs.includes(thisGivenEstablishment.uid)) {
-            const updateThisEstablishment = updateLocalIdOnEstablishment(thisGivenEstablishment, t, updatedTimestamp, username, allAuditEvents);
-            dbUpdatePromises.push(updateThisEstablishment);
-            updatedUids.push(thisGivenEstablishment);
-          } else {
-            // simply ignore it - silient operation, as the frontend is not going to give dodgy UIDs
-          }
-        });
-
-        // wait for all updates to finish
-        await Promise.all(dbUpdatePromises);
-        await models.establishmentAudit.bulkCreate(allAuditEvents, {transaction: t});
-      });
-
       return res.status(200).json({
         id: thisEstablishment.id,
         uid: thisEstablishment.uid,
@@ -210,6 +123,5 @@ router.route('/').put(async (req, res) => {
     return res.status(503).send(err.message);
   }
 });
-
 
 module.exports = router;


### PR DESCRIPTION
Hi Darren

https://trello.com/c/Z93EZqyB

This PR covers some refactoring of local identifier code, moving model specific sequelize code under the `Establishment` and `Worker` entities.

This is done ahead of two optimisations:

1. Only update those local identifiers that have been changed - when faced with 1100 workers, needlessly updating each and every Worker consumes precious resources and time

2. Not to reflect any change on the Worker or Establishment when the local identifier is updated

Thanks

