### PR TITLE
Fix: Downgrade aws-sdk to fix reports not downloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5956,9 +5956,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.824.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.824.0.tgz",
-      "integrity": "sha512-9KNRQBkIMPn+6DWb4gR+RzqTMNyGLEwOgXbE4dDehOIAflfLnv3IFwLnzrhxJnleB4guYrILIsBroJFBzjiekg==",
+      "version": "2.712.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.712.0.tgz",
+      "integrity": "sha512-C3SLWanFydoWJwtKNi73BG9uB6UzrUuECaAiplOEVBltO/R4sBsHWhwTBuxS02eTNdRrgulu19bJ5RWt+OuXiA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@sentry/node": "^5.29.2",
     "ajv": "^6.12.6",
     "angulartics2": "^10.0.0",
-    "aws-sdk": "^2.824.0",
+    "aws-sdk": "^2.712.0",
     "axios": "^0.21.1",
     "bcrypt-nodejs": "0.0.3",
     "canvg": "^3.0.7",


### PR DESCRIPTION
**Issue**

The AWS SDK was upgraded and for some reason it introduced a breaking change that prevented reports being uploaded to S3.

Unsure of the fix, so downgrading for now

**Work done**

- Downgrade `aws-sdk` from `v2.824.0` to `v2.712.0`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
