### PR TITLE
Fix: Missing data for consequential updates to a workplace when updating main service

### DIFF
--- a/server/routes/establishments/mainService.js
+++ b/server/routes/establishments/mainService.js
@@ -9,7 +9,7 @@ const Establishment = require('../../models/classes/establishment');
 const { correctCapacities } = require('../../utils/correctCapacities');
 const { correctServices } = require('../../utils/correctServices');
 
-const filteredProperties = ['Name', 'MainServiceFK', 'CapacityServices'];
+const filteredProperties = ['Name', 'MainServiceFK', 'OtherServices', 'CapacityServices', 'ShareData', 'IsRegulated', 'LocationId'];
 
 // gets current employer type for the known establishment
 router.route('/').get(async (req, res) => {
@@ -106,7 +106,7 @@ async function changeMainService(res, establishment, cqc, mainService, username)
     if (isValidEstablishment) {
       await establishment.save(username);
 
-      return res.status(200).json(establishment.toJSON(false, false, false, true, false, filteredProperties));
+      return res.status(200).json(establishment.toJSON(false, false, false, false, false, filteredProperties));
     } else {
       return res.status(400).json('Unexpected Input.');
     }


### PR DESCRIPTION
**Issue**

When the main service is updated for a Workplace, there are properties which do not change but are needed in the response.

These include:

- OtherServices
- ShareData
- IsRegulated
- LocationId

**Work done**

- Updated `filteredProperties` to include the missing properties.
- Changed `toJSON` parameter to set `modifiedOnlyProperties` to false so that we can include properties that haven't been changed.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
- [x] No, they will be done later