### PR TITLE
Fix: Server coverage

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,4 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,11 +3490,18 @@
         }
       }
     },
+    "@istanbuljs/nyc-config-typescript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz",
+      "integrity": "sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==",
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2"
+      }
+    },
     "@istanbuljs/schema": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
-      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
-      "dev": true
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
     },
     "@jackfranklin/test-data-bot": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@angular/platform-browser-dynamic": "~10.2.1",
     "@angular/router": "~10.2.1",
     "@auth0/angular-jwt": "^5.0.2",
+    "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@sentry/browser": "^6.0.2",
     "@sentry/node": "^6.0.2",
     "@sentry/tracing": "^6.0.2",


### PR DESCRIPTION
**Issue**

Running `npm run server:test:coverage` was broken due to an issue with `nyc` and `typescript`

**Work done**

- Added `@istanbuljs/nyc-config-typescript` dependency
- Added `.nycrc` to extend the typescript config

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
