### PR TITLE
HOTFIX Preventing deleting primary establishment on BU upload

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -56,6 +56,7 @@ class Establishment {
 
   static get EXPECT_JUST_ONE_ERROR() { return 950; }
   static get MISSING_PRIMARY_ERROR() { return 955; }
+  static get CANNOT_DELETE_PRIMARY_ERROR() { return 956; }
 
   static get NOT_OWNER_ERROR() { return 997; }
   static get DUPLICATE_ERROR() { return 998; }
@@ -1755,6 +1756,19 @@ class Establishment {
       errType: `MISSING_PRIMARY_ERROR`,
       error: `Missing the primary establishment: ${name}`,
       source: '',
+      name,
+    };
+  }
+
+  static cannotDeletePrimaryEstablishmentError(name) {
+    return {
+      origin: 'Establishments',
+      lineNumber: 1,
+      errCode: Establishment.CANNOT_DELETE_PRIMARY_ERROR,
+      errType: `CANNOT_DELETE_PRIMARY_ERROR`,
+      error: `STATUS cannot be DELETE for primary establishment: ${name}`,
+      source: '',
+      name,
     };
   }
 

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -1134,6 +1134,11 @@ const validateBulkUploadFiles = async (commit, username , establishmentId, isPar
     const onloadedPrimaryEstablishment = myAPIEstablishments[primaryEstablishment.key];
     if (!onloadedPrimaryEstablishment) {
       csvEstablishmentSchemaErrors.unshift(CsvEstablishmentValidator.missingPrimaryEstablishmentError(primaryEstablishment.name));
+    } else {
+      // primary establishment does exist in given CSV; check STATUS is not DELETE - cannot delete the primary establishment
+      if (onloadedPrimaryEstablishment.status === 'DELETE') {
+        csvEstablishmentSchemaErrors.unshift(CsvEstablishmentValidator.cannotDeletePrimaryEstablishmentError(primaryEstablishment.name));
+      }
     }
   } else {
     console.error(("Seriously, if seeing this then something has truely gone wrong - the primary establishment should always be in the set of current establishments!"));


### PR DESCRIPTION
https://trello.com/c/S1ppD7YK
Adding a trap to prevent setting a status of delete on the primary establishment CSV record

Note - when testing the new validation message, I noticed that the validation message had `undefined` for the establishment name. It was missing the validation message `name` attribute.

As I copied the existing CSV `Establishment::missingPrimaryEstablishmentError` method, then I updated that method too to add the `name` attribute.