### PR TITLE
added missing order by clause

### DIFF
--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -1828,6 +1828,7 @@ class Establishment extends EntityValidator {
           ],
           where,
           order: [
+            models.sequelize.literal('"ParentID" IS NOT NULL'),
             'NameValue'
           ]
         };


### PR DESCRIPTION
https://trello.com/c/A5oyFId9

Missed a order by clause on the "fetch establishements" query that prevented the primary being at the top of the list so results.shift() returned a sub rather than the parent