### PR TITLE
Fix: Add tag filters to all jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,14 +277,26 @@ jobs:
 workflows:
     build-test-deploy:
       jobs:
-        - install
+        - install:
+            filters:
+               tags:
+                 only: /^v[0-9]+(\.[0-9]+)*$/
         - test_frontend:
+            filters:
+               tags:
+                 only: /^v[0-9]+(\.[0-9]+)*$/
             requires:
               - install
         - test_backend:
+            filters:
+               tags:
+                 only: /^v[0-9]+(\.[0-9]+)*$/
             requires:
               - install
         - performance:
+            filters:
+               tags:
+                 only: /^v[0-9]+(\.[0-9]+)*$/
             requires:
               - install
         - blue_green:


### PR DESCRIPTION
**Work done**

Tags by default are not built by Circle - however, if we have a job that requires other jobs, the required jobs also need to have the tag filter on them

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
