### PR TITLE
My Account / User Details: Fix copy, exit links, breadcrumbs and eslint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,10 @@
     }
   },
   "lint-staged": {
-    "*.{js,ts,component.html}": "eslint --cache --fix",
-    "*.{js,css,md}": "prettier --write"
+    "*.{js,ts,component.html}": [
+      "eslint --cache --fix",
+      "prettier --write"
+    ],
+    "*.{css,md}": "prettier --write"
   }
 }

--- a/src/app/core/breadcrumb/breadcrumb.model.ts
+++ b/src/app/core/breadcrumb/breadcrumb.model.ts
@@ -8,6 +8,7 @@ export enum JourneyType {
   SUBSIDIARY_REPORTS,
   NOTIFICATIONS,
   MANDATORY_TRAINING,
+  EDIT_USER,
 }
 
 export interface JourneyRoute {

--- a/src/app/core/breadcrumb/journey.accounts.ts
+++ b/src/app/core/breadcrumb/journey.accounts.ts
@@ -1,6 +1,8 @@
 import { JourneyRoute } from './breadcrumb.model';
 
 enum Path {
+  USER_ACCOUNT = '/workplace/:workplaceUid/user/:workerUid',
+  EDIT_USER_ACCOUNT = '/workplace/:workplaceUid/user/:workerUid/edit-details',
   ACCOUNT_DETAILS = '/account-management',
   YOUR_DETAILS = '/account-management/change-your-details',
   YOUR_PASSWORD = '/account-management/change-password',
@@ -10,7 +12,7 @@ enum Path {
 export const accountJourney: JourneyRoute = {
   children: [
     {
-      title: 'Account details',
+      title: 'My account details',
       path: Path.ACCOUNT_DETAILS,
       children: [
         {
@@ -18,12 +20,27 @@ export const accountJourney: JourneyRoute = {
           path: Path.YOUR_DETAILS,
         },
         {
-          title: 'Your password',
+          title: 'Password',
           path: Path.YOUR_PASSWORD,
         },
         {
-          title: 'Your security question',
+          title: 'Security question',
           path: Path.YOUR_SECURITY_QUESTION,
+        },
+      ],
+    },
+  ],
+};
+
+export const editUserJourney: JourneyRoute = {
+  children: [
+    {
+      title: 'User details',
+      path: Path.USER_ACCOUNT,
+      children: [
+        {
+          title: 'Details',
+          path: Path.EDIT_USER_ACCOUNT,
         },
       ],
     },

--- a/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/src/app/core/breadcrumb/journey.workplaces.ts
@@ -30,15 +30,15 @@ export const myWorkplaceJourney: JourneyRoute = {
       },
     },
     {
-      title: 'New user account',
+      title: 'Add a user',
       path: Path.CREATE_ACCOUNT,
     },
     {
-      title: 'Account details',
+      title: 'User details',
       path: Path.USER_ACCOUNT,
       referrer: {
         path: Path.DASHBOARD,
-        fragment: 'user-accounts',
+        fragment: 'users',
       },
       children: [
         {
@@ -46,7 +46,7 @@ export const myWorkplaceJourney: JourneyRoute = {
           path: Path.USER_PERMISSIONS,
           referrer: {
             path: Path.DASHBOARD,
-            fragment: 'user-accounts',
+            fragment: 'users',
           },
         },
       ],
@@ -81,15 +81,15 @@ export const allWorkplacesJourney: JourneyRoute = {
               },
             },
             {
-              title: 'New user account',
+              title: 'Add a user',
               path: Path.CREATE_ACCOUNT,
             },
             {
-              title: 'Account details',
+              title: 'User details',
               path: Path.USER_ACCOUNT,
               referrer: {
                 path: Path.WORKPLACE,
-                fragment: 'user-accounts',
+                fragment: 'users',
               },
               children: [
                 {
@@ -97,7 +97,7 @@ export const allWorkplacesJourney: JourneyRoute = {
                   path: Path.USER_PERMISSIONS,
                   referrer: {
                     path: Path.WORKPLACE,
-                    fragment: 'user-accounts',
+                    fragment: 'users',
                   },
                 },
               ],

--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -28,7 +28,7 @@
         <ng-container *ngIf="isLoggedIn()">
           <li class="govuk-header__navigation-item">{{ fullname }}</li>
           <li class="govuk-header__navigation-item">
-            <a [routerLink]="['/account-management']" class="govuk-header__link">Account</a>
+            <a [routerLink]="['/account-management']" class="govuk-header__link">My Account</a>
           </li>
           <li class="govuk-header__navigation-item">
             <a href="#" (click)="signOut($event)" class="govuk-header__link">Logout</a>

--- a/src/app/core/model/account.model.ts
+++ b/src/app/core/model/account.model.ts
@@ -9,6 +9,7 @@ export interface CreateAccountRequest {
 }
 
 export interface CreateAccountResponse {
+  uid: string;
   establishmentId: number;
   establishmentUid: string;
   message: string;

--- a/src/app/core/resolvers/user-account.resolver.ts
+++ b/src/app/core/resolvers/user-account.resolver.ts
@@ -14,9 +14,9 @@ export class UserAccountResolver implements Resolve<any> {
 
     return this.userService.getUserDetails(establishmentUid, userUid).pipe(
       catchError(() => {
-        this.router.navigate(['/workplace', establishmentUid], { fragment: 'user-accounts' });
+        this.router.navigate(['/workplace', establishmentUid], { fragment: 'users' });
         return of(null);
-      })
+      }),
     );
   }
 }

--- a/src/app/core/services/breadcrumb.service.ts
+++ b/src/app/core/services/breadcrumb.service.ts
@@ -2,7 +2,7 @@ import { Location } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { NavigationEnd, PRIMARY_OUTLET, Router, UrlSegment } from '@angular/router';
 import { JourneyRoute, JourneyType } from '@core/breadcrumb/breadcrumb.model';
-import { accountJourney } from '@core/breadcrumb/journey.accounts';
+import { accountJourney, editUserJourney } from '@core/breadcrumb/journey.accounts';
 import { bulkUploadJourney } from '@core/breadcrumb/journey.bulk-upload';
 import { mandatoryTrainingJourney } from '@core/breadcrumb/journey.mandatory_training';
 import { notificationsJourney } from '@core/breadcrumb/journey.notifications';
@@ -23,11 +23,11 @@ export class BreadcrumbService {
   constructor(private router: Router, private location: Location) {
     this.router.events
       .pipe(
-        filter(event => event instanceof NavigationEnd),
+        filter((event) => event instanceof NavigationEnd),
         map(() => parse(this.router.url).pathname),
         distinctUntilChanged(),
         map(() => this._routes$.value),
-        filter(val => !!val)
+        filter((val) => !!val),
       )
       .subscribe(() => {
         this._routes$.next(null);
@@ -120,7 +120,7 @@ export class BreadcrumbService {
   }
 
   private getParts(url: string) {
-    return url.split('/').filter(part => part !== '');
+    return url.split('/').filter((part) => part !== '');
   }
 
   private isParameter(part: string) {
@@ -156,6 +156,10 @@ export class BreadcrumbService {
       }
       case JourneyType.ACCOUNT: {
         routes = accountJourney;
+        break;
+      }
+      case JourneyType.EDIT_USER: {
+        routes = editUserJourney;
         break;
       }
       case JourneyType.NOTIFICATIONS: {

--- a/src/app/features/account-management/account-management-routing.module.ts
+++ b/src/app/features/account-management/account-management-routing.module.ts
@@ -14,12 +14,12 @@ const routes: Routes = [
   {
     path: 'change-password',
     component: ChangePasswordComponent,
-    data: { title: 'Your password' },
+    data: { title: 'Password' },
   },
   {
     path: 'change-user-security',
     component: ChangeUserSecurityComponent,
-    data: { title: 'Your security question' },
+    data: { title: 'Security question' },
   },
   {
     path: 'change-your-details',

--- a/src/app/features/account-management/change-password/edit/edit.component.html
+++ b/src/app/features/account-management/change-password/edit/edit.component.html
@@ -12,17 +12,11 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <span class="govuk-caption-l">{{ userDetails?.fullname }}</span>
-          <h1 class="govuk-fieldset__heading">
-            Your password
-          </h1>
+          <h1 class="govuk-fieldset__heading">Password</h1>
         </legend>
 
-        <p>Change password for account {{ userDetails?.username }}</p>
-
         <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && getOldPasswordInput.errors">
-          <label class="govuk-label" for="oldPasswordInput">
-            Password
-          </label>
+          <label class="govuk-label" for="oldPasswordInput">Old password</label>
           <span *ngIf="submitted && getOldPasswordInput.errors" id="oldPasswordInput-error" class="govuk-error-message">
             <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('oldPasswordInput') }}
           </span>
@@ -38,11 +32,9 @@
 
         <div [formGroupName]="'passwordGroup'">
           <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && getCreatePasswordInput.errors">
-            <label class="govuk-label" for="createPasswordInput">
-              New password
-            </label>
+            <label class="govuk-label" for="createPasswordInput">New password</label>
             <span id="createPasswordInput-hint" class="govuk-hint">
-              This must be at least 8 characters, contain one uppercase and one lowercase letter and a number
+              This should be at least 8 characters, contain one uppercase and one lowercase letter and a number
             </span>
             <span
               *ngIf="submitted && getCreatePasswordInput.errors"
@@ -64,9 +56,7 @@
           </div>
 
           <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && getConfirmPasswordInput.errors">
-            <label class="govuk-label" for="confirmPasswordInput">
-              Confirm password
-            </label>
+            <label class="govuk-label" for="confirmPasswordInput">Confirm new password</label>
             <span
               *ngIf="submitted && getConfirmPasswordInput.errors"
               id="passwordGroup-confirmPasswordInput-error"
@@ -89,5 +79,5 @@
     </div>
   </div>
 
-  <app-submit-exit-buttons [cta]="'Save new password'" [return]="return"></app-submit-exit-buttons>
+  <app-submit-exit-buttons [cta]="'Save and return'" [exit]="'Cancel'" [return]="return"></app-submit-exit-buttons>
 </form>

--- a/src/app/features/account-management/change-user-security/change-user-security.component.html
+++ b/src/app/features/account-management/change-user-security/change-user-security.component.html
@@ -12,12 +12,10 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <span class="govuk-caption-l">{{ userDetails?.fullname }}</span>
-          <h1 class="govuk-fieldset__heading">
-            Your security question
-          </h1>
+          <h1 class="govuk-fieldset__heading">Security question</h1>
         </legend>
 
-        <p>You will need this if you forget your username or if you speak to Skills for Care about your account.</p>
+        <p>You'll need this if you forget your username or need to speak to Skills for Care about your account.</p>
 
         <ng-container *ngFor="let item of formControlsMap">
           <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get(item.name).errors">
@@ -45,5 +43,5 @@
     </div>
   </div>
 
-  <app-submit-exit-buttons [return]="return"></app-submit-exit-buttons>
+  <app-submit-exit-buttons [return]="return" [exit]="'Cancel'"></app-submit-exit-buttons>
 </form>

--- a/src/app/features/account-management/change-user-security/change-user-security.component.ts
+++ b/src/app/features/account-management/change-user-security/change-user-security.component.ts
@@ -11,13 +11,13 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
-import { SecurityQuestion } from '@features/account/security-question/security-question';
+import { SecurityQuestionDirective } from '@features/account/security-question/security-question';
 
 @Component({
   selector: 'app-change-user-security',
   templateUrl: './change-user-security.component.html',
 })
-export class ChangeUserSecurityComponent extends SecurityQuestion {
+export class ChangeUserSecurityComponent extends SecurityQuestionDirective {
   private serverErrorsMap: Array<ErrorDefinition>;
   public userDetails: UserDetails;
   private primaryWorkplace: Establishment;
@@ -30,7 +30,7 @@ export class ChangeUserSecurityComponent extends SecurityQuestion {
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
-    protected router: Router
+    protected router: Router,
   ) {
     super(backService, errorSummaryService, formBuilder, router);
   }
@@ -46,13 +46,13 @@ export class ChangeUserSecurityComponent extends SecurityQuestion {
 
   protected setupSubscription(): void {
     this.subscriptions.add(
-      this.userService.loggedInUser$.subscribe(user => {
+      this.userService.loggedInUser$.subscribe((user) => {
         this.userDetails = user;
         this.preFillForm({
           securityQuestion: user.securityQuestion,
           securityQuestionAnswer: user.securityQuestionAnswer,
         });
-      })
+      }),
     );
   }
 
@@ -68,15 +68,15 @@ export class ChangeUserSecurityComponent extends SecurityQuestion {
   private changeUserDetails(userDetails: UserDetails): void {
     this.subscriptions.add(
       this.userService.updateUserDetails(this.primaryWorkplace.uid, this.userDetails.uid, userDetails).subscribe(
-        data => {
+        (data) => {
           this.userService.loggedInUser = { ...this.userDetails, ...data };
           this.router.navigate(['/account-management']);
         },
         (error: HttpErrorResponse) => {
           this.form.setErrors({ serverError: true });
           this.serverError = this.errorSummaryService.getServerErrorMessage(error.status, this.serverErrorsMap);
-        }
-      )
+        },
+      ),
     );
   }
 

--- a/src/app/features/account-management/change-your-details/change-your-details.component.html
+++ b/src/app/features/account-management/change-your-details/change-your-details.component.html
@@ -12,9 +12,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <span class="govuk-caption-l">{{ userDetails?.fullname }}</span>
-          <h1 class="govuk-fieldset__heading">
-            Your details
-          </h1>
+          <h1 class="govuk-fieldset__heading">Your details</h1>
         </legend>
 
         <ng-container *ngFor="let item of formControlsMap">
@@ -43,5 +41,5 @@
     </div>
   </div>
 
-  <app-submit-exit-buttons [return]="return"></app-submit-exit-buttons>
+  <app-submit-exit-buttons [return]="return" [exit]="'Cancel'"></app-submit-exit-buttons>
 </form>

--- a/src/app/features/account-management/change-your-details/change-your-details.component.ts
+++ b/src/app/features/account-management/change-your-details/change-your-details.component.ts
@@ -10,13 +10,13 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
-import { AccountDetails } from '@features/account/account-details/account-details';
+import { AccountDetailsDirective } from '@features/account/account-details/account-details';
 
 @Component({
   selector: 'app-change-your-details',
   templateUrl: './change-your-details.component.html',
 })
-export class ChangeYourDetailsComponent extends AccountDetails {
+export class ChangeYourDetailsComponent extends AccountDetailsDirective {
   public callToActionLabel = 'Save and return';
   public userDetails: UserDetails;
   private primaryWorkplace: Establishment;
@@ -28,7 +28,7 @@ export class ChangeYourDetailsComponent extends AccountDetails {
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
     protected router: Router,
-    protected userService: UserService
+    protected userService: UserService,
   ) {
     super(backService, errorSummaryService, fb, router);
   }
@@ -43,10 +43,10 @@ export class ChangeYourDetailsComponent extends AccountDetails {
 
   private setupSubscriptions(): void {
     this.subscriptions.add(
-      this.userService.loggedInUser$.subscribe(user => {
+      this.userService.loggedInUser$.subscribe((user) => {
         this.userDetails = user;
         this.prefillForm(user);
-      })
+      }),
     );
   }
 
@@ -59,12 +59,12 @@ export class ChangeYourDetailsComponent extends AccountDetails {
   private changeUserDetails(userDetails: UserDetails): void {
     this.subscriptions.add(
       this.userService.updateUserDetails(this.primaryWorkplace.uid, this.userDetails.uid, userDetails).subscribe(
-        data => {
+        (data) => {
           this.userService.loggedInUser = { ...this.userDetails, ...data };
           this.router.navigate(['/account-management']);
         },
-        (error: HttpErrorResponse) => this.onError(error)
-      )
+        (error: HttpErrorResponse) => this.onError(error),
+      ),
     );
   }
 }

--- a/src/app/features/account-management/your-account/your-account.component.html
+++ b/src/app/features/account-management/your-account/your-account.component.html
@@ -1,5 +1,5 @@
 <span class="govuk-caption-l">{{ user?.fullname }}</span>
-<h1 class="govuk-heading-l">Account details</h1>
+<h1 class="govuk-heading-l">My account details</h1>
 
 <app-summary-list [topBorder]="true" [summaryList]="userInfo"></app-summary-list>
 <app-summary-list [topBorder]="true" [summaryList]="loginInfo"></app-summary-list>

--- a/src/app/features/account-management/your-account/your-account.component.ts
+++ b/src/app/features/account-management/your-account/your-account.component.ts
@@ -24,12 +24,12 @@ export class YourAccountComponent implements OnInit, OnDestroy {
     this.breadcrumbService.show(JourneyType.ACCOUNT);
 
     this.subscriptions.add(
-      this.userService.loggedInUser$.subscribe(user => {
+      this.userService.loggedInUser$.subscribe((user) => {
         if (user) {
           this.user = user;
           this.setAccountDetails();
         }
-      })
+      }),
     );
   }
 
@@ -49,7 +49,7 @@ export class YourAccountComponent implements OnInit, OnDestroy {
         data: this.user.email,
       },
       {
-        label: 'Contact phone',
+        label: 'Phone number',
         data: this.user.phone,
       },
     ];

--- a/src/app/features/account/account-details/account-details.ts
+++ b/src/app/features/account/account-details/account-details.ts
@@ -1,5 +1,6 @@
+/*eslint @typescript-eslint/no-empty-function: ["error", { allow: ['methods'] }]*/
 import { HttpErrorResponse } from '@angular/common/http';
-import { AfterViewInit, ElementRef, OnDestroy, OnInit, ViewChild, Directive } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { EMAIL_PATTERN, PHONE_PATTERN } from '@core/constants/constants';
@@ -11,7 +12,7 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { Subscription } from 'rxjs';
 
 @Directive()
-export class AccountDetails implements OnInit, OnDestroy, AfterViewInit {
+export abstract class AccountDetailsDirective implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('formEl') formEl: ElementRef;
   public serverError: string;
   public serverErrorsMap: Array<ErrorDefinition>;
@@ -31,7 +32,7 @@ export class AccountDetails implements OnInit, OnDestroy, AfterViewInit {
       name: 'email',
     },
     {
-      label: 'Contact phone number',
+      label: 'Phone number',
       name: 'phone',
     },
   ];
@@ -127,11 +128,11 @@ export class AccountDetails implements OnInit, OnDestroy, AfterViewInit {
         type: [
           {
             name: 'required',
-            message: 'Please enter contact phone number.',
+            message: 'Please enter phone number.',
           },
           {
             name: 'pattern',
-            message: 'Invalid contact phone number.',
+            message: 'Invalid phone number.',
           },
         ],
       },

--- a/src/app/features/account/security-question/security-question.ts
+++ b/src/app/features/account/security-question/security-question.ts
@@ -1,4 +1,5 @@
-import { AfterViewInit, ElementRef, OnDestroy, OnInit, ViewChild, Directive } from '@angular/core';
+/*eslint @typescript-eslint/no-empty-function: ["error", { allow: ['methods'] }]*/
+import { AfterViewInit, Directive, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ErrorDetails } from '@core/model/errorSummary.model';
@@ -9,7 +10,7 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { Subscription } from 'rxjs';
 
 @Directive()
-export class SecurityQuestion implements OnInit, OnDestroy, AfterViewInit {
+export abstract class SecurityQuestionDirective implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('formEl') formEl: ElementRef;
   public formErrorsMap: Array<ErrorDetails>;
   public callToActionLabel: string;
@@ -18,11 +19,11 @@ export class SecurityQuestion implements OnInit, OnDestroy, AfterViewInit {
   public return: URLStructure;
   public formControlsMap: any[] = [
     {
-      label: 'Enter a security question',
+      label: 'Security question',
       name: 'securityQuestion',
     },
     {
-      label: 'Enter the answer to the security question',
+      label: 'Answer to security question',
       name: 'securityQuestionAnswer',
     },
   ];
@@ -34,7 +35,7 @@ export class SecurityQuestion implements OnInit, OnDestroy, AfterViewInit {
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
-    protected router: Router
+    protected router: Router,
   ) {}
 
   // Get security question

--- a/src/app/features/activate-user-account/change-your-details/change-your-details.component.ts
+++ b/src/app/features/activate-user-account/change-your-details/change-your-details.component.ts
@@ -5,13 +5,13 @@ import { UserDetails } from '@core/model/userDetails.model';
 import { BackService } from '@core/services/back.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { AccountDetails } from '@features/account/account-details/account-details';
+import { AccountDetailsDirective } from '@features/account/account-details/account-details';
 
 @Component({
   selector: 'app-change-your-details',
   templateUrl: './change-your-details.component.html',
 })
-export class ChangeYourDetailsComponent extends AccountDetails {
+export class ChangeYourDetailsComponent extends AccountDetailsDirective {
   private activationToken: string;
   public callToActionLabel = 'Save and return';
 
@@ -39,7 +39,7 @@ export class ChangeYourDetailsComponent extends AccountDetails {
         if (userDetails) {
           this.prefillForm(userDetails);
         }
-      })
+      }),
     );
   }
 

--- a/src/app/features/activate-user-account/confirm-account-details/confirm-account-details.component.ts
+++ b/src/app/features/activate-user-account/confirm-account-details/confirm-account-details.component.ts
@@ -23,7 +23,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
     private createAccountService: CreateAccountService,
     private router: Router,
     protected errorSummaryService: ErrorSummaryService,
-    protected formBuilder: FormBuilder
+    protected formBuilder: FormBuilder,
   ) {
     super(errorSummaryService, formBuilder);
   }
@@ -45,7 +45,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
         this.loginCredentials = loginCredentials;
         this.securityDetails = securityDetails;
         this.setAccountDetails();
-      })
+      }),
     );
   }
 
@@ -65,7 +65,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
         data: this.userDetails.email,
       },
       {
-        label: 'Contact phone',
+        label: 'Phone number',
         data: this.userDetails.phone,
       },
     ];
@@ -115,12 +115,10 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
 
   protected save(): void {
     this.subscriptions.add(
-      this.createAccountService
-        .activateAccount(this.generatePayload())
-        .subscribe(
-          () => this.router.navigate(['/activate-account', this.activationToken, 'complete']),
-          (error: HttpErrorResponse) => this._onError(error)
-        )
+      this.createAccountService.activateAccount(this.generatePayload()).subscribe(
+        () => this.router.navigate(['/activate-account', this.activationToken, 'complete']),
+        (error: HttpErrorResponse) => this._onError(error),
+      ),
     );
   }
 

--- a/src/app/features/activate-user-account/security-question/security-question.component.ts
+++ b/src/app/features/activate-user-account/security-question/security-question.component.ts
@@ -5,13 +5,13 @@ import { SecurityDetails } from '@core/model/security-details.model';
 import { BackService } from '@core/services/back.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { SecurityQuestion } from '@features/account/security-question/security-question';
+import { SecurityQuestionDirective } from '@features/account/security-question/security-question';
 
 @Component({
   selector: 'app-security-question',
   templateUrl: './security-question.component.html',
 })
-export class SecurityQuestionComponent extends SecurityQuestion {
+export class SecurityQuestionComponent extends SecurityQuestionDirective {
   private activationToken: string;
 
   constructor(
@@ -20,7 +20,7 @@ export class SecurityQuestionComponent extends SecurityQuestion {
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
-    protected router: Router
+    protected router: Router,
   ) {
     super(backService, errorSummaryService, formBuilder, router);
   }
@@ -39,12 +39,11 @@ export class SecurityQuestionComponent extends SecurityQuestion {
 
   protected setupSubscription(): void {
     this.subscriptions.add(
-      this.createAccountService.securityDetails$
-        .subscribe((securityDetails: SecurityDetails) => {
-          if (securityDetails) {
-            this.preFillForm(securityDetails);
-          }
-        })
+      this.createAccountService.securityDetails$.subscribe((securityDetails: SecurityDetails) => {
+        if (securityDetails) {
+          this.preFillForm(securityDetails);
+        }
+      }),
     );
   }
 

--- a/src/app/features/add-workplace/change-your-details/change-your-details.component.ts
+++ b/src/app/features/add-workplace/change-your-details/change-your-details.component.ts
@@ -6,14 +6,14 @@ import { BackService } from '@core/services/back.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { WorkplaceService } from '@core/services/workplace.service';
-import { AccountDetails } from '@features/account/account-details/account-details';
+import { AccountDetailsDirective } from '@features/account/account-details/account-details';
 import { combineLatest } from 'rxjs';
 
 @Component({
   selector: 'app-change-your-details',
   templateUrl: './change-your-details.component.html',
 })
-export class ChangeYourDetailsComponent extends AccountDetails {
+export class ChangeYourDetailsComponent extends AccountDetailsDirective {
   private flow: string;
   public callToActionLabel = 'Continue';
   public locationAddress: LocationAddress;
@@ -24,7 +24,7 @@ export class ChangeYourDetailsComponent extends AccountDetails {
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
-    protected router: Router
+    protected router: Router,
   ) {
     super(backService, errorSummaryService, formBuilder, router);
   }
@@ -45,8 +45,8 @@ export class ChangeYourDetailsComponent extends AccountDetails {
           if (userDetails) {
             this.prefillForm(userDetails);
           }
-        }
-      )
+        },
+      ),
     );
   }
 

--- a/src/app/features/add-workplace/confirm-account-details/confirm-account-details.component.ts
+++ b/src/app/features/add-workplace/confirm-account-details/confirm-account-details.component.ts
@@ -29,7 +29,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
     private router: Router,
     private workplaceService: WorkplaceService,
     protected errorSummaryService: ErrorSummaryService,
-    protected formBuilder: FormBuilder
+    protected formBuilder: FormBuilder,
   ) {
     super(errorSummaryService, formBuilder);
   }
@@ -50,7 +50,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
         this.locationAddress = locationAddress;
         this.service = workplaceService;
         this.setAccountDetails();
-      })
+      }),
     );
   }
 
@@ -70,7 +70,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
         data: this.userDetails.email,
       },
       {
-        label: 'Contact phone',
+        label: 'Phone number',
         data: this.userDetails.phone,
       },
     ];
@@ -85,12 +85,12 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
       this.workplaceService
         .addWorkplace(
           this.establishmentService.primaryWorkplace.uid,
-          this.workplaceService.generateAddWorkplaceRequest(this.locationAddress, this.service)
+          this.workplaceService.generateAddWorkplaceRequest(this.locationAddress, this.service),
         )
         .subscribe(
           (response: CreateAccountResponse) => this.createAccount(response.establishmentUid),
-          (error: HttpErrorResponse) => this.onError(error)
-        )
+          (error: HttpErrorResponse) => this.onError(error),
+        ),
     );
   }
 
@@ -114,7 +114,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
           this.workplaceService.addWorkplaceFlow$.next(AddWorkplaceFlow.CQC_WITH_USER);
           this.router.navigate([`${this.flow}/complete`]);
         },
-        (error: HttpErrorResponse) => this.onError(error)
+        (error: HttpErrorResponse) => this.onError(error),
       );
   }
 

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -96,7 +96,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
     this.userService.updateReturnUrl({
       url: ['/dashboard'],
-      fragment: 'user-accounts',
+      fragment: 'users',
     });
 
     // get latest notification after every 30 seconds

--- a/src/app/features/registration/change-your-details/change-your-details.component.ts
+++ b/src/app/features/registration/change-your-details/change-your-details.component.ts
@@ -5,13 +5,13 @@ import { UserDetails } from '@core/model/userDetails.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { UserService } from '@core/services/user.service';
-import { AccountDetails } from '@features/account/account-details/account-details';
+import { AccountDetailsDirective } from '@features/account/account-details/account-details';
 
 @Component({
   selector: 'app-change-your-details',
   templateUrl: './change-your-details.component.html',
 })
-export class ChangeYourDetailsComponent extends AccountDetails {
+export class ChangeYourDetailsComponent extends AccountDetailsDirective {
   public callToActionLabel = 'Save and return';
   private previousAndReturnRoute: any[] = ['/registration/confirm-account-details'];
 
@@ -20,7 +20,7 @@ export class ChangeYourDetailsComponent extends AccountDetails {
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
-    protected router: Router
+    protected router: Router,
   ) {
     super(backService, errorSummaryService, fb, router);
   }
@@ -36,7 +36,7 @@ export class ChangeYourDetailsComponent extends AccountDetails {
         if (userDetails) {
           this.prefillForm(userDetails);
         }
-      })
+      }),
     );
   }
 

--- a/src/app/features/registration/confirm-account-details/confirm-account-details.component.ts
+++ b/src/app/features/registration/confirm-account-details/confirm-account-details.component.ts
@@ -23,7 +23,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
     private router: Router,
     private userService: UserService,
     protected errorSummaryService: ErrorSummaryService,
-    protected formBuilder: FormBuilder
+    protected formBuilder: FormBuilder,
   ) {
     super(errorSummaryService, formBuilder);
   }
@@ -32,9 +32,9 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
     this.setupSubscriptions();
     this.setBackLink();
     this.subscriptions.add(
-    this.registrationService.isCqcRegulated$.subscribe(value => {
-      this.slectedCqcValue = value;
-    })
+      this.registrationService.isCqcRegulated$.subscribe((value) => {
+        this.slectedCqcValue = value;
+      }),
     );
   }
 
@@ -53,7 +53,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
         this.loginCredentials = loginCredentials;
         this.securityDetails = securityDetails;
         this.setAccountDetails();
-      })
+      }),
     );
   }
 
@@ -73,7 +73,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
         data: this.userDetails.email,
       },
       {
-        label: 'Contact phone',
+        label: 'Phone number',
         data: this.userDetails.phone,
       },
     ];
@@ -123,15 +123,13 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetails {
 
   protected save(): void {
     this.subscriptions.add(
-      this.registrationService
-        .postRegistration(this.generatePayload())
-        .subscribe(
-          registration =>
-            registration.userstatus === 'PENDING'
-              ? this.router.navigate(['/registration/awaiting-approval'])
-              : this.router.navigate(['/registration/complete']),
-          (error: HttpErrorResponse) => this.onError(error)
-        )
+      this.registrationService.postRegistration(this.generatePayload()).subscribe(
+        (registration) =>
+          registration.userstatus === 'PENDING'
+            ? this.router.navigate(['/registration/awaiting-approval'])
+            : this.router.navigate(['/registration/complete']),
+        (error: HttpErrorResponse) => this.onError(error),
+      ),
     );
   }
 

--- a/src/app/features/registration/security-question/security-question.component.ts
+++ b/src/app/features/registration/security-question/security-question.component.ts
@@ -5,19 +5,19 @@ import { SecurityDetails } from '@core/model/security-details.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { RegistrationService } from '@core/services/registration.service';
-import { SecurityQuestion } from '@features/account/security-question/security-question';
+import { SecurityQuestionDirective } from '@features/account/security-question/security-question';
 
 @Component({
   selector: 'app-security-question',
   templateUrl: './security-question.component.html',
 })
-export class SecurityQuestionComponent extends SecurityQuestion {
+export class SecurityQuestionComponent extends SecurityQuestionDirective {
   constructor(
     private registrationService: RegistrationService,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
-    protected router: Router
+    protected router: Router,
   ) {
     super(backService, errorSummaryService, formBuilder, router);
   }
@@ -30,12 +30,11 @@ export class SecurityQuestionComponent extends SecurityQuestion {
 
   protected setupSubscription(): void {
     this.subscriptions.add(
-      this.registrationService.securityDetails$
-        .subscribe((securityDetails: SecurityDetails) => {
-          if (securityDetails) {
-            this.preFillForm(securityDetails);
-          }
-        })
+      this.registrationService.securityDetails$.subscribe((securityDetails: SecurityDetails) => {
+        if (securityDetails) {
+          this.preFillForm(securityDetails);
+        }
+      }),
     );
   }
 

--- a/src/app/features/registration/your-details/your-details.component.ts
+++ b/src/app/features/registration/your-details/your-details.component.ts
@@ -4,13 +4,13 @@ import { Router } from '@angular/router';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { UserService } from '@core/services/user.service';
-import { AccountDetails } from '@features/account/account-details/account-details';
+import { AccountDetailsDirective } from '@features/account/account-details/account-details';
 
 @Component({
   selector: 'app-your-details',
   templateUrl: './your-details.component.html',
 })
-export class YourDetailsComponent extends AccountDetails {
+export class YourDetailsComponent extends AccountDetailsDirective {
   constructor(
     private userService: UserService,
     protected backService: BackService,

--- a/src/app/features/workplace/create-user-account/create-user-account.component.html
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.html
@@ -12,9 +12,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <span class="govuk-caption-l">{{ workplace?.name }}</span>
-          <h1 class="govuk-fieldset__heading">
-            New user account
-          </h1>
+          <h1 class="govuk-fieldset__heading">Add a user</h1>
         </legend>
 
         <ng-container *ngFor="let item of formControlsMap">
@@ -44,9 +42,7 @@
       <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('role').errors">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-            <h2 class="govuk-fieldset__heading">
-              Permissions
-            </h2>
+            <h2 class="govuk-fieldset__heading">Permissions</h2>
           </legend>
 
           <span *ngIf="submitted && form.get('role').errors" id="role-error" class="govuk-error-message">
@@ -70,11 +66,11 @@
         </fieldset>
       </div>
 
-      <div class="govuk-button-group">
-        <button class="govuk-button" type="submit">
-          {{ callToActionLabel }}
-        </button>
-      </div>
+      <app-submit-exit-buttons
+        [cta]="callToActionLabel"
+        [exit]="'Cancel'"
+        [return]="returnTo"
+      ></app-submit-exit-buttons>
     </form>
   </div>
 </div>

--- a/src/app/features/workplace/create-user-account/create-user-account.component.ts
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.ts
@@ -11,14 +11,14 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { AccountDetails } from '@features/account/account-details/account-details';
+import { AccountDetailsDirective } from '@features/account/account-details/account-details';
 
 @Component({
   selector: 'app-create-account',
   templateUrl: './create-user-account.component.html',
 })
-export class CreateUserAccountComponent extends AccountDetails {
-  public callToActionLabel = 'Save user account';
+export class CreateUserAccountComponent extends AccountDetailsDirective {
+  public callToActionLabel = 'Save user';
   public establishmentUid: string;
   public workplace: Establishment;
   public roleRadios: RadioFieldData[] = [
@@ -40,7 +40,7 @@ export class CreateUserAccountComponent extends AccountDetails {
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
-    protected router: Router
+    protected router: Router,
   ) {
     super(backService, errorSummaryService, fb, router);
   }
@@ -69,13 +69,21 @@ export class CreateUserAccountComponent extends AccountDetails {
 
   protected save() {
     this.subscriptions.add(
-      this.createAccountService
-        .createAccount(this.establishmentUid, this.form.value)
-        .subscribe(() => this.navigateToNextRoute(), (error: HttpErrorResponse) => this.onError(error))
+      this.createAccountService.createAccount(this.establishmentUid, this.form.value).subscribe(
+        (data) => this.navigateToNextRoute(data),
+        (error: HttpErrorResponse) => this.onError(error),
+      ),
     );
   }
 
-  protected navigateToNextRoute(): void {
-    this.router.navigate(['/workplace', this.establishmentUid, 'user', 'saved']);
+  protected navigateToNextRoute(data): void {
+    this.router.navigate(['/workplace', this.establishmentUid, 'user', 'saved', data.uid]);
+  }
+
+  get returnTo() {
+    return {
+      url: ['/dashboard'],
+      fragment: 'users',
+    };
   }
 }

--- a/src/app/features/workplace/user-account-change-primary-dialog/user-account-change-primary-dialog.component.html
+++ b/src/app/features/workplace/user-account-change-primary-dialog/user-account-change-primary-dialog.component.html
@@ -4,9 +4,7 @@
   <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.invalid">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 id="dialogHeading" class="govuk-fieldset__heading">
-          Select who will be the new primary edit user.
-        </h1>
+        <h1 id="dialogHeading" class="govuk-fieldset__heading">Select the new primary user.</h1>
       </legend>
       <span *ngIf="submitted && form.get('user').invalid" id="user-error" class="govuk-error-message">
         <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('user') }}
@@ -29,8 +27,8 @@
     </fieldset>
   </div>
 
-  <button type="submit" class="govuk-button">Save and return</button>
+  <button type="submit" class="govuk-button">Save new primary user</button>
   <button type="button" (click)="close(null)" class="govuk-button govuk-button--link govuk-util__float-right">
-    Exit
+    Cancel
   </button>
 </form>

--- a/src/app/features/workplace/user-account-delete-dialog/user-account-delete-dialog.component.html
+++ b/src/app/features/workplace/user-account-delete-dialog/user-account-delete-dialog.component.html
@@ -1,10 +1,6 @@
-<h1 id="dialogHeading" class="govuk-heading-l">You are about to delete this user account.</h1>
+<h1 id="dialogHeading" class="govuk-heading-l">You are about to delete this user</h1>
 
-<p>This will delete all the information stored in the account.</p>
+<p>If you do this, {{ data.user.fullname }} will not be able to sign in as a user anymore.</p>
 
-<p>
-  <strong>Once deleted,the user will have no accessto the account.</strong>
-</p>
-
-<button (click)="close($event, true)" class="govuk-button">Delete account</button>
+<button (click)="close($event, true)" class="govuk-button">Delete this user</button>
 <a href="#" class="govuk-list govuk-list--inline govuk-util__float-right" (click)="close($event, false)">Cancel</a>

--- a/src/app/features/workplace/user-account-edit-details/user-account-edit-details.component.html
+++ b/src/app/features/workplace/user-account-edit-details/user-account-edit-details.component.html
@@ -11,10 +11,8 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <span class="govuk-caption-l">User account</span>
-          <h1 class="govuk-fieldset__heading">
-            Details
-          </h1>
+          <span class="govuk-caption-l">{{ userDetails.fullname }}</span>
+          <h1 class="govuk-fieldset__heading">Details</h1>
         </legend>
 
         <ng-container *ngFor="let item of formControlsMap">
@@ -43,5 +41,5 @@
     </div>
   </div>
 
-  <app-submit-exit-buttons [return]="return"></app-submit-exit-buttons>
+  <app-submit-exit-buttons [return]="return" [exit]="'Cancel'"></app-submit-exit-buttons>
 </form>

--- a/src/app/features/workplace/user-account-edit-details/user-account-edit-details.component.ts
+++ b/src/app/features/workplace/user-account-edit-details/user-account-edit-details.component.ts
@@ -8,15 +8,15 @@ import { BackService } from '@core/services/back.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { UserService } from '@core/services/user.service';
-import { AccountDetails } from '@features/account/account-details/account-details';
+import { AccountDetailsDirective } from '@features/account/account-details/account-details';
 
 @Component({
   selector: 'app-user-account-edit-details',
   templateUrl: './user-account-edit-details.component.html',
 })
-export class UserAccountEditDetailsComponent extends AccountDetails {
+export class UserAccountEditDetailsComponent extends AccountDetailsDirective {
   public callToActionLabel = 'Save and return';
-  protected userDetails: UserDetails = this.route.snapshot.data.user;
+  public userDetails: UserDetails = this.route.snapshot.data.user;
 
   constructor(
     private breadcrumbService: BreadcrumbService,
@@ -25,15 +25,16 @@ export class UserAccountEditDetailsComponent extends AccountDetails {
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
     protected router: Router,
-    protected userService: UserService
+    protected userService: UserService,
   ) {
     super(backService, errorSummaryService, fb, router);
   }
 
   protected init() {
-    this.breadcrumbService.show(JourneyType.ACCOUNT);
+    this.breadcrumbService.show(JourneyType.EDIT_USER);
+
     this.prefillForm(this.userDetails);
-    this.return = { url: ['/dashboard'], fragment: 'user-accounts' };
+    this.return = { url: ['/dashboard'], fragment: 'users' };
   }
 
   protected save(): void {
@@ -46,8 +47,8 @@ export class UserAccountEditDetailsComponent extends AccountDetails {
         .updateUserDetails(this.userDetails.establishmentUid, this.userDetails.uid, userDetails)
         .subscribe(
           () => this.router.navigate(['/workplace', this.userDetails.establishmentUid, 'user', this.userDetails.uid]),
-          (error: HttpErrorResponse) => this.onError(error)
-        )
+          (error: HttpErrorResponse) => this.onError(error),
+        ),
     );
   }
 }

--- a/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.html
+++ b/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.html
@@ -43,9 +43,7 @@
                       type="checkbox"
                       [formControlName]="'primary'"
                     />
-                    <label class="govuk-label govuk-checkboxes__label" for="primary">
-                      Make this user a primary user
-                    </label>
+                    <label class="govuk-label govuk-checkboxes__label" for="primary">Make primary user</label>
                   </div>
                 </div>
               </div>
@@ -56,5 +54,5 @@
     </div>
   </div>
 
-  <app-submit-button [return]="true" (clicked)="onSubmit($event)"></app-submit-button>
+  <app-submit-exit-buttons [cta]="'Save and return'" [exit]="'Cancel'" [return]="return"></app-submit-exit-buttons>
 </form>

--- a/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
+++ b/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
@@ -16,9 +16,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
 import { Subscription } from 'rxjs';
 
-import {
-  UserAccountChangePrimaryDialogComponent,
-} from '../user-account-change-primary-dialog/user-account-change-primary-dialog.component';
+import { UserAccountChangePrimaryDialogComponent } from '../user-account-change-primary-dialog/user-account-change-primary-dialog.component';
 
 @Component({
   selector: 'app-user-account-edit-permissions',
@@ -53,7 +51,7 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
     private dialogService: DialogService,
     private userService: UserService,
     private alertService: AlertService,
-    private establishmentService: EstablishmentService
+    private establishmentService: EstablishmentService,
   ) {
     this.user = this.route.snapshot.data.user;
     this.workplace = this.route.parent.snapshot.data.establishment;
@@ -64,7 +62,7 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
         this.workplace.uid === this.route.snapshot.data.primaryWorkplace.uid
           ? ['/dashboard']
           : ['/workplace', this.workplace.uid],
-      fragment: 'user-accounts',
+      fragment: 'users',
     };
   }
 
@@ -97,7 +95,7 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
       workplaceUid: this.workplace.uid,
       currentUserUid: this.user.uid,
     });
-    dialog.afterClosed.subscribe(userFullname => {
+    dialog.afterClosed.subscribe((userFullname) => {
       if (userFullname) {
         const { role } = this.form.value;
         this.save(role, false, userFullname);
@@ -131,19 +129,19 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
 
     this.subscriptions.add(
       this.userService.updateUserDetails(this.workplace.uid, this.user.uid, { ...this.user, ...props }).subscribe(
-        data => {
+        (data) => {
           this.router.navigate(['/workplace', this.workplace.uid, 'user', this.user.uid], {
-            fragment: 'user-accounts',
+            fragment: 'users',
           });
           if (data.isPrimary) {
             name = this.user.fullname;
           }
           if (name) {
-            this.alertService.addAlert({ type: 'success', message: `${name} is the new primary user` });
+            this.alertService.addAlert({ type: 'success', message: `${name} is the new primary user.` });
           }
         },
-        error => this.onError(error)
-      )
+        (error) => this.onError(error),
+      ),
     );
   }
 

--- a/src/app/features/workplace/user-account-saved/user-account-saved.component.html
+++ b/src/app/features/workplace/user-account-saved/user-account-saved.component.html
@@ -1,8 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">User account saved</h1>
+    <h1 class="govuk-heading-l">User has been added</h1>
     <p>
-      An email has been sent to the address provided containing a link to complete the set up of the account.
+      An email has been sent to {{ userDetails.email }} with a link for {{ userDetails.fullname }} to finish setting up
+      as a user.
     </p>
     <div class="govuk-button-group">
       <a
@@ -10,9 +11,9 @@
         draggable="false"
         class="govuk-button"
         [routerLink]="(returnUrl$ | async)?.url"
-        [fragment]="'user-accounts'"
+        [fragment]="'users'"
       >
-        Return to user accounts
+        View users
       </a>
     </div>
   </div>

--- a/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
+++ b/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
@@ -2,15 +2,18 @@ import { Component, OnInit } from '@angular/core';
 import { URLStructure } from '@core/model/url.model';
 import { UserService } from '@core/services/user.service';
 import { Observable } from 'rxjs';
+import { UserDetails } from '@core/model/userDetails.model';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-account-saved',
   templateUrl: './user-account-saved.component.html',
 })
 export class UserAccountSavedComponent implements OnInit {
-  constructor(private userService: UserService) {}
+  constructor(private userService: UserService, private route: ActivatedRoute) {}
 
   public returnUrl$: Observable<URLStructure>;
+  public userDetails: UserDetails = this.route.snapshot.data.user;
 
   ngOnInit() {
     this.returnUrl$ = this.userService.returnUrl$;

--- a/src/app/features/workplace/user-account-view/user-account-view.component.html
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.html
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third-from-desktop">
     <span class="govuk-caption-l">{{ user.fullname }}</span>
-    <h1 class="govuk-heading-l">Account details</h1>
+    <h1 class="govuk-heading-l">User details</h1>
   </div>
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <div class="govuk-button-heading-group">
@@ -13,7 +13,7 @@
         href="#"
         (click)="resendActivationLink($event)"
       >
-        Resend account set up link</a
+        Resend the user set-up email</a
       >
 
       <a
@@ -25,9 +25,7 @@
         (click)="onDeleteUser($event)"
       >
         <img src="/assets/images/bin.svg" alt="" />
-        <span class="govuk-!-margin-left-1">
-          Delete user account
-        </span></a
+        <span class="govuk-!-margin-left-1">Delete this user</span></a
       >
     </div>
   </div>
@@ -40,9 +38,7 @@
       class="govuk-summary-list govuk-summary-list--no-border govuk-summary-list--wrap-border govuk-!-margin-bottom-0"
     >
       <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Permissions
-        </dt>
+        <dt class="govuk-summary-list__key">Permissions</dt>
         <dd class="govuk-summary-list__value">
           {{ user.isPrimary ? 'Primary' : '' }} {{ user.role === 'Read' ? 'Read only' : user.role }}
         </dd>
@@ -57,7 +53,7 @@
   </div>
 </div>
 <div class="govuk-button-group">
-  <a role="button" draggable="false" class="govuk-button" [routerLink]="return.url" [fragment]="'user-accounts'">
-    Return to user accounts
+  <a role="button" draggable="false" class="govuk-button" [routerLink]="return.url" [fragment]="'users'">
+    View users
   </a>
 </div>

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -12,9 +12,7 @@ import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
-import {
-  UserAccountDeleteDialogComponent,
-} from '@features/workplace/user-account-delete-dialog/user-account-delete-dialog.component';
+import { UserAccountDeleteDialogComponent } from '@features/workplace/user-account-delete-dialog/user-account-delete-dialog.component';
 import { Subscription } from 'rxjs';
 import { take, withLatestFrom } from 'rxjs/operators';
 
@@ -65,7 +63,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
     );
 
     this.subscriptions.add(
-      this.userService.returnUrl$.pipe(take(1)).subscribe(returnUrl => {
+      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
         this.return = returnUrl ? returnUrl : { url: ['/workplace', this.establishment.uid] };
       }),
     );
@@ -80,16 +78,16 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.userService.resendActivationLink(this.user.uid).subscribe(
         () => {
-          this.router.navigate(this.return.url, { fragment: 'user-accounts' });
+          this.router.navigate(this.return.url, { fragment: 'users' });
           this.alertService.addAlert({
             type: 'success',
-            message: 'Account set up link has been resent.',
+            message: 'The user set-up email has been sent again.',
           });
         },
         () => {
           this.alertService.addAlert({
             type: 'warning',
-            message: 'There was an error resending account set up link.',
+            message: 'There was an error resending the user set-up email.',
           });
         },
       ),
@@ -99,7 +97,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
   public onDeleteUser(event: Event) {
     event.preventDefault();
     const dialog = this.dialogService.open(UserAccountDeleteDialogComponent, { user: this.user });
-    dialog.afterClosed.subscribe(deleteConfirmed => {
+    dialog.afterClosed.subscribe((deleteConfirmed) => {
       if (deleteConfirmed) {
         this.deleteUser();
       }
@@ -114,15 +112,15 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
             ...this.loggedInUser,
             ...{ isPrimary: true },
           })
-          .subscribe(data => (this.userService.loggedInUser = data)),
+          .subscribe((data) => (this.userService.loggedInUser = data)),
       );
     }
 
     this.subscriptions.add(
       this.userService.deleteUser(this.establishment.uid, this.user.uid).subscribe(
         () => {
-          this.router.navigate(this.return.url, { fragment: 'user-accounts' });
-          this.alertService.addAlert({ type: 'success', message: 'User successfully deleted.' });
+          this.router.navigate(this.return.url, { fragment: 'users' });
+          this.alertService.addAlert({ type: 'success', message: 'The user has been deleted.' });
         },
         () => {
           this.alertService.addAlert({
@@ -150,7 +148,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
         data: this.user.email,
       },
       {
-        label: 'Contact phone',
+        label: 'Phone number',
         data: this.user.phone,
       },
     ];
@@ -166,7 +164,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
   private setPermissions(users: Array<UserDetails>, loggedInUser: UserDetails) {
     const canEditUser = this.permissionsService.can(this.establishment.uid, 'canEditUser');
     const isPending = this.user.username === null;
-    const editUsersList = users.filter(user => user.role === Roles.Edit);
+    const editUsersList = users.filter((user) => user.role === Roles.Edit);
 
     this.canDeleteUser =
       this.permissionsService.can(this.establishment.uid, 'canDeleteUser') &&

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -301,12 +301,13 @@ const routes: Routes = [
         },
       },
       {
-        path: 'user/saved',
+        path: 'user/saved/:useruid',
         canActivate: [CheckPermissionsGuard],
         component: UserAccountSavedComponent,
+        resolve: { user: UserAccountResolver },
         data: {
           permissions: ['canAddUser'],
-          title: 'User Account Saved',
+          title: 'User has been added',
         },
       },
       {

--- a/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.html
+++ b/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
-    <h2 class="govuk-heading-m">User accounts ({{ users.length }})</h2>
+    <h2 class="govuk-heading-m">Users ({{ users.length }})</h2>
   </div>
   <div class="govuk-grid-column-one-half govuk-util__align-right">
     <a
@@ -10,7 +10,7 @@
       class="govuk-button"
       [routerLink]="['/workplace', workplace.uid, 'user', 'create']"
     >
-      Add a new user account
+      Add a user
     </a>
   </div>
 </div>
@@ -23,14 +23,14 @@
             <th class="govuk-table__header" scope="col">Full name</th>
             <th class="govuk-table__header" scope="col">Username</th>
             <th class="govuk-table__header" scope="col">Last updated</th>
-            <th class="govuk-table__header" scope="col">Type</th>
+            <th class="govuk-table__header" scope="col">Permissions</th>
             <th class="govuk-table__header" scope="col">Status</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
           <ng-container *ngFor="let user of users">
             <tr class="govuk-table__row" [class.govuk-error-table__row--highlight]="isPending(user)">
-              <td class="govuk-table__cell" [ngClass]="{'govuk-!-padding-left-3': isPending(user)}">
+              <td class="govuk-table__cell" [ngClass]="{ 'govuk-!-padding-left-3': isPending(user) }">
                 <ng-container *ngIf="canViewUser; else noLink">
                   <a [routerLink]="['/workplace', workplace.uid, 'user', user.uid]">{{ user.fullname }}</a>
                 </ng-container>


### PR DESCRIPTION
**Work done**

- Copy changes
- Fixed eslint errors for `Directives` naming & empty methods
- Fixed `lint-staged` running `eslint` and `prettier` in parallel which caused conflicts
- Fixed links / redirects to Users tab not using the updated fragment
- Added specific journey for editing a user vs editing your own details (to fix issue with breadcrumbs)

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
