### PR TITLE
Revert "Fix: Try halting the deployment if the workflow is for a PR"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,13 +243,6 @@ jobs:
         description: prefix for enviroment variables
         type: string
     steps:
-      - run:
-          name: Check Pull Request
-          command: |
-              if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-                echo "Skipping deployment as this is a pull request"
-                circleci step halt
-              fi
       - checkout
       - restore_cache:
             keys:


### PR DESCRIPTION
Reverts NMDSdevopsServiceAdm/SopraSteria-SFC#2389

`circleci step halt` will stop the job from running, but not the entire workflow which is what we wanted to achieve.