### PR TITLE
Fix service capacity validation

### DIFF
--- a/src/app/features/workplace/services-capacity/services-capacity.component.html
+++ b/src/app/features/workplace/services-capacity/services-capacity.component.html
@@ -38,28 +38,35 @@
               *ngFor="let question of capacity.questions; let idx = index"
               class="govuk-form-group"
               [class.govuk-form-group--error]="
-                submitted && form.get(generateId(capacity.service) + '.' + question.questionId).invalid
+                submitted &&
+                form.get(generateId(capacity.service) + '.' + question.seq + '_' + question.questionId).invalid
               "
             >
-              <label class="govuk-label" for="question-{{ question.questionId }}">
+              <label class="govuk-label" for="question-{{ question.seq }}_{{ question.questionId }}">
                 {{ question.question }}
               </label>
               <span
-                *ngIf="submitted && form.get(generateId(capacity.service) + '.' + question.questionId).invalid"
-                id="question-{{ question.questionId }}-error"
+                *ngIf="
+                  submitted &&
+                  form.get(generateId(capacity.service) + '.' + question.seq + '_' + question.questionId).invalid
+                "
+                id="question-{{ question.seq }}_{{ question.questionId }}-error"
                 class="govuk-error-message"
               >
                 <span class="govuk-visually-hidden">Error:</span>
-                {{ getFirstErrorMessage(generateId(capacity.service) + '.' + question.questionId) }}
+                {{
+                  getFirstErrorMessage(generateId(capacity.service) + '.' + question.seq + '_' + question.questionId)
+                }}
               </span>
               <input
                 class="govuk-input govuk-input--width-4"
                 [class.govuk-input--error]="
-                  submitted && form.get(generateId(capacity.service) + '.' + question.questionId).invalid
+                  submitted &&
+                  form.get(generateId(capacity.service) + '.' + question.seq + '_' + question.questionId).invalid
                 "
-                [formControlName]="question.questionId"
-                id="question-{{ question.questionId }}"
-                name="question-{{ question.questionId }}"
+                [formControlName]="question.seq + '_' + question.questionId"
+                id="question-{{ question.seq }}_{{ question.questionId }}"
+                name="question-{{ question.seq }}_{{ question.questionId }}"
                 type="number"
               />
             </div>

--- a/src/app/features/workplace/services-capacity/services-capacity.component.ts
+++ b/src/app/features/workplace/services-capacity/services-capacity.component.ts
@@ -4,7 +4,6 @@ import { Router } from '@angular/router';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { sortBy } from 'lodash';
 
 import { Question } from '../question/question.component';
 
@@ -43,12 +42,15 @@ export class ServicesCapacityComponent extends Question {
 
         capacities.allServiceCapacities.forEach((service, i) => {
           const group = this.formBuilder.group({});
-          const questions = sortBy(service.questions, question => question.seq);
+          const questions = service.questions;
 
           const id = this.generateId(service.service);
 
           questions.forEach(question => {
-            group.addControl(question.questionId.toString(), new FormControl(question.answer, [Validators.min(0)]));
+            group.addControl(
+              question.seq + '_' + question.questionId.toString(),
+              new FormControl(question.answer, [Validators.min(0)])
+            );
             this.formErrorsMap.push({
               item: `${id}.${question.questionId}`,
               type: [
@@ -99,7 +101,7 @@ export class ServicesCapacityComponent extends Question {
       Object.entries(this.form.get(groupKey).value).reduce((res, [key, value]) => {
         if (value) {
           const parsedValue = typeof value === 'string' ? parseInt(value, 10) : value;
-          capacities.push({ questionId: parseInt(key, 10), answer: parsedValue });
+          capacities.push({ questionId: parseInt(key.split('_')[1], 10), answer: parsedValue });
         }
         return res;
       }, []);


### PR DESCRIPTION
This may look slightly odd but this is the rationale.

* Service capacity validation is broken in some instances (in this case Shared lives)  because the validator method relies on the order of the controls.
* The questions are sorted by question.seq, but when added to form control this makes no difference because a FormGroup is an object map and is always ordered by its key (question.id)
* My preference here was to use a FormArray instead but this caused other issues with the error validation service.
* Fix was to prepend question.seq to form control name so validator will pick up controls in correct order.
* Filtered out this prepend when sending back to server.