### PR TITLE
Fix: Add up to date status to mandatory training table

### DIFF
--- a/src/app/features/workplace/view-all-mandatory-trainings/view-all-mandatory-training.component.html
+++ b/src/app/features/workplace/view-all-mandatory-trainings/view-all-mandatory-training.component.html
@@ -136,9 +136,7 @@
                           {{ worker.missingMandatoryTrainingCount }}
                           Missing
                         </div>
-                        <div *ngIf="worker.trainingCount === 0">
-                          Up-to-date
-                        </div>
+                        <div *ngIf="worker.expiredTrainingCount === 0 && worker.expiringTrainingCount === 0 && worker.missingMandatoryTrainingCount === 0">Up-to-date</div>
                       </td>
                     </tr>
                   </ng-container>


### PR DESCRIPTION
**Issue**

When expanding mandatory training for a training category, the up to date status was not being shown.

**Work Done**

- Updated `view-all-mandatory-training.component.html` template to have the same logic as `training-and-qualifications-summary.component.html` for determining whether a worker has up to date training records.