### PR TITLE
Revert "Add .cfignore"

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,0 @@
-node_modules/


### PR DESCRIPTION
Reverts NMDSdevopsServiceAdm/SopraSteria-SFC#2133

GovPaaS doesn't seem to have `ng` even though it runs `npm install` on the droplet is creates :S

Reverting to look at another time