### PR TITLE
Fix: Remove db name/user from test config and set client_ssl to false

### DIFF
--- a/server/config/test.yaml
+++ b/server/config/test.yaml
@@ -13,10 +13,8 @@ db:
     min: 15
     max: 15
   ssl: true
-  username: sfcapp
-  database: sfctstdb
   client_ssl:
-    status: true
+    status: false
     usingFiles: false
 
 slack:


### PR DESCRIPTION
**Issue**

Moving the staging DB to GovPaaS means we no longer need SSL certificates to connect.

**Work done**

- Update `server/config/test.yaml`
  - remove db name/user as these come from ENV
  - set `client_ssl` status to `false` 

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
