### PR TITLE
Fix Allow ng test to run in watch mode locally to speed up feedback loop

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,5 @@
+const isCI = require('is-ci');
+
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 module.exports = function (config) {
@@ -26,7 +28,8 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: false,
+    autoWatch: !isCI,
+    singleRun: isCI,
     browsers: ['HeadlessChrome'],
     customLaunchers: {
       HeadlessChrome: {
@@ -36,7 +39,6 @@ module.exports = function (config) {
     },
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
-    singleRun: true,
   	browserNoActivityTimeout: 100000
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6060,10 +6060,9 @@
       }
     },
     "ci-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -10219,12 +10218,11 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "requires": {
-        "ci-info": "^1.5.0"
+        "ci-info": "^2.0.0"
       }
     },
     "is-color-stop": {
@@ -23628,6 +23626,23 @@
         "latest-version": "^3.0.0",
         "semver-diff": "^2.0.0",
         "xdg-basedir": "^3.0.0"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^1.5.0"
+          }
+        }
       }
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "govuk-frontend": "^2.13.0",
     "helmet": "^3.23.2",
     "honeycomb-beeline": "^2.1.1",
+    "is-ci": "^2.0.0",
     "js-yaml": "^3.14.0",
     "jsonwebtoken": "^8.5.1",
     "jszip": "^3.5.0",


### PR DESCRIPTION
**Issue**

When writing tests locally, making changes involves waiting for a whole rebuild only to be told you've made a mistake in your set up / expectations etc.

As a result, writing new tests can be quite arduous.

After some investigating, if you have `autoWatch` set to `true` and `singleRun` set to true, then no tests will run.

However, you cannot override `singleRun` from the `ng test` command.

Given that `singleRun` is a config setting for when running tests in CI (to make it exit) - I have included the `is-ci` package so that we can set the values as required by CI.

The end result is:

Locally:

```
autoWatch: true,
singleRun: false,
```

in CI:

```
autoWatch: false
singleRun: true
```

Running `ng test` will now run the tests, wait for any changes then re-build / re-run the suite - the feedback loop is much faster.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
