### PR TITLE
Feat: Keep Workplaces Active screen

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { PageNotFoundComponent } from '@core/components/error/page-not-found/page-not-found.component';
-import { ProblemWithTheServiceComponent } from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
+import {
+  ProblemWithTheServiceComponent,
+} from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
 import { AuthGuard } from '@core/guards/auth/auth.guard';
 import { LoggedOutGuard } from '@core/guards/logged-out/logged-out.guard';
 import { MigratedUserGuard } from '@core/guards/migrated-user/migrated-user.guard';
@@ -16,7 +18,9 @@ import { DashboardComponent } from '@features/dashboard/dashboard.component';
 import { ForgotYourPasswordComponent } from '@features/forgot-your-password/forgot-your-password.component';
 import { LoginComponent } from '@features/login/login.component';
 import { LogoutComponent } from '@features/logout/logout.component';
-import { MigratedUserTermsConditionsComponent } from '@features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
+import {
+  MigratedUserTermsConditionsComponent,
+} from '@features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
 import { ResetPasswordComponent } from '@features/reset-password/reset-password.component';
 import { SatisfactionSurveyComponent } from '@features/satisfaction-survey/satisfaction-survey.component';
 
@@ -186,6 +190,15 @@ const routes: Routes = [
         data: {
           roles: [Roles.Admin],
           title: 'CQC Status Change',
+        },
+      },
+      {
+        path: 'emails',
+        loadChildren: () => import('@features/search/search.module').then((m) => m.SearchModule),
+        canActivate: [RoleGuard],
+        data: {
+          roles: [Roles.Admin],
+          title: 'Emails',
         },
       },
       {

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -16,14 +16,10 @@ export class Dialog<T, R = any> {
     private overlay: Overlay,
     private injector: Injector,
     private focusTrapFactory: FocusTrapFactory,
-    private data: any
+    private data: any,
   ) {
     const config = new OverlayConfig({
-      positionStrategy: this.overlay
-        .position()
-        .global()
-        .centerHorizontally()
-        .centerVertically(),
+      positionStrategy: this.overlay.position().global().centerHorizontally().centerVertically(),
       hasBackdrop: true,
       scrollStrategy: this.overlay.scrollStrategies.block(),
       disposeOnNavigation: true,

--- a/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.html
+++ b/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.html
@@ -1,10 +1,6 @@
-<h1 id="dialogHeading" class="govuk-panel--warning-prompt">You're about to permanently delete.</h1>
+<h1 id="dialogHeading" >Are you sure you want to send these emails?</h1>
 
-<p>This will delete all the workplace information and the records of all the staff.</p>
-
-<p>
-  <strong>This action cannot be undone.</strong>
-</p>
+<p>This will send emails to <strong>5,723</strong> workplaces.</p>
 
 <button (click)="close(true)" class="govuk-button">Send emails</button>
 <button (click)="close(false)" class="govuk-button govuk-button--link govuk-util__float-right">Cancel</button>

--- a/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.html
+++ b/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.html
@@ -1,0 +1,10 @@
+<h1 id="dialogHeading" class="govuk-panel--warning-prompt">You're about to permanently delete.</h1>
+
+<p>This will delete all the workplace information and the records of all the staff.</p>
+
+<p>
+  <strong>This action cannot be undone.</strong>
+</p>
+
+<button (click)="close(true)" class="govuk-button">Send emails</button>
+<button (click)="close(false)" class="govuk-button govuk-button--link govuk-util__float-right">Cancel</button>

--- a/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.spec.ts
+++ b/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SendEmailsConfirmationDialogComponent } from './send-emails-confirmation-dialog.component';
+
+describe('SendEmailsConfirmationDialogComponent', () => {
+  let component: SendEmailsConfirmationDialogComponent;
+  let fixture: ComponentFixture<SendEmailsConfirmationDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SendEmailsConfirmationDialogComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SendEmailsConfirmationDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.spec.ts
+++ b/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.spec.ts
@@ -1,25 +1,24 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Dialog, DIALOG_DATA } from '@core/services/dialog.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
 
 import { SendEmailsConfirmationDialogComponent } from './send-emails-confirmation-dialog.component';
 
 describe('SendEmailsConfirmationDialogComponent', () => {
-  let component: SendEmailsConfirmationDialogComponent;
-  let fixture: ComponentFixture<SendEmailsConfirmationDialogComponent>;
+  async function setup() {
+    return render(SendEmailsConfirmationDialogComponent, {
+      imports: [
+        SharedModule,
+      ],
+      providers: [
+        { provide: DIALOG_DATA, useValue: {} },
+        { provide: Dialog, useValue: {} }
+    ]
+    });
+  }
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ SendEmailsConfirmationDialogComponent ]
-    })
-    .compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SendEmailsConfirmationDialogComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
+  it('should create', async () => {
+    const component = await setup();
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.ts
+++ b/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.ts
@@ -1,0 +1,20 @@
+import { Component, Inject } from '@angular/core';
+import { DialogComponent } from '@core/components/dialog.component';
+import { Dialog, DIALOG_DATA } from '@core/services/dialog.service';
+
+@Component({
+  selector: 'app-send-emails-confirmation-dialog',
+  templateUrl: './send-emails-confirmation-dialog.component.html',
+})
+export class SendEmailsConfirmationDialogComponent extends DialogComponent {
+  constructor(
+    @Inject(DIALOG_DATA) public data: { inactiveWorkplaces: number },
+    public dialog: Dialog<SendEmailsConfirmationDialogComponent>,
+  ) {
+    super(data, dialog);
+  }
+
+  public close(hasConfirmed: boolean) {
+    this.dialog.close(hasConfirmed);
+  }
+}

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -3,7 +3,7 @@
 <dl class="govuk-list--definition">
   <dt>Total number of inactive workplaces</dt>
   <dd>
-    {{ 5 }}
+    {{ '5,723' }}
   </dd>
 </dl>
 
@@ -32,7 +32,7 @@
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">05/01/2021</td>
-      <td class="govuk-table__cell">5,723</td>
+      <td class="govuk-table__cell">1,263</td>
     </tr>
   </tbody>
 </table>

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -1,14 +1,4 @@
 <h1 class="govuk-heading-xl">Inactive Workplaces</h1>
-<a
-      class="govuk-list govuk-list--inline govuk-list govuk__flex govuk__align-items-center"
-      role="button"
-      draggable="false"
-      href=""
-    >
-      <img alt="" src="/assets/images/icon-download.svg" /><span class="govuk-!-margin-left-1">
-        Download report
-      </span>
-    </a>
 
 <dl class="govuk-list--definition">
   <dt>Total number of inactive workplaces</dt>
@@ -16,4 +6,31 @@
     {{ 5 }}
   </dd>
 </dl>
-<button class="govuk-button" type="submit">Send emails</button>
+
+<div class="govuk__flex">
+  <div class="govuk-!-margin-top-6 govuk">
+    <button class="govuk-button govuk-!-margin-right-9" type="submit">Send emails</button>
+  </div>
+  <div class="govuk-!-margin-top-4 govuk__flex govuk-util__vertical-align-center">
+    <a class="govuk-list--inline govuk-list govuk__flex govuk__align-items-center" href="#">
+      <img alt="" src="/assets/images/icon-download.svg" />
+      <span class="govuk-!-margin-left-1">Download report</span>
+    </a>
+  </div>
+</div>
+
+<h2>History</h2>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Date</th>
+      <th class="govuk-table__header" scope="col">Total emails sent</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">05/01/2021</td>
+      <td class="govuk-table__cell">5,723</td>
+    </tr>
+  </tbody>
+</table>

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -1,0 +1,19 @@
+<h1 class="govuk-heading-xl">Inactive Workplaces</h1>
+<a
+      class="govuk-list govuk-list--inline govuk-list govuk__flex govuk__align-items-center"
+      role="button"
+      draggable="false"
+      href=""
+    >
+      <img alt="" src="/assets/images/icon-download.svg" /><span class="govuk-!-margin-left-1">
+        Download report
+      </span>
+    </a>
+
+<dl class="govuk-list--definition">
+  <dt>Total number of inactive workplaces</dt>
+  <dd>
+    {{ 5 }}
+  </dd>
+</dl>
+<button class="govuk-button" type="submit">Send emails</button>

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -9,7 +9,9 @@
 
 <div class="govuk__flex">
   <div class="govuk-!-margin-top-6 govuk">
-    <button class="govuk-button govuk-!-margin-right-9" type="submit">Send emails</button>
+    <button class="govuk-button govuk-!-margin-right-9" (click)="confirmSendEmails($event)" type="submit">
+      Send emails
+    </button>
   </div>
   <div class="govuk-!-margin-top-4 govuk__flex govuk-util__vertical-align-center">
     <a class="govuk-list--inline govuk-list govuk__flex govuk__align-items-center" href="#">

--- a/src/app/features/search/emails/emails.component.spec.ts
+++ b/src/app/features/search/emails/emails.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EmailsComponent } from './emails.component';
+
+describe('EmailsComponent', () => {
+  let component: EmailsComponent;
+  let fixture: ComponentFixture<EmailsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EmailsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EmailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/search/emails/emails.component.spec.ts
+++ b/src/app/features/search/emails/emails.component.spec.ts
@@ -1,25 +1,23 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DialogService } from '@core/services/dialog.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
 
 import { EmailsComponent } from './emails.component';
 
 describe('EmailsComponent', () => {
-  let component: EmailsComponent;
-  let fixture: ComponentFixture<EmailsComponent>;
+  async function setup() {
+    return render(EmailsComponent, {
+      imports: [
+        SharedModule,
+      ],
+      providers: [
+        DialogService,
+      ],
+    });
+  }
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ EmailsComponent ]
-    })
-    .compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(EmailsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
+  it('should create', async () => {
+    const component = await setup();
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-emails',
+  templateUrl: './emails.component.html'
+})
+export class EmailsComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -1,14 +1,26 @@
 import { Component, OnInit } from '@angular/core';
+import { DialogService } from '@core/services/dialog.service';
+
+import {
+  SendEmailsConfirmationDialogComponent,
+} from './dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component';
 
 @Component({
   selector: 'app-emails',
-  templateUrl: './emails.component.html'
+  templateUrl: './emails.component.html',
 })
 export class EmailsComponent implements OnInit {
+  constructor(private dialogService: DialogService) {}
 
-  constructor() { }
+  ngOnInit(): void {}
 
-  ngOnInit(): void {
+  public confirmSendEmails(event: Event): void {
+    event.preventDefault();
+
+    this.dialogService.open(SendEmailsConfirmationDialogComponent, {}).afterClosed.subscribe((hasConfirmed) => {
+      if (hasConfirmed) {
+        console.log('confirmed');
+      }
+    });
   }
-
 }

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -19,7 +19,7 @@ export class EmailsComponent implements OnInit {
 
     this.dialogService.open(SendEmailsConfirmationDialogComponent, {}).afterClosed.subscribe((hasConfirmed) => {
       if (hasConfirmed) {
-        console.log('confirmed');
+
       }
     });
   }

--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -62,9 +62,22 @@
             CQC Changes
           </a>
         </li>
+        <li class="govuk-tabs__list-item" [class.govuk-tabs__list-item--selected]="form.type === 'emails'">
+          <a
+            role="tab"
+            class="govuk-tabs__tab"
+            [class.govuk-tabs__tab--selected]="form.type === 'emails'"
+            [routerLink]="['/emails']"
+          >
+            Emails
+          </a>
+        </li>
       </ul>
 
-      <section class="govuk-tabs__panel has-border" *ngIf="form.type !== 'registrations' && form.type !== 'parent-requests' && form.type !== 'cqc-status-changes' ">
+      <section
+        class="govuk-tabs__panel has-border"
+        *ngIf="form.type !== 'registrations' && form.type !== 'parent-requests' && form.type !== 'cqc-status-changes'"
+      >
         <form (ngSubmit)="onSubmit()" novalidate id="server-error">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -82,9 +95,7 @@
               data-module="error-summary"
               *ngIf="form.errors.length"
             >
-              <h2 class="govuk-error-summary__title" id="error-summary-title">
-                There is a problem
-              </h2>
+              <h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>
               <div class="govuk-error-summary__body">
                 <ul class="govuk-list govuk-error-summary__list">
                   <li *ngFor="let item of form.errors">
@@ -143,9 +154,7 @@
 
               <div class="govuk-grid-column-one-third" *ngIf="form.type === 'establishments'">
                 <div class="govuk-form-group" [class.govuk-form-group--error]="form.errors.length">
-                  <label class="govuk-label" for="locationid">
-                    Location ID
-                  </label>
+                  <label class="govuk-label" for="locationid"> Location ID </label>
                   <input
                     class="govuk-input govuk-input--width-20"
                     [(ngModel)]="form.locationid"
@@ -160,9 +169,7 @@
 
               <div class="govuk-grid-column-one-half" *ngIf="form.type === 'groups'">
                 <div class="govuk-form-group" [class.govuk-form-group--error]="form.errors.length">
-                  <label class="govuk-label" for="employerType">
-                    Employer Type
-                  </label>
+                  <label class="govuk-label" for="employerType"> Employer Type </label>
                   <select
                     class="govuk-select"
                     id="employerType"
@@ -183,21 +190,19 @@
 
               <div class="govuk-grid-column-one-half" *ngIf="form.type === 'groups'">
                 <div class="govuk-form-group" [class.govuk-form-group--error]="form.errors.length">
-                  <label class="govuk-label">
-                    Parents
-                  </label>
+                  <label class="govuk-label"> Parents </label>
                   <div class="govuk-checkboxes">
                     <div class="govuk-checkboxes__item">
-                      <input id="parent"
-                      name="parent"
-                      [(ngModel)]="form.parent"
-                      class="govuk-checkboxes__input"
-                      type="checkbox"
-                      value="true"
-                      [class.govuk-select--error]="form.errors && form.errors.length">
-                      <label class="govuk-label govuk-checkboxes__label" for="parent">
-                        Only search for parents
-                      </label>
+                      <input
+                        id="parent"
+                        name="parent"
+                        [(ngModel)]="form.parent"
+                        class="govuk-checkboxes__input"
+                        type="checkbox"
+                        value="true"
+                        [class.govuk-select--error]="form.errors && form.errors.length"
+                      />
+                      <label class="govuk-label govuk-checkboxes__label" for="parent"> Only search for parents </label>
                     </div>
                   </div>
                 </div>
@@ -224,7 +229,9 @@
       </div>
     </div>
 
-    <p class="govuk-!-font-weight-bold" *ngIf="results && results.length">Your search returned {{ results.length | number }} results.</p>
+    <p class="govuk-!-font-weight-bold" *ngIf="results && results.length">
+      Your search returned {{ results.length | number }} results.
+    </p>
 
     <div *ngIf="form.type === 'users'">
       <table class="govuk-table" *ngIf="results && results.length" data-testid="user-search-results">
@@ -239,23 +246,19 @@
         </thead>
         <tbody class="govuk-table__body">
           <ng-container *ngFor="let item of results; index as index">
-            <tr class="govuk-table__row" >
+            <tr class="govuk-table__row">
               <td class="govuk-table__cell">{{ item.name }}</td>
               <td class="govuk-table__cell">{{ item.username }}</td>
               <td class="govuk-table__cell">
                 <a (click)="setEstablishmentId(item.establishment.uid, item.username, null, $event)" href="#">{{
                   item.establishment.nmdsId
                 }}</a>
-
               </td>
               <td class="govuk-table__cell">{{ item.establishment.postcode }}</td>
               <td class="govuk-table__cell">
-                <a
-                  class="govuk-link--no-visited-state"
-                  href="#"
-                  (click)="toggleDetails(item.uid, $event)"
-                  >{{ workerDetailsLabel[item.uid] ? workerDetailsLabel[item.uid] : 'Open' }}</a
-                >
+                <a class="govuk-link--no-visited-state" href="#" (click)="toggleDetails(item.uid, $event)">{{
+                  workerDetailsLabel[item.uid] ? workerDetailsLabel[item.uid] : 'Open'
+                }}</a>
               </td>
             </tr>
             <tr *ngIf="workerDetails[item.uid]" class="govuk-panel--gray">
@@ -263,11 +266,11 @@
                 <div class="govuk-!-margin-2">
                   <table class="govuk-table">
                     <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Location ID</th>
-                          <th class="govuk-table__header govuk-!-width-one-half" scope="col">Workplace</th>
-                          <th class="govuk-table__header govuk-!-width-one-third" scope="col">&nbsp;</th>
-                        </tr>
+                      <tr class="govuk-table__row">
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Location ID</th>
+                        <th class="govuk-table__header govuk-!-width-one-half" scope="col">Workplace</th>
+                        <th class="govuk-table__header govuk-!-width-one-third" scope="col">&nbsp;</th>
+                      </tr>
                     </thead>
                     <tbody class="govuk-table__body">
                       <tr class="govuk-table__row govuk-util__vertical-align-top">
@@ -275,9 +278,11 @@
                           {{ item.establishment.locationId }}
                         </td>
                         <td class="govuk-table__cell">
-                          <a (click)="setEstablishmentId(item.establishment.uid, item.username, null, $event)" href="#">{{
-                            item.establishment.name
-                          }}</a>
+                          <a
+                            (click)="setEstablishmentId(item.establishment.uid, item.username, null, $event)"
+                            href="#"
+                            >{{ item.establishment.name }}</a
+                          >
                         </td>
                         <th class="govuk-table__cell" scope="col">&nbsp;</th>
                       </tr>
@@ -287,11 +292,11 @@
                 <div class="govuk-!-margin-2">
                   <table class="govuk-table">
                     <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Security question</th>
-                          <th class="govuk-table__header govuk-!-width-one-half" scope="col">Answer</th>
-                          <th class="govuk-table__header govuk-!-width-one-third" scope="col">Locked</th>
-                        </tr>
+                      <tr class="govuk-table__row">
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Security question</th>
+                        <th class="govuk-table__header govuk-!-width-one-half" scope="col">Answer</th>
+                        <th class="govuk-table__header govuk-!-width-one-third" scope="col">Locked</th>
+                      </tr>
                     </thead>
                     <tbody class="govuk-table__body">
                       <tr class="govuk-table__row govuk-util__vertical-align-top">
@@ -302,7 +307,12 @@
                           {{ item.securityQuestionAnswer }}
                         </td>
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
-                          <a (click)="unlockUser(item.username, index, $event)" href="#" *ngIf="item.isLocked else notLocked">Yes, unlock</a>
+                          <a
+                            (click)="unlockUser(item.username, index, $event)"
+                            href="#"
+                            *ngIf="item.isLocked; else notLocked"
+                            >Yes, unlock</a
+                          >
                           <ng-template #notLocked>No</ng-template>
                         </td>
                       </tr>
@@ -339,12 +349,9 @@
               <td class="govuk-table__cell">{{ item.locationId || '-' }}</td>
               <td class="govuk-table__cell">-</td>
               <td class="govuk-table__cell">
-                <a
-                  class="govuk-link--no-visited-state"
-                  href="#"
-                  (click)="toggleDetails(item.uid, $event)"
-                  >{{ workerDetailsLabel[item.uid] ? workerDetailsLabel[item.uid] : 'Open' }}</a
-                >
+                <a class="govuk-link--no-visited-state" href="#" (click)="toggleDetails(item.uid, $event)">{{
+                  workerDetailsLabel[item.uid] ? workerDetailsLabel[item.uid] : 'Open'
+                }}</a>
               </td>
             </tr>
             <tr *ngIf="workerDetails[item.uid]" class="govuk-panel--gray">
@@ -352,12 +359,12 @@
                 <div class="govuk-!-margin-2">
                   <table class="govuk-table">
                     <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                          <th class="govuk-table__header govuk-!-width-one-third" scope="col">Address</th>
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Parent ID</th>
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Regulated</th>
-                          <th class="govuk-table__header" scope="col">Data Owner</th>
-                        </tr>
+                      <tr class="govuk-table__row">
+                        <th class="govuk-table__header govuk-!-width-one-third" scope="col">Address</th>
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Parent ID</th>
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Regulated</th>
+                        <th class="govuk-table__header" scope="col">Data Owner</th>
+                      </tr>
                     </thead>
                     <tbody class="govuk-table__body">
                       <tr class="govuk-table__row govuk-util__vertical-align-top">
@@ -365,8 +372,10 @@
                           {{ displayAddress(item) }}
                         </td>
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
-                          <ng-container *ngIf="item.parent?.nmdsId else noParentID">
-                            <a (click)="setEstablishmentId(item.parent.uid, '', item.parent.nmdsId, $event)" href="#">{{ item.parent.nmdsId }}</a>
+                          <ng-container *ngIf="item.parent?.nmdsId; else noParentID">
+                            <a (click)="setEstablishmentId(item.parent.uid, '', item.parent.nmdsId, $event)" href="#">{{
+                              item.parent.nmdsId
+                            }}</a>
                           </ng-container>
 
                           <ng-template #noParentID>-</ng-template>
@@ -384,15 +393,18 @@
                 <div class="govuk-!-margin-2" *ngIf="item.users.length > 0">
                   <table class="govuk-table">
                     <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                          <th class="govuk-table__header govuk-!-width-one-third" scope="col">Users</th>
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Security question</th>
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Answer</th>
-                          <th class="govuk-table__header" scope="col">Locked</th>
-                        </tr>
+                      <tr class="govuk-table__row">
+                        <th class="govuk-table__header govuk-!-width-one-third" scope="col">Users</th>
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Security question</th>
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Answer</th>
+                        <th class="govuk-table__header" scope="col">Locked</th>
+                      </tr>
                     </thead>
                     <tbody class="govuk-table__body">
-                      <tr class="govuk-table__row govuk-util__vertical-align-top" *ngFor="let user of item.users; index as userIndex">
+                      <tr
+                        class="govuk-table__row govuk-util__vertical-align-top"
+                        *ngFor="let user of item.users; index as userIndex"
+                      >
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
                           {{ user.name }}
                         </td>
@@ -403,7 +415,12 @@
                           {{ user.securityAnswer }}
                         </td>
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
-                          <a (click)="unlockWorkplaceUser(user.username, workplaceIndex, userIndex, $event)" href="#" *ngIf="user.isLocked else notLocked">Yes, unlock</a>
+                          <a
+                            (click)="unlockWorkplaceUser(user.username, workplaceIndex, userIndex, $event)"
+                            href="#"
+                            *ngIf="user.isLocked; else notLocked"
+                            >Yes, unlock</a
+                          >
                           <ng-template #notLocked>No</ng-template>
                         </td>
                       </tr>
@@ -438,12 +455,9 @@
                 {{ item.employerType?.other ? item.employerType.other : item.employerType?.value || '-' }}
               </td>
               <td class="govuk-table__cell">
-                <a
-                  class="govuk-link--no-visited-state"
-                  href="#"
-                  (click)="toggleDetails(item.uid, $event)"
-                  >{{ workerDetailsLabel[item.uid] ? workerDetailsLabel[item.uid] : 'Open' }}</a
-                >
+                <a class="govuk-link--no-visited-state" href="#" (click)="toggleDetails(item.uid, $event)">{{
+                  workerDetailsLabel[item.uid] ? workerDetailsLabel[item.uid] : 'Open'
+                }}</a>
               </td>
             </tr>
             <tr *ngIf="workerDetails[item.uid]" class="govuk-panel--gray" data-testid="groups-workplace-details">
@@ -451,12 +465,12 @@
                 <div class="govuk-!-margin-2">
                   <table class="govuk-table">
                     <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                          <th class="govuk-table__header govuk-!-width-one-third" scope="col">Address</th>
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Parent ID</th>
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Regulated</th>
-                          <th class="govuk-table__header" scope="col">Data Owner</th>
-                        </tr>
+                      <tr class="govuk-table__row">
+                        <th class="govuk-table__header govuk-!-width-one-third" scope="col">Address</th>
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Parent ID</th>
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Regulated</th>
+                        <th class="govuk-table__header" scope="col">Data Owner</th>
+                      </tr>
                     </thead>
                     <tbody class="govuk-table__body">
                       <tr class="govuk-table__row govuk-util__vertical-align-top">
@@ -464,8 +478,10 @@
                           {{ displayAddressForGroups(item) }}
                         </td>
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
-                          <ng-container *ngIf="item.parent?.nmdsId else noParentID">
-                            <a (click)="setEstablishmentId(item.parent.uid, '', item.parent.nmdsId, $event)" href="#">{{ item.parent.nmdsId }}</a>
+                          <ng-container *ngIf="item.parent?.nmdsId; else noParentID">
+                            <a (click)="setEstablishmentId(item.parent.uid, '', item.parent.nmdsId, $event)" href="#">{{
+                              item.parent.nmdsId
+                            }}</a>
                           </ng-container>
 
                           <ng-template #noParentID>-</ng-template>
@@ -483,15 +499,18 @@
                 <div class="govuk-!-margin-2" *ngIf="item.users?.length > 0">
                   <table class="govuk-table">
                     <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                          <th class="govuk-table__header govuk-!-width-one-third" scope="col">Users</th>
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Security question</th>
-                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Answer</th>
-                          <th class="govuk-table__header" scope="col">Locked</th>
-                        </tr>
+                      <tr class="govuk-table__row">
+                        <th class="govuk-table__header govuk-!-width-one-third" scope="col">Users</th>
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Security question</th>
+                        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Answer</th>
+                        <th class="govuk-table__header" scope="col">Locked</th>
+                      </tr>
                     </thead>
                     <tbody class="govuk-table__body">
-                      <tr class="govuk-table__row govuk-util__vertical-align-top" *ngFor="let user of item.users; index as userIndex">
+                      <tr
+                        class="govuk-table__row govuk-util__vertical-align-top"
+                        *ngFor="let user of item.users; index as userIndex"
+                      >
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
                           {{ user.name }}
                         </td>
@@ -502,7 +521,12 @@
                           {{ user.securityAnswer }}
                         </td>
                         <td class="govuk-table__cell govuk-!-font-weight-regular">
-                          <a (click)="unlockWorkplaceUser(user.username, workplaceIndex, userIndex, $event)" href="#" *ngIf="user.isLocked else notLocked">Yes, unlock</a>
+                          <a
+                            (click)="unlockWorkplaceUser(user.username, workplaceIndex, userIndex, $event)"
+                            href="#"
+                            *ngIf="user.isLocked; else notLocked"
+                            >Yes, unlock</a
+                          >
                           <ng-template #notLocked>No</ng-template>
                         </td>
                       </tr>

--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -76,7 +76,7 @@
 
       <section
         class="govuk-tabs__panel has-border"
-        *ngIf="form.type !== 'registrations' && form.type !== 'parent-requests' && form.type !== 'cqc-status-changes'"
+        *ngIf="form.type !== 'registrations' && form.type !== 'parent-requests' && form.type !== 'cqc-status-changes' && form.type !== 'emails'"
       >
         <form (ngSubmit)="onSubmit()" novalidate id="server-error">
           <fieldset class="govuk-fieldset">
@@ -543,5 +543,6 @@
     <app-registrations *ngIf="form.type === 'registrations'"></app-registrations>
     <app-parent-requests *ngIf="form.type === 'parent-requests'"></app-parent-requests>
     <app-cqc-status-changes *ngIf="form.type === 'cqc-status-changes'"></app-cqc-status-changes>
+    <app-emails *ngIf="form.type ==='emails'"></app-emails>
   </div>
 </div>

--- a/src/app/features/search/search.component.spec.ts
+++ b/src/app/features/search/search.component.spec.ts
@@ -2,15 +2,15 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
-import { SharedModule } from '@shared/shared.module';
-import { render, within, fireEvent } from '@testing-library/angular';
+import { RegistrationsService } from '@core/services/registrations.service';
 import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
+import { WindowRef } from '@core/services/window.ref';
+import { MockSwitchWorkplaceService } from '@core/test-utils/MockSwitchWorkplaceService';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render, within } from '@testing-library/angular';
+import { of } from 'rxjs';
 
 import { SearchComponent } from './search.component';
-import { MockSwitchWorkplaceService } from '@core/test-utils/MockSwitchWorkplaceService';
-import { WindowRef } from '@core/services/window.ref';
-import { RegistrationsService } from '@core/services/registrations.service';
-import { of } from 'rxjs';
 
 const getSearchComponent = async () => {
   return render(SearchComponent, {
@@ -273,6 +273,14 @@ describe('SearchComponent', () => {
       fixture.detectChanges();
 
       expect(getByTestId('no-search-results'));
+    });
+  });
+
+  describe('Emails', () => {
+    it('should click the Emails tab', async () => {
+      const { getByText } = await getSearchComponent();
+
+      fireEvent.click(getByText('Emails'));
     });
   });
 });

--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -74,8 +74,10 @@ export class SearchComponent implements OnInit, AfterViewInit {
       this.form.type = 'registrations';
     } else if (this.router.url === '/cqc-status-changes') {
       this.form.type = 'cqc-status-changes';
-    } else {
+    } else if (this.router.url === '/parent-requests') {
       this.form.type = 'parent-requests';
+    } else if (this.router.url === '/emails') {
+      this.form.type = 'emails';
     }
   }
 
@@ -86,8 +88,8 @@ export class SearchComponent implements OnInit, AfterViewInit {
       index,
       removeUnlock: () => {
         this.results[index].isLocked = false;
-      }
-    }
+      },
+    };
     this.dialogService.open(AdminUnlockConfirmationDialogComponent, data);
   }
 
@@ -97,8 +99,8 @@ export class SearchComponent implements OnInit, AfterViewInit {
       username,
       removeUnlock: () => {
         this.results[workplaceIndex].users[userIndex].isLocked = false;
-      }
-    }
+      },
+    };
 
     this.dialogService.open(AdminUnlockConfirmationDialogComponent, data);
   }
@@ -117,10 +119,12 @@ export class SearchComponent implements OnInit, AfterViewInit {
     this.form.submitted = true;
     // this.errorSummaryService.syncFormErrorsEvent.next(true);
 
-    if (this.form.username.length === 0 &&
+    if (
+      this.form.username.length === 0 &&
       this.form.name.length === 0 &&
       this.form.locationid.length === 0 &&
-      this.form.employerType.length === 0) {
+      this.form.employerType.length === 0
+    ) {
       this.form.errors.push({
         error: 'Please enter at least 1 search value',
         id: 'username',
@@ -137,8 +141,8 @@ export class SearchComponent implements OnInit, AfterViewInit {
       } else if (this.form.type === 'groups') {
         data = {
           employerType: this.form.employerType,
-          parent: this.form.parent
-        }
+          parent: this.form.parent,
+        };
       } else {
         data = {
           postcode: this.form.username,
@@ -148,8 +152,8 @@ export class SearchComponent implements OnInit, AfterViewInit {
       }
 
       this.searchType(data, this.form.type).subscribe(
-        response => this.onSuccess(response),
-        error => this.onError(error)
+        (response) => this.onSuccess(response),
+        (error) => this.onError(error),
       );
     }
   }
@@ -165,13 +169,15 @@ export class SearchComponent implements OnInit, AfterViewInit {
   }
 
   protected displayAddress(workplace) {
-    const secondaryAddress = ' ' + [workplace.address2, workplace.town, workplace.county].filter(Boolean).join(', ') || '';
+    const secondaryAddress =
+      ' ' + [workplace.address2, workplace.town, workplace.county].filter(Boolean).join(', ') || '';
 
     return workplace.address1 + secondaryAddress;
   }
 
   protected displayAddressForGroups(workplace) {
-    const secondaryAddress = ' ' + [workplace.address2, workplace.town, workplace.county, workplace.postcode].filter(Boolean).join(', ') || '';
+    const secondaryAddress =
+      ' ' + [workplace.address2, workplace.town, workplace.county, workplace.postcode].filter(Boolean).join(', ') || '';
 
     return workplace.address1 + secondaryAddress;
   }

--- a/src/app/features/search/search.module.ts
+++ b/src/app/features/search/search.module.ts
@@ -11,6 +11,7 @@ import { SharedModule } from '@shared/shared.module';
 
 import { CqcStatusChangeComponent } from './cqc-status-change/cqc-status-change.component';
 import { CqcStatusChangesComponent } from './cqc-status-changes/cqc-status-changes.component';
+import { EmailsComponent } from './emails/emails.component';
 import { ParentRequestComponent } from './parent-request/parent-request.component';
 import { ParentRequestsComponent } from './parent-requests/parent-requests.component';
 import { RegistrationComponent } from './registration/registration.component';
@@ -38,7 +39,8 @@ import { SearchComponent } from './search.component';
     ParentRequestComponent,
     ParentRequestsComponent,
     CqcStatusChangeComponent,
-    CqcStatusChangesComponent
+    CqcStatusChangesComponent,
+    EmailsComponent,
   ],
 })
 export class SearchModule { }

--- a/src/app/features/search/search.module.ts
+++ b/src/app/features/search/search.module.ts
@@ -18,6 +18,7 @@ import { RegistrationComponent } from './registration/registration.component';
 import { RegistrationsComponent } from './registrations/registrations.component';
 import { SearchRoutingModule } from './search-routing.module';
 import { SearchComponent } from './search.component';
+import { SendEmailsConfirmationDialogComponent } from './emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component';
 
 
 @NgModule({
@@ -41,6 +42,7 @@ import { SearchComponent } from './search.component';
     CqcStatusChangeComponent,
     CqcStatusChangesComponent,
     EmailsComponent,
+    SendEmailsConfirmationDialogComponent,
   ],
 })
 export class SearchModule { }


### PR DESCRIPTION
**Work done**

- Added `Emails` tab to admin navigation
- Initial template for sending emails to inactive workplaces
- Added dialog to confirm whether emails would be sent

**Note**

This is a static design of the Keep Workplaces Active screen and has no working functionality - merging into a feature branch rather than `test`

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
