### PR TITLE
Fix: Update .gitignore to include Angular code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,10 @@ testem.log
 .DS_Store
 Thumbs.db
 
-# node v10+ c8 coverage reporting
+# Coverage
 /coverage
 /.nyc_output
+/fecoverage
 
 ./package-lock.json
 */package-lock.json


### PR DESCRIPTION
**Issue**

Running `ng test --code-coverage` creates a folder `fecoverage` which was not git ignored

**Work done**

- Added `fecoverage` folder to `.gitignore`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
