### PR TITLE
Implemented custom breadcrumb model and aligned page h1s

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,7 +16,9 @@ import { DashboardComponent } from '@features/dashboard/dashboard.component';
 import { ForgotYourPasswordComponent } from '@features/forgot-your-password/forgot-your-password.component';
 import { LoginComponent } from '@features/login/login.component';
 import { LogoutComponent } from '@features/logout/logout.component';
-import { MigratedUserTermsConditionsComponent } from '@features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
+import {
+  MigratedUserTermsConditionsComponent,
+} from '@features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
 import { ResetPasswordComponent } from '@features/reset-password/reset-password.component';
 
 const routes: Routes = [
@@ -95,7 +97,7 @@ const routes: Routes = [
       {
         path: 'account-management',
         loadChildren: '@features/account-management/account-management.module#AccountManagementModule',
-        data: { title: 'User Account' },
+        data: { title: 'Account details' },
       },
       {
         path: 'dashboard',

--- a/src/app/core/breadcrumb/breadcrumb.model.ts
+++ b/src/app/core/breadcrumb/breadcrumb.model.ts
@@ -9,7 +9,7 @@ export enum JourneyType {
 
 export interface JourneyRoute {
   title?: string;
-  url?: string;
+  path?: string;
   children?: JourneyRoute[];
   referrer?: JourneyRoute;
   fragment?: string;

--- a/src/app/core/breadcrumb/breadcrumb.model.ts
+++ b/src/app/core/breadcrumb/breadcrumb.model.ts
@@ -1,0 +1,16 @@
+export enum JourneyType {
+  PUBLIC,
+  ACCOUNT,
+  BULK_UPLOAD,
+  MY_WORKPLACE,
+  ALL_WORKPLACES,
+  REPORTS,
+}
+
+export interface JourneyRoute {
+  title?: string;
+  url?: string;
+  children?: JourneyRoute[];
+  referrer?: JourneyRoute;
+  fragment?: string;
+}

--- a/src/app/core/breadcrumb/journey.accounts.ts
+++ b/src/app/core/breadcrumb/journey.accounts.ts
@@ -11,19 +11,19 @@ export const accountJourney: JourneyRoute = {
   children: [
     {
       title: 'Account details',
-      url: Path.ACCOUNT_DETAILS,
+      path: Path.ACCOUNT_DETAILS,
       children: [
         {
           title: 'Your details',
-          url: Path.YOUR_DETAILS,
+          path: Path.YOUR_DETAILS,
         },
         {
           title: 'Your password',
-          url: Path.YOUR_PASSWORD,
+          path: Path.YOUR_PASSWORD,
         },
         {
           title: 'Your security question',
-          url: Path.YOUR_SECURITY_QUESTION,
+          path: Path.YOUR_SECURITY_QUESTION,
         },
       ],
     },

--- a/src/app/core/breadcrumb/journey.accounts.ts
+++ b/src/app/core/breadcrumb/journey.accounts.ts
@@ -1,0 +1,31 @@
+import { JourneyRoute } from './breadcrumb.model';
+
+enum Path {
+  ACCOUNT_DETAILS = '/account-management',
+  YOUR_DETAILS = '/account-management/change-your-details',
+  YOUR_PASSWORD = '/account-management/change-password',
+  YOUR_SECURITY_QUESTION = '/account-management/change-user-security',
+}
+
+export const accountJourney: JourneyRoute = {
+  children: [
+    {
+      title: 'Account details',
+      url: Path.ACCOUNT_DETAILS,
+      children: [
+        {
+          title: 'Your details',
+          url: Path.YOUR_DETAILS,
+        },
+        {
+          title: 'Your password',
+          url: Path.YOUR_PASSWORD,
+        },
+        {
+          title: 'Your security question',
+          url: Path.YOUR_SECURITY_QUESTION,
+        },
+      ],
+    },
+  ],
+};

--- a/src/app/core/breadcrumb/journey.bulk-upload.ts
+++ b/src/app/core/breadcrumb/journey.bulk-upload.ts
@@ -1,0 +1,14 @@
+import { JourneyRoute } from './breadcrumb.model';
+
+enum Path {
+  BULK_UPLOAD = '/bulk-upload',
+}
+
+export const bulkUploadJourney: JourneyRoute = {
+  children: [
+    {
+      title: 'Bulk upload',
+      url: Path.BULK_UPLOAD,
+    },
+  ],
+};

--- a/src/app/core/breadcrumb/journey.bulk-upload.ts
+++ b/src/app/core/breadcrumb/journey.bulk-upload.ts
@@ -8,7 +8,7 @@ export const bulkUploadJourney: JourneyRoute = {
   children: [
     {
       title: 'Bulk upload',
-      url: Path.BULK_UPLOAD,
+      path: Path.BULK_UPLOAD,
     },
   ],
 };

--- a/src/app/core/breadcrumb/journey.public.ts
+++ b/src/app/core/breadcrumb/journey.public.ts
@@ -13,27 +13,27 @@ export const publicJourney: JourneyRoute = {
   children: [
     {
       title: 'Feedback',
-      url: Path.FEEDBACK,
+      path: Path.FEEDBACK,
     },
     {
       title: 'Cookie policy',
-      url: Path.COOKIE_POLICY,
+      path: Path.COOKIE_POLICY,
     },
     {
       title: 'Contact us',
-      url: Path.CONTACT_US,
+      path: Path.CONTACT_US,
     },
     {
       title: 'Accessibility statement',
-      url: Path.ACCESSIBILITY_STATEMENT,
+      path: Path.ACCESSIBILITY_STATEMENT,
     },
     {
       title: 'Terms and conditions',
-      url: Path.TERMS_AND_CONDITIONS,
+      path: Path.TERMS_AND_CONDITIONS,
     },
     {
       title: 'Privacy notice',
-      url: Path.PRIVACY_NOTICE,
+      path: Path.PRIVACY_NOTICE,
     },
   ],
 };

--- a/src/app/core/breadcrumb/journey.public.ts
+++ b/src/app/core/breadcrumb/journey.public.ts
@@ -1,0 +1,39 @@
+import { JourneyRoute } from './breadcrumb.model';
+
+enum Path {
+  FEEDBACK = '/feedback',
+  COOKIE_POLICY = '/cookie-policy',
+  CONTACT_US = '/contact-us',
+  ACCESSIBILITY_STATEMENT = '/accessibility-statement',
+  TERMS_AND_CONDITIONS = '/terms-and-conditions',
+  PRIVACY_NOTICE = '/privacy-notice',
+}
+
+export const publicJourney: JourneyRoute = {
+  children: [
+    {
+      title: 'Feedback',
+      url: Path.FEEDBACK,
+    },
+    {
+      title: 'Cookie policy',
+      url: Path.COOKIE_POLICY,
+    },
+    {
+      title: 'Contact us',
+      url: Path.CONTACT_US,
+    },
+    {
+      title: 'Accessibility statement',
+      url: Path.ACCESSIBILITY_STATEMENT,
+    },
+    {
+      title: 'Terms and conditions',
+      url: Path.TERMS_AND_CONDITIONS,
+    },
+    {
+      title: 'Privacy notice',
+      url: Path.PRIVACY_NOTICE,
+    },
+  ],
+};

--- a/src/app/core/breadcrumb/journey.report.ts
+++ b/src/app/core/breadcrumb/journey.report.ts
@@ -1,0 +1,32 @@
+import { JourneyRoute } from './breadcrumb.model';
+
+enum Path {
+  REPORTS_LANDING_URL = '/workplace/:workplaceUid/reports',
+  WDF = '/workplace/:workplaceUid/reports/wdf',
+  WDF_STAFF_RECORD = '/workplace/:workplaceUid/staff-record/:workerUid/wdf-summary',
+}
+
+export const reportJourney: JourneyRoute = {
+  children: [
+    {
+      title: 'Reports',
+      url: Path.REPORTS_LANDING_URL,
+      children: [
+        {
+          title: 'Workforce Development Fund',
+          url: Path.WDF,
+          children: [
+            {
+              title: 'Staff record summary',
+              url: Path.WDF_STAFF_RECORD,
+              referrer: {
+                url: Path.WDF,
+                fragment: 'staff-records',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/src/app/core/breadcrumb/journey.report.ts
+++ b/src/app/core/breadcrumb/journey.report.ts
@@ -10,17 +10,17 @@ export const reportJourney: JourneyRoute = {
   children: [
     {
       title: 'Reports',
-      url: Path.REPORTS_LANDING_URL,
+      path: Path.REPORTS_LANDING_URL,
       children: [
         {
           title: 'Workforce Development Fund',
-          url: Path.WDF,
+          path: Path.WDF,
           children: [
             {
               title: 'Staff record summary',
-              url: Path.WDF_STAFF_RECORD,
+              path: Path.WDF_STAFF_RECORD,
               referrer: {
-                url: Path.WDF,
+                path: Path.WDF,
                 fragment: 'staff-records',
               },
             },

--- a/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/src/app/core/breadcrumb/journey.workplaces.ts
@@ -14,29 +14,29 @@ export const myWorkplaceJourney: JourneyRoute = {
   children: [
     {
       title: 'Staff record summary',
-      url: Path.STAFF_RECORD,
+      path: Path.STAFF_RECORD,
       referrer: {
-        url: Path.DASHBOARD,
+        path: Path.DASHBOARD,
         fragment: 'staff-records',
       },
     },
     {
       title: 'New user account',
-      url: Path.CREATE_ACCOUNT,
+      path: Path.CREATE_ACCOUNT,
     },
     {
       title: 'Account details',
-      url: Path.USER_ACCOUNT,
+      path: Path.USER_ACCOUNT,
       referrer: {
-        url: Path.DASHBOARD,
+        path: Path.DASHBOARD,
         fragment: 'user-accounts',
       },
       children: [
         {
           title: 'Permissions',
-          url: Path.USER_PERMISSIONS,
+          path: Path.USER_PERMISSIONS,
           referrer: {
-            url: Path.DASHBOARD,
+            path: Path.DASHBOARD,
             fragment: 'user-accounts',
           },
         },
@@ -49,37 +49,37 @@ export const allWorkplacesJourney: JourneyRoute = {
   children: [
     {
       title: 'All workplaces',
-      url: Path.ALL_WORKPLACES,
+      path: Path.ALL_WORKPLACES,
       children: [
         {
           title: 'Workplace',
-          url: Path.WORKPLACE,
+          path: Path.WORKPLACE,
           children: [
             {
               title: 'Staff record summary',
-              url: Path.STAFF_RECORD,
+              path: Path.STAFF_RECORD,
               referrer: {
-                url: Path.WORKPLACE,
+                path: Path.WORKPLACE,
                 fragment: 'staff-records',
               },
             },
             {
               title: 'New user account',
-              url: Path.CREATE_ACCOUNT,
+              path: Path.CREATE_ACCOUNT,
             },
             {
               title: 'Account details',
-              url: Path.USER_ACCOUNT,
+              path: Path.USER_ACCOUNT,
               referrer: {
-                url: Path.WORKPLACE,
+                path: Path.WORKPLACE,
                 fragment: 'user-accounts',
               },
               children: [
                 {
                   title: 'Permissions',
-                  url: Path.USER_PERMISSIONS,
+                  path: Path.USER_PERMISSIONS,
                   referrer: {
-                    url: Path.WORKPLACE,
+                    path: Path.WORKPLACE,
                     fragment: 'user-accounts',
                   },
                 },

--- a/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/src/app/core/breadcrumb/journey.workplaces.ts
@@ -1,0 +1,93 @@
+import { JourneyRoute } from './breadcrumb.model';
+
+enum Path {
+  DASHBOARD = '/dashboard',
+  WORKPLACE = '/workplace/:workplaceUid',
+  ALL_WORKPLACES = '/workplace/view-my-workplaces',
+  STAFF_RECORD = '/workplace/:workplaceUid/staff-record/:workerUid',
+  USER_ACCOUNT = '/workplace/:workplaceUid/user/:workerUid',
+  USER_PERMISSIONS = '/workplace/:workerUid/user/:workerUid/permissions',
+  CREATE_ACCOUNT = '/workplace/:workplaceUid/user/create',
+}
+
+export const myWorkplaceJourney: JourneyRoute = {
+  children: [
+    {
+      title: 'Staff record summary',
+      url: Path.STAFF_RECORD,
+      referrer: {
+        url: Path.DASHBOARD,
+        fragment: 'staff-records',
+      },
+    },
+    {
+      title: 'New user account',
+      url: Path.CREATE_ACCOUNT,
+    },
+    {
+      title: 'Account details',
+      url: Path.USER_ACCOUNT,
+      referrer: {
+        url: Path.DASHBOARD,
+        fragment: 'user-accounts',
+      },
+      children: [
+        {
+          title: 'Permissions',
+          url: Path.USER_PERMISSIONS,
+          referrer: {
+            url: Path.DASHBOARD,
+            fragment: 'user-accounts',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+export const allWorkplacesJourney: JourneyRoute = {
+  children: [
+    {
+      title: 'All workplaces',
+      url: Path.ALL_WORKPLACES,
+      children: [
+        {
+          title: 'Workplace',
+          url: Path.WORKPLACE,
+          children: [
+            {
+              title: 'Staff record summary',
+              url: Path.STAFF_RECORD,
+              referrer: {
+                url: Path.WORKPLACE,
+                fragment: 'staff-records',
+              },
+            },
+            {
+              title: 'New user account',
+              url: Path.CREATE_ACCOUNT,
+            },
+            {
+              title: 'Account details',
+              url: Path.USER_ACCOUNT,
+              referrer: {
+                url: Path.WORKPLACE,
+                fragment: 'user-accounts',
+              },
+              children: [
+                {
+                  title: 'Permissions',
+                  url: Path.USER_PERMISSIONS,
+                  referrer: {
+                    url: Path.WORKPLACE,
+                    fragment: 'user-accounts',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/src/app/core/breadcrumb/journey.workplaces.ts
@@ -3,7 +3,7 @@ import { JourneyRoute } from './breadcrumb.model';
 enum Path {
   DASHBOARD = '/dashboard',
   WORKPLACE = '/workplace/:workplaceUid',
-  ALL_WORKPLACES = '/workplace/view-my-workplaces',
+  ALL_WORKPLACES = '/workplace/view-all-workplaces',
   STAFF_RECORD = '/workplace/:workplaceUid/staff-record/:workerUid',
   USER_ACCOUNT = '/workplace/:workplaceUid/user/:workerUid',
   USER_PERMISSIONS = '/workplace/:workerUid/user/:workerUid/permissions',

--- a/src/app/core/guards/add-workplace-in-progress/add-workplace-in-progress.guard.ts
+++ b/src/app/core/guards/add-workplace-in-progress/add-workplace-in-progress.guard.ts
@@ -12,7 +12,7 @@ export class AddWorkplaceInProgressGuard implements CanActivate {
     if (this.workplaceService.addWorkplaceInProgress$.value) {
       return true;
     } else {
-      this.router.navigate(['/workplace/view-my-workplaces']);
+      this.router.navigate(['/workplace/view-all-workplaces']);
       return false;
     }
   }

--- a/src/app/core/services/breadcrumb.service.ts
+++ b/src/app/core/services/breadcrumb.service.ts
@@ -1,5 +1,12 @@
+import { Location } from '@angular/common';
 import { Injectable } from '@angular/core';
-import { NavigationEnd, Router } from '@angular/router';
+import { NavigationEnd, PRIMARY_OUTLET, Router, UrlSegment } from '@angular/router';
+import { JourneyRoute, JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { accountJourney } from '@core/breadcrumb/journey.accounts';
+import { bulkUploadJourney } from '@core/breadcrumb/journey.bulk-upload';
+import { publicJourney } from '@core/breadcrumb/journey.public';
+import { reportJourney } from '@core/breadcrumb/journey.report';
+import { allWorkplacesJourney, myWorkplaceJourney } from '@core/breadcrumb/journey.workplaces';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { parse } from 'url';
@@ -8,24 +15,143 @@ import { parse } from 'url';
   providedIn: 'root',
 })
 export class BreadcrumbService {
-  private readonly _display$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(null);
-  public readonly display$: Observable<boolean> = this._display$.asObservable();
+  private readonly _routes$: BehaviorSubject<Array<JourneyRoute>> = new BehaviorSubject<Array<JourneyRoute>>(null);
+  public readonly routes$: Observable<Array<JourneyRoute>> = this._routes$.asObservable();
 
-  constructor(private router: Router) {
+  constructor(private router: Router, private location: Location) {
     this.router.events
       .pipe(
         filter(event => event instanceof NavigationEnd),
         map(() => parse(this.router.url).pathname),
         distinctUntilChanged(),
-        map(() => this._display$.value),
+        map(() => this._routes$.value),
         filter(val => !!val)
       )
       .subscribe(() => {
-        this._display$.next(null);
+        this._routes$.next(null);
       });
   }
 
-  public show() {
-    this._display$.next(true);
+  public show(journey: JourneyType) {
+    const urlTree = this.router.parseUrl(this.location.path());
+    const segmentGroup = urlTree.root.children[PRIMARY_OUTLET];
+    const segments = segmentGroup ? segmentGroup.segments : null;
+    const routes = this.getRoutes(this.getRoutesConfig(journey), segments);
+    this._routes$.next(routes);
+  }
+
+  private getRoutes(currentRoute: JourneyRoute, segments: UrlSegment[], routes: JourneyRoute[] = []) {
+    if (!currentRoute) {
+      return routes;
+    }
+
+    const children = currentRoute.children;
+
+    if (!children || children.length === 0) {
+      return routes;
+    }
+
+    let hasMatched = false;
+
+    children.forEach((child, index) => {
+      if (hasMatched) {
+        return routes;
+      }
+
+      const { title, url, referrer } = child;
+
+      const isCurrentRoute = this.isCurrentRoute(url, segments);
+
+      if (isCurrentRoute || index === children.length - 1) {
+        routes.push({
+          title,
+          url: this.getPath(url, segments),
+          ...(referrer && { referrer: this.getReferrer(referrer, segments) }),
+        });
+      }
+
+      if (isCurrentRoute) {
+        hasMatched = true;
+        return routes;
+      }
+
+      return this.getRoutes(child, segments, routes);
+    });
+
+    return routes;
+  }
+
+  private getPath(url: string, segments: UrlSegment[]) {
+    const path = this.getParts(url).map((part, index) => {
+      if (this.isParameter(part)) {
+        return segments[index] ? segments[index].path : part;
+      }
+      return part;
+    });
+    return '/' + path.join('/');
+  }
+
+  private getReferrer(referrer: JourneyRoute, segments: UrlSegment[]) {
+    return {
+      url: this.getPath(referrer.url, segments),
+      fragment: referrer.fragment,
+    };
+  }
+
+  private isCurrentRoute(url: string, segments: UrlSegment[]) {
+    const parts = this.getParts(url);
+    if (parts.length !== segments.length) {
+      return false;
+    }
+    let matched = true;
+    parts.forEach((part, index) => {
+      const segment = segments[index];
+      if (!this.isParameter(part) && part !== segment.path) {
+        matched = false;
+      }
+    });
+    return matched;
+  }
+
+  private getParts(url: string) {
+    return url.split('/').filter(part => part !== '');
+  }
+
+  private isParameter(part: string) {
+    return part.startsWith(':');
+  }
+
+  private getRoutesConfig(journey: JourneyType) {
+    let routes: JourneyRoute;
+    switch (journey) {
+      case JourneyType.REPORTS: {
+        routes = reportJourney;
+        break;
+      }
+      case JourneyType.MY_WORKPLACE: {
+        routes = myWorkplaceJourney;
+        break;
+      }
+      case JourneyType.ALL_WORKPLACES: {
+        routes = allWorkplacesJourney;
+        break;
+      }
+      case JourneyType.PUBLIC: {
+        routes = publicJourney;
+        break;
+      }
+      case JourneyType.BULK_UPLOAD: {
+        routes = bulkUploadJourney;
+        break;
+      }
+      case JourneyType.ACCOUNT: {
+        routes = accountJourney;
+        break;
+      }
+      default: {
+        routes = null;
+      }
+    }
+    return routes;
   }
 }

--- a/src/app/core/services/breadcrumb.service.ts
+++ b/src/app/core/services/breadcrumb.service.ts
@@ -58,14 +58,14 @@ export class BreadcrumbService {
         return routes;
       }
 
-      const { title, url, referrer } = child;
+      const { title, path: url, referrer } = child;
 
       const isCurrentRoute = this.isCurrentRoute(url, segments);
 
       if (isCurrentRoute || index === children.length - 1) {
         routes.push({
           title,
-          url: this.getPath(url, segments),
+          path: this.getPath(url, segments),
           ...(referrer && { referrer: this.getReferrer(referrer, segments) }),
         });
       }
@@ -93,7 +93,7 @@ export class BreadcrumbService {
 
   private getReferrer(referrer: JourneyRoute, segments: UrlSegment[]) {
     return {
-      url: this.getPath(referrer.url, segments),
+      url: this.getPath(referrer.path, segments),
       fragment: referrer.fragment,
     };
   }

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -212,4 +212,8 @@ export class EstablishmentService {
   public deleteWorkplace(workplaceUid: string): Observable<any> {
     return this.http.delete<any>(`/api/establishment/${workplaceUid}`);
   }
+
+  public isOwnWorkplace() {
+    return !this.primaryWorkplace.isParent || this.primaryWorkplace.uid === this.establishment.uid;
+  }
 }

--- a/src/app/features/account-management/account-management-routing.module.ts
+++ b/src/app/features/account-management/account-management-routing.module.ts
@@ -14,17 +14,17 @@ const routes: Routes = [
   {
     path: 'change-password',
     component: ChangePasswordComponent,
-    data: { title: 'Change Password' },
+    data: { title: 'Your password' },
   },
   {
     path: 'change-user-security',
     component: ChangeUserSecurityComponent,
-    data: { title: 'Change Security Question' },
+    data: { title: 'Your security question' },
   },
   {
     path: 'change-your-details',
     component: ChangeYourDetailsComponent,
-    data: { title: 'Change Your Details' },
+    data: { title: 'Your details' },
   },
 ];
 

--- a/src/app/features/account-management/change-password/change-password.component.ts
+++ b/src/app/features/account-management/change-password/change-password.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { UserService } from '@core/services/user.service';
@@ -16,7 +17,7 @@ export class ChangePasswordComponent implements OnInit, OnDestroy {
   constructor(private breadcrumbService: BreadcrumbService, private userService: UserService) {}
 
   ngOnInit() {
-    this.breadcrumbService.show();
+    this.breadcrumbService.show(JourneyType.ACCOUNT);
     this.submitted = false;
     this.subscriptions.add(this.userService.loggedInUser$.subscribe(user => (this.userDetails = user)));
   }

--- a/src/app/features/account-management/change-password/edit/edit.component.html
+++ b/src/app/features/account-management/change-password/edit/edit.component.html
@@ -11,9 +11,9 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <span class="govuk-caption-l">User account</span>
+          <span class="govuk-caption-l">{{ userDetails?.fullname }}</span>
           <h1 class="govuk-fieldset__heading">
-            Change password
+            Your password
           </h1>
         </legend>
 

--- a/src/app/features/account-management/change-user-security/change-user-security.component.html
+++ b/src/app/features/account-management/change-user-security/change-user-security.component.html
@@ -11,9 +11,9 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <span class="govuk-caption-l">User account</span>
+          <span class="govuk-caption-l">{{ userDetails?.fullname }}</span>
           <h1 class="govuk-fieldset__heading">
-            Security question
+            Your security question
           </h1>
         </legend>
 

--- a/src/app/features/account-management/change-user-security/change-user-security.component.ts
+++ b/src/app/features/account-management/change-user-security/change-user-security.component.ts
@@ -2,6 +2,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { ErrorDefinition } from '@core/model/errorSummary.model';
 import { Establishment } from '@core/model/establishment.model';
 import { UserDetails } from '@core/model/userDetails.model';
@@ -18,7 +19,7 @@ import { SecurityQuestion } from '@features/account/security-question/security-q
 })
 export class ChangeUserSecurityComponent extends SecurityQuestion {
   private serverErrorsMap: Array<ErrorDefinition>;
-  private userDetails: UserDetails;
+  public userDetails: UserDetails;
   private primaryWorkplace: Establishment;
   public serverError: string;
 
@@ -36,7 +37,7 @@ export class ChangeUserSecurityComponent extends SecurityQuestion {
 
   protected init(): void {
     this.return = { url: ['/account-management'] };
-    this.breadcrumbService.show();
+    this.breadcrumbService.show(JourneyType.ACCOUNT);
     this.setupSubscription();
     this.setupServerErrorsMap();
 

--- a/src/app/features/account-management/change-your-details/change-your-details.component.html
+++ b/src/app/features/account-management/change-your-details/change-your-details.component.html
@@ -11,7 +11,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <span class="govuk-caption-l">User account</span>
+          <span class="govuk-caption-l">{{ userDetails?.fullname }}</span>
           <h1 class="govuk-fieldset__heading">
             Your details
           </h1>

--- a/src/app/features/account-management/change-your-details/change-your-details.component.ts
+++ b/src/app/features/account-management/change-your-details/change-your-details.component.ts
@@ -2,6 +2,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { BackService } from '@core/services/back.service';
@@ -33,15 +34,11 @@ export class ChangeYourDetailsComponent extends AccountDetails {
   }
 
   protected init() {
-    this.breadcrumbService.show();
+    this.breadcrumbService.show(JourneyType.ACCOUNT);
     this.setupSubscriptions();
     this.return = { url: ['/account-management'] };
 
     this.primaryWorkplace = this.establishmentService.primaryWorkplace;
-  }
-
-  protected setBackLink(): void {
-    this.backService.setBackLink({ url: ['/account-management'] });
   }
 
   private setupSubscriptions(): void {

--- a/src/app/features/account-management/your-account/your-account.component.html
+++ b/src/app/features/account-management/your-account/your-account.component.html
@@ -1,6 +1,5 @@
-<span class="govuk-caption-l">User Account</span>
-<h1 class="govuk-heading-l">{{ user?.fullname }}</h1>
-<h2 class="govuk-heading-m">Account details</h2>
+<span class="govuk-caption-l">{{ user?.fullname }}</span>
+<h1 class="govuk-heading-l">Account details</h1>
 
 <app-summary-list [topBorder]="true" [summaryList]="userInfo"></app-summary-list>
 <app-summary-list [topBorder]="true" [summaryList]="loginInfo"></app-summary-list>

--- a/src/app/features/account-management/your-account/your-account.component.ts
+++ b/src/app/features/account-management/your-account/your-account.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { SummaryList } from '@core/model/summary-list.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
@@ -20,7 +21,7 @@ export class YourAccountComponent implements OnInit, OnDestroy {
   constructor(private userService: UserService, private breadcrumbService: BreadcrumbService) {}
 
   ngOnInit() {
-    this.breadcrumbService.show();
+    this.breadcrumbService.show(JourneyType.ACCOUNT);
 
     this.subscriptions.add(
       this.userService.loggedInUser$.subscribe(user => {

--- a/src/app/features/account/security-question/security-question.ts
+++ b/src/app/features/account/security-question/security-question.ts
@@ -3,13 +3,13 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ErrorDetails } from '@core/model/errorSummary.model';
 import { SecurityDetails } from '@core/model/security-details.model';
+import { URLStructure } from '@core/model/url.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { Subscription } from 'rxjs';
-import { URLStructure } from '@core/model/url.model';
 
 export class SecurityQuestion implements OnInit, OnDestroy {
-  private formErrorsMap: Array<ErrorDetails>;
+  public formErrorsMap: Array<ErrorDetails>;
   private securityDetailsMaxLength = 255;
   protected back: URLStructure;
   protected return: URLStructure;

--- a/src/app/features/add-workplace/add-workplace-complete/add-workplace-complete.component.html
+++ b/src/app/features/add-workplace/add-workplace-complete/add-workplace-complete.component.html
@@ -28,7 +28,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a [routerLink]="['/workplace', 'view-my-workplaces']">return to workplaces</a>
+          <a [routerLink]="['/workplace', 'view-all-workplaces']">return to workplaces</a>
         </li>
         <li>
           <a [routerLink]="['/dashboard']">go to your dashboard</a>
@@ -66,7 +66,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a [routerLink]="['/workplace', 'view-my-workplaces']">return to workplaces</a>
+          <a [routerLink]="['/workplace', 'view-all-workplaces']">return to workplaces</a>
         </li>
         <li>
           <a [routerLink]="['/dashboard']">go to your dashboard</a>

--- a/src/app/features/add-workplace/start/start.component.ts
+++ b/src/app/features/add-workplace/start/start.component.ts
@@ -15,6 +15,6 @@ export class StartComponent implements OnInit {
   }
 
   private setBackLink(): void {
-    this.backService.setBackLink({ url: ['/workplace/view-my-workplaces'] });
+    this.backService.setBackLink({ url: ['/workplace/view-all-workplaces'] });
   }
 }

--- a/src/app/features/bulk-upload/bulk-upload-page/bulk-upload-page.component.ts
+++ b/src/app/features/bulk-upload/bulk-upload-page/bulk-upload-page.component.ts
@@ -1,8 +1,10 @@
 import { I18nPluralPipe } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { Establishment } from '@core/model/establishment.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -25,10 +27,12 @@ export class BulkUploadPageComponent implements OnInit, OnDestroy {
   constructor(
     private establishmentService: EstablishmentService,
     private bulkUploadService: BulkUploadService,
-    private errorSummaryService: ErrorSummaryService
+    private errorSummaryService: ErrorSummaryService,
+    private breadcrumbService: BreadcrumbService
   ) {}
 
   ngOnInit() {
+    this.breadcrumbService.show(JourneyType.BULK_UPLOAD);
     this.establishment = this.establishmentService.primaryWorkplace;
     this.setupFormErrorsMap();
     this.setupUploadValidationErrors();

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <span *ngIf="workplace?.parentName" class="govuk-caption-xl">{{ workplace.parentName }}: Parent</span>
+      <span *ngIf="workplace?.isParent" class="govuk-caption-xl">Parent</span>
       {{ workplace?.name }}
     </h1>
   </div>

--- a/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -26,7 +26,7 @@
           <a [routerLink]="['/bulk-upload']" (click)="setReturn()">Bulk upload</a>
         </li>
         <li *ngIf="workplace.isParent">
-          <a [routerLink]="['/workplace', 'view-my-workplaces']">View my workplaces</a>
+          <a [routerLink]="['/workplace', 'view-my-workplaces']">View all workplaces</a>
         </li>
         <li><a [routerLink]="['/workplace', workplace.uid, 'reports']">View reports</a></li>
       </ng-container>

--- a/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -26,7 +26,7 @@
           <a [routerLink]="['/bulk-upload']" (click)="setReturn()">Bulk upload</a>
         </li>
         <li *ngIf="workplace.isParent">
-          <a [routerLink]="['/workplace', 'view-my-workplaces']">View all workplaces</a>
+          <a [routerLink]="['/workplace', 'view-all-workplaces']">View all workplaces</a>
         </li>
         <li><a [routerLink]="['/workplace', workplace.uid, 'reports']">View reports</a></li>
       </ng-container>

--- a/src/app/features/public/accessibility-statement/accessibility-statement.component.ts
+++ b/src/app/features/public/accessibility-statement/accessibility-statement.component.ts
@@ -1,7 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 
 @Component({
   selector: 'app-accessibility-statement',
-  templateUrl: './accessibility-statement.component.html'
+  templateUrl: './accessibility-statement.component.html',
 })
-export class AccessibilityStatementComponent {}
+export class AccessibilityStatementComponent implements OnInit {
+  constructor(private breadcrumbSerivce: BreadcrumbService) {}
+
+  ngOnInit() {
+    this.breadcrumbSerivce.show(JourneyType.PUBLIC);
+  }
+}

--- a/src/app/features/public/contact-us/contact-us.component.html
+++ b/src/app/features/public/contact-us/contact-us.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">Contact Us</h1>
+    <h1 class="govuk-heading-l">Contact us</h1>
     <p>
       If you require direct assistance, please call 0113 241 0969, to speak to a member of the ASC-WDS Support Team or
       you can email us at <a href="mailto:ascwds-support@skillsforcare.org.uk">ascwds-support@skillsforcare.org.uk</a>.

--- a/src/app/features/public/contact-us/contact-us.component.ts
+++ b/src/app/features/public/contact-us/contact-us.component.ts
@@ -1,9 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 
 @Component({
   selector: 'app-contact-us',
   templateUrl: './contact-us.component.html',
 })
-export class ContactUsComponent {
-  constructor() {}
+export class ContactUsComponent implements OnInit {
+  constructor(private breadcrumbSerivce: BreadcrumbService) {}
+
+  ngOnInit() {
+    this.breadcrumbSerivce.show(JourneyType.PUBLIC);
+  }
 }

--- a/src/app/features/public/cookie-policy/cookie-policy.component.html
+++ b/src/app/features/public/cookie-policy/cookie-policy.component.html
@@ -1,13 +1,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">Cookie Policy</h1>
+    <h1 class="govuk-heading-l">Cookie policy</h1>
     <h2 class="govuk-heading-m">Adult Social Care Workforce Data Set</h2>
     <p>
-      The Adult Social Care Workforce Data Set (the &quot;Service&quot; or &quot;ASC-WDS&quot;) uses cookies to distinguish you from other
-      users of the Service. This helps us to provide you with a good experience when you use our Service and are vital
-      to the basic performance of the Service. Cookies enable critical authentication and validation, session
-      management, and fraud prevention in addition to enabling us to remember the settings you may have previously
-      applied, such as text size.
+      The Adult Social Care Workforce Data Set (the &quot;Service&quot; or &quot;ASC-WDS&quot;) uses cookies to
+      distinguish you from other users of the Service. This helps us to provide you with a good experience when you use
+      our Service and are vital to the basic performance of the Service. Cookies enable critical authentication and
+      validation, session management, and fraud prevention in addition to enabling us to remember the settings you may
+      have previously applied, such as text size.
     </p>
     <p>
       A cookie is a small file of letters and numbers that we store on your browser or the hard drive of your computer

--- a/src/app/features/public/cookie-policy/cookie-policy.component.ts
+++ b/src/app/features/public/cookie-policy/cookie-policy.component.ts
@@ -1,7 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 
 @Component({
   selector: 'app-cookie-policy',
-  templateUrl: './cookie-policy.component.html'
+  templateUrl: './cookie-policy.component.html',
 })
-export class CookiePolicyComponent {}
+export class CookiePolicyComponent implements OnInit {
+  constructor(private breadcrumbSerivce: BreadcrumbService) {}
+
+  ngOnInit() {
+    this.breadcrumbSerivce.show(JourneyType.PUBLIC);
+  }
+}

--- a/src/app/features/public/feedback/feedback.component.ts
+++ b/src/app/features/public/feedback/feedback.component.ts
@@ -1,8 +1,10 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { FeedbackModel } from '@core/model/feedback.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { FeedbackService } from '@core/services/feedback.service';
 import { WindowRef } from '@core/services/window.ref';
@@ -29,10 +31,12 @@ export class FeedbackComponent implements OnInit, OnDestroy {
     private errorSummaryService: ErrorSummaryService,
     private feedbackService: FeedbackService,
     private formBuilder: FormBuilder,
-    private windowRef: WindowRef
+    private windowRef: WindowRef,
+    private breadcrumbSerivce: BreadcrumbService
   ) {}
 
   ngOnInit() {
+    this.breadcrumbSerivce.show(JourneyType.PUBLIC);
     this.setupForm();
     this.setupFormErrorsMap();
     this.setupServerErrorsMap();

--- a/src/app/features/public/privacy-notice/privacy-notice.component.html
+++ b/src/app/features/public/privacy-notice/privacy-notice.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">Privacy Notice</h1>
+    <h1 class="govuk-heading-l">Privacy notice</h1>
     <h2 class="govuk-heading-m">Who we are and what we do</h2>
     <p>
       Skills for Care Ltd (registered company number 03866683 with its registered office at West Gate, 6 Grace Street,

--- a/src/app/features/public/privacy-notice/privacy-notice.component.ts
+++ b/src/app/features/public/privacy-notice/privacy-notice.component.ts
@@ -1,7 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 
 @Component({
   selector: 'app-privacy-notice',
   templateUrl: './privacy-notice.component.html',
 })
-export class PrivacyNoticeComponent {}
+export class PrivacyNoticeComponent implements OnInit {
+  constructor(private breadcrumbSerivce: BreadcrumbService) {}
+
+  ngOnInit() {
+    this.breadcrumbSerivce.show(JourneyType.PUBLIC);
+  }
+}

--- a/src/app/features/public/public-routing.module.ts
+++ b/src/app/features/public/public-routing.module.ts
@@ -11,32 +11,32 @@ const routes: Routes = [
   {
     path: 'contact-us',
     component: ContactUsComponent,
-    data: { title: 'Contact Us' },
+    data: { title: 'Contact us' },
   },
   {
     path: 'feedback',
     component: FeedbackComponent,
-    data: { title: 'Give us Feedback' },
+    data: { title: 'Feedback' },
   },
   {
     path: 'terms-and-conditions',
     component: TermsConditionsComponent,
-    data: { title: 'Terms and Conditions' },
+    data: { title: 'Terms and conditions' },
   },
   {
     path: 'cookie-policy',
     component: CookiePolicyComponent,
-    data: { title: 'Cookie Policy' },
+    data: { title: 'Cookie policy' },
   },
   {
     path: 'accessibility-statement',
     component: AccessibilityStatementComponent,
-    data: { title: 'Accessibility Statement' },
+    data: { title: 'Accessibility statement' },
   },
   {
     path: 'privacy-notice',
     component: PrivacyNoticeComponent,
-    data: { title: 'Privacy Notice' },
+    data: { title: 'Privacy notice' },
   },
 ];
 

--- a/src/app/features/public/terms-conditions/terms-conditions.component.html
+++ b/src/app/features/public/terms-conditions/terms-conditions.component.html
@@ -127,7 +127,7 @@
       To ensure a secured login and to meet web content accessibility guidelines the service uses two
       &apos;cookies&apos; (a small piece of information, normally consisting of just letters and numbers that is sent to
       your computer and stored on its hard drive). You can read more about how we use cookies, and how to change your
-      cookie preferences, in our <a [routerLink]="['/cookie-policy']">Cookie Policy</a>
+      cookie preferences, in our <a [routerLink]="['/cookie-policy']">Cookie policy</a>
     </p>
     <p>These cookies cannot be used to identify you personally.</p>
 

--- a/src/app/features/public/terms-conditions/terms-conditions.component.ts
+++ b/src/app/features/public/terms-conditions/terms-conditions.component.ts
@@ -1,7 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 
 @Component({
   selector: 'app-terms-conditions',
   templateUrl: './terms-conditions.component.html',
 })
-export class TermsConditionsComponent {}
+export class TermsConditionsComponent implements OnInit {
+  constructor(private breadcrumbSerivce: BreadcrumbService) {}
+
+  ngOnInit() {
+    this.breadcrumbSerivce.show(JourneyType.PUBLIC);
+  }
+}

--- a/src/app/features/reports/pages/reports/reports.component.ts
+++ b/src/app/features/reports/pages/reports/reports.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -15,7 +16,7 @@ export class ReportsComponent implements OnInit, OnDestroy {
   constructor(private establishmentService: EstablishmentService, private breadcrumbService: BreadcrumbService) {}
 
   ngOnInit() {
-    this.breadcrumbService.show();
+    this.breadcrumbService.show(JourneyType.REPORTS);
 
     this.subscriptions.add(
       this.establishmentService.establishment$.subscribe(workplace => (this.workplace = workplace))

--- a/src/app/features/reports/pages/wdf/wdf.component.ts
+++ b/src/app/features/reports/pages/wdf/wdf.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { WDFReport } from '@core/model/reports.model';
 import { Roles } from '@core/model/roles.enum';
@@ -48,7 +49,7 @@ export class WdfComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.breadcrumbService.show();
+    this.breadcrumbService.show(JourneyType.REPORTS);
     const workplaceUid = this.route.snapshot.params.establishmentuid;
 
     this.canViewStaffRecords = [Roles.Edit, Roles.Admin].includes(this.userService.loggedInUser.role);

--- a/src/app/features/workers/check-staff-record/check-staff-record.component.html
+++ b/src/app/features/workers/check-staff-record/check-staff-record.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="worker">
   <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl">Staff record summary</span>
-    {{ worker.nameOrId }}
+    <span class="govuk-caption-xl">{{ worker.nameOrId }}</span>
+    Staff record summary
   </h1>
 
   <p class="govuk-!-margin-bottom-8">

--- a/src/app/features/workers/staff-record/staff-record.component.html
+++ b/src/app/features/workers/staff-record/staff-record.component.html
@@ -2,7 +2,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl"> {{ worker.nameOrId }}</span>
+        <span class="govuk-caption-xl">{{ worker.nameOrId }}</span>
         Staff record summary
       </h1>
     </div>

--- a/src/app/features/workers/staff-record/staff-record.component.html
+++ b/src/app/features/workers/staff-record/staff-record.component.html
@@ -2,8 +2,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">Staff record</span>
-        {{ worker.nameOrId }}
+        <span class="govuk-caption-xl"> {{ worker.nameOrId }}</span>
+        Staff record summary
       </h1>
     </div>
 

--- a/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/src/app/features/workers/staff-record/staff-record.component.ts
@@ -1,10 +1,13 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';
 import { Worker } from '@core/model/worker.model';
 import { AlertService } from '@core/services/alert.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { DialogService } from '@core/services/dialog.service';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
@@ -28,11 +31,16 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     private alertService: AlertService,
     private dialogService: DialogService,
     private workerService: WorkerService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private establishmentService: EstablishmentService,
+    private breadcrumbService: BreadcrumbService
   ) {}
 
   ngOnInit() {
     this.workplace = this.route.parent.snapshot.data.establishment;
+    const journey = this.establishmentService.isOwnWorkplace() ? JourneyType.MY_WORKPLACE : JourneyType.ALL_WORKPLACES;
+    this.breadcrumbService.show(journey);
+
     this.subscriptions.add(
       this.workerService.worker$.pipe(take(1)).subscribe(worker => {
         this.worker = worker;

--- a/src/app/features/workers/wdf-staff-summary/wdf-staff-summary.component.html
+++ b/src/app/features/workers/wdf-staff-summary/wdf-staff-summary.component.html
@@ -2,8 +2,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
-        <span class="govuk-caption-xl">Staff record summary</span>
-        {{ worker.nameOrId }}
+        <span class="govuk-caption-xl">{{ worker.nameOrId }}</span>
+        Staff record summary
       </h1>
     </div>
     <div class="govuk-grid-column-one-third">

--- a/src/app/features/workers/wdf-staff-summary/wdf-staff-summary.component.ts
+++ b/src/app/features/workers/wdf-staff-summary/wdf-staff-summary.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';
 import { Eligibility } from '@core/model/wdf.model';
@@ -39,7 +40,7 @@ export class WdfStaffSummaryComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.breadcrumbService.show();
+    this.breadcrumbService.show(JourneyType.REPORTS);
 
     this.workplace = this.establishmentService.establishment;
 

--- a/src/app/features/workplace/create-user-account/create-user-account.component.html
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.html
@@ -11,9 +11,9 @@
     <form novalidate (ngSubmit)="onSubmit()" [formGroup]="form" id="server-error">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <span class="govuk-caption-l">User account</span>
+          <span class="govuk-caption-l">{{ workplace?.name }}</span>
           <h1 class="govuk-fieldset__heading">
-            Add user account
+            New user account
           </h1>
         </legend>
 

--- a/src/app/features/workplace/create-user-account/create-user-account.component.ts
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.ts
@@ -2,12 +2,15 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { FormBuilder, FormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { Establishment } from '@core/model/establishment.model';
 import { RadioFieldData } from '@core/model/form-controls.model';
 import { Roles } from '@core/model/roles.enum';
 import { BackService } from '@core/services/back.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { AccountDetails } from '@features/account/account-details/account-details';
 
 @Component({
@@ -17,6 +20,7 @@ import { AccountDetails } from '@features/account/account-details/account-detail
 export class CreateUserAccountComponent extends AccountDetails {
   public callToActionLabel = 'Save user account';
   public establishmentUid: string;
+  public workplace: Establishment;
   public roleRadios: RadioFieldData[] = [
     {
       value: Roles.Edit,
@@ -32,6 +36,7 @@ export class CreateUserAccountComponent extends AccountDetails {
     private breadcrumbService: BreadcrumbService,
     private createAccountService: CreateAccountService,
     private route: ActivatedRoute,
+    private establishmentService: EstablishmentService,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
@@ -41,7 +46,9 @@ export class CreateUserAccountComponent extends AccountDetails {
   }
 
   protected init(): void {
-    this.breadcrumbService.show();
+    this.workplace = this.route.parent.snapshot.data.establishment;
+    const journey = this.establishmentService.isOwnWorkplace() ? JourneyType.MY_WORKPLACE : JourneyType.ALL_WORKPLACES;
+    this.breadcrumbService.show(journey);
     this.addFormControls();
     this.establishmentUid = this.route.parent.snapshot.params.establishmentuid;
   }
@@ -64,10 +71,7 @@ export class CreateUserAccountComponent extends AccountDetails {
     this.subscriptions.add(
       this.createAccountService
         .createAccount(this.establishmentUid, this.form.value)
-        .subscribe(
-          () => this.navigateToNextRoute(),
-          (error: HttpErrorResponse) => this.onError(error)
-        )
+        .subscribe(() => this.navigateToNextRoute(), (error: HttpErrorResponse) => this.onError(error))
     );
   }
 

--- a/src/app/features/workplace/user-account-edit-details/user-account-edit-details.component.ts
+++ b/src/app/features/workplace/user-account-edit-details/user-account-edit-details.component.ts
@@ -2,11 +2,11 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { BackService } from '@core/services/back.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
 import { AccountDetails } from '@features/account/account-details/account-details';
 
@@ -20,7 +20,6 @@ export class UserAccountEditDetailsComponent extends AccountDetails {
 
   constructor(
     private breadcrumbService: BreadcrumbService,
-    private establishmentService: EstablishmentService,
     private route: ActivatedRoute,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
@@ -32,7 +31,7 @@ export class UserAccountEditDetailsComponent extends AccountDetails {
   }
 
   protected init() {
-    this.breadcrumbService.show();
+    this.breadcrumbService.show(JourneyType.ACCOUNT);
     this.prefillForm(this.userDetails);
     this.return = { url: ['/dashboard'], fragment: 'user-accounts' };
   }

--- a/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.html
+++ b/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.html
@@ -10,8 +10,8 @@
       <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.invalid">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <span class="govuk-caption-l">User Account</span>
-            <h1 class="govuk-fieldset__heading">Change Permissions</h1>
+            <span class="govuk-caption-l">{{ user?.fullname }}</span>
+            <h1 class="govuk-fieldset__heading">Permissions</h1>
           </legend>
           <div class="govuk-radios">
             <ng-container *ngFor="let item of roleRadios; let i = index">

--- a/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
+++ b/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { ErrorDefinition } from '@core/model/errorSummary.model';
 import { Establishment } from '@core/model/establishment.model';
 import { RadioFieldData } from '@core/model/form-controls.model';
@@ -11,6 +12,7 @@ import { AlertService } from '@core/services/alert.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { DialogService } from '@core/services/dialog.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
 import { Subscription } from 'rxjs';
 
@@ -50,7 +52,8 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
     private errorSummaryService: ErrorSummaryService,
     private dialogService: DialogService,
     private userService: UserService,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private establishmentService: EstablishmentService
   ) {
     this.user = this.route.snapshot.data.user;
     this.workplace = this.route.parent.snapshot.data.establishment;
@@ -67,7 +70,8 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.setupServerErrorsMap();
-    this.breadcrumbService.show();
+    const journey = this.establishmentService.isOwnWorkplace() ? JourneyType.MY_WORKPLACE : JourneyType.ALL_WORKPLACES;
+    this.breadcrumbService.show(journey);
 
     this.form = this.formBuilder.group({
       role: [this.user.role, Validators.required],

--- a/src/app/features/workplace/user-account-view/user-account-view.component.html
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.html
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third-from-desktop">
-    <span class="govuk-caption-l">User Account</span>
-    <h1 class="govuk-heading-l">{{ user.fullname }}</h1>
+    <span class="govuk-caption-l">{{ user.fullname }}</span>
+    <h1 class="govuk-heading-l">Account details</h1>
   </div>
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <div class="govuk-button-heading-group">

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { Roles } from '@core/model/roles.enum';
 import { SummaryList } from '@core/model/summary-list.model';
@@ -8,6 +9,7 @@ import { UserDetails } from '@core/model/userDetails.model';
 import { AlertService } from '@core/services/alert.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { DialogService } from '@core/services/dialog.service';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
 import {
   UserAccountDeleteDialogComponent,
@@ -38,7 +40,8 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
     private breadcrumbService: BreadcrumbService,
     private userService: UserService,
     private dialogService: DialogService,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private establishmentService: EstablishmentService
   ) {
     this.user = this.route.snapshot.data.user;
     this.establishment = this.route.parent.snapshot.data.establishment;
@@ -46,7 +49,8 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.breadcrumbService.show();
+    const journey = this.establishmentService.isOwnWorkplace() ? JourneyType.MY_WORKPLACE : JourneyType.ALL_WORKPLACES;
+    this.breadcrumbService.show(journey);
 
     this.subscriptions.add(
       this.userService

--- a/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
+++ b/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-full govuk__flex govuk__justify-content-space-between govuk__align-items-flex-end">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-0">
       <span *ngIf="primaryWorkplace.name" class="govuk-caption-xl">{{ primaryWorkplace.name }}</span>
-      My workplaces ({{ workplacesCount }})
+      All workplaces ({{ workplacesCount }})
     </h1>
     <a
       *ngIf="canAddWorkplace"

--- a/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
+++ b/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
@@ -1,9 +1,11 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { ErrorDefinition } from '@core/model/errorSummary.model';
 import { Establishment } from '@core/model/establishment.model';
 import { GetWorkplacesResponse, Workplace } from '@core/model/my-workplaces.model';
 import { Roles } from '@core/model/roles.enum';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
@@ -25,10 +27,12 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
   constructor(
     private establishmentService: EstablishmentService,
     private userService: UserService,
-    private errorSummaryService: ErrorSummaryService
+    private errorSummaryService: ErrorSummaryService,
+    private breadcrumbService: BreadcrumbService
   ) {}
 
   ngOnInit() {
+    this.breadcrumbService.show(JourneyType.ALL_WORKPLACES);
     this.canAddWorkplace = [Roles.Edit, Roles.Admin].includes(this.userService.loggedInUser.role);
     this.primaryWorkplace = this.establishmentService.primaryWorkplace;
     this.getEstablishments();

--- a/src/app/features/workplace/view-workplace/view-workplace.component.html
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.html
@@ -1,8 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">
-      <span *ngIf="workplace?.parentName" class="govuk-caption-xl">{{ workplace.parentName }}</span>
-      {{ workplace.name }}
+      <span class="govuk-caption-xl">{{ workplace.name }}</span>
+      Workplace
     </h1>
   </div>
 

--- a/src/app/features/workplace/view-workplace/view-workplace.component.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.ts
@@ -90,7 +90,7 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.establishmentService.deleteWorkplace(this.workplace.uid).subscribe(
         () => {
-          this.router.navigate(['workplace/view-my-workplaces']).then(() => {
+          this.router.navigate(['workplace/view-all-workplaces']).then(() => {
             this.alertService.addAlert({
               type: 'success',
               message: `${this.workplace.name} has been permanently deleted.`,

--- a/src/app/features/workplace/view-workplace/view-workplace.component.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { DataPermissions } from '@core/model/my-workplaces.model';
 import { Roles } from '@core/model/roles.enum';
 import { URLStructure } from '@core/model/url.model';
 import { AlertService } from '@core/services/alert.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
@@ -34,10 +36,12 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
     private dialogService: DialogService,
     private establishmentService: EstablishmentService,
     private userService: UserService,
-    private workerService: WorkerService
+    private workerService: WorkerService,
+    private breadcrumbService: BreadcrumbService
   ) {}
 
   ngOnInit() {
+    this.breadcrumbService.show(JourneyType.ALL_WORKPLACES);
     this.primaryEstablishment = this.establishmentService.primaryWorkplace;
     this.workplace = this.establishmentService.establishment;
 

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -7,7 +7,9 @@ import { Roles } from '@core/model/roles.enum';
 import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
 import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
 import { CreateUserAccountComponent } from '@features/workplace/create-user-account/create-user-account.component';
-import { UserAccountEditDetailsComponent } from '@features/workplace/user-account-edit-details/user-account-edit-details.component';
+import {
+  UserAccountEditDetailsComponent,
+} from '@features/workplace/user-account-edit-details/user-account-edit-details.component';
 import { UserAccountSavedComponent } from '@features/workplace/user-account-saved/user-account-saved.component';
 import { UserAccountViewComponent } from '@features/workplace/user-account-view/user-account-view.component';
 import { ViewMyWorkplacesComponent } from '@features/workplace/view-my-workplaces/view-my-workplaces.component';
@@ -38,7 +40,7 @@ import { VacanciesComponent } from './vacancies/vacancies.component';
 
 const routes: Routes = [
   {
-    path: 'view-my-workplaces',
+    path: 'view-all-workplaces',
     component: ViewMyWorkplacesComponent,
     canActivate: [ParentGuard],
     data: { title: 'View My Workplaces' },

--- a/src/app/features/workplace/workplace.module.ts
+++ b/src/app/features/workplace/workplace.module.ts
@@ -33,6 +33,7 @@ import {
   UserAccountChangePrimaryDialogComponent,
 } from './user-account-change-primary-dialog/user-account-change-primary-dialog.component';
 import { UserAccountDeleteDialogComponent } from './user-account-delete-dialog/user-account-delete-dialog.component';
+import { UserAccountEditDetailsComponent } from './user-account-edit-details/user-account-edit-details.component';
 import {
   UserAccountEditPermissionsComponent,
 } from './user-account-edit-permissions/user-account-edit-permissions.component';
@@ -44,7 +45,6 @@ import {
 } from './wdf-workplace-confirmation-dialog/wdf-workplace-confirmation-dialog.component';
 import { WorkplaceInfoPanelComponent } from './workplace-info-panel/workplace-info-panel.component';
 import { WorkplaceRoutingModule } from './workplace-routing.module';
-import { UserAccountEditDetailsComponent } from './user-account-edit-details/user-account-edit-details.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, WorkplaceRoutingModule],

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.html
@@ -8,7 +8,7 @@
         [attr.aria-current]="i + 1 === breadcrumbs.length ? 'page' : null"
       >
         <ng-container *ngIf="i + 1 !== breadcrumbs.length; else final">
-          <a class="govuk-breadcrumbs__link" [routerLink]="breadcrumb.url" [fragment]="breadcrumb.fragment">{{
+          <a class="govuk-breadcrumbs__link" [routerLink]="breadcrumb.path" [fragment]="breadcrumb.fragment">{{
             breadcrumb.title
           }}</a>
         </ng-container>

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.html
@@ -1,17 +1,16 @@
-<ng-container *ngIf="display">
+<ng-container *ngIf="breadcrumbs">
   <div class="govuk-breadcrumbs">
     Go back to:
     <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" [routerLink]="['/dashboard']">Home</a>
-      </li>
       <li
         class="govuk-breadcrumbs__list-item"
         *ngFor="let breadcrumb of breadcrumbs; let i = index"
         [attr.aria-current]="i + 1 === breadcrumbs.length ? 'page' : null"
       >
         <ng-container *ngIf="i + 1 !== breadcrumbs.length; else final">
-          <a class="govuk-breadcrumbs__link" [routerLink]="breadcrumb.url">{{ breadcrumb.title }}</a>
+          <a class="govuk-breadcrumbs__link" [routerLink]="breadcrumb.url" [fragment]="breadcrumb.fragment">{{
+            breadcrumb.title
+          }}</a>
         </ng-container>
         <ng-template #final>
           {{ breadcrumb.title }}

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
@@ -31,14 +31,14 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
     routes = [
       {
         title: 'Home',
-        url: '/dashboard',
+        path: '/dashboard',
       },
       ...routes,
     ];
 
     if (currentPath.referrer) {
       routes = routes.map(route => {
-        if (route.url === currentPath.referrer.url) {
+        if (route.path === currentPath.referrer.path) {
           return {
             ...route,
             fragment: currentPath.referrer.fragment,


### PR DESCRIPTION
**UPDATED Previous comments not valid as discussed with Charlie removing dependancy on NestRoutesService.**

The usage of the breadcrumb service remains pretty much the same (import the service and call the show() method. 

Using the show method without any arguments will produce the same behaviour (breadcrumbs will be generated from the router tree).

If this logic does not fit then a new argument `journey` is introduced. A journey is essentially a custom route config that describes the breadcrumb tree.

`this.breadcrumbService.show(Journey.REPORTS)`

When this argument is provided the breadcrumbs will be generated off this config. 

At a very high level that is it.

The custom service matches the paths in much the same way as the Angular router does and then replaces parameters with the actual values from the segment tree.

I did have a look at titles but have not done anything with those. The nestedRouteService behaves in the same way. 

No doubt there will be some comments / questions