### PR TITLE
Fix: Filter Archived users from Workplace search results

### DIFF
--- a/server/routes/admin/search/establishments/index.js
+++ b/server/routes/admin/search/establishments/index.js
@@ -84,6 +84,7 @@ const search = async function (req, res) {
           required: false,
           where: {
             UserRoleValue: 'Edit',
+            archived: false,
           },
           include: [
             {


### PR DESCRIPTION
**Issue**

When expanding a Workplace on the search results page, the list of users also included those who are archived.

**Work done**

- Updated query to filter out archived users

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
