### PR TITLE
Fix: Confirm WDF dialog

### DIFF
--- a/src/app/features/reports/reports.module.ts
+++ b/src/app/features/reports/reports.module.ts
@@ -8,6 +8,9 @@ import { ReportsHeaderComponent } from '@features/reports/components/reports-hea
 import { WdfEligibilityComponent } from '@features/reports/components/wdf-eligibility/wdf-eligibility.component';
 import { WdfUpdateWarningComponent } from '@features/reports/components/wdf-update-warning/wdf-update-warning.component';
 import { WdfComponent } from '@features/reports/pages/wdf/wdf.component';
+import {
+  WdfWorkplaceConfirmationDialogComponent,
+} from '@features/workplace/wdf-workplace-confirmation-dialog/wdf-workplace-confirmation-dialog.component';
 import { SharedModule } from '@shared/shared.module';
 
 import { ReportsComponent } from './pages/reports/reports.component';
@@ -23,7 +26,9 @@ import { ReportsRoutingModule } from './reports-routing.module';
     ReportsHeaderComponent,
     WdfUpdateWarningComponent,
     WorkplacesComponent,
+    WdfWorkplaceConfirmationDialogComponent,
   ],
   providers: [WorkerResolver, DialogService],
+  entryComponents: [WdfWorkplaceConfirmationDialogComponent],
 })
 export class ReportsModule {}

--- a/src/app/features/workplace/workplace.module.ts
+++ b/src/app/features/workplace/workplace.module.ts
@@ -43,9 +43,6 @@ import {
 import { VacanciesComponent } from './vacancies/vacancies.component';
 import { ViewMyWorkplacesComponent } from './view-my-workplaces/view-my-workplaces.component';
 import { ViewWorkplaceComponent } from './view-workplace/view-workplace.component';
-import {
-  WdfWorkplaceConfirmationDialogComponent,
-} from './wdf-workplace-confirmation-dialog/wdf-workplace-confirmation-dialog.component';
 import { WorkplaceInfoPanelComponent } from './workplace-info-panel/workplace-info-panel.component';
 import { WorkplaceNotFoundComponent } from './workplace-not-found/workplace-not-found.component';
 import { WorkplaceRoutingModule } from './workplace-routing.module';
@@ -79,7 +76,6 @@ import { WorkplaceRoutingModule } from './workplace-routing.module';
     ViewMyWorkplacesComponent,
     ViewWorkplaceComponent,
     WorkplaceInfoPanelComponent,
-    WdfWorkplaceConfirmationDialogComponent,
     SelectMainServiceComponent,
     UserAccountEditDetailsComponent,
     RegulatedByCqcComponent,
@@ -92,7 +88,6 @@ import { WorkplaceRoutingModule } from './workplace-routing.module';
     DeleteWorkplaceDialogComponent,
     UserAccountChangePrimaryDialogComponent,
     UserAccountDeleteDialogComponent,
-    WdfWorkplaceConfirmationDialogComponent,
   ],
 })
 export class WorkplaceModule {}


### PR DESCRIPTION
**Issue**

It seems the `WdfWorkplaceConfirmationDialogComponent` was used on the WDF report page but was imported in the `workplace.module.ts` NgModule and not the `reports.module.ts`

I have checked the usage of this component and it looks like we can remove it from `workplace.module.ts`

The WDF dialog used in the components that are under `workplace.module.ts` is `WdfWorkerConfirmationDialogComponent` which is a different dialog.

**Work done**

- Moved `WdfWorkplaceConfirmationDialogComponent` to `reports.module.ts`