### PR TITLE
Bugfix/change password

### DIFF
--- a/src/app/core/services/error-summary.service.ts
+++ b/src/app/core/services/error-summary.service.ts
@@ -48,6 +48,7 @@ export class ErrorSummaryService {
    * @param errorDefinitions
    */
   public getServerErrorMessage(errorCode: number, serverErrorsMap: Array<ErrorDefinition>): string {
-    return filter(serverErrorsMap, ['name', errorCode])[0].message || `Server Error. code ${errorCode}`;
+    const error: ErrorDefinition = filter(serverErrorsMap, ['name', errorCode])[0];
+    return error ? error.message : `Server Error. code ${errorCode}`;
   }
 }

--- a/src/app/core/services/password-reset.service.ts
+++ b/src/app/core/services/password-reset.service.ts
@@ -31,10 +31,7 @@ export class PasswordResetService {
   }
 
   changePassword(data) {
-    const token = localStorage.getItem('auth-token');
-    const headers = new HttpHeaders({ Authorization: token });
-
-    return this.http.post<any>('/api/user/changePassword', data, { headers, responseType: 'text' as 'json' });
+    return this.http.post<any>('/api/user/changePassword', data);
   }
 
   updateState(data) {

--- a/src/app/features/account-management/change-password/change-password.component.ts
+++ b/src/app/features/account-management/change-password/change-password.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { UserDetails } from '@core/model/userDetails.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { UserService } from '@core/services/user.service';
@@ -13,18 +14,21 @@ export class ChangePasswordComponent implements OnInit, OnDestroy {
   public userDetails: UserDetails;
   private subscriptions: Subscription = new Subscription();
 
-  constructor(private userService: UserService, private breadcrumbService: BreadcrumbService) {}
+  constructor(
+    private breadcrumbService: BreadcrumbService,
+    private router: Router,
+    private userService: UserService,
+  ) {}
 
   ngOnInit() {
     this.breadcrumbService.show();
-
     this.submitted = false;
-
     this.subscriptions.add(this.userService.loggedInUser$.subscribe(user => (this.userDetails = user)));
   }
 
   public onResetPasswordSuccess(): void {
     this.submitted = true;
+    this.router.navigate(['/account-management']);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
- gracefully handle unknown error code and return fallback server error with code string so no more console errors
- remove auth token code from changePassword method as the http interceptor is already doing this
- on successful password change route to account management page just like other account change sections