### PR TITLE
Fix: ng build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
   install:
     working_directory: ~/project
     docker:
-      - image: circleci/node:lts-browsers
+      - image: circleci/node:12.19.0-browsers
     environment:
       NODE_OPTIONS=--max_old_space_size=4096
     steps:
@@ -146,7 +146,7 @@ jobs:
                 - dist
   test_frontend:
     docker:
-      - image: circleci/node:lts-browsers
+      - image: circleci/node:12.19.0-browsers
     steps:
       - checkout
       - restore_cache:
@@ -158,7 +158,7 @@ jobs:
           command: npm run test
   test_backend:
     docker:
-      - image: circleci/node:lts-browsers
+      - image: circleci/node:12.19.0-browsers
     steps:
       - checkout
       - restore_cache:
@@ -168,7 +168,7 @@ jobs:
           command: npm run server:test:unit
   performance:
     docker:
-      - image: circleci/node:lts-browsers
+      - image: circleci/node:12.19.0-browsers
     steps:
         - checkout
         - attach_workspace:
@@ -280,7 +280,7 @@ jobs:
           live_domain: <<parameters.live_domain>>
   sentry_release:
     docker:
-      - image: circleci/node:lts-browsers
+      - image: circleci/node:12.19.0-browsers
     environment:
       SENTRY_ORG: skills-for-care
       SENTRY_PROJECT: skills-for-care

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,8 @@ jobs:
     working_directory: ~/project
     docker:
       - image: circleci/node:lts-browsers
-        environment:
-          NODE_OPTIONS=--max_old_space_size=4096
+    environment:
+      NODE_OPTIONS=--max_old_space_size=4096
     steps:
         - checkout
         - node/install-packages:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "npm run cf:migrate && node --max-old-space-size=4096 server.js",
-    "build": "ng build",
+    "build": "ng build --no-progress",
     "build:clean": "rimraf dist",
     "build:watch": "ng serve --proxy-config proxy.conf.json",
     "build:prod": "npm run build:clean && ng build --prod",


### PR DESCRIPTION
**Issue**

v14 of Node was made LTS 2 days ago and that seems to coincide with when the issue with `ng build` started happening.

`ng build` also uses ~2GB of memory but the default is 1.5GB.

**Work done**

- Fixed `lts-browsers` image to use `12.19.0-browsers`
- Fixed `.circleci/config.yml` environment variable for `NODE_OPTIONS` to set the `--max-old-space`
- Added `--no-progress` to `ng build`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
