### PR TITLE
Benchmarks Turnover: adding new type of stateMessage then turnover cant be calculated

### DIFF
--- a/server/routes/establishments/benchmarks/index.js
+++ b/server/routes/establishments/benchmarks/index.js
@@ -92,6 +92,9 @@ const turnoverGetData = async (establishmentId) => {
   }
   const permTemptCount = await models.worker.permAndTempCountForEstablishment(establishmentId);
   const leavers = await models.establishmentJobs.leaversForEstablishment(establishmentId);
+  if (permTemptCount === 0 ){
+    return { percentOfPermTemp: 0 , stateMessage: 'no-permTemp' };
+  }
   const percentOfPermTemp = (leavers / permTemptCount);
   if (percentOfPermTemp > 9.95) {
     return { percentOfPermTemp: 0, stateMessage: 'check-data' };

--- a/server/test/unit/routes/establishments/benchmarks.spec.js
+++ b/server/test/unit/routes/establishments/benchmarks.spec.js
@@ -193,6 +193,28 @@ describe('benchmarks', () => {
       };
       expect(json).to.deep.equal(expectedJSON);
     });
+    it('should return no-permtemp are currently no perm or temp workers', async () => {
+      const establishmentId = 123;
+      sinon.stub(models.establishment, 'turnOverData').returns(
+        {id:"2",NumberOfStaffValue:3,LeaversValue:"5"}
+      );
+      sinon.stub(models.worker, 'permAndTempCountForEstablishment').returns(0);
+      sinon.stub(models.worker, 'countForEstablishment').returns(3);
+      sinon.stub(models.establishmentJobs, 'leaversForEstablishment').returns(1);
+      const json = await benchmarks.turnover(establishmentId);
+      const expectedJSON = {
+        workplaceValue: {
+          value: 0,
+          hasValue: false,
+          stateMessage:"no-permTemp"
+        },
+        comparisonGroup: {
+          value: 0,
+          hasValue: false
+        }
+      };
+      expect(json).to.deep.equal(expectedJSON);
+    });
     it('should return no-data if  leavers isnt filled out', async () => {
       const establishmentId = 123;
       sinon.stub(models.establishment, 'turnOverData').returns(

--- a/src/app/shared/components/benchmarks-tab/benchmarks-tab.component.html
+++ b/src/app/shared/components/benchmarks-tab/benchmarks-tab.component.html
@@ -42,7 +42,7 @@
           Your turnover seems to be over 999%, please contact us.
         </ng-container>
         <ng-container *ngSwitchCase="'no-permTemp'">
-          Turnover only displays when you’ve records for permanent or temporary staff.
+          You need records for permanent or temporary staff to see turnover.
         </ng-container>
       </ng-container>
     </your-workplace>

--- a/src/app/shared/components/benchmarks-tab/benchmarks-tab.component.html
+++ b/src/app/shared/components/benchmarks-tab/benchmarks-tab.component.html
@@ -42,7 +42,7 @@
           Your turnover seems to be over 999%, please contact us.
         </ng-container>
         <ng-container *ngSwitchCase="'no-permTemp'">
-          Your turnover seems to be over 999%, please contact us.
+          Turnover only displays when you’ve records for permanent or temporary staff.
         </ng-container>
       </ng-container>
     </your-workplace>

--- a/src/app/shared/components/benchmarks-tab/benchmarks-tab.component.html
+++ b/src/app/shared/components/benchmarks-tab/benchmarks-tab.component.html
@@ -41,6 +41,9 @@
         <ng-container *ngSwitchCase="'check-data'">
           Your turnover seems to be over 999%, please contact us.
         </ng-container>
+        <ng-container *ngSwitchCase="'no-permTemp'">
+          Your turnover seems to be over 999%, please contact us.
+        </ng-container>
       </ng-container>
     </your-workplace>
     <comparison-group>


### PR DESCRIPTION
#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
