### PR TITLE
Nodejs Heap Memory fix to allow LA report to download. I ahve increas…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "ng": "ng",
-    "start": "npm run build && node server.js",
+    "start": "npm run build && node --max-old-space-size=4096 server.js",
     "dev": "npm-run-all -p -l build:watch api:proxy",
     "build": "ng build  --extract-css",
     "build:clean": "rimraf dist",


### PR DESCRIPTION
the gov paas container storage is 4gb hence i set the max node to 4gb. This allows Js to have more heap memory and able download report.