### PR TITLE
Remove npm run build from startup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "ng": "ng",
-    "start": "npm run build && node --max-old-space-size=4096 server.js",
+    "start": "node --max-old-space-size=4096 server.js",
     "dev": "npm-run-all -p -l build:watch api:proxy",
     "build": "ng build  --extract-css",
     "build:clean": "rimraf dist",


### PR DESCRIPTION
Investigating the logs for deployment, it actually tries to do a health check while running `ng build`

The startup script should only run the server

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x ] No, they are not required for this change
