### PR TITLE
Remove .cfignore and revert npm start

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "ng": "ng",
-    "start": "node --max-old-space-size=4096 server.js",
+    "start": "npm run build && node --max-old-space-size=4096 server.js",
     "dev": "npm-run-all -p -l build:watch api:proxy",
     "build": "ng build  --extract-css",
     "build:clean": "rimraf dist",


### PR DESCRIPTION
GovPaaS cannot find Express - even though it runs `npm install`.

Super confusing.

Reverting so as to not block the pipeline

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
