### PR TITLE
Fix: BU v2 sidebar links

### DIFF
--- a/src/app/features/bulk-upload-v2/bulk-upload-sidebar/bulk-upload-sidebar.component.html
+++ b/src/app/features/bulk-upload-v2/bulk-upload-sidebar/bulk-upload-sidebar.component.html
@@ -1,10 +1,10 @@
 <h2 class="govuk-heading-s">Related content</h2>
 <ul class="govuk-list">
   <li>
-    <a [routerLink]="['/dev', 'bulk-upload', 'about-bulk-upload']">About bulk upload</a>
+    <a [routerLink]="['../about-bulk-upload']">About bulk upload</a>
   </li>
   <li>
-    <a [routerLink]="['/bulk-upload', 'workplace-references']">View workplace and staff references</a>
+    <a [routerLink]="['../workplace-references']">View workplace and staff references</a>
   </li>
 </ul>
 <h2 class="govuk-!-margin-top-6 govuk-heading-s">Download your current data</h2>


### PR DESCRIPTION
**Issue**

About the bulk upload link in the sidebar of BU v2 had `dev` hardcoded.

**Work done**

- Updated BU v2 sidebar links to use relative URLs

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
