### PR TITLE
Fix: Issue where training by category endpoint returns a 404

### DIFF
--- a/server/routes/workerTrainingCategories.js
+++ b/server/routes/workerTrainingCategories.js
@@ -19,7 +19,7 @@ const getAllTraining = async function (_req, res) {
     });
   } catch (err) {
     console.error(err);
-    return res.status(503).send();
+    return res.status(503).json();
   }
 };
 
@@ -27,21 +27,21 @@ const getTrainingByCategory = async (req, res) => {
   try {
     const establishmentId = req.params.establishmentId;
 
-    let establishment = await models.establishment.findWithWorkersAndTraining(establishmentId);
-    if (!establishment) {
-      return res.status(404).json({
-        message: 'Establishment was not found.',
+    const establishmentWithWorkersAndTraining = await models.establishment.findWithWorkersAndTraining(establishmentId);
+    if (establishmentWithWorkersAndTraining === null) {
+      return res.json({
+        trainingCategories: [],
       });
     }
 
-    let trainingCategories = await models.workerTrainingCategories.findAllWithMandatoryTraining(establishmentId);
+    const trainingCategories = await models.workerTrainingCategories.findAllWithMandatoryTraining(establishmentId);
 
     res.json({
-      trainingCategories: transformTrainingCategoriesWithMandatoryTraining(establishment, trainingCategories),
+      trainingCategories: transformTrainingCategoriesWithMandatoryTraining(establishmentWithWorkersAndTraining, trainingCategories),
     });
   } catch (err) {
     console.error(err);
-    return res.status(503).send();
+    return res.status(503).json();
   }
 };
 

--- a/server/test/unit/routes/trainingCategories/index.spec.js
+++ b/server/test/unit/routes/trainingCategories/index.spec.js
@@ -141,5 +141,25 @@ describe('test training categories endpoint functions', () => {
         },
       });
     });
+
+    it('returns a list of empty training categories if an establishment has no staff', async () => {
+      const establishmentId = 123;
+      sinon.stub(models.establishment, 'findWithWorkersAndTraining').returns(null);
+
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: `/api/trainingCategories/${establishmentId}/with-training`,
+      });
+
+      const res = httpMocks.createResponse();
+
+      // Act
+      await workerTrainingCategoriesRoute.getTrainingByCategory(req, res);
+
+      // Assert
+      const { trainingCategories } = res._getJSONData();
+
+      expect(trainingCategories).to.deep.equal([]);
+    });
   });
 });

--- a/server/transformers/trainingCategoryTransformer.js
+++ b/server/transformers/trainingCategoryTransformer.js
@@ -76,7 +76,7 @@ const transformTrainingCategoriesWithMandatoryTraining = function (establishment
         seq: trainingCategory.seq,
         category: trainingCategory.category,
         training: training,
-        isMandatory: trainingCategory.MandatoryTraining.length > 0
+        isMandatory: trainingCategory.MandatoryTraining && trainingCategory.MandatoryTraining.length > 0
       };
     })
     .filter((trainingCategory) => {


### PR DESCRIPTION
**Issue**

When getting training by category, if a Workplace has no staff members, the endpoint was returning a 404 which was causing display issues.

**Work done**

- Amended `/api/trainingCategories/${establishmentId}/with-training` endpoint to return an empty array if the Workplace has no staff.
- Fixed 503 errors to return JSON headers
- Fixed issue checking `.length` on `trainingCategory.MandatoryTraining` if it didn't exist.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
