### PR TITLE
Fix: capture timeout for Karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,5 +40,6 @@ module.exports = function (config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserNoActivityTimeout: 100000,
+    captureTimeout:  120000,
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,6 +40,6 @@ module.exports = function (config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserNoActivityTimeout: 100000,
-    captureTimeout:  120000,
+    captureTimeout:  140000,
   });
 };


### PR DESCRIPTION
**Issue**

When running the tests, Chrome will start and then compile the assets before running the tests. However, the default timeout is 60s and the time to compile is ~90s.

There doesn't seem to be an elegant wait to wait for `ng build` before trying to run the tests.

**Work done**

- Have upped the `captureTimeout` to 120s

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
