### PR TITLE
Fix: Tab alert

### DIFF
--- a/src/app/shared/components/tabs/tabs.component.html
+++ b/src/app/shared/components/tabs/tabs.component.html
@@ -7,8 +7,6 @@
         id="tab_{{ tab.slug }}"
         class="govuk-tabs__tab"
         [class.govuk-tabs__tab--selected]="tab.active"
-        [class.govuk-tabs__tab--alert]="tab.alert"
-        [class.govuk-tabs__tab--red-alert]="tab.redAlert"
         href="#{{ tab.slug }}"
         role="tab"
         [attr.aria-controls]="tab.slug"
@@ -21,6 +19,8 @@
       >
         {{ tab.title }}
       </a>
+
+      <i [class.govuk-tabs__tab--alert]="tab.alert" [class.govuk-tabs__tab--red-alert]="tab.redAlert"></i>
     </li>
   </ng-container>
 </ul>


### PR DESCRIPTION
**Issue**

When the tab is focused and has an alert flag, the highlight was also highlighting the icon.

If there was an icon that was the same colour it would not be visible.

**Work done**

- Moved the icon outside of the focus state.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
