### PR TITLE
Fix: Non CQC to CQC flow

### DIFF
--- a/src/app/features/workplace-find-and-select/select-main-service/select-main-service.component.html
+++ b/src/app/features/workplace-find-and-select/select-main-service/select-main-service.component.html
@@ -49,6 +49,7 @@
                     name="workplaceService"
                     type="radio"
                     [formControlName]="'workplaceService'"
+                    [class.govuk-input--error]="submitted && form.get('workplaceService').errors"
                   />
                   <label class="govuk-label govuk-radios__label" for="workplaceService-{{ service.id }}">
                     {{ service.name }}

--- a/src/app/features/workplace-find-and-select/select-main-service/select-main-service.ts
+++ b/src/app/features/workplace-find-and-select/select-main-service/select-main-service.ts
@@ -143,6 +143,7 @@ export class SelectMainService implements OnInit, OnDestroy, AfterViewInit {
     }
 
     this.renderForm = true;
+    this.errorSummaryService.formEl$.next(this.formEl);
   }
 
   protected getSelectedWorkPlaceService(): Service {

--- a/src/app/features/workplace-find-and-select/select-main-service/select-main-service.ts
+++ b/src/app/features/workplace-find-and-select/select-main-service/select-main-service.ts
@@ -134,7 +134,7 @@ export class SelectMainService implements OnInit, OnDestroy, AfterViewInit {
    * Then set boolean flag for ui to render the form
    */
   protected preFillForm(): void {
-    if (this.selectedMainService) {
+    if (this.selectedMainService && this.allServices.findIndex(s => s.id === this.selectedMainService.id) > -1) {
       this.form.get('workplaceService').patchValue(this.selectedMainService.id);
 
       if (this.selectedMainService.other && this.form.get(`otherWorkplaceService${this.selectedMainService.id}`)) {

--- a/src/app/features/workplace/select-main-service/select-main-service-cqc-confirm.component.html
+++ b/src/app/features/workplace/select-main-service/select-main-service-cqc-confirm.component.html
@@ -1,6 +1,6 @@
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half-from-desktop">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">Skills For Care have been notified</h1>
     <p class="govuk-body">We'll check your details match the CQC database and then contact you by phone or email within 24 hours.</p>
     <p class="govuk-body">

--- a/src/app/features/workplace/select-main-service/select-main-service-cqc-confirm.component.html
+++ b/src/app/features/workplace/select-main-service/select-main-service-cqc-confirm.component.html
@@ -1,6 +1,14 @@
-<h1 class="govuk-heading-l">Skills For Care have been notified</h1>
-<p class="govuk-body">We'll check your details match the CQC database and then contact you by phone or email within 24 hours.</p>
 
-<p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" [routerLink]="['/contact-us']">Contact us</a> if you have any questions.</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half-from-desktop">
+    <h1 class="govuk-heading-l">Skills For Care have been notified</h1>
+    <p class="govuk-body">We'll check your details match the CQC database and then contact you by phone or email within 24 hours.</p>
+    <p class="govuk-body">
+      <a class="govuk-link govuk-link--no-visited-state" [routerLink]="['/contact-us']">Contact us</a> if you have any questions.
+    </p>
 
-<button class="govuk-button" data-module="govuk-button" [routerLink]="establishmentService.returnTo.url" [fragment]="establishmentService.returnTo.fragment">View your workplace</button>
+    <div class="govuk-!-margin-top-8">
+      <button class="govuk-button" data-module="govuk-button" [routerLink]="establishmentService.returnTo.url" [fragment]="establishmentService.returnTo.fragment">View your workplace</button>
+    </div>
+  </div>
+</div>

--- a/src/app/features/workplace/select-main-service/select-main-service-cqc-confirm.component.html
+++ b/src/app/features/workplace/select-main-service/select-main-service-cqc-confirm.component.html
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l">Skills For Care have been notified</h1>
-<p class="govuk-body">We'll check your details match the CQC database and then contact you by phone or email within 24 hours</p>
+<p class="govuk-body">We'll check your details match the CQC database and then contact you by phone or email within 24 hours.</p>
 
 <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" [routerLink]="['/contact-us']">Contact us</a> if you have any questions.</p>
 

--- a/src/app/features/workplace/select-main-service/select-main-service-cqc.component.html
+++ b/src/app/features/workplace/select-main-service/select-main-service-cqc.component.html
@@ -8,9 +8,7 @@
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">Is your new main service regulated by the Care Quality Commission (CQC)?</h1>
           </legend>
-          <span class="govuk-hint">
-            If your service is regulated, Skills for Care will need to check your details match the CQC database.
-          </span>
+          <p class="govuk-!-margin-bottom-4">If your service is regulated, Skills for Care will need to check your details match the CQC database.</p>
           <span
             *ngIf="submitted && form.get('cqc').invalid"
             id="cqc-error"

--- a/src/app/features/workplace/select-main-service/select-main-service-cqc.component.html
+++ b/src/app/features/workplace/select-main-service/select-main-service-cqc.component.html
@@ -5,7 +5,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.invalid">
         <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">Is your new main service regulated by the Care Quality Commission (CQC)?</h1>
           </legend>
           <span class="govuk-hint">

--- a/src/app/features/workplace/select-main-service/select-main-service-cqc.component.ts
+++ b/src/app/features/workplace/select-main-service/select-main-service-cqc.component.ts
@@ -31,7 +31,7 @@ export class SelectMainServiceCqcComponent extends Question {
         type: [
           {
             name: 'required',
-            message: 'Select Yes if your new main service is regulated by the CQC.',
+            message: 'Select yes if your new main service is regulated by the CQC',
           },
         ],
       },

--- a/src/app/features/workplace/select-main-service/select-main-service.component.ts
+++ b/src/app/features/workplace/select-main-service/select-main-service.component.ts
@@ -74,6 +74,6 @@ export class SelectMainServiceComponent extends SelectMainService {
   }
 
   get callToActionLabel() {
-    return 'Save and return';
+    return 'Save this change';
   }
 }

--- a/src/app/shared/components/submit-exit-buttons/submit-exit-buttons.component.html
+++ b/src/app/shared/components/submit-exit-buttons/submit-exit-buttons.component.html
@@ -1,23 +1,27 @@
-<div class="govuk-button-group">
-  <button type="submit" class="govuk-button">
-    <ng-container *ngIf="cta; else default">
-      {{ cta }}
-    </ng-container>
-    <ng-template #default> Save and {{ return ? 'return' : 'continue' }} </ng-template>
-  </button>
-  <ng-container *ngIf="return">
-    <span class="govuk-visually-hidden">or</span>
-    <a
-      [routerLink]="return.url"
-      [fragment]="return.fragment"
-      role="button"
-      draggable="false"
-      class="govuk-list govuk-list--inline govuk-util__float-right"
-    >
-      <ng-container *ngIf="exit; else defaultexit">
-        {{ exit }}
+<div class="govuk-grid-row govuk-!-margin-top-6">
+  <div class="govuk-grid-column-one-third">
+    <button type="submit" class="govuk-button">
+      <ng-container *ngIf="cta; else default">
+        {{ cta }}
       </ng-container>
-      <ng-template #defaultexit>Exit</ng-template>
-    </a>
-  </ng-container>
+      <ng-template #default> Save and {{ return ? 'return' : 'continue' }} </ng-template>
+    </button>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <ng-container *ngIf="return">
+      <span class="govuk-visually-hidden">or</span>
+      <a
+        [routerLink]="return.url"
+        [fragment]="return.fragment"
+        role="button"
+        draggable="false"
+        class="govuk-list govuk-list--inline"
+      >
+        <ng-container *ngIf="exit; else defaultexit">
+          {{ exit }}
+        </ng-container>
+        <ng-template #defaultexit>Exit</ng-template>
+      </a>
+    </ng-container>
+  </div>
 </div>

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -78,7 +78,7 @@
     <dt class="govuk-summary-list__key" [ngClass]="{'govuk-panel--light-blue': cqcStatusRequested}">
       Main service
     </dt>
-    <dd class="govuk-summary-list__value" [ngClass]="{'govuk-!-padding-top-3 asc-util-panel-no-pad--light-blue': cqcStatusRequested}">
+    <dd class="govuk-summary-list__value" [ngClass]="{'asc-util-panel-no-pad--light-blue': cqcStatusRequested}">
       <app-summary-record-value [wdfView]="wdfView" [wdfValue]="workplace.wdf?.mainService">
         {{ cqcStatusRequested ? requestedMainService.name : workplace.mainService?.name }}
         <ng-container *ngIf="(cqcStatusRequested && requestedMainService.otherName)

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -78,7 +78,7 @@
     <dt class="govuk-summary-list__key" [ngClass]="{'govuk-panel--light-blue': cqcStatusRequested}">
       Main service
     </dt>
-    <dd class="govuk-summary-list__value" [ngClass]="{'asc-util-panel-no-pad--light-blue': cqcStatusRequested}">
+    <dd class="govuk-summary-list__value" [ngClass]="{'govuk-!-padding-top-3 asc-util-panel-no-pad--light-blue': cqcStatusRequested}">
       <app-summary-record-value [wdfView]="wdfView" [wdfValue]="workplace.wdf?.mainService">
         {{ cqcStatusRequested ? requestedMainService.name : workplace.mainService?.name }}
         <ng-container *ngIf="(cqcStatusRequested && requestedMainService.otherName)

--- a/src/assets/scss/components/_buttons.scss
+++ b/src/assets/scss/components/_buttons.scss
@@ -36,7 +36,7 @@ $button-shadow-size: $govuk-border-width-form-element;
 }
 
 .govuk-button-group {
-  margin-top: govuk-spacing(8);
+  margin-top: govuk-spacing(6);
 }
 
 .govuk-button-heading-group {


### PR DESCRIPTION
**Work done**

**Selecting a main service screen**
- Fixed issue where clicking an error message wasn't focusing on the related form element
- Added input error class to radio buttons
- Fixed `preFillForm` when selectedMainService wasn't available in the list of options (only happens when going from non CQC to CQC)

**Confirmation screen**
- Update `src/app/features/workplace/select-main-service/select-main-service-cqc-confirm.component.html` to use the grid system

**Yes/No screen**
- Updated `src/app/shared/components/submit-exit-buttons/submit-exit-buttons.component.html` to use the grid system
- Updated hint text to be a paragraph

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
