### PR TITLE
Local authority report user - revisions following review with Jackie

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -366,7 +366,7 @@ const config = convict({
         fromDate: {
           doc: 'A fixed from reporting date; in the format YYYY-MM-DD',
           format: String,
-          default: '2019-06-01'
+          default: '2019-09-09'
         },
         toDate: {
           doc: 'A fixed to reporting date; in the format YYYY-MM-DD',

--- a/server/models/localAuthorityReportsWorkers.js
+++ b/server/models/localAuthorityReportsWorkers.js
@@ -8,10 +8,10 @@ module.exports = function(sequelize, DataTypes) {
       primaryKey: true,
       field: '"ID"'
     },
-    localAuthorityReportEstablishmentFK: {
+    establishmentFk: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      field: '"LocalAuthorityReportEstablishmentFK"'
+      field: '"EstablishmentFK"'
     },
     workerFK: {
       type: DataTypes.INTEGER,
@@ -109,14 +109,6 @@ module.exports = function(sequelize, DataTypes) {
     createdAt: false,
     updatedAt: false
   });
-
-  LocalAuthorityReportWorker.associate = (models) => {
-    LocalAuthorityReportWorker.belongsTo(models.localAuthorityReportEstablishment, {
-      foreignKey: 'localAuthorityReportEstablishmentFK',
-      targetKey: 'id',
-      as: 'establishment'
-    });
-  };
 
   return LocalAuthorityReportWorker;
 };

--- a/server/routes/admin/search/users/index.js
+++ b/server/routes/admin/search/users/index.js
@@ -32,6 +32,7 @@ router.route('/').post(async function (req, res) {
           "Login"."Username" AS "Username",
           "Login"."Active" AS "UserIsActive",
           "Login"."PasswdLastChanged" AS "UserPasswdLastChanged",
+          "Login"."InvalidAttempt" AS "InvalidAttempt",
           "Login"."LastLoggedIn" AS "UserLastLoggedIn",
           "User"."FullNameValue" AS "UserFullname",
           "User"."IsPrimary" AS "UserIsPrimary",
@@ -71,6 +72,7 @@ router.route('/').post(async function (req, res) {
           "Login"."Active" AS "UserIsActive",
           "Login"."PasswdLastChanged" AS "UserPasswdLastChanged",
           "Login"."LastLoggedIn" AS "UserLastLoggedIn",
+          "Login"."InvalidAttempt" AS "InvalidAttempt",
           "User"."FullNameValue" AS "UserFullname",
           "User"."IsPrimary" AS "UserIsPrimary",
           "User"."SecurityQuestionValue" AS "UserSecurityQuestion",
@@ -109,6 +111,7 @@ router.route('/').post(async function (req, res) {
         email: thisLogin.UserEmail,
         phone: thisLogin.UserPhone,
         isLocked: !thisLogin.UserIsActive,
+        invalidAttempt: thisLogin.InvalidAttempt,
         passwdLastChanged: thisLogin.UserPasswdLastChanged,
         lastLoggedIn: thisLogin.UserLastLoggedIn,
         establishment: {

--- a/server/routes/reports/localAuthorityReport/admin.js
+++ b/server/routes/reports/localAuthorityReport/admin.js
@@ -6,6 +6,7 @@ const router = express.Router();
 
 // for database
 const models = require('../../../models');
+const config = require('../../../config/config');
 
 // local helper helper functions
 const _csvQuote = (toCsv) => {
@@ -40,6 +41,8 @@ router.route('/').get(async (req, res) => {
   const userAgent = UserAgentParser(req.headers['user-agent']);
   const windowsTest = /windows/i;
   const NEWLINE = windowsTest.test(userAgent.os.name) ? "\r\n" : "\n";
+  const fromDate = config.get('app.reports.localAuthority.fromDate');
+  const toDate = config.get('app.reports.localAuthority.toDate');
 
   try {
 
@@ -47,14 +50,142 @@ router.route('/').get(async (req, res) => {
     res.setHeader('Content-disposition', 'attachment; filename=' + `${date}-SFC-Local-Authority-Admin-Report.csv`);
     res.setHeader('Content-Type', 'text/csv');
 
-    // write dummy data
-    res.write('COLUMNA,\
-COLUMN2,\
-COLUMNC3'+NEWLINE);
+    // write the report header
+    res.write('Local Authority, \
+Workplace ID,\
+Number of parent account,\
+Name of parent account(s),\
+Latest update date,\
+Status,\
+Confirmed staff record numbers,\
+Workplace data complete?,\
+Staff records compleyte?,\
+Number of workplaces/teams at these accounts,\
+Number of complete workplaces/teams,\
+Establishment Type,\
+Main Service,\
+Service User Group data,\
+Capacity of Main Service,\
+Utilisation of Main Service,\
+Number of Staff Records (by job role),\
+Number of Vacancies,\
+Leavers in the past 12 months,\
+Number of starters in the past 12 months,\
+Number of staff records based on the organisation,\
+Number of individual staff records,\
+Number of individual staff records (not agency),\
+Number of complete staff records (not agency),\
+Percentage of complete staff reocrds (not agency),\
+Number of individual agency records,\
+Number of complete agency records,\
+Percentage of complete agency staff records,\
+Gender,\
+Date of Birth,\
+Ethinic Group,\
+Main job role,\
+Employment status,\
+Contracted/Average hours,\
+Sickness,\
+Pay,\
+Qualifications,\
+Last Years confirmed numbers'+NEWLINE);
 
-    res.write(`1,\
-${_csvQuote('A "quoted" text value')},\
-${date}`+NEWLINE);
+    const runReport = await models.sequelize.query(
+      `select * from cqc.localAuthorityReportAdmin(:givenFromDate, :givenToDate);`,
+      {
+        replacements: {
+          givenFromDate: fromDate,
+          givenToDate: toDate,
+        },
+        type: models.sequelize.QueryTypes.SELECT
+      }
+    );
+
+    console.log("WA DEBUG !!!!!!!!!!!! - runReport: ", runReport)
+
+
+    /*
+    		"LocalAuthority" TEXT,
+		"WorkplaceName" TEXT,
+		"WorkplaceID" TEXT,
+	 	"PrimaryEstablishmentID" INTEGER,
+		"LastYearsConfirmedNumbers" INTEGER,
+		"LatestUpdate" DATE,
+		"WorkplacesCompleted" BIGINT,
+		"StaffCompleted" BIGINT,
+		"NumberOfWorkplaces" BIGINT,
+    "NumberOfWorkplacesCompleted" BIGINT,
+		"CountEstablishmentType" BIGINT,
+		"CountMainService" BIGINT,
+		"CountServiceUserGroups" BIGINT,
+		"CountCapacity" BIGINT,
+    "CountUiltisation" BIGINT,
+		"CountNumberOfStaff" BIGINT,
+		"CountVacancies" BIGINT,
+		"CountStarters" BIGINT,
+		"CountLeavers" BIGINT,
+    "SumStaff" BIGINT,
+		"CountIndividualStaffRecords" BIGINT,
+		"CountOfIndividualStaffRecordsNotAgency" BIGINT,
+		"CountOfIndividualStaffRecordsNotAgencyComplete" BIGINT,
+		"PercentageNotAgencyComplete" DECIMAL(4,1),
+		"CountOfIndividualStaffRecordsAgency" BIGINT,
+		"CountOfIndividualStaffRecordsAgencyComplete" BIGINT,
+    "PercentageAgencyComplete" DECIMAL(4,1),
+
+		"CountOfGender" BIGINT,
+		"CountOfDateOfBirth" BIGINT,
+		"CountOfEthnicity" BIGINT,
+		"CountOfMainJobRole" BIGINT,
+		"CountOfEmploymentStatus" BIGINT,
+		"CountOfContractedAverageHours" BIGINT,
+		"CountOfSickness" BIGINT,
+		"CountOfPay" BIGINT,
+		"CountOfQualification" BIGINT
+    */
+
+    if (runReport && Array.isArray(runReport)) {
+      runReport.forEach(thisPrimaryLaEstablishment => {
+        res.write(`${thisPrimaryLaEstablishment.LocalAuthority},\
+${thisPrimaryLaEstablishment.WorkplaceID},\
+1,\
+${thisPrimaryLaEstablishment.WorkplaceName},\
+${thisPrimaryLaEstablishment.LatestUpdate},\
+,\
+,\
+${thisPrimaryLaEstablishment.WorkplacesCompleted},\
+${thisPrimaryLaEstablishment.StaffCompleted},\
+${thisPrimaryLaEstablishment.NumberOfWorkplaces},\
+${thisPrimaryLaEstablishment.NumberOfWorkplacesCompleted},\
+${thisPrimaryLaEstablishment.CountEstablishmentType},\
+${thisPrimaryLaEstablishment.CountMainService},\
+${thisPrimaryLaEstablishment.CountServiceUserGroups},\
+${thisPrimaryLaEstablishment.CountCapacity},\
+${thisPrimaryLaEstablishment.CountUiltisation},\
+${thisPrimaryLaEstablishment.CountNumberOfStaff},\
+${thisPrimaryLaEstablishment.CountVacancies},\
+${thisPrimaryLaEstablishment.CountStarters},\
+${thisPrimaryLaEstablishment.CountLeavers},\
+${thisPrimaryLaEstablishment.SumStaff},\
+${thisPrimaryLaEstablishment.CountIndividualStaffRecords},\
+${thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsNotAgency},\
+${thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsNotAgencyComplete},\
+${thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsNotAgency > 0  && thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsNotAgencyComplete > 0  ? Math.floor(thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsNotAgencyComplete / thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsNotAgency * 100) : 0 },\
+${thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsAgency},\
+${thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsAgencyComplete},\
+${thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsAgency > 0  && thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsAgencyComplete > 0  ? Math.floor(thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsAgencyComplete / thisPrimaryLaEstablishment.CountOfIndividualStaffRecordsAgency * 100) : 0 },\
+${thisPrimaryLaEstablishment.CountOfGender},\
+${thisPrimaryLaEstablishment.CountOfDateOfBirth},\
+${thisPrimaryLaEstablishment.CountOfEthnicity},\
+${thisPrimaryLaEstablishment.CountOfMainJobRole},\
+${thisPrimaryLaEstablishment.CountOfEmploymentStatus},\
+${thisPrimaryLaEstablishment.CountOfContractedAverageHours},\
+${thisPrimaryLaEstablishment.CountOfSickness},\
+${thisPrimaryLaEstablishment.CountOfPay},\
+${thisPrimaryLaEstablishment.CountOfQualification},\
+${thisPrimaryLaEstablishment.LastYearsConfirmedNumbers}`+NEWLINE);
+      });
+    }
 
     return res.status(200).end();
 

--- a/server/routes/reports/localAuthorityReport/user.js
+++ b/server/routes/reports/localAuthorityReport/user.js
@@ -160,16 +160,9 @@ router.route('/').get(async (req, res) => {
 
           // now grab the workers and format the report data
           const reportWorkers = await models.localAuthorityReportWorker.findAll({
-            include: [
-              {
-                  model: models.localAuthorityReportEstablishment,
-                  as: 'establishment',
-                  attributes: [],
-                  where: {
-                    establishmentFk: establishmentId
-                  }
-              }
-            ],
+            where: {
+              establishmentFk: establishmentId
+            },
             order: [
               ['workplaceName', 'ASC'],
               ['localId', 'ASC'],

--- a/server/routes/reports/localAuthorityReport/user.js
+++ b/server/routes/reports/localAuthorityReport/user.js
@@ -91,8 +91,12 @@ const staffTab = async (establishmentName, localAuhtority, workers) => {
 const workplaceTab = async (establishmentName, establishmentNmdsId, reportDate, localAuhtority, establishments) => {
   if (establishments && Array.isArray(establishments)) {
     const ourEstablishmentsorkers = establishments.map(thisEstablishment => {
+
+      // main service capacity/utilisation can be null - implying "n/a"
+
       return {
         workplaceName: thisEstablishment.localID,
+        mainServiceCapacity: thisEstablishment.CapacityOfMainService ? `${thisEstablishment.CapacityOfMainService}` : 'n/a',
       };
     });
     console.log("WA DEBUG - report/localAuthority/user::workplaceTab - establishments: ", ourEstablishmentsorkers)

--- a/server/routes/reports/localAuthorityReport/user.js
+++ b/server/routes/reports/localAuthorityReport/user.js
@@ -77,7 +77,7 @@ const staffTab = async (establishmentName, localAuhtority, workers) => {
   if (workers && Array.isArray(workers)) {
     const ourWorkers = workers.map(thisWorker => {
       return {
-        localId: thisWorker.localID,
+        localId: thisWorker.localId,
       };
     });
     console.log("WA DEBUG - report/localAuthority/user::staffTab - workers: ", ourWorkers)

--- a/server/routes/reports/localAuthorityReport/user.js
+++ b/server/routes/reports/localAuthorityReport/user.js
@@ -93,13 +93,14 @@ const workplaceTab = async (establishmentName, establishmentNmdsId, reportDate, 
     const ourEstablishmentsorkers = establishments.map(thisEstablishment => {
 
       // main service capacity/utilisation can be null - implying "n/a"
+      //console.log("WA DEBUG - thisEstablishment: ", thisEstablishment)
 
       return {
-        workplaceName: thisEstablishment.localID,
-        mainServiceCapacity: thisEstablishment.CapacityOfMainService ? `${thisEstablishment.CapacityOfMainService}` : 'n/a',
+        workplaceName: thisEstablishment.workplaceName,
+        mainServiceCapacity: thisEstablishment.capacityOfMainService ? `${thisEstablishment.capacityOfMainService}` : 'n/a',
       };
     });
-    console.log("WA DEBUG - report/localAuthority/user::workplaceTab - establishments: ", ourEstablishmentsorkers)
+    console.log("WA DEBUG - report/localAuthority/user::workplaceTab - establishments:\n", ourEstablishmentsorkers)
   }
 
   return '';

--- a/server/routes/reports/localAuthorityReport/user.js
+++ b/server/routes/reports/localAuthorityReport/user.js
@@ -149,7 +149,10 @@ router.route('/').get(async (req, res) => {
           const reportEstablishments = await models.localAuthorityReportEstablishment.findAll({
             where: {
               establishmentFk: establishmentId
-            }
+            },
+            order: [
+              ['workplaceName', 'ASC'],
+            ],
           });
           if (reportEstablishments && Array.isArray(reportEstablishments)) {
             await workplaceTab(establishmentName, establishmentNmdsId, reportDateUK, localAuthority, reportEstablishments);
@@ -166,7 +169,11 @@ router.route('/').get(async (req, res) => {
                     establishmentFk: establishmentId
                   }
               }
-            ]
+            ],
+            order: [
+              ['workplaceName', 'ASC'],
+              ['localId', 'ASC'],
+            ],
           });
           if (reportWorkers && Array.isArray(reportWorkers)) {
             await staffTab(establishmentName, localAuthority, reportWorkers);


### PR DESCRIPTION
https://trello.com/c/UsiGWFJU

Removing the wrong dependency on worker report records to establishment records, because worker records must be created before establishment, and the establishment needs to aggregate against the Worker records.

In fact, this simplifies the local authority establishment/worker model, because now they both use the primary establishment id as pass when generating the report.

Also adding ordering to the establishment and worker data, in preparation for writing out to Excel (the latter still yet not supported).
