### PR TITLE
Fix: Worker training categories 404

### DIFF
--- a/server/routes/workerTrainingCategories.js
+++ b/server/routes/workerTrainingCategories.js
@@ -29,7 +29,9 @@ const getTrainingByCategory = async (req, res) => {
 
     let establishment = await models.establishment.findWithWorkersAndTraining(establishmentId);
     if (!establishment) {
-      return res.sendStatus(404);
+      return res.status(404).json({
+        message: 'Establishment was not found.',
+      });
     }
 
     let trainingCategories = await models.workerTrainingCategories.findAllWithMandatoryTraining(establishmentId);

--- a/server/test/integration/routes/trainingCategories/index.spec.js
+++ b/server/test/integration/routes/trainingCategories/index.spec.js
@@ -43,7 +43,7 @@ describe('Training Categories API', () => {
     }
   });
 
-  describe.only('/api/trainingCategories/{establishmentId}/with-training', () => {
+  describe('/api/trainingCategories/{establishmentId}/with-training', () => {
     it('should return a 404 if establishment is not found', async () => {
       // Arrange
       const establishmentId = 123;

--- a/server/test/integration/routes/trainingCategories/index.spec.js
+++ b/server/test/integration/routes/trainingCategories/index.spec.js
@@ -43,7 +43,7 @@ describe('Training Categories API', () => {
     }
   });
 
-  describe('/api/trainingCategories/{establishmentId}/with-training', () => {
+  describe.only('/api/trainingCategories/{establishmentId}/with-training', () => {
     it('should return a 404 if establishment is not found', async () => {
       // Arrange
       const establishmentId = 123;
@@ -57,6 +57,10 @@ describe('Training Categories API', () => {
 
         // Assert
         .expect(404);
+
+        expect(response.body).to.deep.equal({
+          message: 'Establishment was not found.',
+        });
       }
     });
   })


### PR DESCRIPTION
**Issue**

When trying to get the training by category and there's no results returned from the database, it sends a 404, but it was sending back HTML instead of JSON.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
