### PR TITLE
fix(sentry): Fix tracing for Express app

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,2 +1,6 @@
+
+# Loader IO
+63e80cd3c669177f22e9ec997ea2594d
+
 # Sentry
 59c078b68dc0429aa404e59920f288fd@o409195

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 var config = require('./server/config/config');
 const Sentry = require('@sentry/node');
-const Apm = require('@sentry/apm');
+const { Integrations } = require('@sentry/tracing');
 const beeline = require('honeycomb-beeline')({
   dataset: config.get('env'),
   serviceName: 'sfc',
@@ -84,7 +84,7 @@ if (config.get('sentry.dsn')) {
     dsn: config.get('sentry.dsn'),
     integrations: [
       // enable Express.js middleware tracing
-      new Apm.Integrations.Express({ app }),
+      new Integrations.Express({ app }),
     ],
     environment: config.get('env'),
   });


### PR DESCRIPTION
**Issue**

There was an update to the `Tracing` integration for Sentry which failed `ng build` - this was fixed in #2909

However, we also use Sentry on the Express app and the `Tracing` integration wasn't updated.

**Work done**

- Update `Tracing` integration for Sentry in `server.js`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
