### PR TITLE
Fix: ALLJOBROLES Bulk Upload validation

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -921,7 +921,7 @@ class Establishment {
             lineNumber: this._lineNumber,
             errCode: Establishment.LOCATION_ID_ERROR,
             errType: 'LOCATION_ID_ERROR',
-            error: 'LOCATIONID already exists in ASC-WDS please contact Support on 0113 241 0969',
+            error: 'LOCATIONID already exists in ASC-WDS please contact Support on 0113 241 09691',
             source: myLocationID,
             name: this._currentLine.LOCALESTID
           });
@@ -1331,7 +1331,7 @@ class Establishment {
 
   _validateAllJobs () {
     // optional
-    const allJobs = this._currentLine.ALLJOBROLES.split(';');
+    const allJobs = (this._currentLine.ALLJOBROLES) ? this._currentLine.ALLJOBROLES.split(';') : [];
     const localValidationErrors = [];
     const vacancies = this._currentLine.VACANCIES.split(';');
     const starters = this._currentLine.STARTERS.split(';');
@@ -2053,38 +2053,36 @@ class Establishment {
 
   // returns true on success, false is any attribute of Establishment fails
   async validate () {
-    let status = true;
-
-    status = !this._validateLocalisedId() ? false : status;
-    status = !this._validateEstablishmentName() ? false : status;
-    status = !this._validateStatus() ? false : status;
+    this._validateLocalisedId();
+    this._validateEstablishmentName();
+    this._validateStatus();
 
     // if the status is unchecked or deleted, then don't continue validation
     if (!STOP_VALIDATING_ON.includes(this._status)) {
-      status = await this._validateAddress() ? false : status;
-      status = !this._validateEstablishmentType() ? false : status;
+      await this._validateAddress();
+      this._validateEstablishmentType();
 
-      status = !this._validateShareWithCQC() ? false : status;
-      status = !this._validateShareWithLA() ? false : status;
-      status = !this._validateLocalAuthorities() ? false : status;
+      this._validateShareWithCQC();
+      this._validateShareWithLA();
+      this._validateLocalAuthorities();
 
-      status = !this._validateMainService() ? false : status;
-      status = !this._validateRegType() ? false : status;
-      status = !this._validateProvID() ? false : status;
-      status = await this._validateLocationID() ? false : status;
+      this._validateMainService();
+      this._validateRegType();
+      this._validateProvID();
+      await this._validateLocationID();
 
-      status = !this._validateAllServices() ? false : status;
-      status = !this._validateServiceUsers() ? false : status;
-      status = !this._validateCapacitiesAndUtilisations() ? false : status;
+      this._validateAllServices();
+      this._validateServiceUsers();
+      this._validateCapacitiesAndUtilisations();
 
-      status = !this._validateTotalPermTemp() ? false : status;
-      status = !this._validateAllJobs() ? false : status;
-      status = !this._validateJobRoleTotals() ? false : status;
+      this._validateTotalPermTemp();
+      this._validateAllJobs();
+      this._validateJobRoleTotals();
 
-      status = !this._validateReasonsForLeaving() ? false : status;
+      this._validateReasonsForLeaving();
     }
 
-    return status;
+    return this.validationErrors.length === 0;
   }
 
   // Adds items to csvEstablishmentSchemaErrors if validations that depend on

--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -921,7 +921,7 @@ class Establishment {
             lineNumber: this._lineNumber,
             errCode: Establishment.LOCATION_ID_ERROR,
             errType: 'LOCATION_ID_ERROR',
-            error: 'LOCATIONID already exists in ASC-WDS please contact Support on 0113 241 09691',
+            error: 'LOCATIONID already exists in ASC-WDS please contact Support on 0113 241 0969',
             source: myLocationID,
             name: this._currentLine.LOCALESTID
           });

--- a/server/test/unit/models/Bulkimport/csv/establishments-old.spec.js
+++ b/server/test/unit/models/Bulkimport/csv/establishments-old.spec.js
@@ -1642,7 +1642,7 @@ describe('/server/models/Bulkimport/csv/establishment.js', () => {
         {
           "errCode": 1110,
           "errType": "LOCATION_ID_ERROR",
-          "error": "LOCATIONID already exists in ASC-WDS please contact Support on 0113 241 0969",
+          "error": "LOCATIONID already exists in ASC-WDS please contact Support on 0113 241 09691",
           "lineNumber": 2,
           "name": "omar3",
           "origin": "Establishments",

--- a/server/test/unit/models/Bulkimport/csv/establishments-old.spec.js
+++ b/server/test/unit/models/Bulkimport/csv/establishments-old.spec.js
@@ -1642,7 +1642,7 @@ describe('/server/models/Bulkimport/csv/establishment.js', () => {
         {
           "errCode": 1110,
           "errType": "LOCATION_ID_ERROR",
-          "error": "LOCATIONID already exists in ASC-WDS please contact Support on 0113 241 09691",
+          "error": "LOCATIONID already exists in ASC-WDS please contact Support on 0113 241 0969",
           "lineNumber": 2,
           "name": "omar3",
           "origin": "Establishments",

--- a/server/test/unit/models/Bulkimport/csv/establishments.spec.js
+++ b/server/test/unit/models/Bulkimport/csv/establishments.spec.js
@@ -46,12 +46,30 @@ const crossValidate = async (establishmentRow, workerRow, callback) => {
 describe('Bulk Upload - Establishment CSV', () => {
   beforeEach(() => {
     sandbox.stub(BUDI, 'initialize');
-    sandbox.stub(models.pcodedata, 'findAll').returns([]);
+    sandbox.stub(models.pcodedata, 'findAll').returns([
+      {}
+    ]);
     sandbox.stub(models.establishment, 'findAll').returns([]);
   });
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  describe('Validations', () => {
+    it('should not validate Starters, Leavers, Vacancies if All Job Roles is blank', async () => {
+      const establishmentRow = buildEstablishmentCSV();
+
+      establishmentRow.ALLJOBROLES = '';
+      establishmentRow.STARTERS = '';
+      establishmentRow.LEAVERS = '';
+      establishmentRow.VACANCIES = '';
+
+      const establishment = await generateEstablishmentFromCsv(establishmentRow);
+      const isValid = await establishment.validate();
+
+      expect(isValid).to.be.true;
+    });
   });
 
   describe('Cross Validations', () => {

--- a/server/test/unit/models/Bulkimport/csv/establishments.spec.js
+++ b/server/test/unit/models/Bulkimport/csv/establishments.spec.js
@@ -57,18 +57,37 @@ describe('Bulk Upload - Establishment CSV', () => {
   });
 
   describe('Validations', () => {
-    it('should not validate Starters, Leavers, Vacancies if All Job Roles is blank', async () => {
+    it('should validate Starters, Leavers, Vacancies if All Job Roles is blank but S/L/V is not blank', async () => {
       const establishmentRow = buildEstablishmentCSV();
+      establishmentRow.ALLJOBROLES = '';
+      establishmentRow.STARTERS = '1';
+      establishmentRow.LEAVERS = '2';
+      establishmentRow.VACANCIES = '3';
 
+      const establishment = await generateEstablishmentFromCsv(establishmentRow);
+
+      expect(establishment.validationErrors).to.deep.equal([
+        {
+          origin: 'Establishments',
+          lineNumber: establishment.lineNumber,
+          errCode: 1280,
+          errType: 'ALL_JOBS_ERROR',
+          error: 'ALLJOBROLES cannot be blank as you have STARTERS, LEAVERS, VACANCIES greater than zero',
+          source: '',
+          name: establishmentRow.LOCALESTID
+        }
+      ]);
+    });
+
+    it('should skip validating Starters, Leavers, Vacancies if All Job Roles and S/L/V is blank', async () => {
+      const establishmentRow = buildEstablishmentCSV();
       establishmentRow.ALLJOBROLES = '';
       establishmentRow.STARTERS = '';
       establishmentRow.LEAVERS = '';
       establishmentRow.VACANCIES = '';
 
       const establishment = await generateEstablishmentFromCsv(establishmentRow);
-      const isValid = await establishment.validate();
-
-      expect(isValid).to.be.true;
+      expect(establishment.validationErrors).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
**Issue**

When doing a bulk upload, if `ALLJOBROLES` was an empty string, it was validating Starters, Leavers and Vacancies.

The reason it was still validating is because an empty string that is `.split` returns an array element of an empty string:

```
[""]
```

As a result, when doing a `.length` check to determine whether to run the validation rule, it was returning a length of 1 element.

**Work done**

In order to skip validation, I have wrapped the split in a ternary so that it will default to an empty array if ALLJOBROLES returns a falsey value.

```
console.log(allJobs);

// before: [""] 
// after: []
```

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
