### PR TITLE
Fix: Remove cross-env dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6990,30 +6990,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-env": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.1.tgz",
-      "integrity": "sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^6.0.5"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
-      }
-    },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "aws-sdk-mock": "^4.5.0",
     "chai": "^4.2.0",
     "codelyzer": "^5.1.2",
-    "cross-env": "^5.2.1",
     "faker": "^4.1.0",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",


### PR DESCRIPTION
We used to use `cross-env` in our `npm run start` command but this is no longer the case.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
