### PR TITLE
Feat: disable 'Send emails' button when there are no inactive workplaces

### DIFF
--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -9,7 +9,12 @@
 
 <div class="govuk__flex">
   <div class="govuk-!-margin-top-6 govuk">
-    <button class="govuk-button govuk-!-margin-right-9" (click)="confirmSendEmails($event)" type="submit">
+    <button
+      class="govuk-button govuk-!-margin-right-9"
+      [disabled]="!inactiveWorkplaces"
+      (click)="confirmSendEmails($event)"
+      type="submit"
+    >
       Send emails
     </button>
   </div>

--- a/src/app/features/search/emails/emails.component.spec.ts
+++ b/src/app/features/search/emails/emails.component.spec.ts
@@ -47,7 +47,19 @@ describe('EmailsComponent', () => {
     component.fixture.detectChanges();
 
     const numInactiveWorkplaces = component.getByTestId('inactiveWorkplaces');
+    const sendEmailsButton = component.fixture.nativeElement.querySelector('button');
     expect(numInactiveWorkplaces.innerHTML).toContain('1,250');
+    expect(sendEmailsButton.disabled).toBeFalsy();
+  });
+
+  it('should disable the "Send emails" button when there are no inactive workplaces', async () => {
+    const component = await setup();
+
+    component.fixture.componentInstance.inactiveWorkplaces = 0;
+    component.fixture.detectChanges();
+
+    const sendEmailsButton = component.fixture.nativeElement.querySelector('button');
+    expect(sendEmailsButton.disabled).toBeTruthy();
   });
 
   it('should display all existing history', async () => {


### PR DESCRIPTION
#### Changes
- Disable button if there are no inactive workplaces
- Add tests 

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
