### PR TITLE
Cater for instances where main service exists in other services list

### DIFF
--- a/src/app/features/workplace/other-services/other-services.component.ts
+++ b/src/app/features/workplace/other-services/other-services.component.ts
@@ -122,18 +122,20 @@ export class OtherServicesComponent extends Question {
 
   protected generateUpdateProps() {
     const { otherServices } = this.form.value;
+    const allServicesKeys = this.allServices.map(service => service.id);
 
     return {
-      services: otherServices.map(id => {
-        const service = { id };
-        const otherService: Service = filter(this.allServices, { id: id })[0];
+      services: otherServices
+        .filter(id => allServicesKeys.includes(id))
+        .map(id => {
+          const service = { id };
+          const otherService: Service = filter(this.allServices, { id: id })[0];
 
-        if (otherService.other) {
-          service['other'] = this.form.get(`additionalOtherService${id}`).value;
-        }
-
-        return service;
-      }),
+          if (otherService.other) {
+            service['other'] = this.form.get(`additionalOtherService${id}`).value;
+          }
+          return service;
+        }),
     };
   }
 

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -81,7 +81,7 @@
       <ng-template #otherServices>
         <ul class="govuk-list govuk-!-margin-bottom-0">
           <ng-container *ngFor="let categories of workplace.otherServices">
-            <li *ngFor="let service of categories.services">
+            <li *ngFor="let service of filterAndSortOtherServices(categories.services)">
               {{ service.name }}<ng-container *ngIf="service.other"> - {{ service.other }}</ng-container>
             </li>
           </ng-container>

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.ts
@@ -1,10 +1,12 @@
 import { I18nPluralPipe } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { Roles } from '@core/model/roles.enum';
+import { Service } from '@core/model/services.model';
 import { URLStructure } from '@core/model/url.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
+import { sortBy } from 'lodash';
 import { isArray } from 'util';
 
 @Component({
@@ -83,6 +85,10 @@ export class WorkplaceSummaryComponent {
     };
 
     this.canEdit = [Roles.Edit, Roles.Admin].includes(this.userService.loggedInUser.role);
+  }
+
+  public filterAndSortOtherServices(services: Service[]) {
+    return sortBy(services.filter(service => service.name !== this.workplace.mainService.name), 'id');
   }
 
   public isArray(variable): boolean {


### PR DESCRIPTION
It can be argued that the BE should also remove from other services list when a main service is selected (and will mention that in the ticket). However this PR guards against ui errors in this scenario and does fix the bug.