### PR TITLE
View training by categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8683,6 +8683,23 @@
         }
       }
     },
+    "node-mocks-http": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.8.1.tgz",
+      "integrity": "sha512-qtd9YwXzCTdLfqjP7XSOtFei3TggwnjFIppmYEneQBaDIuknwgJTpItLskC5/pWOpU3lsK5aqdo+5CfIKHkXLg==",
+      "dev": true,
+      "requires": {
+        "accepts": "^1.3.7",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      }
+    },
     "node-releases": {
       "version": "1.1.48",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "karma-jasmine": "~1.1.2",
     "karma-jasmine-html-reporter": "^0.2.2",
     "mocha": "^6.2.2",
+    "node-mocks-http": "^1.8.1",
     "nodemon": "^1.18.9",
     "npm": "^6.11.1",
     "npm-run-all": "^4.1.5",

--- a/server.js
+++ b/server.js
@@ -180,7 +180,7 @@ app.use('/api/jobs', [refCacheMiddleware.refcache, jobs]);
 app.use('/api/localAuthority', [refCacheMiddleware.refcache, la]);
 app.use('/api/worker/leaveReasons', [refCacheMiddleware.refcache, workerLeaveReasons]);
 app.use('/api/serviceUsers', [refCacheMiddleware.refcache, serviceUsers]);
-app.use('/api/trainingCategories', [refCacheMiddleware.refcache, workingTrainingCategories]);
+app.use('/api/trainingCategories', [cacheMiddleware.nocache, workingTrainingCategories]);
 app.use('/api/nurseSpecialism', [refCacheMiddleware.refcache, nurseSpecialism]);
 app.use('/api/availableQualifications', [refCacheMiddleware.refcache, availableQualifications]);
 

--- a/server.js
+++ b/server.js
@@ -180,7 +180,7 @@ app.use('/api/jobs', [refCacheMiddleware.refcache, jobs]);
 app.use('/api/localAuthority', [refCacheMiddleware.refcache, la]);
 app.use('/api/worker/leaveReasons', [refCacheMiddleware.refcache, workerLeaveReasons]);
 app.use('/api/serviceUsers', [refCacheMiddleware.refcache, serviceUsers]);
-app.use('/api/trainingCategories', [cacheMiddleware.nocache, workingTrainingCategories]);
+app.use('/api/trainingCategories', workingTrainingCategories);
 app.use('/api/nurseSpecialism', [refCacheMiddleware.refcache, nurseSpecialism]);
 app.use('/api/availableQualifications', [refCacheMiddleware.refcache, availableQualifications]);
 

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -707,5 +707,32 @@ module.exports = function(sequelize, DataTypes) {
     });
   };
 
+  Establishment.findWithWorkersAndTraining = function (establishmentId) {
+    return this.findByPk(establishmentId, {
+      attributes: ['id'],
+      include: {
+        model: sequelize.models.worker,
+        attributes: ['id', 'uid', 'NameOrIdValue'],
+        as: 'workers',
+        where: {
+          archived: false,
+        },
+        include: [
+          {
+            model: sequelize.models.job,
+            as: 'mainJob',
+            attributes: ['id', 'title'],
+            required: false,
+          },
+          {
+            model: sequelize.models.workerTraining,
+            as: 'workerTraining',
+            attributes: ['id', 'uid', 'title', 'expires', 'categoryFk'],
+          },
+        ],
+      },
+    });
+  }
+
   return Establishment;
 };

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -1014,6 +1014,12 @@ module.exports = function(sequelize, DataTypes) {
       as: 'auditEvents',
       onDelete: 'CASCADE'
     });
+    Worker.hasMany(models.workerTraining, {
+      foreignKey: 'workerFk',
+      sourceKey: 'id',
+      as: 'workerTraining',
+      onDelete: 'CASCADE'
+    });
     Worker.belongsTo(models.ethnicity, {
       foreignKey: 'EthnicityFkValue',
       targetKey: 'id',

--- a/server/models/workerTrainingCategories.js
+++ b/server/models/workerTrainingCategories.js
@@ -1,7 +1,5 @@
 /* jshint indent: 2 */
 
-const models = require('../models/index');
-
 module.exports = function(sequelize, DataTypes) {
   const Categories =  sequelize.define('workerTrainingCategories', {
     id: {
@@ -27,6 +25,21 @@ module.exports = function(sequelize, DataTypes) {
     createdAt: false,
     updatedAt: false
   });
+
+  Categories.findAllWithMandatoryTraining = function (establishmentId) {
+    return this.findAll({
+      include: [
+        {
+          model: sequelize.models.MandatoryTraining,
+          as: 'MandatoryTraining',
+          where: {
+            EstablishmentFK: establishmentId,
+          },
+          required: false,
+        },
+      ],
+    });
+  };
 
   Categories.associate = (models) => {
     Categories.hasMany(models.MandatoryTraining, {

--- a/server/models/workerTrainingCategories.js
+++ b/server/models/workerTrainingCategories.js
@@ -1,5 +1,7 @@
 /* jshint indent: 2 */
 
+const models = require('../models/index');
+
 module.exports = function(sequelize, DataTypes) {
   const Categories =  sequelize.define('workerTrainingCategories', {
     id: {
@@ -25,6 +27,14 @@ module.exports = function(sequelize, DataTypes) {
     createdAt: false,
     updatedAt: false
   });
+
+  Categories.associate = (models) => {
+    Categories.hasMany(models.MandatoryTraining, {
+      foreignKey: 'TrainingCategoryFK',
+      sourceKey: 'id',
+      as: 'MandatoryTraining',
+    });
+  };
 
   return Categories;
 };

--- a/server/routes/workerTrainingCategories.js
+++ b/server/routes/workerTrainingCategories.js
@@ -1,6 +1,7 @@
 var express = require('express');
 var router = express.Router();
 const models = require('../models/index');
+const trainingCategoryTransformer = require('../transformers/trainingCategoryTransformer');
 
 /* GET ALL Training Categories */
 router.route('/').get(async function (req, res) {
@@ -22,106 +23,15 @@ const getTrainingByCategory = async (req, res) => {
   try {
     const establishmentId = req.params.establishmentId;
 
-    let establishment = await models.establishment.findByPk(establishmentId, {
-      attributes: ['id'],
-      include: {
-        model: models.worker,
-        attributes: ['id', 'uid', 'NameOrIdValue'],
-        as: 'workers',
-        where: {
-          archived: false,
-        },
-        include: [
-          {
-            model: models.job,
-            as: 'mainJob',
-            attributes: ['id', 'title'],
-            required: false,
-          },
-          {
-            model: models.workerTraining,
-            as: 'workerTraining',
-            attributes: ['id', 'uid', 'title', 'expires', 'categoryFk'],
-          },
-        ],
-      },
-    });
-
-    let trainingCategories = await models.workerTrainingCategories.findAllWithMandatoryTraining(establishmentId);
-
+    let establishment = await models.establishment.findWithWorkersAndTraining(establishmentId);
     if (!establishment) {
       return res.sendStatus(404);
     }
 
-    let results = trainingCategories.map((trainingCategory) => {
-      let training = []
-
-      establishment.workers.forEach((worker) => {
-        let workerTraining = worker.workerTraining.filter((workerTraining) => {
-          return workerTraining.categoryFk == trainingCategory.id
-        }).map(workerTraining => {
-          return {
-            id: workerTraining.id,
-            uid: workerTraining.uid,
-            title: workerTraining.title,
-            expires: workerTraining.expires,
-            worker: {
-              id: worker.id,
-              uid: worker.uid,
-              NameOrIdValue: worker.NameOrIdValue,
-              mainJob: {
-                id: worker.mainJob.id,
-                title: worker.mainJob.title,
-              },
-            },
-          }
-        });
-
-        training = training.concat(workerTraining);
-
-        if (trainingCategory.MandatoryTraining !== undefined && trainingCategory.MandatoryTraining.length > 0) {
-          let missingTraining = [];
-
-          missingTraining = trainingCategory.MandatoryTraining.filter(mandatoryTraining => {
-            if (worker.mainJob !== undefined && (worker.mainJob.id !== mandatoryTraining.jobFK)) {
-              return false;
-            }
-
-            return worker.workerTraining.filter((workerTraining) => {
-              return workerTraining.categoryFk == mandatoryTraining.trainingCategoryFK
-            }).length == 0;
-          }).map(missingTraining => {
-            return {
-              id: missingTraining.id,
-              missing: true,
-              worker: {
-                id: worker.id,
-                uid: worker.uid,
-                NameOrIdValue: worker.NameOrIdValue,
-                mainJob: {
-                  id: worker.mainJob.id,
-                  title: worker.mainJob.title,
-                },
-              },
-            };
-          });
-
-          training = training.concat(missingTraining);
-        }
-      });
-
-      return {
-        id: trainingCategory.id,
-        seq: trainingCategory.seq,
-        category: trainingCategory.category,
-        training: training,
-      };
-    }).filter(trainingCategory => {
-      return trainingCategory.training.length > 0;
-    });
+    let trainingCategories = await models.workerTrainingCategories.findAllWithMandatoryTraining(establishmentId);
 
     res.json({
-      trainingCategories: results,
+      trainingCategories: trainingCategoryTransformer(establishment, trainingCategories),
     });
   } catch (err) {
     console.error(err);

--- a/server/routes/workerTrainingCategories.js
+++ b/server/routes/workerTrainingCategories.js
@@ -19,6 +19,10 @@ router.route('/').get(async function (req, res) {
 });
 
 router.route('/:establishmentId/with-training').get(async function (req, res) {
+  return await getTrainingByCategory(req, res);
+});
+
+const getTrainingByCategory = async (req, res) => {
   try {
     let establishment = await models.establishment.findByPk(req.params.establishmentId, {
       attributes: ['id'],
@@ -57,6 +61,10 @@ router.route('/:establishmentId/with-training').get(async function (req, res) {
         },
       ],
     });
+
+    if (!establishment) {
+      return res.sendStatus(404);
+    }
 
     let results = trainingCategories.map((trainingCategory) => {
       let training = []
@@ -132,7 +140,7 @@ router.route('/:establishmentId/with-training').get(async function (req, res) {
     console.error(err);
     return res.status(503).send();
   }
-});
+}
 
 function trainingCategoriesJSON(givenCategories) {
   let categories = [];
@@ -150,3 +158,4 @@ function trainingCategoriesJSON(givenCategories) {
 }
 
 module.exports = router;
+module.exports.getTrainingByCategory = getTrainingByCategory;

--- a/server/routes/workerTrainingCategories.js
+++ b/server/routes/workerTrainingCategories.js
@@ -18,10 +18,6 @@ router.route('/').get(async function (req, res) {
   }
 });
 
-router.route('/:establishmentId/with-training').get(async function (req, res) {
-  return await getTrainingByCategory(req, res);
-});
-
 const getTrainingByCategory = async (req, res) => {
   try {
     let establishment = await models.establishment.findByPk(req.params.establishmentId, {
@@ -92,7 +88,7 @@ const getTrainingByCategory = async (req, res) => {
 
         training = training.concat(workerTraining);
 
-        if (trainingCategory.MandatoryTraining.length) {
+        if (trainingCategory.MandatoryTraining !== undefined && trainingCategory.MandatoryTraining.length > 0) {
           let missingTraining = [];
 
           missingTraining = trainingCategory.MandatoryTraining.filter(mandatoryTraining => {
@@ -133,7 +129,7 @@ const getTrainingByCategory = async (req, res) => {
       return trainingCategory.training.length > 0;
     });
 
-    res.send({
+    res.json({
       trainingCategories: results,
     });
   } catch (err) {
@@ -141,6 +137,8 @@ const getTrainingByCategory = async (req, res) => {
     return res.status(503).send();
   }
 }
+
+router.route('/:establishmentId/with-training').get(getTrainingByCategory);
 
 function trainingCategoriesJSON(givenCategories) {
   let categories = [];

--- a/server/routes/workerTrainingCategories.js
+++ b/server/routes/workerTrainingCategories.js
@@ -20,7 +20,9 @@ router.route('/').get(async function (req, res) {
 
 const getTrainingByCategory = async (req, res) => {
   try {
-    let establishment = await models.establishment.findByPk(req.params.establishmentId, {
+    const establishmentId = req.params.establishmentId;
+
+    let establishment = await models.establishment.findByPk(establishmentId, {
       attributes: ['id'],
       include: {
         model: models.worker,
@@ -45,18 +47,7 @@ const getTrainingByCategory = async (req, res) => {
       },
     });
 
-    let trainingCategories = await models.workerTrainingCategories.findAll({
-      include: [
-        {
-          model: models.MandatoryTraining,
-          as: 'MandatoryTraining',
-          where: {
-            EstablishmentFK: req.params.establishmentId,
-          },
-          required: false,
-        },
-      ],
-    });
+    let trainingCategories = await models.workerTrainingCategories.findAllWithMandatoryTraining(establishmentId);
 
     if (!establishment) {
       return res.sendStatus(404);

--- a/server/routes/workerTrainingCategories.js
+++ b/server/routes/workerTrainingCategories.js
@@ -2,17 +2,15 @@ var express = require('express');
 var router = express.Router();
 const models = require('../models/index');
 
-/* GET ALL ethnicities*/
+/* GET ALL Training Categories */
 router.route('/').get(async function (req, res) {
   try {
     let results = await models.workerTrainingCategories.findAll({
-        order: [
-          ["seq", "ASC"]
-        ]
-      });
+      order: [['seq', 'ASC']],
+    });
 
     res.send({
-      trainingCategories: trainingCategoriesJSON(results)
+      trainingCategories: trainingCategoriesJSON(results),
     });
   } catch (err) {
     console.error(err);
@@ -20,8 +18,124 @@ router.route('/').get(async function (req, res) {
   }
 });
 
-function trainingCategoriesJSON(givenCategories){
-  let categories=[];
+router.route('/:establishmentId/with-training').get(async function (req, res) {
+  try {
+    let establishment = await models.establishment.findByPk(req.params.establishmentId, {
+      attributes: ['id'],
+      include: {
+        model: models.worker,
+        attributes: ['id', 'uid', 'NameOrIdValue'],
+        as: 'workers',
+        where: {
+          archived: false,
+        },
+        include: [
+          {
+            model: models.job,
+            as: 'mainJob',
+            attributes: ['id', 'title'],
+            required: false,
+          },
+          {
+            model: models.workerTraining,
+            as: 'workerTraining',
+            attributes: ['id', 'uid', 'title', 'expires', 'categoryFk'],
+          },
+        ],
+      },
+    });
+
+    let trainingCategories = await models.workerTrainingCategories.findAll({
+      include: [
+        {
+          model: models.MandatoryTraining,
+          as: 'MandatoryTraining',
+          where: {
+            EstablishmentFK: req.params.establishmentId,
+          },
+          required: false,
+        },
+      ],
+    });
+
+    let results = trainingCategories.map((trainingCategory) => {
+      let training = []
+
+      establishment.workers.forEach((worker) => {
+        let workerTraining = worker.workerTraining.filter((workerTraining) => {
+          return workerTraining.categoryFk == trainingCategory.id
+        }).map(workerTraining => {
+          return {
+            id: workerTraining.id,
+            uid: workerTraining.uid,
+            title: workerTraining.title,
+            expires: workerTraining.expires,
+            worker: {
+              id: worker.id,
+              uid: worker.uid,
+              NameOrIdValue: worker.NameOrIdValue,
+              mainJob: {
+                id: worker.mainJob.id,
+                title: worker.mainJob.title,
+              },
+            },
+          }
+        });
+
+        training = training.concat(workerTraining);
+
+        if (trainingCategory.MandatoryTraining.length) {
+          let missingTraining = [];
+
+          missingTraining = trainingCategory.MandatoryTraining.filter(mandatoryTraining => {
+            if (worker.mainJob !== undefined && (worker.mainJob.id !== mandatoryTraining.jobFK)) {
+              return false;
+            }
+
+            return worker.workerTraining.filter((workerTraining) => {
+              return workerTraining.categoryFk == mandatoryTraining.trainingCategoryFK
+            }).length == 0;
+          }).map(missingTraining => {
+            return {
+              id: missingTraining.id,
+              missing: true,
+              worker: {
+                id: worker.id,
+                uid: worker.uid,
+                NameOrIdValue: worker.NameOrIdValue,
+                mainJob: {
+                  id: worker.mainJob.id,
+                  title: worker.mainJob.title,
+                },
+              },
+            };
+          });
+
+          training = training.concat(missingTraining);
+        }
+      });
+
+      return {
+        id: trainingCategory.id,
+        seq: trainingCategory.seq,
+        category: trainingCategory.category,
+        training: training,
+      };
+    }).filter(trainingCategory => {
+      return trainingCategory.training.length > 0;
+    });
+
+    res.send({
+      trainingCategories: results,
+    });
+  } catch (err) {
+    console.error(err);
+    return res.status(503).send();
+  }
+});
+
+function trainingCategoriesJSON(givenCategories) {
+  let categories = [];
 
   //Go through any results found from DB and map to JSON
   givenCategories.forEach(thisCategory => {
@@ -33,6 +147,6 @@ function trainingCategoriesJSON(givenCategories){
   });
 
   return categories;
-};
+}
 
 module.exports = router;

--- a/server/test/factories/models.js
+++ b/server/test/factories/models.js
@@ -1,5 +1,11 @@
 const { build, fake, sequence, perBuild } = require('@jackfranklin/test-data-bot');
 
+const establishmentBuilder = build('Establishment', {
+  fields: {
+    id: sequence(),
+  }
+});
+
 const categoryBuilder = build('Category', {
   fields: {
     id: sequence(),
@@ -27,6 +33,21 @@ const trainingBuilder = build('Training', {
   }
 });
 
+const mandatoryTrainingBuilder = build('MandatoryTraining', {
+  fields: {
+    id: sequence(),
+    establishmentFk: perBuild(() => {
+      return establishmentBuilder().id;
+    }),
+    trainingCategoryFK: perBuild(() => {
+      return trainingBuilder().id;
+    }),
+    jobFK: perBuild(() => {
+      return jobBuilder().id;
+    }),
+  }
+});
+
 const workerBuilder = build('Worker', {
   fields: {
     id: sequence(),
@@ -47,3 +68,4 @@ module.exports.workerBuilder = workerBuilder;
 module.exports.jobBuilder = jobBuilder;
 module.exports.categoryBuilder = categoryBuilder;
 module.exports.trainingBuilder = trainingBuilder;
+module.exports.mandatoryTrainingBuilder = mandatoryTrainingBuilder;

--- a/server/test/factories/models.js
+++ b/server/test/factories/models.js
@@ -1,0 +1,49 @@
+const { build, fake, sequence, perBuild } = require('@jackfranklin/test-data-bot');
+
+const categoryBuilder = build('Category', {
+  fields: {
+    id: sequence(),
+    seq: sequence(),
+    category: fake(f => f.lorem.sentence()),
+  }
+})
+
+const jobBuilder = build('Job', {
+  fields: {
+    id: sequence(),
+    title: fake(f => f.lorem.sentence()),
+  }
+});
+
+const trainingBuilder = build('Training', {
+  fields: {
+    id: sequence(),
+    uid: fake(f => f.random.uuid()),
+    title: fake(f => f.lorem.sentence()),
+    expires: fake(f => f.date.future(1).toISOString()),
+    categoryFk: perBuild(() => {
+      return categoryBuilder().id;
+    }),
+  }
+});
+
+const workerBuilder = build('Worker', {
+  fields: {
+    id: sequence(),
+    uid: fake(f => f.random.uuid()),
+    NameOrIdValue: fake(f => f.name.findName()),
+    mainJob: perBuild(() => {
+      return jobBuilder();
+    }),
+    workerTraining: [
+      perBuild(() => {
+        return trainingBuilder();
+      }),
+    ],
+  },
+});
+
+module.exports.workerBuilder = workerBuilder;
+module.exports.jobBuilder = jobBuilder;
+module.exports.categoryBuilder = categoryBuilder;
+module.exports.trainingBuilder = trainingBuilder;

--- a/server/test/integration/routes/trainingCategories/index.spec.js
+++ b/server/test/integration/routes/trainingCategories/index.spec.js
@@ -43,7 +43,7 @@ describe('Training Categories API', () => {
     }
   });
 
-  describe.only('/api/trainingCategories/{establishmentId}/with-training', () => {
+  describe('/api/trainingCategories/{establishmentId}/with-training', () => {
     it('should return a 404 if establishment is not found', async () => {
       // Arrange
       const establishmentId = 123;

--- a/server/test/integration/routes/trainingCategories/index.spec.js
+++ b/server/test/integration/routes/trainingCategories/index.spec.js
@@ -1,0 +1,63 @@
+const supertest = require('supertest');
+const baseEndpoint = require('../../utils/baseUrl').baseurl;
+const apiEndpoint = supertest(baseEndpoint);
+const expect = require('chai').expect;
+
+// mocked real postcode/location data
+// http://localhost:3000/api/test/locations/random?limit=5
+const postcodes = require('../../mockdata/postcodes').data;
+const registrationUtils = require('../../utils/registration');
+const admin = require('../../utils/admin').admin;
+
+var adminLogin = null;
+
+describe('Training Categories API', () => {
+  let nonCqcServices = null;
+  let nonCQCSite = null;
+
+  before(async() => {
+    // Find a valid service (eg "Carers Support")
+    const nonCqcServicesResults = await apiEndpoint
+      .get('/services/byCategory?cqc=false')
+      .expect('Content-Type', /json/)
+      .expect(200);
+    nonCqcServices = nonCqcServicesResults.body;
+
+    // Set up the data to register a new user with a new establishment
+    nonCQCSite = registrationUtils.newNonCqcSite(postcodes[2], nonCqcServices);
+
+    // Register the new user / establishment
+    const registration = await apiEndpoint
+      .post('/registration')
+      .send([nonCQCSite])
+      .expect('Content-Type', /json/)
+      .expect(200);
+
+    // Login as an admin user to access approvals (would normally be accessed via "Registrations").
+    if (registration) {
+      adminLogin = await apiEndpoint
+        .post('/login')
+        .send(admin)
+        .expect('Content-Type', /json/)
+        .expect(200);
+    }
+  });
+
+  describe.only('/api/trainingCategories/{establishmentId}/with-training', () => {
+    it('should return a 404 if establishment is not found', async () => {
+      // Arrange
+      const establishmentId = 123;
+
+      if (adminLogin.headers.authorization) {
+        const response = await apiEndpoint
+
+        // Act
+        .get(`/trainingCategories/${establishmentId}/with-training`)
+        .set({ Authorization: adminLogin.headers.authorization })
+
+        // Assert
+        .expect(404);
+      }
+    });
+  })
+});

--- a/server/test/unit/routes/trainingCategories/index.spec.js
+++ b/server/test/unit/routes/trainingCategories/index.spec.js
@@ -1,0 +1,59 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const httpMocks = require('node-mocks-http');
+const models = require('../../../../models/index');
+const { workerBuilder, categoryBuilder, trainingBuilder } = require('../../../factories/models');
+const workerTrainingCategoriesRoute = require('../../../../routes/workerTrainingCategories');
+
+describe.only('test training categories', () => {
+  describe('getTrainingByCategory', () => {
+    it('returns a list of training categories that have training', async () => {
+      // Arrange
+      const category = categoryBuilder();
+      const training = trainingBuilder({
+        overrides: {
+          categoryFk: category.id,
+        },
+      });
+      const worker = workerBuilder({
+        overrides: {
+          workerTraining: [
+            training
+          ],
+        },
+      });
+
+      sinon.stub(models.establishment, 'findByPk').callsFake(() => {
+        return {
+          id: 123,
+          workers: [
+            worker,
+          ],
+        };
+      });
+
+      sinon.stub(models.workerTrainingCategories, 'findAll').callsFake(() => {
+        return [
+          category,
+        ];
+      });
+
+      const req  = httpMocks.createRequest({
+        method: 'GET',
+        url: `/api/trainingCategories/123/with-training`,
+      });
+
+      const res = httpMocks.createResponse();
+
+      // Act
+      await workerTrainingCategoriesRoute.getTrainingByCategory(req, res);
+
+      // Assert
+      const { trainingCategories } = res._getJSONData();
+
+      expect(res.statusCode).equals(200);
+      expect(trainingCategories.length).equals(1);
+      expect(trainingCategories[0].training.length).equals(1);
+    });
+  });
+});

--- a/server/test/unit/routes/trainingCategories/index.spec.js
+++ b/server/test/unit/routes/trainingCategories/index.spec.js
@@ -2,13 +2,19 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const httpMocks = require('node-mocks-http');
 const models = require('../../../../models/index');
-const { workerBuilder, categoryBuilder, trainingBuilder } = require('../../../factories/models');
+const { workerBuilder, categoryBuilder, trainingBuilder, mandatoryTrainingBuilder } = require('../../../factories/models');
 const workerTrainingCategoriesRoute = require('../../../../routes/workerTrainingCategories');
 
 describe.only('test training categories', () => {
   describe('getTrainingByCategory', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it('returns a list of training categories that have training', async () => {
       // Arrange
+      const establishmentId = 123;
+
       const category = categoryBuilder();
       const training = trainingBuilder({
         overrides: {
@@ -17,30 +23,24 @@ describe.only('test training categories', () => {
       });
       const worker = workerBuilder({
         overrides: {
-          workerTraining: [
-            training
-          ],
+          workerTraining: [training],
         },
       });
 
       sinon.stub(models.establishment, 'findByPk').callsFake(() => {
         return {
           id: 123,
-          workers: [
-            worker,
-          ],
+          workers: [worker],
         };
       });
 
       sinon.stub(models.workerTrainingCategories, 'findAll').callsFake(() => {
-        return [
-          category,
-        ];
+        return [category];
       });
 
-      const req  = httpMocks.createRequest({
+      const req = httpMocks.createRequest({
         method: 'GET',
-        url: `/api/trainingCategories/123/with-training`,
+        url: `/api/trainingCategories/${establishmentId}/with-training`,
       });
 
       const res = httpMocks.createResponse();
@@ -53,7 +53,93 @@ describe.only('test training categories', () => {
 
       expect(res.statusCode).equals(200);
       expect(trainingCategories.length).equals(1);
+
       expect(trainingCategories[0].training.length).equals(1);
+      expect(trainingCategories[0].training[0].id).eqls(training.id);
+      expect(trainingCategories[0].training[0].uid).equals(training.uid);
+      expect(trainingCategories[0].training[0].title).equals(training.title);
+      expect(trainingCategories[0].training[0].expires).equals(training.expires);
+
+      expect(trainingCategories[0].training[0].worker).eqls({
+        id: worker.id,
+        uid: worker.uid,
+        NameOrIdValue: worker.NameOrIdValue,
+        mainJob: {
+          id: worker.mainJob.id,
+          title: worker.mainJob.title,
+        },
+      });
+    });
+
+    it('returns a list of training categories with training missing', async () => {
+      // Arrange
+      const establishmentId = 123;
+      const category = categoryBuilder();
+      const training = trainingBuilder({
+        overrides: {
+          categoryFk: category.id,
+        },
+      });
+      const worker = workerBuilder({
+        overrides: {
+          workerTraining: [training],
+        },
+      });
+
+      const categoryWithMandatoryTraining = (() => {
+        let categoryWithMandatoryTraining = categoryBuilder();
+        const mandatoryTraining = mandatoryTrainingBuilder({
+          overrides: {
+            trainingCategoryFK: categoryWithMandatoryTraining.id,
+            jobFK: worker.mainJob.id,
+          },
+        });
+
+        categoryWithMandatoryTraining.MandatoryTraining = [mandatoryTraining];
+
+        return categoryWithMandatoryTraining;
+      })();
+
+      sinon.stub(models.establishment, 'findByPk').callsFake(() => {
+        return {
+          id: 123,
+          workers: [worker],
+        };
+      });
+
+      sinon.stub(models.workerTrainingCategories, 'findAll').callsFake(() => {
+        return [categoryWithMandatoryTraining];
+      });
+
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: `/api/trainingCategories/${establishmentId}/with-training`,
+      });
+
+      const res = httpMocks.createResponse();
+
+      // Act
+      await workerTrainingCategoriesRoute.getTrainingByCategory(req, res);
+
+      // Assert
+      const { trainingCategories } = res._getJSONData();
+
+      expect(res.statusCode).equals(200);
+      expect(trainingCategories.length).equals(1);
+
+      expect(trainingCategories[0].training.length).equals(1);
+      expect(trainingCategories[0].training[0].id).eqls(categoryWithMandatoryTraining.MandatoryTraining[0].id);
+      expect(trainingCategories[0].training[0].missing).equals(true);
+
+      expect(trainingCategories[0].training[0].worker).eqls({
+        id: worker.id,
+        uid: worker.uid,
+        NameOrIdValue: worker.NameOrIdValue,
+        mainJob: {
+          id: worker.mainJob.id,
+          title: worker.mainJob.title,
+        },
+      });
     });
   });
 });

--- a/server/test/unit/routes/trainingCategories/index.spec.js
+++ b/server/test/unit/routes/trainingCategories/index.spec.js
@@ -5,7 +5,7 @@ const models = require('../../../../models/index');
 const { workerBuilder, categoryBuilder, trainingBuilder, mandatoryTrainingBuilder } = require('../../../factories/models');
 const workerTrainingCategoriesRoute = require('../../../../routes/workerTrainingCategories');
 
-describe.only('test training categories', () => {
+describe('test training categories endpoint functions', () => {
   describe('getTrainingByCategory', () => {
     afterEach(() => {
       sinon.restore();
@@ -29,7 +29,7 @@ describe.only('test training categories', () => {
 
       sinon.stub(models.establishment, 'findByPk').callsFake(() => {
         return {
-          id: 123,
+          id: establishmentId,
           workers: [worker],
         };
       });
@@ -102,7 +102,7 @@ describe.only('test training categories', () => {
 
       sinon.stub(models.establishment, 'findByPk').callsFake(() => {
         return {
-          id: 123,
+          id: establishmentId,
           workers: [worker],
         };
       });

--- a/server/transformers/trainingCategoryTransformer.js
+++ b/server/transformers/trainingCategoryTransformer.js
@@ -1,0 +1,72 @@
+module.exports = function (establishment, trainingCategories) {
+  return trainingCategories.map((trainingCategory) => {
+    let training = [];
+
+    establishment.workers.forEach((worker) => {
+      let workerTraining = worker.workerTraining
+        .filter((workerTraining) => {
+          return workerTraining.categoryFk == trainingCategory.id;
+        })
+        .map((workerTraining) => {
+          return {
+            id: workerTraining.id,
+            uid: workerTraining.uid,
+            title: workerTraining.title,
+            expires: workerTraining.expires,
+            worker: {
+              id: worker.id,
+              uid: worker.uid,
+              NameOrIdValue: worker.NameOrIdValue,
+              mainJob: {
+                id: worker.mainJob.id,
+                title: worker.mainJob.title,
+              },
+            },
+          };
+        });
+
+      training = training.concat(workerTraining);
+
+      if (trainingCategory.MandatoryTraining !== undefined && trainingCategory.MandatoryTraining.length > 0) {
+        let missingTraining = [];
+
+        missingTraining = trainingCategory.MandatoryTraining.filter((mandatoryTraining) => {
+          if (worker.mainJob !== undefined && worker.mainJob.id !== mandatoryTraining.jobFK) {
+            return false;
+          }
+
+          return (
+            worker.workerTraining.filter((workerTraining) => {
+              return workerTraining.categoryFk == mandatoryTraining.trainingCategoryFK;
+            }).length == 0
+          );
+        }).map((missingTraining) => {
+          return {
+            id: missingTraining.id,
+            missing: true,
+            worker: {
+              id: worker.id,
+              uid: worker.uid,
+              NameOrIdValue: worker.NameOrIdValue,
+              mainJob: {
+                id: worker.mainJob.id,
+                title: worker.mainJob.title,
+              },
+            },
+          };
+        });
+
+        training = training.concat(missingTraining);
+      }
+    });
+
+    return {
+      id: trainingCategory.id,
+      seq: trainingCategory.seq,
+      category: trainingCategory.category,
+      training: training,
+    };
+  }).filter(trainingCategory => {
+    return trainingCategory.training.length > 0;
+  });
+};

--- a/server/transformers/trainingCategoryTransformer.js
+++ b/server/transformers/trainingCategoryTransformer.js
@@ -1,72 +1,87 @@
-module.exports = function (establishment, trainingCategories) {
-  return trainingCategories.map((trainingCategory) => {
-    let training = [];
-
-    establishment.workers.forEach((worker) => {
-      let workerTraining = worker.workerTraining
-        .filter((workerTraining) => {
-          return workerTraining.categoryFk == trainingCategory.id;
-        })
-        .map((workerTraining) => {
-          return {
-            id: workerTraining.id,
-            uid: workerTraining.uid,
-            title: workerTraining.title,
-            expires: workerTraining.expires,
-            worker: {
-              id: worker.id,
-              uid: worker.uid,
-              NameOrIdValue: worker.NameOrIdValue,
-              mainJob: {
-                id: worker.mainJob.id,
-                title: worker.mainJob.title,
-              },
-            },
-          };
-        });
-
-      training = training.concat(workerTraining);
-
-      if (trainingCategory.MandatoryTraining !== undefined && trainingCategory.MandatoryTraining.length > 0) {
-        let missingTraining = [];
-
-        missingTraining = trainingCategory.MandatoryTraining.filter((mandatoryTraining) => {
-          if (worker.mainJob !== undefined && worker.mainJob.id !== mandatoryTraining.jobFK) {
-            return false;
-          }
-
-          return (
-            worker.workerTraining.filter((workerTraining) => {
-              return workerTraining.categoryFk == mandatoryTraining.trainingCategoryFK;
-            }).length == 0
-          );
-        }).map((missingTraining) => {
-          return {
-            id: missingTraining.id,
-            missing: true,
-            worker: {
-              id: worker.id,
-              uid: worker.uid,
-              NameOrIdValue: worker.NameOrIdValue,
-              mainJob: {
-                id: worker.mainJob.id,
-                title: worker.mainJob.title,
-              },
-            },
-          };
-        });
-
-        training = training.concat(missingTraining);
-      }
-    });
-
+const transformTrainingCategories = function (givenCategories) {
+  return givenCategories.map((thisCategory) => {
     return {
-      id: trainingCategory.id,
-      seq: trainingCategory.seq,
-      category: trainingCategory.category,
-      training: training,
+      id: thisCategory.id,
+      seq: thisCategory.seq,
+      category: thisCategory.category,
     };
-  }).filter(trainingCategory => {
-    return trainingCategory.training.length > 0;
   });
 };
+
+const transformTrainingCategoriesWithMandatoryTraining = function (establishment, trainingCategories) {
+  return trainingCategories
+    .map((trainingCategory) => {
+      let training = [];
+
+      establishment.workers.forEach((worker) => {
+        let workerTraining = worker.workerTraining
+          .filter((workerTraining) => {
+            return workerTraining.categoryFk == trainingCategory.id;
+          })
+          .map((workerTraining) => {
+            return {
+              id: workerTraining.id,
+              uid: workerTraining.uid,
+              title: workerTraining.title,
+              expires: workerTraining.expires,
+              worker: {
+                id: worker.id,
+                uid: worker.uid,
+                NameOrIdValue: worker.NameOrIdValue,
+                mainJob: {
+                  id: worker.mainJob.id,
+                  title: worker.mainJob.title,
+                },
+              },
+            };
+          });
+
+        training = training.concat(workerTraining);
+
+        if (trainingCategory.MandatoryTraining !== undefined && trainingCategory.MandatoryTraining.length > 0) {
+          let missingTraining = [];
+
+          missingTraining = trainingCategory.MandatoryTraining.filter((mandatoryTraining) => {
+            if (worker.mainJob !== undefined && worker.mainJob.id !== mandatoryTraining.jobFK) {
+              return false;
+            }
+
+            return (
+              worker.workerTraining.filter((workerTraining) => {
+                return workerTraining.categoryFk == mandatoryTraining.trainingCategoryFK;
+              }).length == 0
+            );
+          }).map((missingTraining) => {
+            return {
+              id: missingTraining.id,
+              missing: true,
+              worker: {
+                id: worker.id,
+                uid: worker.uid,
+                NameOrIdValue: worker.NameOrIdValue,
+                mainJob: {
+                  id: worker.mainJob.id,
+                  title: worker.mainJob.title,
+                },
+              },
+            };
+          });
+
+          training = training.concat(missingTraining);
+        }
+      });
+
+      return {
+        id: trainingCategory.id,
+        seq: trainingCategory.seq,
+        category: trainingCategory.category,
+        training: training,
+      };
+    })
+    .filter((trainingCategory) => {
+      return trainingCategory.training.length > 0;
+    });
+};
+
+module.exports.transformTrainingCategories = transformTrainingCategories;
+module.exports.transformTrainingCategoriesWithMandatoryTraining = transformTrainingCategoriesWithMandatoryTraining;

--- a/src/app/core/services/training-category.service.ts
+++ b/src/app/core/services/training-category.service.ts
@@ -1,0 +1,17 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TrainingCategoryService {
+  constructor(private http: HttpClient) {}
+
+  getCategoriesWithTraining(establishmentId): Observable<[]> {
+    return this.http
+      .get<any>(`/api/trainingCategories/${establishmentId}/with-training`)
+      .pipe(map((res) => res.trainingCategories));
+  }
+}

--- a/src/app/core/services/trainingStatus.service.ts
+++ b/src/app/core/services/trainingStatus.service.ts
@@ -60,4 +60,20 @@ export class TrainingStatusService {
     }
     return this.ACTIVE;
   }
+
+  public trainingStatusForRecord(trainingRecord) {
+    return this.getTrainingStatus(trainingRecord.expires, trainingRecord.missing);
+  }
+
+  public totalTrainingRecords(training) {
+    return training.filter((trainingRecord) => {
+      return this.trainingStatusForRecord(trainingRecord) !== this.MISSING;
+    }).length;
+  }
+
+  public trainingStatusCount(training, status) {
+    return training.filter((trainingRecord) => {
+      return this.trainingStatusForRecord(trainingRecord) === status;
+    }).length;
+  }
 }

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -59,13 +59,7 @@
             />
             {{ trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRING) }} Expiring soon
           </div>
-          <div
-            *ngIf="
-              totalTrainingRecords(trainingCategory.training) > 0 &&
-              trainingStatusCount(trainingCategory.training, trainingStatusService.ACTIVE) ==
-                totalTrainingRecords(trainingCategory.training)
-            "
-          >
+          <div *ngIf="trainingIsComplete(trainingCategory.training)">
             Up-to-date
           </div>
         </td>

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -1,5 +1,7 @@
 <div class="govuk-!-margin-bottom-6">
-  <a href="javascript://" (click)="this.viewTrainingByCategory.emit(false);" class="govuk-!-margin-right-6">View by staff name</a>
+  <a href="javascript://" (click)="this.viewTrainingByCategory.emit(false)" class="govuk-!-margin-right-6"
+    >View by staff name</a
+  >
   <span>View by training category</span>
 </div>
 
@@ -22,7 +24,10 @@
           {{ totalTrainingRecords(trainingCategory.training) }}
         </td>
         <td class="govuk-table__cell">
-          <div *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRED) > 0" class="govuk-!-margin-bottom-1">
+          <div
+            *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRED) > 0"
+            class="govuk-!-margin-bottom-1"
+          >
             <img
               src="/assets/images/flag-red.svg"
               alt="expired"
@@ -31,7 +36,10 @@
             {{ trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRED) }}
             Expired
           </div>
-          <div *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.MISSING) > 0" class="govuk-!-margin-bottom-1">
+          <div
+            *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.MISSING) > 0"
+            class="govuk-!-margin-bottom-1"
+          >
             <img
               src="/assets/images/flag-red.svg"
               alt="missing mandatory training"
@@ -40,7 +48,10 @@
             {{ trainingStatusCount(trainingCategory.training, trainingStatusService.MISSING) }}
             Missing
           </div>
-          <div *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRING) > 0" class="govuk-!-margin-bottom-1">
+          <div
+            *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRING) > 0"
+            class="govuk-!-margin-bottom-1"
+          >
             <img
               src="/assets/images/flag-orange.svg"
               alt="expiring"
@@ -52,9 +63,11 @@
             *ngIf="
               totalTrainingRecords(trainingCategory.training) > 0 &&
               trainingStatusCount(trainingCategory.training, trainingStatusService.ACTIVE) ==
-              totalTrainingRecords(trainingCategory.training)
+                totalTrainingRecords(trainingCategory.training)
             "
-          >Up-to-date</div>
+          >
+            Up-to-date
+          </div>
         </td>
         <td class="govuk-table__cell govuk-!-font-weight-regular">
           <a
@@ -79,7 +92,7 @@
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
-                <ng-container *ngFor="let training of orderByTrainingStatus(trainingCategory.training)">
+                <ng-container *ngFor="let training of orderByTrainingStatusAndName(trainingCategory.training)">
                   <tr class="govuk-table__row">
                     <td class="govuk-table__cell govuk-!-font-weight-regular">
                       <a

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -1,5 +1,5 @@
 <div class="govuk-!-margin-bottom-6" *ngIf="showViewByToggle">
-  <a href="javascript://" (click)="this.viewTrainingByCategory.emit(false)" class="govuk-!-margin-right-6"
+  <a href="#" (click)="this.viewTrainingByCategory.emit(false); false" class="govuk-!-margin-right-6"
     >View by staff name</a
   >
   <span>View by training category</span>

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -58,7 +58,7 @@
             href="#"
             (click)="toggleDetails(trainingCategory.id, $event)"
           >
-            {{ workerDetailsLabel[trainingCategory.id] ? workerDetailsLabel[trainingCategory.id] : 'Open' }}
+            {{ workerDetailsLabel[trainingCategory.id] ? workerDetailsLabel[trainingCategory.id] : 'More' }}
           </a>
         </td>
       </tr>

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -74,7 +74,6 @@
                   <th class="govuk-table__header govuk-!-width-one-third" scope="col">Worker ID</th>
                   <th class="govuk-table__header govuk-!-width-one-third" scope="col">Job role</th>
                   <th class="govuk-table__header govuk-!-width-one-third" scope="col">Status</th>
-                  <th class="govuk-table__header govuk-!-width-one-third" scope="col"></th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
@@ -132,21 +131,6 @@
                       <div *ngIf="trainingStatus(training) === trainingStatusService.ACTIVE">
                         Up-to-date
                       </div>
-                    </td>
-                    <td class="govuk-table__cell govuk-!-font-weight-regular">
-                      <a
-                        *ngIf="canEditWorker && training.uid"
-                        [routerLink]="[
-                          '/workplace',
-                          this.workplace.uid,
-                          'training-and-qualifications-record',
-                          training.worker.uid,
-                          'training',
-                          training.uid
-                        ]"
-                      >
-                        Update
-                      </a>
                     </td>
                   </tr>
                 </ng-container>

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -49,10 +49,7 @@
               trainingStatusCount(trainingCategory.training, trainingStatusService.ACTIVE) ==
               totalTrainingRecords(trainingCategory.training)
             "
-            class="govuk-!-padding-left-1 govuk-!-margin-left-6"
-          >
-          Up-to-date
-          </div>
+          >Up-to-date</div>
         </td>
         <td class="govuk-table__cell govuk-!-font-weight-regular">
           <a

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -1,3 +1,8 @@
+<div class="govuk-!-margin-bottom-6">
+  <a href="javascript://" (click)="this.viewTrainingByCategory.emit(false);" class="govuk-!-margin-right-6">View by staff name</a>
+  <span>View by training category</span>
+</div>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -5,7 +5,7 @@
   <span>View by training category</span>
 </div>
 
-<table class="govuk-table">
+<table class="govuk-table" data-testid="training-category-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">Category</th>
@@ -69,6 +69,7 @@
             class="govuk-link--no-visited-state"
             href="#"
             (click)="toggleDetails(trainingCategory.id, $event)"
+            data-testid="more-link"
           >
             {{ workerDetailsLabel[trainingCategory.id] ? workerDetailsLabel[trainingCategory.id] : 'More' }}
           </a>

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -1,0 +1,160 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Category</th>
+      <th class="govuk-table__header" scope="col">Records</th>
+      <th class="govuk-table__header" scope="col">Status</th>
+      <th class="govuk-table__header" scope="col"></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <ng-container *ngFor="let trainingCategory of trainingCategories">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-font-weight-regular">
+          {{ trainingCategory.category }}
+        </td>
+        <td class="govuk-table__cell govuk-!-font-weight-regular">
+          {{ totalTrainingRecords(trainingCategory.training) }}
+        </td>
+        <td class="govuk-table__cell">
+          <div *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRED) > 0" class="govuk-!-margin-bottom-1">
+            <img
+              src="/assets/images/flag-red.svg"
+              alt="expired"
+              class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
+            />
+            {{ trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRED) }}
+            Expired
+          </div>
+          <div *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.MISSING) > 0" class="govuk-!-margin-bottom-1">
+            <img
+              src="/assets/images/flag-red.svg"
+              alt="missing mandatory training"
+              class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
+            />
+            {{ trainingStatusCount(trainingCategory.training, trainingStatusService.MISSING) }}
+            Missing
+          </div>
+          <div *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRING) > 0" class="govuk-!-margin-bottom-1">
+            <img
+              src="/assets/images/flag-orange.svg"
+              alt="expiring"
+              class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
+            />
+            {{ trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRING) }} Expiring soon
+          </div>
+          <div
+            *ngIf="
+              totalTrainingRecords(trainingCategory.training) > 0 &&
+              trainingStatusCount(trainingCategory.training, trainingStatusService.ACTIVE) ==
+              totalTrainingRecords(trainingCategory.training)
+            "
+            class="govuk-!-padding-left-1 govuk-!-margin-left-6"
+          >
+          Up-to-date
+          </div>
+        </td>
+        <td class="govuk-table__cell govuk-!-font-weight-regular">
+          <a
+            *ngIf="trainingCategory.training.length"
+            class="govuk-link--no-visited-state"
+            href="#"
+            (click)="toggleDetails(trainingCategory.id, $event)"
+          >
+            {{ workerDetailsLabel[trainingCategory.id] ? workerDetailsLabel[trainingCategory.id] : 'Open' }}
+          </a>
+        </td>
+      </tr>
+      <tr *ngIf="workerDetails[trainingCategory.id]" class="govuk-panel--gray govuk-!-margin-2">
+        <td colspan="4">
+          <div class="govuk-!-margin-2">
+            <table class="govuk-table">
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th class="govuk-table__header govuk-!-width-one-third" scope="col">Worker ID</th>
+                  <th class="govuk-table__header govuk-!-width-one-third" scope="col">Job role</th>
+                  <th class="govuk-table__header govuk-!-width-one-third" scope="col">Status</th>
+                  <th class="govuk-table__header govuk-!-width-one-third" scope="col"></th>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                <ng-container *ngFor="let training of orderByTrainingStatus(trainingCategory.training)">
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell govuk-!-font-weight-regular">
+                      <a
+                        *ngIf="canEditWorker"
+                        [routerLink]="[
+                          '/workplace',
+                          this.workplace.uid,
+                          'training-and-qualifications-record',
+                          training.worker.uid,
+                          'training'
+                        ]"
+                      >
+                        {{ training.worker.NameOrIdValue }}</a
+                      >
+                    </td>
+                    <td class="govuk-table__cell govuk-!-font-weight-regular">
+                      {{ training.worker.mainJob?.title }}
+                    </td>
+                    <td class="govuk-table__cell">
+                      <div
+                        *ngIf="trainingStatus(training) === trainingStatusService.EXPIRED"
+                        class="govuk-!-margin-bottom-1"
+                      >
+                        <img
+                          src="/assets/images/flag-red.svg"
+                          alt="expired"
+                          class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
+                        />
+                        Expired
+                      </div>
+                      <div
+                        *ngIf="trainingStatus(training) === trainingStatusService.MISSING"
+                        class="govuk-!-margin-bottom-1"
+                      >
+                        <img
+                          src="/assets/images/flag-red.svg"
+                          alt="Missing"
+                          class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
+                        />
+                        Missing
+                      </div>
+                      <div *ngIf="trainingStatus(training) === trainingStatusService.EXPIRING">
+                        <img
+                          src="/assets/images/flag-orange.svg"
+                          alt="expiring"
+                          class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
+                        />
+                        Expiring soon
+                      </div>
+
+                      <div *ngIf="trainingStatus(training) === trainingStatusService.ACTIVE">
+                        Up-to-date
+                      </div>
+                    </td>
+                    <td class="govuk-table__cell govuk-!-font-weight-regular">
+                      <a
+                        *ngIf="canEditWorker && training.uid"
+                        [routerLink]="[
+                          '/workplace',
+                          this.workplace.uid,
+                          'training-and-qualifications-record',
+                          training.worker.uid,
+                          'training',
+                          training.uid
+                        ]"
+                      >
+                        Update
+                      </a>
+                    </td>
+                  </tr>
+                </ng-container>
+              </tbody>
+            </table>
+          </div>
+        </td>
+      </tr>
+    </ng-container>
+  </tbody>
+</table>

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-!-margin-bottom-6">
+<div class="govuk-!-margin-bottom-6" *ngIf="showViewByToggle">
   <a href="javascript://" (click)="this.viewTrainingByCategory.emit(false)" class="govuk-!-margin-right-6"
     >View by staff name</a
   >
@@ -25,7 +25,7 @@
         </td>
         <td class="govuk-table__cell">
           <div
-            *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRED) > 0"
+            *ngIf="trainingStatusService.trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRED) > 0"
             class="govuk-!-margin-bottom-1"
           >
             <img
@@ -33,11 +33,11 @@
               alt="expired"
               class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
             />
-            {{ trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRED) }}
+            {{ trainingStatusService.trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRED) }}
             Expired
           </div>
           <div
-            *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.MISSING) > 0"
+            *ngIf="trainingStatusService.trainingStatusCount(trainingCategory.training, trainingStatusService.MISSING) > 0"
             class="govuk-!-margin-bottom-1"
           >
             <img
@@ -45,11 +45,11 @@
               alt="missing mandatory training"
               class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
             />
-            {{ trainingStatusCount(trainingCategory.training, trainingStatusService.MISSING) }}
+            {{ trainingStatusService.trainingStatusCount(trainingCategory.training, trainingStatusService.MISSING) }}
             Missing
           </div>
           <div
-            *ngIf="trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRING) > 0"
+            *ngIf="trainingStatusService.trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRING) > 0"
             class="govuk-!-margin-bottom-1"
           >
             <img
@@ -57,7 +57,7 @@
               alt="expiring"
               class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
             />
-            {{ trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRING) }} Expiring soon
+            {{ trainingStatusService.trainingStatusCount(trainingCategory.training, trainingStatusService.EXPIRING) }} Expiring soon
           </div>
           <div *ngIf="trainingIsComplete(trainingCategory.training)">
             Up-to-date
@@ -108,7 +108,7 @@
                     </td>
                     <td class="govuk-table__cell">
                       <div
-                        *ngIf="trainingStatus(training) === trainingStatusService.EXPIRED"
+                        *ngIf="trainingStatusService.trainingStatusForRecord(training) === trainingStatusService.EXPIRED"
                         class="govuk-!-margin-bottom-1"
                       >
                         <img
@@ -119,7 +119,7 @@
                         Expired
                       </div>
                       <div
-                        *ngIf="trainingStatus(training) === trainingStatusService.MISSING"
+                        *ngIf="trainingStatusService.trainingStatusForRecord(training) === trainingStatusService.MISSING"
                         class="govuk-!-margin-bottom-1"
                       >
                         <img
@@ -129,7 +129,7 @@
                         />
                         Missing
                       </div>
-                      <div *ngIf="trainingStatus(training) === trainingStatusService.EXPIRING">
+                      <div *ngIf="trainingStatusService.trainingStatusForRecord(training) === trainingStatusService.EXPIRING">
                         <img
                           src="/assets/images/flag-orange.svg"
                           alt="expiring"
@@ -138,7 +138,7 @@
                         Expiring soon
                       </div>
 
-                      <div *ngIf="trainingStatus(training) === trainingStatusService.ACTIVE">
+                      <div *ngIf="trainingStatusService.trainingStatusForRecord(training) === trainingStatusService.ACTIVE">
                         Up-to-date
                       </div>
                     </td>

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.spec.ts
@@ -1,0 +1,34 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { render, RenderResult } from '@testing-library/angular';
+
+import { TrainingAndQualificationsCategoriesComponent } from './training-and-qualifications-categories.component';
+
+const sinon = require('sinon');
+
+describe('TrainingAndQualificationsCategoriesComponent', () => {
+  let component: RenderResult<TrainingAndQualificationsCategoriesComponent>;
+
+  it('should create', async () => {
+    var mockPermissionsService = sinon.createStubInstance(PermissionsService, {
+      can: sinon.stub().returns(true),
+    });
+
+    component = await render(TrainingAndQualificationsCategoriesComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [ { provide: PermissionsService, useValue: mockPermissionsService } ],
+      componentProperties: {
+        workplace: {
+          id: 123,
+          uid: '123',
+          name: 'Test Workplace',
+        } as Establishment,
+        trainingCategories: [],
+      }
+    });
+
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.spec.ts
@@ -2,10 +2,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { TrainingCategoryService } from '@core/services/training-category.service';
 import { render, RenderResult, within } from '@testing-library/angular';
 import * as moment from 'moment';
-import { of } from 'rxjs';
 
 import { TrainingAndQualificationsCategoriesComponent } from './training-and-qualifications-categories.component';
 
@@ -113,6 +111,8 @@ describe('TrainingAndQualificationsCategoriesComponent', () => {
       can: sinon.stub().returns(true),
     });
 
+    const workplace = establishmentBuilder() as Establishment;
+
     const trainingCategories = [
       trainingCategoryBuilder({
         overrides: {
@@ -154,20 +154,14 @@ describe('TrainingAndQualificationsCategoriesComponent', () => {
       }),
     ];
 
-    const mockTrainingCategoryService = {
-      getCategoriesWithTraining() {
-        return of(trainingCategories);
-      },
-    };
-
     const { fixture } = await render(TrainingAndQualificationsCategoriesComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule],
       providers: [
         { provide: PermissionsService, useValue: mockPermissionsService },
-        { provide: TrainingCategoryService, useValue: mockTrainingCategoryService },
       ],
       componentProperties: {
-        workplace: establishmentBuilder() as Establishment,
+        workplace,
+        trainingCategories,
       },
     });
 

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.spec.ts
@@ -2,33 +2,183 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { render, RenderResult } from '@testing-library/angular';
+import { TrainingCategoryService } from '@core/services/training-category.service';
+import { render, RenderResult, within } from '@testing-library/angular';
+import * as moment from 'moment';
+import { of } from 'rxjs';
 
 import { TrainingAndQualificationsCategoriesComponent } from './training-and-qualifications-categories.component';
 
 const sinon = require('sinon');
+const { build, fake, sequence, perBuild } = require('@jackfranklin/test-data-bot');
+
+const establishmentBuilder = build('Establishment', {
+  fields: {
+    id: sequence(),
+    uid: fake((f) => f.random.uuid()),
+    name: fake((f) => f.lorem.sentence()),
+  },
+});
+
+const workerBuilder = build('Worker', {
+  fields: {
+    id: sequence(),
+    uid: fake((f) => f.random.uuid()),
+    NameOrIdValue: fake((f) => f.name.findName()),
+    mainJob: perBuild(() => {
+      return {
+        id: sequence(),
+        title: fake((f) => f.lorem.sentence()),
+      };
+    }),
+  },
+});
+
+const trainingBuilder = build('Training', {
+  fields: {
+    id: sequence(),
+    uid: fake((f) => f.random.uuid()),
+    expires: fake((f) => f.date.future(1).toISOString()),
+    worker: perBuild(() => {
+      return workerBuilder();
+    }),
+  },
+});
+
+const missingTrainingBuilder = build('Training', {
+  fields: {
+    id: sequence(),
+    missing: true,
+    worker: perBuild(() => {
+      return workerBuilder();
+    }),
+  },
+});
+
+const trainingCategoryBuilder = build('TrainingCategory', {
+  fields: {
+    id: sequence(),
+    seq: sequence(),
+    category: fake((f) => f.lorem.sentence()),
+    training: perBuild(() => {
+      return [trainingBuilder()];
+    }),
+  },
+});
 
 describe('TrainingAndQualificationsCategoriesComponent', () => {
   let component: RenderResult<TrainingAndQualificationsCategoriesComponent>;
 
   it('should create', async () => {
-    var mockPermissionsService = sinon.createStubInstance(PermissionsService, {
+    const mockPermissionsService = sinon.createStubInstance(PermissionsService, {
       can: sinon.stub().returns(true),
     });
 
     component = await render(TrainingAndQualificationsCategoriesComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule],
-      providers: [ { provide: PermissionsService, useValue: mockPermissionsService } ],
+      providers: [{ provide: PermissionsService, useValue: mockPermissionsService }],
       componentProperties: {
-        workplace: {
-          id: 123,
-          uid: '123',
-          name: 'Test Workplace',
-        } as Establishment,
+        workplace: establishmentBuilder() as Establishment,
         trainingCategories: [],
-      }
+      },
     });
 
     expect(component).toBeTruthy();
+  });
+
+  it('should show Worker information when clicking the More link', async () => {
+    const mockPermissionsService = sinon.createStubInstance(PermissionsService, {
+      can: sinon.stub().returns(true),
+    });
+
+    const trainingCategory = trainingCategoryBuilder();
+
+    const { click, getByTestId } = await render(TrainingAndQualificationsCategoriesComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [{ provide: PermissionsService, useValue: mockPermissionsService }],
+      componentProperties: {
+        workplace: establishmentBuilder() as Establishment,
+        trainingCategories: [trainingCategory],
+      },
+    });
+
+    const container = within(getByTestId('training-category-table'));
+
+    click(container.getAllByTestId('more-link')[0]);
+    expect(container.getAllByText(trainingCategory.training[0].worker.NameOrIdValue));
+  });
+
+  it('should list the Categories by Status', async () => {
+    const mockPermissionsService = sinon.createStubInstance(PermissionsService, {
+      can: sinon.stub().returns(true),
+    });
+
+    const trainingCategories = [
+      trainingCategoryBuilder({
+        overrides: {
+          training: [
+            trainingBuilder({
+              overrides: {
+                expires: moment().subtract(1, 'month').toISOString(),
+              },
+            }),
+          ],
+        },
+      }),
+      trainingCategoryBuilder({
+        overrides: {
+          training: [
+            trainingBuilder({
+              overrides: {
+                expires: moment().add(1, 'month').toISOString(),
+              },
+            }),
+          ],
+        },
+      }),
+      trainingCategoryBuilder({
+        overrides: {
+          training: [
+            trainingBuilder({
+              overrides: {
+                expires: moment().add(1, 'year').toISOString(),
+              },
+            }),
+          ],
+        },
+      }),
+      trainingCategoryBuilder({
+        overrides: {
+          training: [missingTrainingBuilder()],
+        },
+      }),
+    ];
+
+    const mockTrainingCategoryService = {
+      getCategoriesWithTraining() {
+        return of(trainingCategories);
+      },
+    };
+
+    const { fixture } = await render(TrainingAndQualificationsCategoriesComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: PermissionsService, useValue: mockPermissionsService },
+        { provide: TrainingCategoryService, useValue: mockTrainingCategoryService },
+      ],
+      componentProperties: {
+        workplace: establishmentBuilder() as Establishment,
+      },
+    });
+
+    fixture.detectChanges();
+
+    const rows = fixture.nativeElement.querySelectorAll(`table[data-testid='training-category-table'] tbody tr`);
+
+    expect(rows.length).toBe(4);
+    expect(rows[0].innerHTML).toContain('1 Expired');
+    expect(rows[1].innerHTML).toContain('1 Missing');
+    expect(rows[2].innerHTML).toContain('1 Expiring soon');
+    expect(rows[3].innerHTML).toContain('Up-to-date');
   });
 });

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -42,7 +42,7 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit {
     event.preventDefault();
 
     this.workerDetails[id] = !this.workerDetails[id];
-    this.workerDetailsLabel[id] = this.workerDetailsLabel[id] === 'Close' ? 'Open' : 'Close';
+    this.workerDetailsLabel[id] = this.workerDetailsLabel[id] === 'Less' ? 'More' : 'Less';
   }
 
   public totalTrainingRecords(training) {

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Establishment } from '@core/model/establishment.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { TrainingCategoryService } from '@core/services/training-category.service';
 import { TrainingStatusService } from '@core/services/trainingStatus.service';
 import { orderBy } from 'lodash';
 
@@ -10,30 +11,31 @@ import { orderBy } from 'lodash';
 })
 export class TrainingAndQualificationsCategoriesComponent implements OnInit {
   @Input() workplace: Establishment;
-  @Input() trainingCategories: Array<any>;
 
   @Output() viewTrainingByCategory: EventEmitter<boolean> = new EventEmitter();
 
+  public trainingCategories: Array<any>;
   public workerDetails = [];
   public workerDetailsLabel = [];
-
   public canEditWorker = false;
 
   constructor(
     private permissionsService: PermissionsService,
+    private trainingCategoryService: TrainingCategoryService,
     private trainingStatusService: TrainingStatusService,
   ) {}
 
   ngOnInit() {
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
 
-    this.trainingCategories = orderBy(this.trainingCategories, [
-        tc => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRED),
-        tc => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRING),
-        tc => this.trainingStatusCount(tc.training, this.trainingStatusService.MISSING),
-      ],
-      ['desc', 'desc', 'desc'],
-    );
+    this.trainingCategoryService.getCategoriesWithTraining(this.workplace.id).subscribe((trainingCategories) => {
+      this.trainingCategories = orderBy(trainingCategories, [
+          (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRED),
+          (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRING),
+          (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.MISSING),
+        ], ['desc', 'desc', 'desc']
+      );
+    });
   }
 
   public orderByTrainingStatus(training: Array<any>) {

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -35,8 +35,9 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit {
           (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRED),
           (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRING),
           (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.MISSING),
+          (tc) => tc.category,
         ],
-        ['desc', 'desc', 'desc'],
+        ['desc', 'desc', 'desc', 'asc'],
       );
     });
   }
@@ -73,5 +74,15 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit {
     return training.filter((trainingRecord) => {
       return this.trainingStatus(trainingRecord) === status;
     }).length;
+  }
+
+  public trainingIsComplete(training) {
+    let count = 0;
+
+    count += this.trainingStatusCount(training, this.trainingStatusService.EXPIRED);
+    count += this.trainingStatusCount(training, this.trainingStatusService.EXPIRING);
+    count += this.trainingStatusCount(training, this.trainingStatusService.MISSING);
+
+    return count === 0;
   }
 }

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -41,8 +41,15 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit {
     });
   }
 
-  public orderByTrainingStatus(training: Array<any>) {
-    return orderBy(training, (record) => this.trainingStatus(record), ['desc']);
+  public orderByTrainingStatusAndName(training: Array<any>) {
+    return orderBy(
+      training,
+      [
+        (trainingRecord) => this.trainingStatus(trainingRecord),
+        (trainingRecord) => trainingRecord.worker.NameOrIdValue,
+      ],
+      ['desc', 'asc'],
+    );
   }
 
   public toggleDetails(id, event) {

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Establishment } from '@core/model/establishment.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TrainingStatusService } from '@core/services/trainingStatus.service';
@@ -11,6 +11,8 @@ import { orderBy } from 'lodash';
 export class TrainingAndQualificationsCategoriesComponent implements OnInit {
   @Input() workplace: Establishment;
   @Input() trainingCategories: Array<any>;
+
+  @Output() viewTrainingByCategory: EventEmitter<boolean> = new EventEmitter();
 
   public workerDetails = [];
   public workerDetailsLabel = [];

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -33,8 +33,8 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit {
         trainingCategories,
         [
           (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRED),
-          (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRING),
           (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.MISSING),
+          (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRING),
           (tc) => tc.category,
         ],
         ['desc', 'desc', 'desc', 'asc'],
@@ -77,12 +77,14 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit {
   }
 
   public trainingIsComplete(training) {
-    let count = 0;
-
-    count += this.trainingStatusCount(training, this.trainingStatusService.EXPIRED);
-    count += this.trainingStatusCount(training, this.trainingStatusService.EXPIRING);
-    count += this.trainingStatusCount(training, this.trainingStatusService.MISSING);
-
-    return count === 0;
+    return (
+      [
+        this.trainingStatusCount(training, this.trainingStatusService.EXPIRED),
+        this.trainingStatusCount(training, this.trainingStatusService.EXPIRING),
+        this.trainingStatusCount(training, this.trainingStatusService.MISSING),
+      ].reduce((total, num) => {
+        return total + num;
+      }) === 0
+    );
   }
 }

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -3,7 +3,7 @@ import { Establishment } from '@core/model/establishment.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TrainingCategoryService } from '@core/services/training-category.service';
 import { TrainingStatusService } from '@core/services/trainingStatus.service';
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 
 @Component({
   selector: 'app-training-and-qualifications-categories',
@@ -29,17 +29,20 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit {
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
 
     this.trainingCategoryService.getCategoriesWithTraining(this.workplace.id).subscribe((trainingCategories) => {
-      this.trainingCategories = orderBy(trainingCategories, [
+      this.trainingCategories = orderBy(
+        trainingCategories,
+        [
           (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRED),
           (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRING),
           (tc) => this.trainingStatusCount(tc.training, this.trainingStatusService.MISSING),
-        ], ['desc', 'desc', 'desc']
+        ],
+        ['desc', 'desc', 'desc'],
       );
     });
   }
 
   public orderByTrainingStatus(training: Array<any>) {
-    return orderBy(training, record => this.trainingStatus(record), ['desc']);
+    return orderBy(training, (record) => this.trainingStatus(record), ['desc']);
   }
 
   public toggleDetails(id, event) {
@@ -61,7 +64,7 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit {
 
   public trainingStatusCount(training, status) {
     return training.filter((trainingRecord) => {
-        return this.trainingStatus(trainingRecord) === status;
+      return this.trainingStatus(trainingRecord) === status;
     }).length;
   }
 }

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -24,6 +24,14 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit {
 
   ngOnInit() {
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
+
+    this.trainingCategories = orderBy(this.trainingCategories, [
+        tc => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRED),
+        tc => this.trainingStatusCount(tc.training, this.trainingStatusService.EXPIRING),
+        tc => this.trainingStatusCount(tc.training, this.trainingStatusService.MISSING),
+      ],
+      ['desc', 'desc', 'desc'],
+    );
   }
 
   public orderByTrainingStatus(training: Array<any>) {

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -1,0 +1,55 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Establishment } from '@core/model/establishment.model';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { TrainingStatusService } from '@core/services/trainingStatus.service';
+import { orderBy } from 'lodash';
+
+@Component({
+  selector: 'app-training-and-qualifications-categories',
+  templateUrl: './training-and-qualifications-categories.component.html',
+})
+export class TrainingAndQualificationsCategoriesComponent implements OnInit {
+  @Input() workplace: Establishment;
+  @Input() trainingCategories: Array<any>;
+
+  public workerDetails = [];
+  public workerDetailsLabel = [];
+
+  public canEditWorker = false;
+
+  constructor(
+    private permissionsService: PermissionsService,
+    private trainingStatusService: TrainingStatusService,
+  ) {}
+
+  ngOnInit() {
+    this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
+  }
+
+  public orderByTrainingStatus(training: Array<any>) {
+    return orderBy(training, record => this.trainingStatus(record), ['desc']);
+  }
+
+  public toggleDetails(id, event) {
+    event.preventDefault();
+
+    this.workerDetails[id] = !this.workerDetails[id];
+    this.workerDetailsLabel[id] = this.workerDetailsLabel[id] === 'Close' ? 'Open' : 'Close';
+  }
+
+  public totalTrainingRecords(training) {
+    return training.filter((trainingRecord) => {
+      return this.trainingStatus(trainingRecord) !== this.trainingStatusService.MISSING;
+    }).length;
+  }
+
+  public trainingStatus(trainingRecord) {
+    return this.trainingStatusService.getTrainingStatus(trainingRecord.expires, trainingRecord.missing);
+  }
+
+  public trainingStatusCount(training, status) {
+    return training.filter((trainingRecord) => {
+        return this.trainingStatus(trainingRecord) === status;
+    }).length;
+  }
+}

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
@@ -2,7 +2,7 @@
   <div class="govuk__flex govuk__justify-content-space-between">
     <div *ngIf="showViewByToggle">
       <span class="govuk-!-margin-right-6">View by staff name</span>
-      <a href="javascript://" (click)="this.viewTrainingByCategory.emit(true);" class="govuk-!-margin-right-6">View by training category</a>
+      <a href="#" (click)="this.viewTrainingByCategory.emit(true); false" class="govuk-!-margin-right-6">View by training category</a>
     </div>
     <div>
       <label class="govuk-label" for="sort">

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-form-group govuk-!-margin-bottom-6">
   <div class="govuk__flex govuk__justify-content-space-between">
-    <div>
+    <div *ngIf="showViewByToggle">
       <span class="govuk-!-margin-right-6">View by staff name</span>
       <a href="javascript://" (click)="this.viewTrainingByCategory.emit(true);" class="govuk-!-margin-right-6">View by training category</a>
     </div>

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
@@ -1,21 +1,29 @@
-<div class="govuk-form-group">
-  <label class="govuk-label" for="sort">
-    Sort by
-  </label>
-  <select
-    class="govuk-select"
-    id="sortBy"
-    name="sortBy"
-    [value]="sortByDefault"
-    (change)="sortByColumn($event.target.value)"
-  >
-    <option
-      *ngFor="let sortTrainingAndQualsOption of sortTrainingAndQualsOptions | keyvalue"
-      value="{{ sortTrainingAndQualsOption.key }}"
-    >
-      {{ sortTrainingAndQualsOption.value }}
-    </option>
-  </select>
+<div class="govuk-form-group govuk-!-margin-bottom-6">
+  <div class="govuk__flex govuk__justify-content-space-between">
+    <div>
+      <span class="govuk-!-margin-right-6">View by staff name</span>
+      <a href="javascript://" (click)="this.viewTrainingByCategory.emit(true);" class="govuk-!-margin-right-6">View by training category</a>
+    </div>
+    <div>
+      <label class="govuk-label" for="sort">
+        Sort by
+      </label>
+      <select
+        class="govuk-select"
+        id="sortBy"
+        name="sortBy"
+        [value]="sortByDefault"
+        (change)="sortByColumn($event.target.value)"
+      >
+        <option
+          *ngFor="let sortTrainingAndQualsOption of sortTrainingAndQualsOptions | keyvalue"
+          value="{{ sortTrainingAndQualsOption.key }}"
+        >
+          {{ sortTrainingAndQualsOption.value }}
+        </option>
+      </select>
+    </div>
+  </div>
 </div>
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Establishment, SortTrainingAndQualsOptions } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 
 @Component({
   selector: 'app-training-and-qualifications-summary',
@@ -39,19 +39,19 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
   public sortByColumn(selectedColumn: any) {
     switch (selectedColumn) {
       case '0_asc': {
-        this.workers = orderBy(this.workers, [worker => worker.nameOrId.toLowerCase()], ['asc']);
+        this.workers = orderBy(this.workers, [(worker) => worker.nameOrId.toLowerCase()], ['asc']);
         break;
       }
       case '0_dsc': {
-        this.workers = orderBy(this.workers, [worker => worker.nameOrId.toLowerCase()], ['desc']);
+        this.workers = orderBy(this.workers, [(worker) => worker.nameOrId.toLowerCase()], ['desc']);
         break;
       }
       case '1_asc': {
-        this.workers = orderBy(this.workers, [worker => worker.trainingCount + worker.qualificationCount], ['asc']);
+        this.workers = orderBy(this.workers, [(worker) => worker.trainingCount + worker.qualificationCount], ['asc']);
         break;
       }
       case '1_dsc': {
-        this.workers = orderBy(this.workers, [worker => worker.trainingCount + worker.qualificationCount], ['desc']);
+        this.workers = orderBy(this.workers, [(worker) => worker.trainingCount + worker.qualificationCount], ['desc']);
         break;
       }
       case '2_asc': {

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Establishment, SortTrainingAndQualsOptions } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -12,6 +12,9 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
   @Input() workplace: Establishment;
   @Input() workers: Array<Worker>;
   @Input() wdfView = false;
+
+  @Output() viewTrainingByCategory: EventEmitter<boolean> = new EventEmitter();
+
   public canViewWorker: boolean;
   public workersData: Array<Worker>;
   public sortTrainingAndQualsOptions;

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
@@ -13,6 +13,8 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
   @Input() workers: Array<Worker>;
   @Input() wdfView = false;
 
+  @Input() showViewByToggle = false;
+
   @Output() viewTrainingByCategory: EventEmitter<boolean> = new EventEmitter();
 
   public canViewWorker: boolean;

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
@@ -22,9 +22,8 @@
   ></app-training-info-panel>
 
   <app-training-and-qualifications-categories
-    *ngIf="trainingCategories && viewTrainingByCategory"
+    *ngIf="viewTrainingByCategory"
     [workplace]="workplace"
-    [trainingCategories]="trainingCategories"
     (viewTrainingByCategory)="handleViewTrainingByCategory($event)"
   ></app-training-and-qualifications-categories>
 

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
@@ -22,15 +22,17 @@
   ></app-training-info-panel>
 
   <app-training-and-qualifications-categories
-    *ngIf="trainingCategories"
+    *ngIf="trainingCategories && viewTrainingByCategory"
     [workplace]="workplace"
     [trainingCategories]="trainingCategories"
+    (viewTrainingByCategory)="handleViewTrainingByCategory($event)"
   ></app-training-and-qualifications-categories>
 
   <app-training-and-qualifications-summary
-    *ngIf="workers"
+    *ngIf="workers && viewTrainingByCategory === false"
     [workplace]="workplace"
     [workers]="workers"
+    (viewTrainingByCategory)="handleViewTrainingByCategory($event)"
   ></app-training-and-qualifications-summary>
 </ng-container>
 <ng-template #noStaffRecords>

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
@@ -21,6 +21,12 @@
     [totalMissingMandatoryTraining]="missingMandatoryTraining"
   ></app-training-info-panel>
 
+  <app-training-and-qualifications-categories
+    *ngIf="trainingCategories"
+    [workplace]="workplace"
+    [trainingCategories]="trainingCategories"
+  ></app-training-and-qualifications-categories>
+
   <app-training-and-qualifications-summary
     *ngIf="workers"
     [workplace]="workplace"

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
@@ -22,8 +22,10 @@
   ></app-training-info-panel>
 
   <app-training-and-qualifications-categories
-    *ngIf="viewTrainingByCategory"
+    *ngIf="viewTrainingByCategory && trainingCategories.length > 0"
     [workplace]="workplace"
+    [trainingCategories]="trainingCategories"
+    [showViewByToggle]="trainingCategories.length > 0"
     (viewTrainingByCategory)="handleViewTrainingByCategory($event)"
   ></app-training-and-qualifications-categories>
 
@@ -31,6 +33,7 @@
     *ngIf="workers && viewTrainingByCategory === false"
     [workplace]="workplace"
     [workers]="workers"
+    [showViewByToggle]="trainingCategories.length > 0"
     (viewTrainingByCategory)="handleViewTrainingByCategory($event)"
   ></app-training-and-qualifications-summary>
 </ng-container>

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { TrainingCategoryService } from '@core/services/training-category.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Subscription } from 'rxjs';
 
@@ -14,16 +15,34 @@ export class TrainingAndQualificationsTabComponent implements OnInit, OnDestroy 
 
   private subscriptions: Subscription = new Subscription();
   public workers: Worker[];
+
+  public trainingCategories: [];
   public totalRecords;
   public totalExpiredTraining;
   public totalExpiringTraining;
   public missingMandatoryTraining;
   public totalStaff: number;
   public isShowAllTrainings: boolean;
-  constructor(private workerService: WorkerService, protected establishmentService: EstablishmentService) {}
+  constructor(
+    private workerService: WorkerService,
+    private trainingCategoryService: TrainingCategoryService,
+    protected establishmentService: EstablishmentService,
+  ) {}
 
   ngOnInit() {
     this.establishmentService.isMandatoryTrainingView.next(false);
+
+    this.getAllWorkers();
+    this.getAllTrainingCategories();
+  }
+
+  getAllTrainingCategories() {
+    this.trainingCategoryService.getCategoriesWithTraining(this.workplace.id).subscribe((trainingCategories) => {
+      this.trainingCategories = trainingCategories;
+    });
+  }
+
+  getAllWorkers() {
     this.subscriptions.add(
       this.workerService.getAllWorkers(this.workplace.uid).subscribe(
         workers => {

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
@@ -2,6 +2,8 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { TrainingCategoryService } from '@core/services/training-category.service';
+import { TrainingStatusService } from '@core/services/trainingStatus.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Subscription } from 'rxjs';
 
@@ -29,12 +31,21 @@ export class TrainingAndQualificationsTabComponent implements OnInit, OnDestroy 
     private workerService: WorkerService,
 
     protected establishmentService: EstablishmentService,
+    protected trainingCategoryService: TrainingCategoryService,
+    protected trainingStatusService: TrainingStatusService
   ) {}
 
   ngOnInit() {
     this.establishmentService.isMandatoryTrainingView.next(false);
 
     this.getAllWorkers();
+    this.getAllTrainingByCategory();
+  }
+
+  getAllTrainingByCategory() {
+    this.trainingCategoryService.getCategoriesWithTraining(this.workplace.id).subscribe((trainingCategories) => {
+      this.trainingCategories = trainingCategories;
+    });
   }
 
   getAllWorkers() {

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
@@ -43,9 +43,11 @@ export class TrainingAndQualificationsTabComponent implements OnInit, OnDestroy 
   }
 
   getAllTrainingByCategory() {
-    this.trainingCategoryService.getCategoriesWithTraining(this.workplace.id).subscribe((trainingCategories) => {
-      this.trainingCategories = trainingCategories;
-    });
+    this.subscriptions.add(
+      this.trainingCategoryService.getCategoriesWithTraining(this.workplace.id).subscribe((trainingCategories) => {
+        this.trainingCategories = trainingCategories;
+      }),
+    );
   }
 
   getAllWorkers() {

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
@@ -23,6 +23,9 @@ export class TrainingAndQualificationsTabComponent implements OnInit, OnDestroy 
   public missingMandatoryTraining;
   public totalStaff: number;
   public isShowAllTrainings: boolean;
+
+  public viewTrainingByCategory = false;
+
   constructor(
     private workerService: WorkerService,
     private trainingCategoryService: TrainingCategoryService,
@@ -64,6 +67,10 @@ export class TrainingAndQualificationsTabComponent implements OnInit, OnDestroy 
         },
       ),
     );
+  }
+
+  public handleViewTrainingByCategory(visible: boolean) {
+    this.viewTrainingByCategory = visible;
   }
 
   public showAllTrainings() {

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { TrainingCategoryService } from '@core/services/training-category.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Subscription } from 'rxjs';
 
@@ -28,7 +27,7 @@ export class TrainingAndQualificationsTabComponent implements OnInit, OnDestroy 
 
   constructor(
     private workerService: WorkerService,
-    private trainingCategoryService: TrainingCategoryService,
+
     protected establishmentService: EstablishmentService,
   ) {}
 
@@ -36,13 +35,6 @@ export class TrainingAndQualificationsTabComponent implements OnInit, OnDestroy 
     this.establishmentService.isMandatoryTrainingView.next(false);
 
     this.getAllWorkers();
-    this.getAllTrainingCategories();
-  }
-
-  getAllTrainingCategories() {
-    this.trainingCategoryService.getCategoriesWithTraining(this.workplace.id).subscribe((trainingCategories) => {
-      this.trainingCategories = trainingCategories;
-    });
   }
 
   getAllWorkers() {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,11 +1,19 @@
+import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { DialogService } from '@core/services/dialog.service';
+import {
+  DeleteWorkplaceDialogComponent,
+} from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
+import {
+  ViewAllMandatoryTrainingComponent,
+} from '@features/workplace/view-all-mandatory-trainings/view-all-mandatory-training.component';
 import { AlertComponent } from '@shared/components/alert/alert.component';
 import { SummaryRecordValueComponent } from '@shared/components/summary-record-value/summary-record-value.component';
 import { WorkplaceTabComponent } from '@shared/components/workplace-tab/workplace-tab.component';
-import { DialogService } from '@core/services/dialog.service';
+
 import { AutoSuggestComponent } from './components/auto-suggest/auto-suggest.component';
 import { BackLinkComponent } from './components/back-link/back-link.component';
 import { BreadcrumbsComponent } from './components/breadcrumbs/breadcrumbs.component';
@@ -17,12 +25,17 @@ import { DetailsComponent } from './components/details/details.component';
 import { EligibilityIconComponent } from './components/eligibility-icon/eligibility-icon.component';
 import { ErrorSummaryComponent } from './components/error-summary/error-summary.component';
 import { InsetTextComponent } from './components/inset-text/inset-text.component';
-import { OverlayModule } from '@angular/cdk/overlay';
-import { LinkToParentCancelDialogComponent } from './components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
-import { LinkToParentRemoveDialogComponent } from './components/link-to-parent-remove/link-to-parent-remove-dialog.component';
+import {
+  LinkToParentCancelDialogComponent,
+} from './components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
+import {
+  LinkToParentRemoveDialogComponent,
+} from './components/link-to-parent-remove/link-to-parent-remove-dialog.component';
 import { LinkToParentDialogComponent } from './components/link-to-parent/link-to-parent-dialog.component';
 import { MessagesComponent } from './components/messages/messages.component';
-import { OwnershipChangeMessageDialogComponent } from './components/ownership-change-message/ownership-change-message-dialog.component';
+import {
+  OwnershipChangeMessageDialogComponent,
+} from './components/ownership-change-message/ownership-change-message-dialog.component';
 import { PanelComponent } from './components/panel/panel.component';
 import { PhaseBannerComponent } from './components/phase-banner/phase-banner.component';
 import { ProgressComponent } from './components/progress/progress.component';
@@ -31,7 +44,9 @@ import { SetDataPermissionDialogComponent } from './components/set-data-permissi
 import { BasicRecordComponent } from './components/staff-record-summary/basic-record/basic-record.component';
 import { EmploymentComponent } from './components/staff-record-summary/employment/employment.component';
 import { PersonalDetailsComponent } from './components/staff-record-summary/personal-details/personal-details.component';
-import { QualificationsAndTrainingComponent } from './components/staff-record-summary/qualifications-and-training/qualifications-and-training.component';
+import {
+  QualificationsAndTrainingComponent,
+} from './components/staff-record-summary/qualifications-and-training/qualifications-and-training.component';
 import { StaffRecordSummaryComponent } from './components/staff-record-summary/staff-record-summary.component';
 import { StaffRecordsTabComponent } from './components/staff-records-tab/staff-records-tab.component';
 import { StaffSummaryComponent } from './components/staff-summary/staff-summary.component';
@@ -42,9 +57,17 @@ import { SummaryListComponent } from './components/summary-list/summary-list.com
 import { TabComponent } from './components/tabs/tab.component';
 import { TabsComponent } from './components/tabs/tabs.component';
 import { TotalStaffPanelComponent } from './components/total-staff-panel/total-staff-panel.component';
-import { TrainingAndQualificationsSummaryComponent } from './components/training-and-qualifications-summary/training-and-qualifications-summary.component';
-import { TrainingAndQualificationsTabComponent } from './components/training-and-qualifications-tab/training-and-qualifications-tab.component';
+import {
+  TrainingAndQualificationsCategoriesComponent,
+} from './components/training-and-qualifications-categories/training-and-qualifications-categories.component';
+import {
+  TrainingAndQualificationsSummaryComponent,
+} from './components/training-and-qualifications-summary/training-and-qualifications-summary.component';
+import {
+  TrainingAndQualificationsTabComponent,
+} from './components/training-and-qualifications-tab/training-and-qualifications-tab.component';
 import { TainingInfoPanelComponent } from './components/training-info-panel/training-info-panel.component';
+import { TrainingLinkPanelComponent } from './components/trianing-link-panel/trianing-link-panel.component.component';
 import { UserAccountsSummaryComponent } from './components/user-accounts-summary/user-accounts-summary.component';
 import { WdfConfirmationPanelComponent } from './components/wdf-confirmation-panel/wdf-confirmation-panel.component';
 import { WorkplaceSummaryComponent } from './components/workplace-summary/workplace-summary.component';
@@ -60,11 +83,6 @@ import { SelectRecordTypePipe } from './pipes/select-record-type.pipe';
 import { WorkerDaysPipe } from './pipes/worker-days.pipe';
 import { WorkerPayPipe } from './pipes/worker-pay.pipe';
 import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-bearer.pipe';
-import { ViewAllMandatoryTrainingComponent } from '@features/workplace/view-all-mandatory-trainings/view-all-mandatory-training.component';
-import { TrainingLinkPanelComponent } from './components/trianing-link-panel/trianing-link-panel.component.component';
-import {
-  DeleteWorkplaceDialogComponent,
-} from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, RouterModule, OverlayModule],
@@ -120,6 +138,7 @@ import {
     LongDatePipe,
     RejectRequestDialogComponent,
     SetDataPermissionDialogComponent,
+    TrainingAndQualificationsCategoriesComponent,
     TrainingAndQualificationsTabComponent,
     TrainingAndQualificationsSummaryComponent,
     TainingInfoPanelComponent,
@@ -180,6 +199,7 @@ import {
     LongDatePipe,
     RejectRequestDialogComponent,
     SetDataPermissionDialogComponent,
+    TrainingAndQualificationsCategoriesComponent,
     TrainingAndQualificationsTabComponent,
     TrainingAndQualificationsSummaryComponent,
     TainingInfoPanelComponent,


### PR DESCRIPTION
**Work done:**

- Added endpoint for getting a list of training categories with training & workers
- Updated `worker` model to associate training 
- Updated `workerTrainingCategories` model to associate mandatory training
- Updated `workerTrainingCategories` model to have a `findAllWithMandatoryTraining` method
- Updated `establishment` model to have a `findWithWorkersAndTraining` method
- Added a `trainingCategoryService` to talk to the new endpoint
- Added components to view training by category
- Added `trainingCategoryTransformer` to convert Sequelize data into a object for JSON
- Introduced `node-mocks-http` to easily mock Express requests
