### PR TITLE
Revert "Fix: Skip Deploy/Release for PRs"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,15 +118,7 @@ commands:
             # Switch name of "dark" version to claim correct name
             cf rename "<<parameters.appname>>-dark" "<<parameters.appname>>"
           name: Cloud Foundry - Re-route live Domain
-  skip_if_pr:
-    steps:
-      - run:
-          name: Skip if Pull Request
-          command: |
-              if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-                echo "Skipping as this is a pull request"
-                circleci step halt
-              fi
+
 orbs:
   node: circleci/node@3.0.0
 
@@ -251,7 +243,6 @@ jobs:
         description: prefix for enviroment variables
         type: string
     steps:
-      - skip_if_pr
       - checkout
       - restore_cache:
             keys:
@@ -294,7 +285,6 @@ jobs:
         description: Environment
         type: string
     steps:
-      - skip_if_pr
       - checkout
       - attach_workspace:
           at: .


### PR DESCRIPTION
The `CIRCLE_PULL_REQUEST` isn't set to the current PR for the workflow, it's set for an "associated PR for a branch"

If we merge a PR into `test` but there is an PR open for `test` (i.e `test > `live`) then the `CIRCLE_PULL_REQUEST` will still be set and therefore not deploy to staging.

What I was hoping for, was that `CIRCLE_PULL_REQUEST` wouldn't be set when merging into a branch but would be set when opening a PR.

Reverts NMDSdevopsServiceAdm/SopraSteria-SFC#2394