### PR TITLE
Fix: Require step for prod deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,10 +367,10 @@ workflows:
              workspace_path: .
         - hold_prod:
             type: approval
-             requires:
-               - test_frontend
-               - test_backend
-               - performance
+            requires:
+                - test_frontend
+                - test_backend
+                - performance
             filters:
                 # ignore any commit on any branch by default
                 branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,8 +367,10 @@ workflows:
              workspace_path: .
         - hold_prod:
             type: approval
-            requires:
-                - preprod_deploy
+             requires:
+               - test_frontend
+               - test_backend
+               - performance
             filters:
                 # ignore any commit on any branch by default
                 branches:


### PR DESCRIPTION
**Issue**

We changed the pre prod deployment to be based off the live branch rather than a tag but forgot to update the require block of the `hold_prod` step

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
