### PR TITLE
Fix: commas when address fields are empty when searching Workplaces

### DIFF
--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -248,7 +248,7 @@
                     <tbody class="govuk-table__body">
                       <tr class="govuk-table__row govuk-util__vertical-align-top">
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
-                          {{ item.address1 }} {{ [item.address2, item.town, item.county].join(', ') }}
+                          {{ displayAddress(item) }}
                         </td>
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
                           <ng-container *ngIf="item.parent?.nmdsId else noParentID">

--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -248,7 +248,7 @@
                     <tbody class="govuk-table__body">
                       <tr class="govuk-table__row govuk-util__vertical-align-top">
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
-                          {{ item.address1 }} {{ item.address2 }}, {{ item.town }}, {{ item.county }}
+                          {{ item.address1 }} {{ [item.address2, item.town, item.county].join(', ') }}
                         </td>
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
                           <ng-container *ngIf="item.parent?.nmdsId else noParentID">

--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -144,6 +144,12 @@ export class SearchComponent implements OnInit {
     this.backService.setBackLink({ url: ['/dashboard'] });
   }
 
+  protected displayAddress(workplace) {
+    const secondaryAddress = ' ' + [workplace.address2, workplace.town, workplace.county].filter(Boolean).join(', ') || '';
+
+    return workplace.address1 + secondaryAddress;
+  }
+
   public toggleDetails(uid: string, event) {
     event.preventDefault();
     this.workerDetails[uid] = !this.workerDetails[uid];


### PR DESCRIPTION
**Issue**

When an address had missing fields, it was being displayed on the search results as:

```
Address1, , ,
```

**Work done**

- Added function to build up address and filter falsey values.
- Updated template to use new address function

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
