### PR TITLE
Fix: Update reference length for workplace/staff to be same as bulk upload

### DIFF
--- a/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
+++ b/src/app/features/bulk-upload/bulk-upload-references/bulk-upload-references.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { AfterViewInit, ElementRef, OnDestroy, OnInit, ViewChild, Directive } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BulkUploadFileType } from '@core/model/bulk-upload.model';
@@ -16,7 +16,7 @@ import { Subscription } from 'rxjs';
 @Directive()
 export class BulkUploadReferences implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('formEl') formEl: ElementRef;
-  protected maxLength = 120;
+  protected maxLength = 50;
   protected subscriptions: Subscription = new Subscription();
   public establishmentName: string;
   public form: FormGroup;


### PR DESCRIPTION
**Work done**

- Changed the max length for workplace and staff references to be 50 characters.

This is inline with the bulk upload validation.

**Note**

I have checked with Jackie and the maximum reference in the current database is 50 characters for Workplaces and 49 characters for Staff

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
