### PR TITLE
Bug/cant see add user: Fixing bug where User can't see Add a user button

### DIFF
--- a/src/app/core/test-utils/MockPermissionsService.ts
+++ b/src/app/core/test-utils/MockPermissionsService.ts
@@ -1,8 +1,9 @@
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { PermissionsList, PermissionType } from '@core/model/permissions.model';
+import { PermissionsList, PermissionsResponse, PermissionType } from '@core/model/permissions.model';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { UserService } from '@core/services/user.service';
+import { Observable, of } from 'rxjs';
 
 export class MockPermissionsService extends PermissionsService {
   private _permissions: PermissionType[] = [];
@@ -17,7 +18,16 @@ export class MockPermissionsService extends PermissionsService {
 
   permissions(workplaceUid: string): PermissionsList {
     const perms = {};
-    this._permissions.forEach((p) => perms[p] = true);
+    this._permissions.forEach((p) => (perms[p] = true));
     return perms;
+  }
+  public getPermissions(workplaceUid: string): Observable<PermissionsResponse> {
+    const perms = {};
+    this._permissions.forEach((p) => (perms[p] = true));
+
+    return of({
+      uid: '',
+      permissions: perms,
+    } as PermissionsResponse);
   }
 }

--- a/src/app/core/test-utils/MockUserService.ts
+++ b/src/app/core/test-utils/MockUserService.ts
@@ -1,8 +1,7 @@
 import { UserService } from '@core/services/user.service';
 import { UserDetails } from '@core/model/userDetails.model';
 import { Observable, of } from 'rxjs';
-import { GetWorkplacesResponse, Workplace } from '@core/model/my-workplaces.model';
-import { Mock } from 'protractor/built/driverProviders';
+import { GetWorkplacesResponse } from '@core/model/my-workplaces.model';
 import { HttpClient } from '@angular/common/http';
 import { Roles } from '@core/model/roles.enum';
 
@@ -38,5 +37,16 @@ export class MockUserService extends UserService {
         establishments: [],
       },
     } as GetWorkplacesResponse);
+  }
+  public getAllUsersForEstablishment(workplaceUid: string): Observable<Array<UserDetails>> {
+    return of([
+      {
+        email: '',
+        fullname: null,
+        jobTitle: 'JobTile',
+        phone: '01222222222',
+        role: 'Edit',
+      },
+    ] as UserDetails[]);
   }
 }

--- a/src/app/core/test-utils/MockUserService.ts
+++ b/src/app/core/test-utils/MockUserService.ts
@@ -4,7 +4,23 @@ import { Observable, of } from 'rxjs';
 import { GetWorkplacesResponse } from '@core/model/my-workplaces.model';
 import { HttpClient } from '@angular/common/http';
 import { Roles } from '@core/model/roles.enum';
+import { build, fake, oneOf } from '@jackfranklin/test-data-bot/build';
 
+export const EditUser = build('EditUser', {
+  fields: {
+    contract: oneOf('Permanent', 'Temporary', 'Pool or Bank', 'Agency', 'Other'),
+    email: '',
+    fullname: fake((f) => f.name.findName()),
+    jobTitle: fake((f) => f.lorem.sentence()),
+    phone: '01222222222',
+    role: Roles.Edit,
+  },
+});
+
+const readUser = EditUser();
+readUser.role = Roles.Read;
+
+const editUser = EditUser();
 export class MockUserService extends UserService {
   private subsidiaries = 0;
   private isAdmin = false;
@@ -39,14 +55,10 @@ export class MockUserService extends UserService {
     } as GetWorkplacesResponse);
   }
   public getAllUsersForEstablishment(workplaceUid: string): Observable<Array<UserDetails>> {
-    return of([
-      {
-        email: '',
-        fullname: null,
-        jobTitle: 'JobTile',
-        phone: '01222222222',
-        role: 'Edit',
-      },
-    ] as UserDetails[]);
+    if (workplaceUid === 'overLimit') {
+      return of([readUser, readUser, readUser, editUser, editUser, editUser] as UserDetails[]);
+    }
+
+    return of([editUser] as UserDetails[]);
   }
 }

--- a/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.spec.ts
+++ b/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.spec.ts
@@ -1,34 +1,89 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserAccountsSummaryComponent } from '@shared/components/user-accounts-summary/user-accounts-summary.component';
 
 import { Establishment } from '../../../../mockdata/establishment';
-import { PermissionsList } from '../../../../mockdata/permissions';
+import { UserService } from '@core/services/user.service';
+import { MockUserService } from '@core/test-utils/MockUserService';
+import { SharedModule } from '@shared/shared.module';
+import { Router, RouterModule } from '@angular/router';
+import { WindowRef } from '@core/services/window.ref';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { HttpClient } from '@angular/common/http';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { AuthService } from '@core/services/auth.service';
+import { MockAuthService } from '@core/test-utils/MockAuthService';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 
-describe('UserAccountsSummaryComponent', () => {
-  let component: UserAccountsSummaryComponent;
-  let fixture: ComponentFixture<UserAccountsSummaryComponent>;
-  let permissionsService: PermissionsService;
+fdescribe('UserAccountsSummaryComponent', () => {
+  async function setup(isAdmin = true, subsidiaries = 0) {
+    const component: UserAccountsSummaryComponent;
 
-  beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, HttpClientTestingModule],
-      declarations: [UserAccountsSummaryComponent],
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(UserAccountsSummaryComponent);
-    permissionsService = TestBed.inject(PermissionsService);
-    permissionsService.setPermissions(Establishment.uid, PermissionsList);
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+      declarations: [],
+      providers: [
+        {
+          provide: WindowRef,
+          useClass: WindowRef,
+        },
+        {
+          provide: PermissionsService,
+          useFactory: MockPermissionsService.factory(),
+          deps: [HttpClient, Router, UserService],
+        },
+        {
+          provide: UserService,
+          useFactory: MockUserService.factory(subsidiaries, isAdmin),
+          deps: [HttpClient],
+        },
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
+        },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
+        },
+        {
+          provide: BreadcrumbService,
+          useClass: MockBreadcrumbService,
+        },
+      ],
+    });
+    const fixture = TestBed.createComponent(UserAccountsSummaryComponent);
     component = fixture.componentInstance;
-    component.workplace = Establishment;
-    fixture.detectChanges();
+
+    return {
+      component,
+      fixture,
+    };
+  }
+
+  it('should render a User Account Summary Workplace Component', async () => {
+    const { component, fixture } = await setup();
+    fixture.componentInstance.workplace = Establishment;
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should still show Add User if existing user doesnt have a name', async () => {
+    const { component, fixture } = await setup();
+
+    fixture.componentInstance.workplace = Establishment;
+    component.ngOnInit();
+    expect(component.users.length).toEqual(1);
+    expect(component.canAddUser).toBeTruthy();
+  });
+  it('should still show Add User if existing user doesnt have a name', async () => {
+    const { component, fixture } = await setup();
+
+    fixture.componentInstance.workplace = Establishment;
+    component.ngOnInit();
+    expect(component.users.length).toEqual(1);
+    expect(component.canAddUser).toBeTruthy();
   });
 });

--- a/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.spec.ts
+++ b/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.spec.ts
@@ -19,10 +19,8 @@ import { MockAuthService } from '@core/test-utils/MockAuthService';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 
-fdescribe('UserAccountsSummaryComponent', () => {
+describe('UserAccountsSummaryComponent', () => {
   async function setup(isAdmin = true, subsidiaries = 0) {
-    const component: UserAccountsSummaryComponent;
-
     TestBed.configureTestingModule({
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [],
@@ -56,8 +54,7 @@ fdescribe('UserAccountsSummaryComponent', () => {
       ],
     });
     const fixture = TestBed.createComponent(UserAccountsSummaryComponent);
-    component = fixture.componentInstance;
-
+    const component: UserAccountsSummaryComponent = fixture.componentInstance;
     return {
       component,
       fixture,
@@ -69,21 +66,26 @@ fdescribe('UserAccountsSummaryComponent', () => {
     fixture.componentInstance.workplace = Establishment;
     expect(component).toBeTruthy();
   });
-
   it('should still show Add User if existing user doesnt have a name', async () => {
     const { component, fixture } = await setup();
 
     fixture.componentInstance.workplace = Establishment;
+    fixture.componentInstance.workplace.uid = '4698f4a4-ab82-4906-8b0e-3f4972375927';
+
     component.ngOnInit();
     expect(component.users.length).toEqual(1);
     expect(component.canAddUser).toBeTruthy();
   });
-  it('should still show Add User if existing user doesnt have a name', async () => {
+
+  it('should not be able to add user if 3 edit users exist', async () => {
     const { component, fixture } = await setup();
 
     fixture.componentInstance.workplace = Establishment;
+    fixture.componentInstance.workplace.uid = 'overLimit';
+    fixture.componentInstance.workplace.isParent = false;
+
     component.ngOnInit();
-    expect(component.users.length).toEqual(1);
-    expect(component.canAddUser).toBeTruthy();
+    expect(component.users.length).toEqual(6);
+    expect(component.canAddUser).toBeFalsy();
   });
 });

--- a/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.ts
+++ b/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.ts
@@ -28,13 +28,18 @@ export class UserAccountsSummaryComponent implements OnInit, OnDestroy {
           this.permissionsService.setPermissions(this.workplace.uid, hasPermissions.permissions);
           this.canViewUser = this.permissionsService.can(this.workplace.uid, 'canViewUser');
           this.userService.getAllUsersForEstablishment(this.workplace.uid).subscribe((users) => {
-            this.users = orderBy(
-              users,
-              ['status', 'isPrimary', 'role', (user: UserDetails) => user.fullname.toLowerCase()],
-              ['desc', 'desc', 'asc', 'asc'],
-            );
             this.canAddUser =
               this.permissionsService.can(this.workplace.uid, 'canAddUser') && this.userSlotsAvailable(users);
+            this.users = orderBy(
+              users,
+              [
+                'status',
+                'isPrimary',
+                'role',
+                (user: UserDetails) => (user.fullname ? user.fullname.toLowerCase() : 'a'),
+              ],
+              ['desc', 'desc', 'asc', 'asc'],
+            );
           });
         }
       }),


### PR DESCRIPTION
If a workplace user doesn't have a name (this can only happen if the user was migrated) then the Add a user Button disappears.  Added a check to avoid this in the future.

#### Tests
Does this PR include tests for the changes introduced?
- [x ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
