### PR TITLE
Bugfix | wdf report <-> parent sub routing

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -96,6 +96,11 @@ const routes: Routes = [
         data: { title: 'Workplace' },
       },
       {
+        path: 'reports',
+        loadChildren: '@features/reports/reports.module#ReportsModule',
+        data: { title: 'Reports' },
+      },
+      {
         path: 'add-workplace',
         loadChildren: '@features/add-workplace/add-workplace.module#AddWorkplaceModule',
         canActivate: [CheckPermissionsGuard],

--- a/src/app/core/breadcrumb/journey.report.ts
+++ b/src/app/core/breadcrumb/journey.report.ts
@@ -1,7 +1,7 @@
 import { JourneyRoute } from './breadcrumb.model';
 
 enum Path {
-  REPORTS_LANDING_URL = '/workplace/:workplaceUid/reports',
+  REPORTS_LANDING_URL = '/workplace/reports',
   ALL_WORKPLACES = '/workplace/:workplaceUid/reports/workplaces',
   WDF = '/workplace/:workplaceUid/reports/wdf',
   WDF_STAFF_RECORD = '/workplace/:workplaceUid/staff-record/:workerUid/wdf-summary',

--- a/src/app/core/breadcrumb/journey.report.ts
+++ b/src/app/core/breadcrumb/journey.report.ts
@@ -1,10 +1,10 @@
 import { JourneyRoute } from './breadcrumb.model';
 
 enum Path {
-  REPORTS_LANDING_URL = '/workplace/reports',
-  ALL_WORKPLACES = '/workplace/:workplaceUid/reports/workplaces',
-  WDF = '/workplace/:workplaceUid/reports/wdf',
-  WDF_STAFF_RECORD = '/workplace/:workplaceUid/staff-record/:workerUid/wdf-summary',
+  REPORTS_LANDING_URL = '/reports',
+  ALL_WORKPLACES = '/reports/all-workplaces',
+  WDF = '/reports/workplace/:workplaceUid/wdf',
+  WDF_STAFF_RECORD = '/reports/workplace/:workplaceUid/staff-record/:workerUid/wdf-summary',
 }
 
 export const reportJourney: JourneyRoute = {

--- a/src/app/core/guards/reports.guard.ts
+++ b/src/app/core/guards/reports.guard.ts
@@ -1,18 +1,29 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { UserService } from '@core/services/user.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ReportsGuard implements CanActivate {
-  constructor(private permissionsService: PermissionsService) {}
+  constructor(
+    private permissionsService: PermissionsService,
+    private establishmentService: EstablishmentService,
+    private router: Router
+  ) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    const workplaceUid = route.paramMap.get('establishmentuid');
-    return (
-      this.permissionsService.can(workplaceUid, 'canViewWdfReport') ||
-      this.permissionsService.can(workplaceUid, 'canRunLocalAuthorityReport')
-    );
+    const workplace = this.establishmentService.primaryWorkplace;
+    if (workplace) {
+      return (
+        this.permissionsService.can(workplace.uid, 'canViewWdfReport') ||
+        this.permissionsService.can(workplace.uid, 'canRunLocalAuthorityReport')
+      );
+    } else {
+      this.router.navigate(['/dashboard']);
+      return false;
+    }
   }
 }

--- a/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -47,7 +47,7 @@
         <li *ngIf="canViewWorkplaces">
           <a [routerLink]="['/workplace', 'view-all-workplaces']">View all workplaces</a>
         </li>
-        <li *ngIf="canViewReports"><a [routerLink]="['/workplace', workplace.uid, 'reports']">View reports</a></li>
+        <li *ngIf="canViewReports"><a [routerLink]="['/workplace', 'reports']">View reports</a></li>
       </ul>
     </ng-container>
     <ul *ngIf="[adminRole].includes(user.role)" class="govuk-list">

--- a/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -47,7 +47,7 @@
         <li *ngIf="canViewWorkplaces">
           <a [routerLink]="['/workplace', 'view-all-workplaces']">View all workplaces</a>
         </li>
-        <li *ngIf="canViewReports"><a [routerLink]="['/workplace', 'reports']">View reports</a></li>
+        <li *ngIf="canViewReports"><a [routerLink]="['/reports']">View reports</a></li>
       </ul>
     </ng-container>
     <ul *ngIf="[adminRole].includes(user.role)" class="govuk-list">

--- a/src/app/features/reports/pages/reports/reports.component.html
+++ b/src/app/features/reports/pages/reports/reports.component.html
@@ -1,4 +1,4 @@
-<app-reports-header *ngIf="workplace" [workplace]="workplace"></app-reports-header>
+<app-reports-header *ngIf="primaryWorkplace" [workplace]="primaryWorkplace"></app-reports-header>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-3">
   <div class="govuk-grid-column-full">

--- a/src/app/features/reports/pages/reports/reports.component.html
+++ b/src/app/features/reports/pages/reports/reports.component.html
@@ -14,12 +14,12 @@
         </a>
       </li>
       <li>
-        <a class="govuk-body-m" [routerLink]="['../wdf']">
+        <a class="govuk-body-m" [routerLink]="['workplace', primaryWorkplace.uid, 'wdf']">
           {{ isParent ? 'My workplace' : 'Workforce Development Fund' }}
         </a>
       </li>
       <li *ngIf="isParent">
-        <a class="govuk-body-m" [routerLink]="['workplaces']">All workplaces</a>
+        <a class="govuk-body-m" [routerLink]="['all-workplaces']">All workplaces</a>
       </li>
     </ul>
 

--- a/src/app/features/reports/pages/reports/reports.component.ts
+++ b/src/app/features/reports/pages/reports/reports.component.ts
@@ -18,6 +18,7 @@ import { take } from 'rxjs/operators';
 })
 export class ReportsComponent implements OnInit, OnDestroy {
   public workplace: Establishment;
+  public primaryWorkplace: Establishment;
   public canRunLocalAuthorityReport: boolean;
   public isAdmin: boolean;
   public isParent: boolean;
@@ -36,12 +37,11 @@ export class ReportsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.breadcrumbService.show(JourneyType.REPORTS);
     this.isAdmin = [Roles.Admin].includes(this.userService.loggedInUser.role);
+    this.primaryWorkplace = this.establishmentService.primaryWorkplace;
     this.subscriptions.add(
       this.establishmentService.establishment$.pipe(take(1)).subscribe(workplace => {
         this.workplace = workplace;
-        this.isParent = this.establishmentService.primaryWorkplace
-          ? this.establishmentService.primaryWorkplace.isParent
-          : workplace.isParent;
+        this.isParent = this.primaryWorkplace ? this.primaryWorkplace.isParent : workplace.isParent;
         this.isLocalAuthority = workplace.employerType && workplace.employerType.value.startsWith('Local Authority');
         this.canRunLocalAuthorityReport =
           this.isParent &&

--- a/src/app/features/reports/pages/wdf/wdf.component.ts
+++ b/src/app/features/reports/pages/wdf/wdf.component.ts
@@ -58,8 +58,8 @@ export class WdfComponent implements OnInit, OnDestroy {
     this.breadcrumbService.show(breadcrumbConfig);
 
     this.canViewWorker = this.permissionsService.can(workplaceUid, 'canViewWorker');
-    this.returnUrl = { url: ['/workplace', workplaceUid, 'reports', 'wdf'] };
-    this.exitUrl = { url: ['/workplace', workplaceUid, 'reports'] };
+    this.returnUrl = { url: ['/reports', 'workplace', workplaceUid, 'wdf'] };
+    this.exitUrl = { url: ['/reports', 'reports'] };
     this.workerService.setReturnTo(null);
 
     this.subscriptions.add(

--- a/src/app/features/reports/pages/workplaces/workplaces.component.html
+++ b/src/app/features/reports/pages/workplaces/workplaces.component.html
@@ -31,7 +31,7 @@
         <app-eligibility-icon [eligible]="workplace.wdf.overall"></app-eligibility-icon>
       </td>
       <td class="govuk-table__cell">
-        <a [routerLink]="['/workplace', workplace.uid, 'reports', 'wdf']">View report</a>
+        <a [routerLink]="['/reports', 'workplace', workplace.uid, 'wdf']">View report</a>
       </td>
     </tr>
   </tbody>

--- a/src/app/features/reports/reports-routing.module.ts
+++ b/src/app/features/reports/reports-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CheckPermissionsGuard } from '@core/guards/permissions/check-permissions/check-permissions.guard';
+import { HasPermissionsGuard } from '@core/guards/permissions/has-permissions/has-permissions.guard';
 import { ReportsGuard } from '@core/guards/reports.guard';
 
 import { ReportsComponent } from './pages/reports/reports.component';
@@ -14,17 +15,18 @@ const routes: Routes = [
     component: ReportsComponent,
   },
   {
-    path: 'workplaces',
+    path: 'all-workplaces',
     component: WorkplacesComponent,
   },
   {
-    path: 'wdf',
-    canActivate: [CheckPermissionsGuard],
+    path: 'workplace/:establishmentuid/wdf',
+    canActivate: [HasPermissionsGuard],
     data: { permissions: ['canViewWdfReport'], title: 'Workforce Development Fund Report' },
     children: [
       {
         path: '',
         component: WdfComponent,
+        canActivate: [CheckPermissionsGuard],
       },
     ],
   },

--- a/src/app/features/reports/reports.module.ts
+++ b/src/app/features/reports/reports.module.ts
@@ -1,7 +1,9 @@
+import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { WorkerResolver } from '@core/resolvers/worker.resolver';
+import { DialogService } from '@core/services/dialog.service';
 import { ReportsHeaderComponent } from '@features/reports/components/reports-header/reports-header.component';
 import { WdfEligibilityComponent } from '@features/reports/components/wdf-eligibility/wdf-eligibility.component';
 import { WdfUpdateWarningComponent } from '@features/reports/components/wdf-update-warning/wdf-update-warning.component';
@@ -13,7 +15,7 @@ import { WorkplacesComponent } from './pages/workplaces/workplaces.component';
 import { ReportsRoutingModule } from './reports-routing.module';
 
 @NgModule({
-  imports: [CommonModule, ReactiveFormsModule, SharedModule, ReportsRoutingModule],
+  imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, ReportsRoutingModule],
   declarations: [
     ReportsComponent,
     WdfEligibilityComponent,
@@ -22,6 +24,6 @@ import { ReportsRoutingModule } from './reports-routing.module';
     WdfUpdateWarningComponent,
     WorkplacesComponent,
   ],
-  providers: [WorkerResolver],
+  providers: [WorkerResolver, DialogService],
 })
 export class ReportsModule {}

--- a/src/app/features/workers/wdf-staff-summary/wdf-staff-summary.component.ts
+++ b/src/app/features/workers/wdf-staff-summary/wdf-staff-summary.component.ts
@@ -54,7 +54,7 @@ export class WdfStaffSummaryComponent implements OnInit {
       .subscribe(worker => {
         this.worker = worker;
         this.isEligible = this.worker.wdf.isEligible && this.worker.wdf.currentEligibility;
-        this.exitUrl = { url: ['/workplace', this.workplace.uid, 'reports', 'wdf'], fragment: 'staff-records' };
+        this.exitUrl = { url: ['/reports', 'workplace', this.workplace.uid, 'wdf'], fragment: 'staff-records' };
       });
   }
 

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -48,11 +48,6 @@ const routes: Routes = [
     data: { title: 'View My Workplaces' },
   },
   {
-    path: 'reports',
-    loadChildren: '@features/reports/reports.module#ReportsModule',
-    data: { title: 'Reports' },
-  },
-  {
     path: 'start-screen',
     data: { title: 'Start' },
   },

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -48,6 +48,11 @@ const routes: Routes = [
     data: { title: 'View My Workplaces' },
   },
   {
+    path: 'reports',
+    loadChildren: '@features/reports/reports.module#ReportsModule',
+    data: { title: 'Reports' },
+  },
+  {
     path: 'start-screen',
     data: { title: 'Start' },
   },
@@ -276,11 +281,6 @@ const routes: Routes = [
           permissions: ['canViewWorker'],
           title: 'Staff Records',
         },
-      },
-      {
-        path: 'reports',
-        loadChildren: '@features/reports/reports.module#ReportsModule',
-        data: { title: 'Reports' },
       },
     ],
   },


### PR DESCRIPTION
WIP pr for ensuring that the reports landing page always displays primary workplace info. This meant relocating the reports routes outside of the workplace module and lots of subsquent refactoring afterwords.

the original issue is resolved, and I believe this is the most elegant fix. however as its my last day this branch should be picked up by another dev in order to iron out any routing issues [if they exist].