### PR TITLE
Fix: Remove GA meta for account ownership

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta content="GooGhywoiu9839t543j0s7543uw1 - pls add areo45@gmail.com to GA account 132324399 with ‘Manage Users and Edit’ permissions - date 14/04/2020." />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <!-- Google Tag Manager -->
     <script>


### PR DESCRIPTION
**Work done**

- Remove meta tag that we used to get ownership of our GA account.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
