### PR TITLE
Feat: Add tests for SearchComponent Groups tab

### DIFF
--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -339,7 +339,7 @@
     </div>
 
     <div *ngIf="form.type === 'groups'">
-      <table class="govuk-table" *ngIf="results && results.length">
+      <table class="govuk-table" *ngIf="results && results.length" data-testid="group-search-results">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header govuk-!-width-one-third" scope="col">Workplace name</th>
@@ -356,7 +356,7 @@
               </td>
               <td class="govuk-table__cell">{{ item.nmdsId || '-' }}</td>
               <td class="govuk-table__cell">
-                {{ item.employerType.other ? item.employerType.other : item.employerType.value || '-' }}
+                {{ item.employerType?.other ? item.employerType.other : item.employerType?.value || '-' }}
               </td>
               <td class="govuk-table__cell">
                 <a

--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -186,7 +186,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-4">
   <div class="govuk-grid-column-full">
-    <div *ngIf="form.submitted && !results.length && !form.errors.length">
+    <div *ngIf="form.submitted && !results.length && !form.errors.length" data-testid="no-search-results">
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
@@ -367,7 +367,7 @@
                 >
               </td>
             </tr>
-            <tr *ngIf="workerDetails[item.uid]" class="govuk-panel--gray">
+            <tr *ngIf="workerDetails[item.uid]" class="govuk-panel--gray" data-testid="groups-workplace-details">
               <td colspan="6">
                 <div class="govuk-!-margin-2">
                   <table class="govuk-table">
@@ -401,7 +401,7 @@
                     </tbody>
                   </table>
                 </div>
-                <div class="govuk-!-margin-2" *ngIf="item.users.length > 0">
+                <div class="govuk-!-margin-2" *ngIf="item.users?.length > 0">
                   <table class="govuk-table">
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">

--- a/src/app/features/search/search.component.spec.ts
+++ b/src/app/features/search/search.component.spec.ts
@@ -1,25 +1,83 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { render, within } from '@testing-library/angular';
 
 import { SearchComponent } from './search.component';
 
-fdescribe('SearchComponent', () => {
+describe('SearchComponent', () => {
   it('should render the search component', async () => {
-    const { click, getByText, debug, fixture } = await render(SearchComponent, {
+    await render(SearchComponent, {
+      detectChanges: false,
       imports: [
+        FormsModule,
         ReactiveFormsModule,
         HttpClientTestingModule,
         SharedModule,
-        RouterTestingModule.withRoutes([{ path: 'search-groups', component: SearchComponent }]),
+        RouterTestingModule.withRoutes([
+          { path: 'search-groups', component: SearchComponent }
+        ]),
       ],
     });
+  });
 
-    click(getByText('Groups'));
-    fixture.detectChanges();
+  describe('Groups', () => {
+    it('should show the Groups tab', async () => {
+      const { fixture, navigate, getByText } = await render(SearchComponent, {
+        detectChanges: false,
+        imports: [
+          FormsModule,
+          ReactiveFormsModule,
+          HttpClientTestingModule,
+          SharedModule,
+          RouterTestingModule.withRoutes([
+            { path: 'search-groups', component: SearchComponent }
+          ]),
+        ],
+      });
 
-    debug();
+      await navigate('search-groups');
+
+      fixture.detectChanges();
+
+      expect(getByText('Search for a group'));
+    });
+
+    it('should render the search results when searching for a group', async () => {
+      const { fixture, navigate, click, getByText, getByTestId } = await render(SearchComponent, {
+        detectChanges: false,
+        imports: [
+          FormsModule,
+          ReactiveFormsModule,
+          HttpClientTestingModule,
+          SharedModule,
+          RouterTestingModule.withRoutes([
+            { path: 'search-groups', component: SearchComponent }
+          ]),
+        ],
+      });
+
+      const httpTestingController = TestBed.inject(HttpTestingController);
+
+      await navigate('search-groups');
+
+      fixture.detectChanges();
+
+      click(getByText('Search groups'));
+
+      const req = httpTestingController.expectOne('/api/admin/search/groups');
+      req.flush([{
+        uid: 'ad3bbca7-2913-4ba7-bb2d-01014be5c48f',
+        name: 'Workplace Name',
+      }]);
+
+      httpTestingController.verify();
+
+      fixture.detectChanges();
+
+      await within(getByTestId('group-search-results')).getByText('Workplace Name');
+    });
   });
 });

--- a/src/app/features/search/search.component.spec.ts
+++ b/src/app/features/search/search.component.spec.ts
@@ -1,0 +1,25 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { SearchComponent } from './search.component';
+
+fdescribe('SearchComponent', () => {
+  it('should render the search component', async () => {
+    const { click, getByText, debug, fixture } = await render(SearchComponent, {
+      imports: [
+        ReactiveFormsModule,
+        HttpClientTestingModule,
+        SharedModule,
+        RouterTestingModule.withRoutes([{ path: 'search-groups', component: SearchComponent }]),
+      ],
+    });
+
+    click(getByText('Groups'));
+    fixture.detectChanges();
+
+    debug();
+  });
+});

--- a/src/app/features/search/search.component.spec.ts
+++ b/src/app/features/search/search.component.spec.ts
@@ -7,36 +7,30 @@ import { render, within } from '@testing-library/angular';
 
 import { SearchComponent } from './search.component';
 
+const getSearchComponent = async () => {
+  return render(SearchComponent, {
+    detectChanges: false,
+    imports: [
+      FormsModule,
+      ReactiveFormsModule,
+      HttpClientTestingModule,
+      SharedModule,
+      RouterTestingModule.withRoutes([
+        { path: 'search-groups', component: SearchComponent }
+      ]),
+    ],
+  });
+}
+
 describe('SearchComponent', () => {
-  it('should render the search component', async () => {
-    await render(SearchComponent, {
-      detectChanges: false,
-      imports: [
-        FormsModule,
-        ReactiveFormsModule,
-        HttpClientTestingModule,
-        SharedModule,
-        RouterTestingModule.withRoutes([
-          { path: 'search-groups', component: SearchComponent }
-        ]),
-      ],
-    });
+  afterEach(() => {
+    const httpTestingController = TestBed.inject(HttpTestingController);
+    httpTestingController.verify();
   });
 
   describe('Groups', () => {
     it('should show the Groups tab', async () => {
-      const { fixture, navigate, getByText } = await render(SearchComponent, {
-        detectChanges: false,
-        imports: [
-          FormsModule,
-          ReactiveFormsModule,
-          HttpClientTestingModule,
-          SharedModule,
-          RouterTestingModule.withRoutes([
-            { path: 'search-groups', component: SearchComponent }
-          ]),
-        ],
-      });
+      const { fixture, navigate, getByText } = await getSearchComponent();
 
       await navigate('search-groups');
 
@@ -46,18 +40,7 @@ describe('SearchComponent', () => {
     });
 
     it('should render the search results when searching for a group', async () => {
-      const { fixture, navigate, click, getByText, getByTestId } = await render(SearchComponent, {
-        detectChanges: false,
-        imports: [
-          FormsModule,
-          ReactiveFormsModule,
-          HttpClientTestingModule,
-          SharedModule,
-          RouterTestingModule.withRoutes([
-            { path: 'search-groups', component: SearchComponent }
-          ]),
-        ],
-      });
+      const { fixture, navigate, click, getByText, getByTestId } = await getSearchComponent();
 
       const httpTestingController = TestBed.inject(HttpTestingController);
 
@@ -73,11 +56,89 @@ describe('SearchComponent', () => {
         name: 'Workplace Name',
       }]);
 
-      httpTestingController.verify();
-
       fixture.detectChanges();
 
       await within(getByTestId('group-search-results')).getByText('Workplace Name');
+    });
+
+    it('should expand the Workplace details when clicking Open', async () => {
+      const { fixture, navigate, click, getByText, getByTestId } = await getSearchComponent();
+
+      const httpTestingController = TestBed.inject(HttpTestingController);
+
+      await navigate('search-groups');
+
+      fixture.detectChanges();
+
+      click(getByText('Search groups'));
+
+      const req = httpTestingController.expectOne('/api/admin/search/groups');
+      req.flush([{
+        uid: 'ad3bbca7-2913-4ba7-bb2d-01014be5c48f',
+        name: 'Workplace Name',
+        address1: '44',
+        address2: 'Grace St',
+        town: 'Leeds',
+        county: 'West Yorkshire',
+        postcode: 'WF14 9TS',
+      }]);
+
+      fixture.detectChanges();
+
+      const searchResults = within(getByTestId('group-search-results'));
+      click(searchResults.getByText('Open'));
+
+      expect(searchResults.getByText('44 Grace St, Leeds, West Yorkshire, WF14 9TS'));
+    });
+
+    it('should collapse the Workplace details when clicking Close', async () => {
+      const { fixture, navigate, click, getByText, getByTestId } = await getSearchComponent();
+
+      const httpTestingController = TestBed.inject(HttpTestingController);
+
+      await navigate('search-groups');
+
+      fixture.detectChanges();
+
+      click(getByText('Search groups'));
+
+      const req = httpTestingController.expectOne('/api/admin/search/groups');
+      req.flush([{
+        uid: 'ad3bbca7-2913-4ba7-bb2d-01014be5c48f',
+        name: 'Workplace Name',
+        address1: '44',
+        address2: 'Grace St',
+        town: 'Leeds',
+        county: 'West Yorkshire',
+        postcode: 'WF14 9TS',
+      }]);
+
+      fixture.detectChanges();
+
+      const searchResults = within(getByTestId('group-search-results'));
+      click(searchResults.getByText('Open'));
+      click(searchResults.getByText('Close'));
+
+      expect(searchResults.queryByTestId('groups-workplace-details')).toBeNull();
+    });
+
+    it('should show a warning when there are no search results', async () => {
+      const { fixture, navigate, click, getByText, getByTestId } = await getSearchComponent();
+
+      const httpTestingController = TestBed.inject(HttpTestingController);
+
+      await navigate('search-groups');
+
+      fixture.detectChanges();
+
+      click(getByText('Search groups'));
+
+      const req = httpTestingController.expectOne('/api/admin/search/groups');
+      req.flush([]);
+
+      fixture.detectChanges();
+
+      expect(getByTestId('no-search-results'));
     });
   });
 });


### PR DESCRIPTION
**Work done**

- Added tests for the groups tab in the `SearchComponent`
- Used null propagation to guard against empty properties in the results object.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
