### PR TITLE
Allow Administrators to delete Workplaces

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -17,6 +17,7 @@ export class AuthService {
   private _isAuthenticated$: BehaviorSubject<boolean> = new BehaviorSubject(null);
   private jwt = new JwtHelperService();
   private previousUser: string;
+  private previousToken: string = null;
   private redirect: string;
 
   constructor(
@@ -102,6 +103,20 @@ export class AuthService {
     this.userService.resetAgreedUpdatedTermsStatus = null;
     this.establishmentService.resetState();
     this.permissionsService.clearPermissions();
+  }
+
+  public setPreviousToken(): void {
+    if(this.previousToken === null)
+      this.previousToken = this.token
+  }
+
+  public restorePreviousToken(): void {
+    if(this.previousToken !== null)
+      this.token = this.previousToken
+  }
+
+  public getPreviousToken(): any {
+    return this.jwt.decodeToken(this.previousToken)
   }
 
   private setPreviousUser(): void {

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -7,12 +7,25 @@
       }}</span>
       {{ workplace?.name }}
     </h1>
+
+    <div *ngIf="isAdmin">
+      <button
+        class="govuk-button govuk-button--link govuk__flex govuk__align-items-center"
+        (click)="onDeleteWorkplace($event)"
+      >
+        <img src="/assets/images/bin.svg" alt="" />
+        <span class="govuk-!-margin-left-1">
+        Delete <span class="govuk-visually-hidden">{{ workplace.name }}</span> Workplace
+      </span>
+      </button>
+    </div>
     <p class="govuk-!-font-size-16 govuk-!-margin-top-4 govuk-!-margin-bottom-0">
-      Workplace ID: {{ workplace?.nmdsId }}
+      Workplace ID: {{ workplace?.nmdsId }} 
     </p>
     <p *ngIf="lastLoggedIn" class="govuk-!-font-size-16 govuk-!-margin-top-2">
       Last signed in on {{ lastLoggedIn | date: 'd MMMM y' }}
     </p>
+
   </div>
 
   <div class="govuk-grid-column-one-third contact-col" [class.contact-col--parent]="workplace?.isParent">

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -8,7 +8,7 @@
       {{ workplace?.name }}
     </h1>
 
-    <div *ngIf="isAdmin">
+    <div *ngIf="canDeleteEstablishment">
       <button
         class="govuk-button govuk-button--link govuk__flex govuk__align-items-center"
         (click)="onDeleteWorkplace($event)"

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -20,6 +20,7 @@ import { AuthService } from '@core/services/auth.service';
 })
 export class DashboardComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
+  public canDeleteEstablishment: boolean;
   public canViewEstablishment: boolean;
   public canViewListOfUsers: boolean;
   public canViewListOfWorkers: boolean;
@@ -27,7 +28,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   public totalStaffRecords: number;
   public workplace: Establishment;
   public trainingAlert: number;
-  public isAdmin: any;
 
 
   constructor(
@@ -48,6 +48,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.canViewListOfUsers = this.permissionsService.can(workplaceUid, 'canViewListOfUsers');
     this.canViewListOfWorkers = this.permissionsService.can(workplaceUid, 'canViewListOfWorkers');
     this.canViewEstablishment = this.permissionsService.can(workplaceUid, 'canViewEstablishment');
+    this.canDeleteEstablishment = this.permissionsService.can(workplaceUid, 'canDeleteEstablishment');
 
     if (this.workplace) {
       this.subscriptions.add(
@@ -76,7 +77,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
         )
       );
     }
-    this.isAdmin = this.userService.loggedInUser.role === 'Admin';
     const lastLoggedIn = this.userService.loggedInUser.lastLoggedIn;
     this.lastLoggedIn = lastLoggedIn ? lastLoggedIn : null;
 
@@ -104,9 +104,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   public onDeleteWorkplace(event: Event): void {
     event.preventDefault();
-    const isAdmin = this.userService.loggedInUser.role === 'Admin';
 
-    if (!isAdmin) {
+    if (!this.canDeleteEstablishment) {
       return;
     }
 
@@ -120,7 +119,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   private deleteWorkplace(): void {
-    if (this.userService.loggedInUser.role !== 'Admin') {
+    if (!this.canDeleteEstablishment) {
       return;
     }
 

--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -167,6 +167,7 @@ export class SearchComponent implements OnInit {
 
   private onSwapSuccess(data) {
     if (data.body && data.body.establishment && data.body.establishment.uid) {
+      this.authService.setPreviousToken();
       this.authService.token = data.headers.get('authorization');
       const workplaceUid = data.body.establishment.uid;
       this.establishmentService

--- a/src/app/features/workplace/workplace.module.ts
+++ b/src/app/features/workplace/workplace.module.ts
@@ -19,7 +19,6 @@ import {
   DataSharingWithLocalAuthoritiesComponent,
 } from './data-sharing-with-local-authorities/data-sharing-with-local-authorities.component';
 import { DataSharingComponent } from './data-sharing/data-sharing.component';
-import { DeleteWorkplaceDialogComponent } from './delete-workplace-dialog/delete-workplace-dialog.component';
 import { EditWorkplaceComponent } from './edit-workplace/edit-workplace.component';
 import { EnterWorkplaceAddressComponent } from './enter-workplace-address/enter-workplace-address.component';
 import { LeaversComponent } from './leavers/leavers.component';
@@ -57,7 +56,6 @@ import { WorkplaceRoutingModule } from './workplace-routing.module';
     CreateUserAccountComponent,
     DataSharingComponent,
     DataSharingWithLocalAuthoritiesComponent,
-    DeleteWorkplaceDialogComponent,
     EditWorkplaceComponent,
     LeaversComponent,
     OtherServicesComponent,
@@ -85,7 +83,6 @@ import { WorkplaceRoutingModule } from './workplace-routing.module';
   ],
   providers: [DialogService, WorkplaceResolver, UserAccountResolver],
   entryComponents: [
-    DeleteWorkplaceDialogComponent,
     UserAccountChangePrimaryDialogComponent,
     UserAccountDeleteDialogComponent,
   ],

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -62,6 +62,9 @@ import { WorkerPayPipe } from './pipes/worker-pay.pipe';
 import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-bearer.pipe';
 import { ViewAllMandatoryTrainingComponent } from '@features/workplace/view-all-mandatory-trainings/view-all-mandatory-training.component';
 import { TrainingLinkPanelComponent } from './components/trianing-link-panel/trianing-link-panel.component.component';
+import {
+  DeleteWorkplaceDialogComponent,
+} from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, RouterModule, OverlayModule],
@@ -125,6 +128,7 @@ import { TrainingLinkPanelComponent } from './components/trianing-link-panel/tri
     LinkToParentRemoveDialogComponent,
     OwnershipChangeMessageDialogComponent,
     ViewAllMandatoryTrainingComponent,
+    DeleteWorkplaceDialogComponent
   ],
   exports: [
     AlertComponent,
@@ -184,9 +188,11 @@ import { TrainingLinkPanelComponent } from './components/trianing-link-panel/tri
     LinkToParentRemoveDialogComponent,
     OwnershipChangeMessageDialogComponent,
     ViewAllMandatoryTrainingComponent,
+    DeleteWorkplaceDialogComponent
   ],
   providers: [DialogService],
   entryComponents: [
+    DeleteWorkplaceDialogComponent,
     ChangeDataOwnerDialogComponent,
     CancelDataOwnerDialogComponent,
     RejectRequestDialogComponent,
@@ -194,7 +200,7 @@ import { TrainingLinkPanelComponent } from './components/trianing-link-panel/tri
     LinkToParentDialogComponent,
     LinkToParentCancelDialogComponent,
     LinkToParentRemoveDialogComponent,
-    OwnershipChangeMessageDialogComponent,
+    OwnershipChangeMessageDialogComponent
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
This adds the capability for administrators to delete Workplaces.

The flow to do so is as follows:
- Click Search Establishments
- Search for Establishment, by postcode, ID, etc
- Click Establishment, this switches context to the Establishment
- Click Delete Workplace and Confirm
- This will _archive_ the Workplace and return the user to the Search Establishment screen with their original login context.