### PR TITLE
Wdf backend refactoring - delete worker/establishment and bulk upload and service users

### DIFF
--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -2016,6 +2016,11 @@ class Establishment extends EntityValidator {
         throw err;
       }
     }
+
+    async bulkUploadWdf(savedby, externalTransaction) {
+      // recalculate WDF - if not bulk upload (this._status)
+      return await WdfCalculator.calculate(savedby, this._id, null, externalTransaction, WdfCalculator.BULK_UPLOAD, false);
+    }
 };
 
 module.exports.Establishment = Establishment;

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -1277,7 +1277,7 @@ class Establishment extends EntityValidator {
                     }
 
                     // always recalculate WDF - if not bulk upload (this._status)
-                    this._status === null ? await WdfCalculator.calculate(savedBy, this._id, null, thisTransaction, WdfCalculator.ESTABLISHMENT_DELETE, false) : true;
+                    this._status === null ? await WdfCalculator.calculate(deletedBy, this._id, null, thisTransaction, WdfCalculator.ESTABLISHMENT_DELETE, false) : true;
 
                     // this is an async method - don't wait for it to return
                     AWSKinesis.establishmentPump(AWSKinesis.DELETED, this.toJSON());

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -1628,7 +1628,9 @@ class Establishment extends EntityValidator {
         }
 
         myWdf['serviceUsers'] = {
-            isEligible:  this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('ServiceUsers')) ? 'Yes' : 'No',
+            // for service users, it is not enough that the property itself is valid, to be WDF eligible it
+            //   there must be at least one service user
+            isEligible:  this._isPropertyWdfBasicEligible(effectiveFromEpoch, this._properties.get('ServiceUsers')) ? this._properties.get('ServiceUsers').property.length > 0 ? 'Yes'  : 'No' : 'No',
             updatedSinceEffectiveDate: this._properties.get('ServiceUsers').toJSON(false, true, WdfCalculator.effectiveDate)
         }
 

--- a/server/models/classes/wdfCalculator.js
+++ b/server/models/classes/wdfCalculator.js
@@ -379,7 +379,7 @@ class WdfCalculator {
         console.error('WdfCalculator::calculate - Failed to find establishment having id/uid: ', establishmentID, establishmentUID);
         return false;
       } else {
-        console.log("WA DEBUG - WDF: ", wdf);
+        console.log("WA DEBUG - WDF: ", wdf, wdf.reasons ? wdf.reasons : null);
         return wdf;
       }
     } catch (err) {

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -915,7 +915,7 @@ class Worker extends EntityValidator {
                     }
 
                     // always recalculate WDF - if not bulk upload (this._status)
-                    this._status === null ?  await WdfCalculator.calculate(savedBy, this._establishmentId, null, thisTransaction, WdfCalculator.WORKER_DELETE, false) : true;
+                    this._status === null ?  await WdfCalculator.calculate(deletedBy, this._establishmentId, null, thisTransaction, WdfCalculator.WORKER_DELETE, false) : true;
 
                     // this is an async method - don't wait for it to return
                     AWSKinesis.workerPump(AWSKinesis.DELETED, this.toJSON());

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -1708,6 +1708,7 @@ const completeNewEstablishment = async (thisNewEstablishment, theLoggedInUser, t
       // as this new establishment is created from a parent, it automatically becomes a sub
       foundOnloadEstablishment.initialiseSub(primaryEstablishmentId, primaryEstablishmentUid);
       await foundOnloadEstablishment.save(theLoggedInUser, true, 0, transaction, true);
+      await foundOnloadEstablishment.bulkUploadWdf(theLoggedInUser, transaction);
     }
 
     const endTime = new Date();
@@ -1739,6 +1740,7 @@ const completeUpdateEstablishment = async (thisUpdatedEstablishment, theLoggedIn
 
       await foundCurrentEstablishment.load(thisEstablishmentJSON, true, true);
       await foundCurrentEstablishment.save(theLoggedInUser, true, 0, transaction, true)
+      await foundCurrentEstablishment.bulkUploadWdf(theLoggedInUser, transaction);
 
       const endTime = new Date();
       const numberOfWorkers = foundCurrentEstablishment.workers.length;


### PR DESCRIPTION
https://trello.com/c/ouUV10ZZ
Now incorporating the bulk upload integration for WdfCalculator. And a couple of subtle changes for deleting workers and establishments (`savedBy` is `deletedBy`).

https://trello.com/c/oK09M0XL
Correcting service users WDF eligible to include a minimum of one service users.