### PR TITLE
Feat: Approval request to change Main Service to be CQC regulated

### DIFF
--- a/server/routes/admin/cqc-status-change/index.js
+++ b/server/routes/admin/cqc-status-change/index.js
@@ -3,8 +3,8 @@ const router = express.Router();
 const models = require('../../../models');
 const moment = require('moment-timezone');
 const config = require('../../../config/config');
-const uuid = require('uuid');
 const mainServiceRouter = require('../../establishments/mainService');
+const Establishment = require('../../../models/classes/establishment');
 
 const cqcStatusChangeApprovalConfirmation = 'CQC status change approved';
 const cqcStatusChangeRejectionConfirmation = 'CQC status change rejected';
@@ -66,7 +66,7 @@ const _mapResults = async (approvalResults) => {
 
 const _approveChange = async (req, res) => {
   await _updateApprovalStatus(req.body.approvalId, 'Approved');
-  const results = await _updateMainService(req.body.approvalId, req.username);
+  const results = await _updateMainService(req, res);
   if (results.success) {
     return res.status(200).json({ status: '0', message: cqcStatusChangeApprovalConfirmation });
   } else {
@@ -90,33 +90,37 @@ const _updateApprovalStatus = async (approvalId, status) => {
   }
 };
 
-const _updateMainService = async (approvalId, username) => {
+const _updateMainService = async (req, res) => {
+  const approvalId = req.body.approvalId;
+  const username = req.username;
+
   const singleApproval = await models.Approvals.findbyId(approvalId);
-  data = singleApproval.Data;
-  const establishmentId = singleApproval.EstablishmentID;
   if (singleApproval) {
+    const data = singleApproval.Data;
+    const establishmentId = singleApproval.EstablishmentID;
+
     const mainService = {
       id: data.requestedService.id,
       name: data.requestedService.name,
       ...(data.requestedService.other && { other: data.requestedService.other })
     };
-    const addIsRegulated = true;
-    return await mainServiceRouter.updateMainService(establishmentId, username, mainService, addIsRegulated);
 
+    const thisEstablishment = new Establishment.Establishment(username);
+    await thisEstablishment.restore(establishmentId);
+
+    const addIsRegulated = true;
+
+    return await mainServiceRouter.changeMainService(res, thisEstablishment, addIsRegulated, mainService, username);
   } else {
     throw `Can't find Approval with id ${approvalId}`;
   }
 };
 
-
 router.route('/').post(cqcStatusChanges);
 router.route('/').get(getCqcStatusChanges);
-
 
 module.exports = router;
 module.exports.cqcStatusChanges = cqcStatusChanges;
 module.exports.getCqcStatusChanges = getCqcStatusChanges;
-
-
 module.exports.cqcStatusChangeApprovalConfirmation = cqcStatusChangeApprovalConfirmation;
 module.exports.cqcStatusChangeRejectionConfirmation = cqcStatusChangeRejectionConfirmation;

--- a/src/app/core/services/cqc-status-change.service.ts
+++ b/src/app/core/services/cqc-status-change.service.ts
@@ -1,8 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import {  CqcStatusChanges } from '@core/model/cqc-status-changes.model';
+import { CqcStatusChanges } from '@core/model/cqc-status-changes.model';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -18,7 +17,7 @@ export class CqcStatusChangeService {
     return this.http.post<any>('/api/admin/cqc-status-change/', data);
   }
 
-  public getCqcRequestByEstablishmentId(establishmentId: number): Observable<boolean> {
+  public getCqcRequestByEstablishmentId(establishmentId: number): Observable<any> {
     return this.http.get<boolean>(`/api/approvals/establishment/${establishmentId}?type=CqcStatusChange&status=Pending`);
   }
 }

--- a/src/app/features/workplace-find-and-select/select-main-service/select-main-service.ts
+++ b/src/app/features/workplace-find-and-select/select-main-service/select-main-service.ts
@@ -137,7 +137,7 @@ export class SelectMainService implements OnInit, OnDestroy, AfterViewInit {
     if (this.selectedMainService) {
       this.form.get('workplaceService').patchValue(this.selectedMainService.id);
 
-      if (this.selectedMainService.other) {
+      if (this.selectedMainService.other && this.form.get(`otherWorkplaceService${this.selectedMainService.id}`)) {
         this.form.get(`otherWorkplaceService${this.selectedMainService.id}`).patchValue(this.selectedMainService.other);
       }
     }


### PR DESCRIPTION
## Work done

- Updated `setMainService` to create an Approval request when a Workplace changes their Main Service from a non CQC regulated service to a CQC regulated service.
- Fixed issue where approving a request wasn't working because the `updateMainService` function had been renamed
- Fixed issue where if you had set your Main Service to "Other" and filled out the text input and then tried to change from non CQC to CQC - it would try and pre-fill the form with the custom name but wouldn't find the input because the list of CQC services don't have the option of "Other"

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
- [x] No, they will be added later
