### PR TITLE
Revert es2015 to es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es2015",
+    "target": "es5",
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"]
   }


### PR DESCRIPTION
**Issue**

Since changing the target from `es5` to `es2015` it introduced a new build feature called "differential loading"

However this is a feature that is constantly failing due to a lack of memory and we only get 4GB on our CircleCI free plan.

**Work done**

- Revert `tsconfig.json` target from `es2015` to `es5`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
