### PR TITLE
Removed canViewEstablishment permission from establishment endpoint

### DIFF
--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -366,7 +366,7 @@ const updateEstablishment = async (req, res) => {
   }
 };
 
-router.route('/:id').get(hasPermission('canViewEstablishment'), getEstablishment);
+router.route('/:id').get(getEstablishment);
 router.route('/:id').post(hasPermission('canAddEstablishment'), addEstablishment);
 router.route('/:id').put(hasPermission('canEditEstablishment'), updateEstablishment);
 router.route('/:id').delete(hasPermission('canDeleteEstablishment'), deleteEstablishment);

--- a/src/app/core/resolvers/primary-workplace.resolver.ts
+++ b/src/app/core/resolvers/primary-workplace.resolver.ts
@@ -10,10 +10,11 @@ export class PrimaryWorkplaceResolver implements Resolve<any> {
 
   resolve(route: ActivatedRouteSnapshot) {
     const workplaceUid = this.establishmentService.establishmentId;
+    // This should include a permissions check, but it doesn't currently: this.permissionsService.can(workplaceUid, 'canViewEstablishment')
     if (workplaceUid) {
       return this.establishmentService
         .getEstablishment(workplaceUid)
-        .pipe(tap(workplace => this.establishmentService.setPrimaryWorkplace(workplace)));
+        .pipe(tap((workplace) => this.establishmentService.setPrimaryWorkplace(workplace)));
     }
 
     return of(null);


### PR DESCRIPTION
No data users can login and see workplace name
It shouldn't be like this, instead there should be a check to make sure
they have access to the correct permissions only, I have left a comment
on this for now

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
