### PR TITLE
Fix: Alignment on training by category table

### DIFF
--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -37,7 +37,7 @@
   <tbody class="govuk-table__body">
   <ng-container *ngFor="let trainingCategory of trainingCategories">
     <ng-container *ngIf="filterValue === 'mandatory' ? trainingCategory.isMandatory : true;">
-      <tr class="govuk-table__row">
+      <tr class="govuk-table__row govuk-util__vertical-align-top">
         <td class="govuk-table__cell govuk-!-font-weight-regular">
           {{ trainingCategory.category }}
         </td>
@@ -111,7 +111,7 @@
               </thead>
               <tbody class="govuk-table__body">
               <ng-container *ngFor="let training of orderByTrainingStatusAndName(trainingCategory.training)">
-                <tr class="govuk-table__row">
+                <tr class="govuk-table__row govuk-util__vertical-align-top">
                   <td class="govuk-table__cell govuk-!-font-weight-regular">
                     <a
                       *ngIf="canEditWorker"


### PR DESCRIPTION
**Work done**

Fix issue where table cells were aligned in the middle, but needed to be aligned at the top - this was an issue when a training category had multiple training statuses (expired, expiring soon etc)

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
