### PR TITLE
Fix: Training by category links

### DIFF
--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -1,7 +1,7 @@
 
-<div class="govuk-form-group govuk-!-margin-bottom-6"  *ngIf="showViewByToggle">
+<div class="govuk-form-group govuk-!-margin-bottom-6">
   <div class="govuk__flex govuk__justify-content-space-between">
-    <div *ngIf="showViewByToggle">
+    <div class="govuk-list govuk-list--inline">
       <a href="#" (click)="this.viewTrainingByCategory.emit(false);false" class="govuk-!-margin-right-6"
       >View by staff name</a
       >

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -10,11 +10,7 @@ import orderBy from 'lodash/orderBy';
 })
 export class TrainingAndQualificationsCategoriesComponent implements OnInit {
   @Input() workplace: Establishment;
-
   @Input() trainingCategories: Array<any>;
-
-  @Input() showViewByToggle = false;
-
   @Output() viewTrainingByCategory: EventEmitter<boolean> = new EventEmitter();
 
   public workerDetails = [];

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-form-group govuk-!-margin-bottom-6">
   <div class="govuk__flex govuk__justify-content-space-between">
-    <div *ngIf="showViewByToggle">
+    <div *ngIf="showViewByToggle" class="govuk-list govuk-list--inline">
       <span class="govuk-!-margin-right-6">View by staff name</span>
       <a href="#" (click)="this.viewTrainingByCategory.emit(true); false" class="govuk-!-margin-right-6">View by training category</a>
     </div>

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
@@ -25,7 +25,6 @@
     *ngIf="viewTrainingByCategory && trainingCategories.length > 0"
     [workplace]="workplace"
     [trainingCategories]="trainingCategories"
-    [showViewByToggle]="trainingCategories.length > 0"
     (viewTrainingByCategory)="handleViewTrainingByCategory($event)"
   ></app-training-and-qualifications-categories>
 


### PR DESCRIPTION
**Work done:**
- Fixed sizing of View by staff name / View by category links
- Removed `showViewByToggle` when viewing training by category - this is not needed as the *ngIf in the parent component means it'd always be set to true so we can just show them.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
