### PR TITLE
Bug/403 la

### DIFF
--- a/server/routes/reports/localAuthorityReport/user.js
+++ b/server/routes/reports/localAuthorityReport/user.js
@@ -1549,19 +1549,18 @@ const reportGet = async (req, res) => {
         } else {
           // only allow on those establishments being a parent
 
-          console.error('report/training 403 response');
-          await reportLock.saveResponse(req, res, 403, {});
+          console.error('report/localAuthority/user 503 response');
+          await reportLock.saveResponse(req, res, 503, {});
         }
       } else {
-        console.error('report/training - failed restoring establishment');
-        await reportLock.saveResponse(req, res, 503, {});
+        console.error('report/localAuthority/user 403 response');
+          await reportLock.saveResponse(req, res, 403, {});
       }
     } else {
       // only allow on those establishments being a local authority
 
-      console.log('report/localAuthority/user 403 response');
-
-      return res.status(403).send();
+      console.error('report/localAuthority/user - failed restoring establishment');
+      await reportLock.saveResponse(req, res, 503, {});
     }
   } catch (err) {
     console.error('report/localAuthority/user - failed', err);

--- a/server/utils/fileLock.js
+++ b/server/utils/fileLock.js
@@ -64,9 +64,11 @@ const releaseLock = async (reportType, req, res, next) => {
   const establishmentId = req.query.subEstId || req.establishmentId;
   if (!reportsAvailable.includes(reportType)) {
     console.error('Lock *NOT* acquired.');
-    res.status(500).send({
-      message: `reportType not correct`
-    });
+    if (res !== null) {
+      res.status(500).send({
+        message: `reportType not correct`
+      });
+    }
     return;
   }
   const LockHeldTitle = reportType + 'ReportLockHeld';
@@ -80,9 +82,11 @@ const releaseLock = async (reportType, req, res, next) => {
         }
       });
   }
-  res.status(200).send({
-    establishmentId
-  });
+  if (res !== null) {
+    res.status(200).send({
+      establishmentId
+    });
+  }
 };
 
 const saveResponse = async (req, res, statusCode, body, headers) => {


### PR DESCRIPTION
#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change

res can sometimes be null because we call the function after logic has finished, which means we already reply with a 200 status

```javascript 
res.status(200).send({
    message: `Lock for establishment ${establishmentId} acquired.`,
    requestId: req.buRequestId
  });
​
  // run whatever the original logic was
  try {
    await logic(req, res);
  } catch (e) {
  }
​
  // release the lock
  await releaseLock(reportType, req, null, null);
````