### PR TITLE
Fix: Test stubs

### DIFF
--- a/server/test/integration/routes/admin/approval/index.spec.js
+++ b/server/test/integration/routes/admin/approval/index.spec.js
@@ -49,7 +49,7 @@ describe('Admin/Approval', () => {
   describe('/admin/approval', () => {
     it('should return a confirmation message and status 200 when a new user is approved', async () => {
       // Arrange
-      const approve = true; 
+      const approve = true;
       if (adminLogin.headers.authorization) {
         const approval = await apiEndpoint
 
@@ -68,10 +68,10 @@ describe('Admin/Approval', () => {
         expect(approval.body.message).to.equal('User has been set as active');
       }
     });
-    
+
     it('should return a confirmation message and status 200 when a new user is removed because the user is rejected', async () => {
       // Arrange
-      const approve = false; 
+      const approve = false;
       if (adminLogin.headers.authorization) {
         const approval = await apiEndpoint
 

--- a/server/test/unit/routes/admin/unlock-account/index.spec.js
+++ b/server/test/unit/routes/admin/unlock-account/index.spec.js
@@ -17,15 +17,21 @@ const user = {
   }
 };
 
-sinon.stub(models.login, 'findOne').callsFake(async (args) => {
-  if (args.where.username=== user.username) {
-    return user;
-  } else {
-    return null;
-  }
-});
-
 describe('unlock-account route', () => {
+  before(() => {
+    sinon.stub(models.login, 'findOne').callsFake(async (args) => {
+      if (args.where.username=== user.username) {
+        return user;
+      } else {
+        return null;
+      }
+    });
+  });
+
+  after(() => {
+    sinon.restore();
+  });
+
   describe('unlockAccount()', () => {
     it('should return with an unlocked account status', async() => {
       const updateStatus = (status) => {

--- a/server/test/unit/routes/establishments/worker.spec.js
+++ b/server/test/unit/routes/establishments/worker.spec.js
@@ -15,28 +15,34 @@ const establishment = {
   establishmentId: 2
 };
 
-sinon.stub(models.worker, 'findOne').callsFake(async (args) => {
-  return args.i === 3 ? {} : worker;
-});
-sinon.stub(models.worker, 'create').callsFake(async (args) => {
-  return worker;
-});
-sinon.stub(models.worker, 'update').callsFake(async (args) => {
-  const mockWorker = {
-    get: () => {
-      return worker;
-    }
-  }
-  return [1, [mockWorker]];
-});
-sinon.stub(models.workerAudit, 'bulkCreate').callsFake(async (args) => {
-  return {};
-});
-sinon.stub(models.establishment, 'findOne').callsFake(async (args) => {
-  return establishment;
-});
-
 describe('worker route', () => {
+  before(() => {
+    sinon.stub(models.worker, 'findOne').callsFake(async (args) => {
+      return args.i === 3 ? {} : worker;
+    });
+    sinon.stub(models.worker, 'create').callsFake(async (args) => {
+      return worker;
+    });
+    sinon.stub(models.worker, 'update').callsFake(async (args) => {
+      const mockWorker = {
+        get: () => {
+          return worker;
+        }
+      }
+      return [1, [mockWorker]];
+    });
+    sinon.stub(models.workerAudit, 'bulkCreate').callsFake(async (args) => {
+      return {};
+    });
+    sinon.stub(models.establishment, 'findOne').callsFake(async (args) => {
+      return establishment;
+    });
+  });
+
+  after(() => {
+    sinon.restore();
+  });
+
   describe('editWorker()', () => {
     it('should return worker changes', async() => {
       const updateStatus = (status) => {


### PR DESCRIPTION
**Issue:**

When running `npm run server:test` - if a method has already been stubbed in another file then sinon throws an error that it has already been wrapped.

**Work done:**

I have moved the stubs into a `before` and restored `sinon` after each test.
