### PR TITLE
[## 16372 ##] Bulk upload pre populating the UNIQUEWORKERID on the training file

### DIFF
--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -2341,7 +2341,11 @@ const exportToCsv = async (NEWLINE, allMyEstablishments, primaryEstablishmentId,
             responseSend(NEWLINE + WorkerCsvValidator.toCSV(thisEstablishment.localIdentifier, thisWorker, MAX_QUALS), 'worker');
           } else if (thisWorker.training) { // or for this Worker's training records
             thisWorker.training.forEach(thisTrainingRecord => {
-              responseSend(NEWLINE + TrainingCsvValidator.toCSV(thisEstablishment.key, thisWorker.key, thisTrainingRecord), 'training');
+              responseSend(NEWLINE + TrainingCsvValidator.toCSV(
+                thisEstablishment.key,
+                thisWorker.localIdentifier ? thisWorker.localIdentifier.replace(/\s/g, '') : '',
+                thisTrainingRecord),
+              'training');
             });
           }
         });

--- a/server/routes/establishments/bulkUpload.js
+++ b/server/routes/establishments/bulkUpload.js
@@ -2294,7 +2294,7 @@ const completePost = async (req, res) => {
 };
 
 const determineMaxQuals = async (primaryEstablishmentId) => {
-  await dbModels.sequelize.query(
+  return dbModels.sequelize.query(
     'select cqc.maxQualifications(:givenPrimaryEstablishment);',
     {
       replacements: {
@@ -2388,13 +2388,14 @@ const downloadGet = async (req, res) => {
 
   if (ALLOWED_DOWNLOAD_TYPES.includes(downloadType)) {
     try {
+      const maxQuals = await determineMaxQuals(primaryEstablishmentId);
       await exportToCsv(
         NEWLINE,
         // only restore those subs that this primary establishment owns
         await restoreExistingEntities(theLoggedInUser, primaryEstablishmentId, isParent, ENTITY_RESTORE_LEVEL, true),
         primaryEstablishmentId,
         downloadType,
-        determineMaxQuals(primaryEstablishmentId),
+        maxQuals,
         responseSend
       );
 

--- a/server/test/unit/routes/establishments/bulkUpload.spec.js
+++ b/server/test/unit/routes/establishments/bulkUpload.spec.js
@@ -496,6 +496,8 @@ describe('/server/routes/establishment/bulkUpload.js', () => {
         }
       ]);
 
+      const trainingCategory = 1;
+
       const lines = [];
 
       const responseSend = (line, stepName = '') => {
@@ -511,7 +513,7 @@ describe('/server/routes/establishment/bulkUpload.js', () => {
             training: [
               {
                 trainingCategory: {
-                  id: 1
+                  id: trainingCategory
                 }
               }
             ]
@@ -525,7 +527,7 @@ describe('/server/routes/establishment/bulkUpload.js', () => {
         }
       ], responseSend);
 
-      expect(lines[1]).to.equal(`${establishment.name},,${BUDI.trainingCategory(BUDI.FROM_ASC, 1)},,,,,`);
+      expect(lines[1]).to.equal(`${establishment.name},,${BUDI.trainingCategory(BUDI.FROM_ASC, trainingCategory)},,,,,`);
     });
 
     it('should have a UNIQUEWORKERID if worker has a LocalIdentifier', async () => {
@@ -535,6 +537,9 @@ describe('/server/routes/establishment/bulkUpload.js', () => {
         }
       ]);
 
+      const trainingCategory = 1;
+      const workerName = 'TesterMcTesterson';
+
       const lines = [];
 
       const responseSend = (line, stepName = '') => {
@@ -547,11 +552,11 @@ describe('/server/routes/establishment/bulkUpload.js', () => {
         workers: [
           {
             nameOrId: 'foobar',
-            localIdentifier: 'TesterMcTesterson',
+            localIdentifier: workerName,
             training: [
               {
                 trainingCategory: {
-                  id: 1
+                  id: trainingCategory
                 }
               }
             ]
@@ -565,7 +570,7 @@ describe('/server/routes/establishment/bulkUpload.js', () => {
         }
       ], responseSend);
 
-      expect(lines[1]).to.equal(`${establishment.name},TesterMcTesterson,${BUDI.trainingCategory(BUDI.FROM_ASC, 1)},,,,,`);
+      expect(lines[1]).to.equal(`${establishment.name},${workerName},${BUDI.trainingCategory(BUDI.FROM_ASC, trainingCategory)},,,,,`);
     });
 
   });


### PR DESCRIPTION
Uses Worker.localIdentifier instead of Worker.key.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
