### PR TITLE
Fix: Check app exists before stopping it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ commands:
             # Stop sending traffic to previous version
             cf unmap-route "<<parameters.appname>>" "<<parameters.live_domain>>"<<# parameters.live_subdomain>> -n "<<parameters.live_subdomain>>"<</ parameters.live_subdomain>>
             # stop previous version
-            cf app <<parameters.appname>> && cf stop "<<parameters.appname>>"
+            cf stop "<<parameters.appname>>" || echo "Could not stop previous app"
             # delete previous version
             cf delete "<<parameters.appname>>" -f
             # Switch name of "dark" version to claim correct name

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ commands:
             # Stop sending traffic to previous version
             cf unmap-route "<<parameters.appname>>" "<<parameters.live_domain>>"<<# parameters.live_subdomain>> -n "<<parameters.live_subdomain>>"<</ parameters.live_subdomain>>
             # stop previous version
-            cf stop "<<parameters.appname>>"
+            cf app <<parameters.appname>> && cf stop "<<parameters.appname>>"
             # delete previous version
             cf delete "<<parameters.appname>>" -f
             # Switch name of "dark" version to claim correct name


### PR DESCRIPTION
**Issue**

If you stop an app that does not exist, the cf CLI tool will exit with an error code - by using `|| echo` we can make sure the exit code is 0.

If the app already exists, and it fails to stop - then `cf delete -f` will force delete the app anyway.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
