### PR TITLE
Fix: Loading states for home tab

### DIFF
--- a/src/app/features/dashboard/home-tab/home-tab.component.spec.ts
+++ b/src/app/features/dashboard/home-tab/home-tab.component.spec.ts
@@ -103,6 +103,7 @@ describe('HomeTabComponent', () => {
     const { component } = await setup();
     // Act
     component.fixture.componentInstance.updateStaffRecords = true;
+    component.fixture.detectChanges();
 
     const link = component.getByTestId('add-staff-banner');
     // Assert

--- a/src/app/features/dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/dashboard/home-tab/home-tab.component.ts
@@ -14,13 +14,25 @@ import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { WorkerService } from '@core/services/worker.service';
 import { BecomeAParentDialogComponent } from '@shared/components/become-a-parent/become-a-parent-dialog.component';
-import { CancelDataOwnerDialogComponent } from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
-import { ChangeDataOwnerDialogComponent } from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
-import { LinkToParentCancelDialogComponent } from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
-import { LinkToParentRemoveDialogComponent } from '@shared/components/link-to-parent-remove/link-to-parent-remove-dialog.component';
+import {
+  CancelDataOwnerDialogComponent,
+} from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
+import {
+  ChangeDataOwnerDialogComponent,
+} from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
+import {
+  LinkToParentCancelDialogComponent,
+} from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
+import {
+  LinkToParentRemoveDialogComponent,
+} from '@shared/components/link-to-parent-remove/link-to-parent-remove-dialog.component';
 import { LinkToParentDialogComponent } from '@shared/components/link-to-parent/link-to-parent-dialog.component';
-import { OwnershipChangeMessageDialogComponent } from '@shared/components/ownership-change-message/ownership-change-message-dialog.component';
-import { SetDataPermissionDialogComponent } from '@shared/components/set-data-permission/set-data-permission-dialog.component';
+import {
+  OwnershipChangeMessageDialogComponent,
+} from '@shared/components/ownership-change-message/ownership-change-message-dialog.component';
+import {
+  SetDataPermissionDialogComponent,
+} from '@shared/components/set-data-permission/set-data-permission-dialog.component';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -48,7 +60,7 @@ export class HomeTabComponent implements OnInit, OnDestroy {
   public canViewWorkplaces: boolean;
   public canViewReports: boolean;
   public isParent: boolean;
-  public updateStaffRecords = true;
+  public updateStaffRecords: boolean;
   public user: UserDetails;
   public canViewChangeDataOwner: boolean;
   public canViewDataPermissionsLink: boolean;


### PR DESCRIPTION
**Issue**

In most components, we have a `.subscribe()` Observable that makes an API request and then updates the UI with data from the response.

However, some of the variables that are updated by the response have a default value, and this means we end up with a scenario of:

```
updateStaffRecords = true

.subscribe(() => {
  updateStaffRecords = false
}
```

When this is the case, the initial rendering of the UI displays a banner that tells the user they need to add staff records even though the API request to get the staff records hasn't finished. Once it has finished, the banner disappears.

By removing the default value we then end up with:

```
updateStaffRecords = undefined

.subscribe(() => {
  updateStaffRecords = false
}
```

When a variable is undefined, the UI will wait until it has been set before rendering any `*ngIf` tags etc.

**Work done**

- Removed the default value from `updateStaffRecords` so that it's truthy is based on whether there are staff records or not.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
