### PR TITLE
La admin report endpoint timeout

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -322,7 +322,7 @@ const config = convict({
       timeout: {
         doc: 'The timeout in seconds for bulk upload validations',
         format: 'int',
-        default: '300'
+        default: 300
       },
       storeIntermediaries: {
         doc: 'If true, intermediary trace data will be stored',
@@ -332,9 +332,16 @@ const config = convict({
     },
     completion: {
       timeout: {
-        doc: 'The timeout in seconds for bulk upload validations',
+        doc: 'The timeout in seconds for bulk upload completion',
         format: 'int',
-        default: '300'
+        default: 300
+      },
+    },
+    download: {
+      timeout: {
+        doc: 'The timeout in seconds for bulk upload download',
+        format: 'int',
+        default: 300
       },
     }
   },
@@ -373,6 +380,11 @@ const config = convict({
           format: String,
           default: '2019-10-31'
         },
+        timeout: {
+          doc: "The timeout, in seconds, on the Local Authority user and admin API endpoints",
+          format: 'int',
+          default: 180,
+        }
       }
     }
   }

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -1941,6 +1941,8 @@ const exportToCsv = async (NEWLINE, allMyEstablishemnts, primaryEstablishmentId)
 // TODO - note, regardless of which download type is requested, the way establishments, workers and training entities are restored, it is easy enough to create all three exports every time
 //  Ideally, the CSV content should be prepared and uploaded to S3, and then signed URLs returned for the browsers to download directly, thus not imposing the streaming of large data files through node.js API
 router.route('/download/:downloadType').get(async (req, res) => {
+  req.setTimeout(config.get('bulkupload.download.timeout') * 1000);
+
     // this report returns as plain text. The report line endings are dependent on not the
   //  runtime platform, but on the requesting platform (99.9999% of the users will be on Windows)
   const userAgent = UserAgentParser(req.headers['user-agent']);

--- a/server/routes/reports/localAuthorityReport/admin.js
+++ b/server/routes/reports/localAuthorityReport/admin.js
@@ -38,6 +38,8 @@ const _fromDateToCsvDate = (convertThis) => {
 
 // gets report
 router.route('/').get(async (req, res) => {
+  req.setTimeout(config.get('app.reports.localAuthority.timeout')*1000);
+
   const userAgent = UserAgentParser(req.headers['user-agent']);
   const windowsTest = /windows/i;
   const NEWLINE = windowsTest.test(userAgent.os.name) ? "\r\n" : "\n";
@@ -100,9 +102,6 @@ Last Years confirmed numbers'+NEWLINE);
         type: models.sequelize.QueryTypes.SELECT
       }
     );
-
-    console.log("WA DEBUG !!!!!!!!!!!! - runReport: ", runReport)
-
 
     /*
     		"LocalAuthority" TEXT,

--- a/server/routes/reports/localAuthorityReport/user.js
+++ b/server/routes/reports/localAuthorityReport/user.js
@@ -1454,7 +1454,7 @@ const express = require('express');
 const router = express.Router();
 
 router.route('/').get(async (req, res) => {
-  console.log("report/localAuthority/user request started");
+  req.setTimeout(config.get('app.reports.localAuthority.timeout')*1000);
 
   try {
     // first ensure this report can only be ran by those establishments with a Local Authority employer type


### PR DESCRIPTION
https://trello.com/c/H1CVyIKZ
Increasing the endpoint timeout for LA Admin report - the DB call takes a little over two minutes, the default Express timeout.

Note - whilst in there implementing endpoint timeout, have also added one to the Bulk Upload downloads - a focus of other performance discussions today - to complement the existing config property based timeouts on Bulk Upload `validation` and `completion`.