### PR TITLE
Feat: Remove client ssl config

### DIFF
--- a/server/config/accessibility.yaml
+++ b/server/config/accessibility.yaml
@@ -13,9 +13,6 @@ db:
     ssl: true
     username: sfcdemoadmin
     database: sfcdemodb
-    client_ssl:
-        status: true
-        usingFiles: false
 
 slack:
     level : 3     # enables Slack notifications

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -91,57 +91,6 @@ const config = convict({
       default: false,
       env: 'DB_SSL',
     },
-    client_ssl: {
-      status: {
-        doc: 'Client SSL enabled or not',
-        format: 'Boolean',
-        default: false,
-        env: 'DB_CLIENT_SSL_STATUS',
-      },
-      usingFiles: {
-        doc:
-          'If true, retrieves client certificate, client key and root certificate from file; if false, using data values',
-        format: 'Boolean',
-        default: true,
-      },
-      files: {
-        certificate: {
-          doc: 'The full path location of the client certificate file',
-          format: String,
-          default: 'TBC',
-          env: 'DB_CLIENT_SSL_CERTIFICATE',
-        },
-        key: {
-          doc: 'The full path location of the client key file',
-          format: String,
-          default: 'TBC',
-          env: 'DB_CLIENT_SSL_KEY',
-        },
-        ca: {
-          doc: 'The full path location of the server certificate (authority - ca) file',
-          format: String,
-          default: 'TBC',
-          env: 'DB_CLIENT_SSL_CA',
-        },
-      },
-      data: {
-        certificate: {
-          doc: 'The client certificate',
-          format: String,
-          default: 'TBC',
-        },
-        key: {
-          doc: 'The client key',
-          format: String,
-          default: 'TBC',
-        },
-        ca: {
-          doc: 'The server certificate (authority - ca)',
-          format: String,
-          default: 'TBC',
-        },
-      },
-    },
     pool: {
       min: {
         doc: 'Minimum number of connections in the pool',
@@ -497,14 +446,14 @@ const config = convict({
     timeSpan: {
       doc: 'The amount of time to look back and see whether the survey should be shown',
       format: Number,
-      default: 90
+      default: 90,
     },
     unit: {
       doc: 'The unit of time to use (e.g days in moment format)',
       format: String,
-      default: 'd'
-    }
-  }
+      default: 'd',
+    },
+  },
 });
 
 // Load environment dependent configuration
@@ -522,16 +471,10 @@ config.validate({ allowed: 'strict' });
 
 // now, if defined, load secrets from AWS Secret Manager
 if (config.get('aws.secrets.use')) {
-  AWSSecrets.initialiseSecrets(config.get('aws.region'), config.get('aws.secrets.wallet')).then((ret) => {
+  AWSSecrets.initialiseSecrets(config.get('aws.region'), config.get('aws.secrets.wallet')).then(() => {
     // DB rebind
     config.set('db.host', AWSSecrets.dbHost());
     config.set('db.password', AWSSecrets.dbPass());
-
-    if (config.get('db.client_ssl.status')) {
-      config.set('db.client_ssl.data.certificate', AWSSecrets.dbAppUserCertificate().replace(/\\n/g, '\n'));
-      config.set('db.client_ssl.data.key', AWSSecrets.dbAppUserKey().replace(/\\n/g, '\n'));
-      config.set('db.client_ssl.data.ca', AWSSecrets.dbAppRootCertificate().replace(/\\n/g, '\n'));
-    }
 
     // external APIs
     config.set('slack.url', AWSSecrets.slackUrl());

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -14,9 +14,6 @@ db:
     max: 15
   ssl: true
   username: sfcapp
-  client_ssl:
-    status: true
-    usingFiles: false
 
 slack:
   level: 3 # enables Slack notifications

--- a/server/config/localhost.yaml
+++ b/server/config/localhost.yaml
@@ -20,9 +20,7 @@ db:
     max: 15
   ssl: false
   username: sfcadmin
-  client_ssl:
-    status: false
-    usingFiles: false
+
 log:
   sequelize: false
 

--- a/server/config/preproduction.yaml
+++ b/server/config/preproduction.yaml
@@ -23,9 +23,6 @@ db:
     acquire: 240000
     idle: 200000
   ssl: true
-  client_ssl:
-    status: false
-    usingFiles: false
 
 notify:
   replyTo: '73711295-a4da-4303-9127-65be2a409681'

--- a/server/config/production.yaml
+++ b/server/config/production.yaml
@@ -24,9 +24,6 @@ db:
     idle: 200000
   ssl: true
   username: sfcapp
-  client_ssl:
-    status: false
-    usingFiles: false
 
 notify:
   replyTo: '44e98371-2e44-4c6b-ad76-235136be0f8a'

--- a/server/config/sequelize.js
+++ b/server/config/sequelize.js
@@ -3,19 +3,10 @@ const AWSSecrets = require('../aws/secrets');
 
 module.exports = async () => {
   if (config.get('aws.secrets.use')) {
-    await AWSSecrets.initialiseSecrets(
-      config.get('aws.region'),
-      config.get('aws.secrets.wallet')
-    );
+    await AWSSecrets.initialiseSecrets(config.get('aws.region'), config.get('aws.secrets.wallet'));
 
     config.set('db.host', AWSSecrets.dbHost());
     config.set('db.password', AWSSecrets.dbPass());
-
-    if (config.get('db.client_ssl.status')) {
-      config.set('db.client_ssl.data.certificate', AWSSecrets.dbAppUserCertificate().replace(/\\n/g, "\n"));
-      config.set('db.client_ssl.data.key', AWSSecrets.dbAppUserKey().replace(/\\n/g, "\n"));
-      config.set('db.client_ssl.data.ca', AWSSecrets.dbAppRootCertificate().replace(/\\n/g, "\n"));
-    }
   }
 
   return {
@@ -42,15 +33,10 @@ module.exports = async () => {
       host: config.get('db.host'),
       port: config.get('db.port'),
       dialect: config.get('db.dialect'),
-      migrationStorageTableSchema: 'cqc',
       dialectOptions: {
-        ssl: {
-          rejectUnauthorized : false,
-          ca   : config.get('db.client_ssl.data.ca'),
-          key  : config.get('db.client_ssl.data.key'),
-          cert : config.get('db.client_ssl.data.certificate'),
-        }
-      }
+        ssl: config.get('db.ssl'),
+      },
+      migrationStorageTableSchema: 'cqc',
     },
     benchmarks: {
       use_env_variable: 'DATABASE_URL',
@@ -70,7 +56,7 @@ module.exports = async () => {
       migrationStorageTableSchema: 'cqc',
       dialectOptions: {
         ssl: config.get('db.ssl'),
-      }
-    }
-  }
-}
+      },
+    },
+  };
+};

--- a/server/config/test.yaml
+++ b/server/config/test.yaml
@@ -13,9 +13,6 @@ db:
     min: 15
     max: 15
   ssl: true
-  client_ssl:
-    status: false
-    usingFiles: false
 
 slack:
   level: 3 # enables Slack notifications

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -8,14 +8,15 @@ const Sequelize = require('sequelize');
 const basename = path.basename(__filename);
 const db = {};
 
-
 class DBEmitter extends EventEmitter {
   constructor() {
     super();
     this._ready = false;
-  };
+  }
 
-  get READY_EVENT() { return 'Ready'};
+  get READY_EVENT() {
+    return 'Ready';
+  }
 
   get ready() {
     return this._ready;
@@ -24,7 +25,7 @@ class DBEmitter extends EventEmitter {
   set ready(status) {
     this._ready = status;
   }
-};
+}
 db.status = new DBEmitter();
 
 let sequelize;
@@ -38,44 +39,31 @@ config.username = appConfig.get('db.username');
 config.password = appConfig.get('db.password');
 config.dialect = appConfig.get('db.dialect');
 config.dialectOptions = {
-  ssl: appConfig.get('db.ssl')
+  ssl: appConfig.get('db.ssl'),
 };
 config.logging = appConfig.get('log.sequelize');
-
-if (appConfig.get('db.client_ssl.status')) {
-  // when initialising SSL direct from config, can only use files.
-  if (appConfig.get('db.client_ssl.usingFiles')) {
-    config.dialectOptions.ssl = {
-      rejectUnauthorized : false,
-      ca   : fs.readFileSync(appConfig.get('db.client_ssl.files.ca')).toString(),
-      key  : fs.readFileSync(appConfig.get('db.client_ssl.files.key')).toString(),
-      cert : fs.readFileSync(appConfig.get('db.client_ssl.files.certificate')).toString(),
-    };
-  }
-}
 
 // setup connection pool
 config.pool = {
   max: appConfig.get('db.pool.max'),
   min: appConfig.get('db.pool.min'),
   acquire: appConfig.get('db.pool.acquire'),
-  idle: appConfig.get('db.pool.idle')
+  idle: appConfig.get('db.pool.idle'),
   //idle: 10000,
 };
 
 sequelize = new Sequelize(config.database, config.username, config.password, config);
 
-fs
-  .readdirSync(__dirname)
-  .filter(file => {
-    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+fs.readdirSync(__dirname)
+  .filter((file) => {
+    return file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js';
   })
-  .forEach(file => {
+  .forEach((file) => {
     const model = sequelize['import'](path.join(__dirname, file));
     db[model.name] = model;
   });
 
-Object.keys(db).forEach(modelName => {
+Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {
     db[modelName].associate(db);
   }
@@ -83,7 +71,6 @@ Object.keys(db).forEach(modelName => {
 
 db.sequelize = sequelize;
 db.Sequelize = Sequelize;
-
 
 if (AppConfig.ready) {
   // the config is ready, so the config properties are true and thus the database is ready to use
@@ -97,26 +84,12 @@ if (AppConfig.ready) {
     sequelize.connectionManager.config.host = appConfig.get('db.host');
     sequelize.connectionManager.config.password = appConfig.get('db.password');
 
-
-    // when initialising on config "ready" can only use SSL data
-    if (appConfig.get('db.client_ssl.status')) {
-      if (!appConfig.get('db.client_ssl.usingFiles')) {
-        sequelize.connectionManager.config.dialectOptions.ssl = {
-          rejectUnauthorized : false,
-          ca   : appConfig.get('db.client_ssl.data.ca'),
-          key  : appConfig.get('db.client_ssl.data.key'),
-          cert : appConfig.get('db.client_ssl.data.certificate'),
-        };
-      }
-    }
-
     sequelize.connectionManager.pool.clear();
 
     // now the database is ready
     db.status.ready = true;
     db.status.emit(db.status.READY_EVENT);
   });
-
 }
 
 module.exports = db;


### PR DESCRIPTION
**Issue**

Now that all DBs for the environments are in GovPaaS we no longer need to configure whether to use client certificates to connect to a DB instance.

**Work done**

- Removed `client_ssl` config

**Notes**

- The `client_ssl` config is still present in the CQCLocationAPI - we need to keep this until we refactor how location data is synced between environments

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
