### PR TITLE
Fix: Skip permission check until bugs have been tested

### DIFF
--- a/server/utils/security/hasPermission.js
+++ b/server/utils/security/hasPermission.js
@@ -2,6 +2,11 @@ const { PermissionCache } = require('../../models/cache/singletons/permissions')
 
 const hasPermission = (permission) => {
   return async (req, res, next) => {
+    next(); // TODO - renable once changes to staging have gone live
+
+    return;
+
+
     const permissions = await PermissionCache.myPermissions(req);
     const hasPermission = permissions.filter((p) => Object.keys(p)[0] === permission && p[permission]);
 


### PR DESCRIPTION
**Issue**

There is an issue on staging with the permissions not quite right that have not been tested.

However we also want to deploy a bunch of changes that are on staging.

Rather than undoing every change to the endpoints that have permission checks applied to them, I am making the request passthrough by calling `next()` and returning early.

Once `test` has been merged into `live` this PR will be reverted.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
