### PR TITLE
Allow handling of nulls passed into _csvQuote in BU Worker download

### DIFF
--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -3269,7 +3269,7 @@ class Worker {
   }
 
   _csvQuote(toCsv) {
-    if (toCsv.replace(/ /g, '').match(/[\s,"]/)) {
+    if (toCsv && toCsv.replace(/ /g, '').match(/[\s,"]/)) {
       return '"' + toCsv.replace(/"/g, '""') + '"';
     } else {
       return toCsv;


### PR DESCRIPTION
https://trello.com/c/5s1BaWgz

Note - establishment CSV download also has a cqv quote function, and that already does what this PR is doing, checking for `toCSV`. Doh. Damn duplication of code. We simply don't get enough time to refactor.