### PR TITLE
Adding Mandatory training link to relevant links

### DIFF
--- a/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -88,6 +88,9 @@
         <li *ngIf="canRemoveParentAssociation">
           <a (click)="removeLinkToParent($event)" href="#">Remove link to my parent organisation</a>
         </li>
+        <li *ngIf="canAddWorker">
+          <a [routerLink]="['/add-mandatory-training']">Manage mandatory training</a>
+        </li>
       </ul>
     </ng-container>
     <ul *ngIf="[adminRole].includes(user.role)" class="govuk-list">


### PR DESCRIPTION
Adding the link to mandatory training.    Follows the same viewing rules as canAddWorker.   Does that make sense or should I rename the canAddWorker Boolean?