### PR TITLE
Feat: keep workplaces active Send In Blue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23008,6 +23008,33 @@
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
+    "sib-api-v3-sdk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/sib-api-v3-sdk/-/sib-api-v3-sdk-8.2.0.tgz",
+      "integrity": "sha512-Qqr6y1wT7BZMWAKn5ouuCyqz8X0L3fB6jFRJK4pOIcnzvaSK2HLKwj0Enxz8Rsk+wuitWRptiJOBJgkcGm6dxA==",
+      "requires": {
+        "superagent": "3.7.0"
+      },
+      "dependencies": {
+        "superagent": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.7.0.tgz",
+          "integrity": "sha512-/8trxO6NbLx4YXb7IeeFTSmsQ35pQBiTBsLNvobZx7qBzBeHYvKCyIIhW2gNcWbLzYxPAjdgFbiepd8ypwC0Gw==",
+          "requires": {
+            "component-emitter": "^1.2.0",
+            "cookiejar": "^2.1.0",
+            "debug": "^3.1.0",
+            "extend": "^3.0.0",
+            "form-data": "^2.3.1",
+            "formidable": "^1.1.1",
+            "methods": "^1.1.1",
+            "mime": "^1.4.1",
+            "qs": "^6.5.1",
+            "readable-stream": "^2.0.5"
+          }
+        }
+      }
+    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "sequelize-cli": "^5.5.1",
     "sequelize-replace-enum-postgres": "^1.6.0",
     "serve-favicon": "^2.5.0",
+    "sib-api-v3-sdk": "^8.2.0",
     "slugify": "^1.4.6",
     "tslib": "^2.1.0",
     "typescript": "^4.0.5",

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -454,6 +454,15 @@ const config = convict({
       default: 'd',
     },
   },
+  sendInBlue: {
+    apiKey: {
+      doc: 'Send in Blue API Key',
+      format: String,
+      default: '',
+      sensitive: true,
+      env: 'SEND_IN_BLUE_KEY',
+    },
+  },
 });
 
 // Load environment dependent configuration

--- a/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -4,7 +4,7 @@ const findInactiveWorkplaces = async () => {
       name: 'Workplace Name',
       nmdsId: 'J1234567',
       lastUpdated: '2020-06-01',
-      emailTemplate: 6,
+      emailTemplateId: 6,
       dataOwner: 'Workplace',
       user: {
         name: 'Test Name',
@@ -15,7 +15,7 @@ const findInactiveWorkplaces = async () => {
       name: 'Second Workplace Name',
       nmdsId: 'A0012345',
       lastUpdated: '2020-01-01',
-      emailTemplate: 12,
+      emailTemplateId: 12,
       dataOwner: 'Workplace',
       user: {
         name: 'Name McName',
@@ -25,4 +25,6 @@ const findInactiveWorkplaces = async () => {
   ];
 }
 
-module.exports = findInactiveWorkplaces;
+module.exports = {
+  findInactiveWorkplaces
+};

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -2,10 +2,10 @@ const express = require('express');
 const router = express.Router();
 
 const findInactiveWorkplaces = require('./findInactiveWorkplaces');
-const sendGroupEmail = require('./sendEmail');
+const sendEmail = require('./sendEmail');
 
 const getInactiveWorkplaces = async (_, res) => {
-  const inactiveWorkplaces = await findInactiveWorkplaces();
+  const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
 
   return res.json({
     inactiveWorkplaces: inactiveWorkplaces.length,
@@ -14,8 +14,8 @@ const getInactiveWorkplaces = async (_, res) => {
 
 const createCampaign = async (_, res) => {
   try {
-    const inactiveWorkplaces = await findInactiveWorkplaces();
-    sendGroupEmail(inactiveWorkplaces, 1);
+    const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
+    inactiveWorkplaces.map(sendEmail.sendEmail);
 
     const newCampaign = {
       date: '2021-02-05',
@@ -25,7 +25,7 @@ const createCampaign = async (_, res) => {
     return res.json(newCampaign);
   } catch (err) {
     console.error(err);
-    return res.status(503).send();
+    return res.status(503).json();
   }
 }
 
@@ -48,7 +48,6 @@ router.route('/').get(getInactiveWorkplaces);
 router.route('/').post(createCampaign);
 router.route('/history').get(getHistory);
 router.use('/report', require('./report'));
-router.use('/sendEmail', require('./sendEmail'));
 
 module.exports = router;
 module.exports.createCampaign = createCampaign;

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -39,6 +39,7 @@ router.route('/').get(getInactiveWorkplaces);
 router.route('/').post(createCampaign);
 router.route('/history').get(getHistory);
 router.use('/report', require('./report'));
+router.use('/sendEmail', require('./sendEmail'));
 
 module.exports = router;
 module.exports.createCampaign = createCampaign;

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 const findInactiveWorkplaces = require('./findInactiveWorkplaces');
+const sendGroupEmail = require('./sendEmail');
 
 const getInactiveWorkplaces = async (_, res) => {
   const inactiveWorkplaces = await findInactiveWorkplaces();
@@ -12,12 +13,20 @@ const getInactiveWorkplaces = async (_, res) => {
 }
 
 const createCampaign = async (_, res) => {
-  const newCampaign = {
-    date: '2021-02-05',
-    emails: 5673,
-  };
+  try {
+    const inactiveWorkplaces = await findInactiveWorkplaces();
+    sendGroupEmail(inactiveWorkplaces, 1);
 
-  return res.json(newCampaign);
+    const newCampaign = {
+      date: '2021-02-05',
+      emails: 5673,
+    };
+
+    return res.json(newCampaign);
+  } catch (err) {
+    console.error(err);
+    return res.status(503).send();
+  }
 }
 
 const getHistory = async (_, res) => {

--- a/server/routes/admin/email-campaigns/inactive-workplaces/report.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/report.js
@@ -36,7 +36,7 @@ const generateReport = async (_, res) => {
   const headerRow = worksheet.getRow(1);
   headerRow.font = { bold: true, name: 'Calibri' };
 
-  const inactiveWorkplaces = await findInactiveWorkplaces();
+  const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
   inactiveWorkplaces.forEach(workplace => {
     printRow(worksheet, workplace);
   });

--- a/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
@@ -1,18 +1,13 @@
-const express = require('express');
 const { sendEmail } = require('../../../../utils/email/sendInBlueEmail');
-const findInactiveWorkplaces = require('./findInactiveWorkplaces');
 
-const sendGroupEmail = async (_, res) => {
-  const inactiveWorkplaces = await findInactiveWorkplaces();
-
-  inactiveWorkplaces.map(async (workplace) => {
-    console.log(workplace);
-    await sendEmail(
+const sendGroupEmail = async (inactiveWorkplaces, templateId) => {
+  inactiveWorkplaces.map((workplace) => {
+    sendEmail(
       {
         email: workplace.user.email,
         name: workplace.user.name,
       },
-      1, // workplace.emailTemplate
+      templateId,
       {
         name: workplace.name,
         workplaceId: workplace.nmdsId,
@@ -20,13 +15,7 @@ const sendGroupEmail = async (_, res) => {
         nameOfUser: workplace.user.name,
       },
     );
-    // add email to history?
   });
-  return res.status(200);
 };
 
-const router = express.Router();
-router.route('/').post(sendGroupEmail);
-
-module.exports = router;
-module.exports.sendGroupEmail = sendGroupEmail;
+module.exports = sendGroupEmail;

--- a/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
@@ -1,21 +1,21 @@
-const { sendEmail } = require('../../../../utils/email/sendInBlueEmail');
+const sendInBlueEmail = require('../../../../utils/email/sendInBlueEmail');
 
-const sendGroupEmail = async (inactiveWorkplaces, templateId) => {
-  inactiveWorkplaces.map((workplace) => {
-    sendEmail(
-      {
-        email: workplace.user.email,
-        name: workplace.user.name,
-      },
-      templateId,
-      {
-        name: workplace.name,
-        workplaceId: workplace.nmdsId,
-        lastUpdated: workplace.lastUpdated,
-        nameOfUser: workplace.user.name,
-      },
-    );
-  });
+const sendEmail = async (workplace) => {
+  sendInBlueEmail.sendEmail(
+    {
+      email: workplace.user.email,
+      name: workplace.user.name,
+    },
+    workplace.emailTemplateId,
+    {
+      name: workplace.name,
+      workplaceId: workplace.nmdsId,
+      lastUpdated: workplace.lastUpdated,
+      nameOfUser: workplace.user.name,
+    },
+  );
 };
 
-module.exports = sendGroupEmail;
+module.exports = {
+  sendEmail
+};

--- a/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const { sendEmail } = require('../../../../utils/email/sendInBlueEmail');
+const findInactiveWorkplaces = require('./findInactiveWorkplaces');
+
+const sendGroupEmail = async (_, res) => {
+  const inactiveWorkplaces = await findInactiveWorkplaces();
+
+  inactiveWorkplaces.map(async (workplace) => {
+    console.log(workplace);
+    await sendEmail(
+      {
+        email: workplace.user.email,
+        name: workplace.user.name,
+      },
+      1, // workplace.emailTemplate
+      {
+        name: workplace.name,
+        workplaceId: workplace.nmdsId,
+        lastUpdated: workplace.lastUpdated,
+        nameOfUser: workplace.user.name,
+      },
+    );
+    // add email to history?
+  });
+  return res.status(200);
+};
+
+const router = express.Router();
+router.route('/').post(sendGroupEmail);
+
+module.exports = router;
+module.exports.sendGroupEmail = sendGroupEmail;

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -1,10 +1,41 @@
 const expect = require('chai').expect;
 const httpMocks = require('node-mocks-http');
+const sinon = require('sinon');
 
 const findInactiveWorkplaces = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
-const { createCampaign, getHistory, getInactiveWorkplaces } = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces');
+const sendEmail = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/sendEmail');
+const inactiveWorkplaceRoutes = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces');
 
 describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const dummyInactiveWorkplaces = [
+    {
+      name: 'Workplace Name',
+      nmdsId: 'J1234567',
+      lastUpdated: '2020-06-01',
+      emailTemplateId: 6,
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Test Name',
+        email: 'test@example.com',
+      },
+    },
+    {
+      name: 'Second Workplace Name',
+      nmdsId: 'A0012345',
+      lastUpdated: '2020-01-01',
+      emailTemplateId: 12,
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Name McName',
+        email: 'name@mcname.com',
+      },
+    }
+  ]
+
   it('should get the number of inactive workplaces', async () => {
     const req = httpMocks.createRequest({
       method: 'GET',
@@ -14,80 +45,65 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
     req.role = 'Admin';
 
     const res = httpMocks.createResponse();
-    await getInactiveWorkplaces(req, res);
+    await inactiveWorkplaceRoutes.getInactiveWorkplaces(req, res);
     const response = res._getJSONData();
 
     expect(response.inactiveWorkplaces).to.deep.equal(2);
   });
 
-  it('should create a campaign', async () => {
-    const req = httpMocks.createRequest({
-      method: 'POST',
-      url: `/api/admin/email-campaigns/inactive-workplaces`,
-    });
-
-    req.role = 'Admin';
-
-    const res = httpMocks.createResponse();
-    await createCampaign(req, res);
-    const response = res._getJSONData();
-
-    expect(response).to.deep.equal({
-      date: '2021-02-05',
-      emails: 5673,
-    });
-  });
-
-  it('should get the email campaign history', async () => {
-    const req = httpMocks.createRequest({
-      method: 'GET',
-      url: `/api/admin/email-campaigns/inactive-workplaces/history`,
-    });
-
-    req.role = 'Admin';
-
-    const res = httpMocks.createResponse();
-    await getHistory(req, res);
-    const response = res._getJSONData();
-
-    expect(response).to.deep.equal([
-      {
-        date: '2021-01-05',
-        emails: 1356,
-      },
-      {
-        date: '2020-12-05',
-        emails: 278,
-      },
-    ]);
-  });
-
   it('should return inactive workplaces', async () => {
-    const inactiveWorkplaces = await findInactiveWorkplaces();
+    const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
 
-    expect(inactiveWorkplaces).to.deep.equal([
-      {
-        name: 'Workplace Name',
-        nmdsId: 'J1234567',
-        lastUpdated: '2020-06-01',
-        emailTemplate: 6,
-        dataOwner: 'Workplace',
-        user: {
-          name: 'Test Name',
-          email: 'test@example.com',
+    expect(inactiveWorkplaces).to.deep.equal(dummyInactiveWorkplaces);
+  });
+
+  describe('createCampaign', async () => {
+    it('should create a campaign', async () => {
+      sinon.stub(findInactiveWorkplaces, 'findInactiveWorkplaces').returns(dummyInactiveWorkplaces);
+      const sendEmailMock = sinon.stub(sendEmail, 'sendEmail').returns();
+
+      const req = httpMocks.createRequest({
+        method: 'POST',
+        url: `/api/admin/email-campaigns/inactive-workplaces`,
+      });
+
+      req.role = 'Admin';
+
+      const res = httpMocks.createResponse();
+      await inactiveWorkplaceRoutes.createCampaign(req, res);
+      const response = res._getJSONData();
+
+      expect(response).to.deep.equal({
+        date: '2021-02-05',
+        emails: 5673,
+      });
+
+      sinon.assert.calledWith(sendEmailMock, dummyInactiveWorkplaces[0]);
+      sinon.assert.calledWith(sendEmailMock, dummyInactiveWorkplaces[1]);
+    });
+
+    it('should get the email campaign history', async () => {
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: `/api/admin/email-campaigns/inactive-workplaces/history`,
+      });
+
+      req.role = 'Admin';
+
+      const res = httpMocks.createResponse();
+      await inactiveWorkplaceRoutes.getHistory(req, res);
+      const response = res._getJSONData();
+
+      expect(response).to.deep.equal([
+        {
+          date: '2021-01-05',
+          emails: 1356,
         },
-      },
-      {
-        name: 'Second Workplace Name',
-        nmdsId: 'A0012345',
-        lastUpdated: '2020-01-01',
-        emailTemplate: 12,
-        dataOwner: 'Workplace',
-        user: {
-          name: 'Name McName',
-          email: 'name@mcname.com',
+        {
+          date: '2020-12-05',
+          emails: 278,
         },
-      }
-    ]);
+      ]);
+    });
   });
 });

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -1,0 +1,20 @@
+const expect = require('chai').expect;
+const httpMocks = require('node-mocks-http');
+const { sendGroupEmail } = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/sendEmail');
+
+describe.only('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', () => {
+  it('should send emails to inactive workplaces', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      url: `/api/admin/email-campaigns/inactive-workplaces/sendEmail`,
+    });
+
+    req.role = 'Admin';
+
+    const res = httpMocks.createResponse();
+
+    await sendGroupEmail(req, res);
+
+    expect(res.statusCode).to.equal(200);
+  });
+});

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -1,20 +1,42 @@
-const expect = require('chai').expect;
-const httpMocks = require('node-mocks-http');
-const { sendGroupEmail } = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/sendEmail');
+const sinon = require('sinon');
+const sendEmail = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/sendEmail');
+const sendInBlueEmail = require('../../../../../../utils/email/sendInBlueEmail');
 
-describe.only('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', () => {
-  it('should send emails to inactive workplaces', async () => {
-    const req = httpMocks.createRequest({
-      method: 'POST',
-      url: `/api/admin/email-campaigns/inactive-workplaces/sendEmail`,
-    });
+describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
 
-    req.role = 'Admin';
+  it('should call sendEmails for inactive workplace', async () => {
+    const inactiveWorkplace =
+      {
+        name: 'Workplace Name',
+        nmdsId: 'J1234567',
+        lastUpdated: '2020-06-01',
+        emailTemplateId: 6,
+        dataOwner: 'Workplace',
+        user: {
+          name: 'Test Name',
+          email: 'test@example.com',
+        },
+      };
 
-    const res = httpMocks.createResponse();
+    const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
 
-    await sendGroupEmail(req, res);
+    await sendEmail.sendEmail(inactiveWorkplace);
 
-    expect(res.statusCode).to.equal(200);
+    sinon.assert.calledWith(sendEmailStub,
+      {
+        email: 'test@example.com',
+        name: 'Test Name',
+      },
+      6,
+      {
+        name: 'Workplace Name',
+        workplaceId: 'J1234567',
+        lastUpdated: '2020-06-01',
+        nameOfUser: 'Test Name',
+      },
+    );
   });
 });

--- a/server/test/unit/utils/email/sendInBlueEmail.spec.js
+++ b/server/test/unit/utils/email/sendInBlueEmail.spec.js
@@ -1,0 +1,39 @@
+const SibApiV3Sdk = require('sib-api-v3-sdk');
+const sinon = require('sinon');
+const { sendEmail } = require('../../../../utils/email/sendInBlueEmail')
+
+describe('sendInBlueEmail', async () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('sends an email', async () => {
+    const sendTransacEmail = sinon.stub();
+    sinon.stub(SibApiV3Sdk, 'TransactionalEmailsApi').returns({
+      sendTransacEmail,
+    });
+
+    const to = {
+      name: "test",
+      email: 'test@test.com'
+    };
+    const templateId = 2;
+    const params = {
+      firstName: 'Test',
+    };
+
+    await sendEmail(to, templateId, params);
+
+    const sendSmtpEmail = new SibApiV3Sdk.SendSmtpEmail();
+    sendSmtpEmail.to = [{
+      name: "test",
+      email: "test@test.com",
+    }];
+    sendSmtpEmail.templateId = 2;
+    sendSmtpEmail.params = {
+      firstName: 'Test',
+    };
+
+    sinon.assert.calledWith(sendTransacEmail, sendSmtpEmail);
+  })
+});

--- a/server/utils/email/sendInBlueEmail.js
+++ b/server/utils/email/sendInBlueEmail.js
@@ -19,17 +19,14 @@ apiKey.apiKey = config.get('sendInBlue.apiKey');
 const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();
 
 const sendEmail = async (to, templateId, params) => {
-  let sendSmtpEmail = new SibApiV3Sdk.SendSmtpEmail();
-
-  sendSmtpEmail = {
-    to: [to],
-    templateId,
-    params,
-  };
   try {
-    console.log('Sending email');
-    const email = await apiInstance.sendTransacEmail(sendSmtpEmail);
-    console.log("************", email);
+    const sendSmtpEmail = new SibApiV3Sdk.SendSmtpEmail();
+
+    sendSmtpEmail.to = [to];
+    sendSmtpEmail.templateId = templateId;
+    sendSmtpEmail.params = params;
+
+    await apiInstance.sendTransacEmail(sendSmtpEmail);
   } catch (error) {
     console.log(error);
     throw new Error(error);

--- a/server/utils/email/sendInBlueEmail.js
+++ b/server/utils/email/sendInBlueEmail.js
@@ -1,0 +1,39 @@
+const SibApiV3Sdk = require('sib-api-v3-sdk');
+const config = require('../../config/config');
+const defaultClient = SibApiV3Sdk.ApiClient.instance;
+
+// Configure API key authorization: api-key
+const apiKey = defaultClient.authentications['api-key'];
+apiKey.apiKey = config.get('sendInBlue.apiKey');
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//apiKey.apiKeyPrefix['api-key'] = "Token"
+
+// getAccount(): Get your account information, plan and credits details
+// const api = new SibApiV3Sdk.AccountApi()
+// api.getAccount().then(function(data) {
+//   console.log('API called successfully. Returned data: ' + data);
+// }, function(error) {
+//   console.error(error);
+// });
+
+const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();
+
+const sendEmail = async (to, templateId, params) => {
+  let sendSmtpEmail = new SibApiV3Sdk.SendSmtpEmail();
+
+  sendSmtpEmail = {
+    to: [to],
+    templateId,
+    params,
+  };
+  try {
+    console.log('Sending email');
+    const email = await apiInstance.sendTransacEmail(sendSmtpEmail);
+    console.log("************", email);
+  } catch (error) {
+    console.log(error);
+    throw new Error(error);
+  }
+};
+
+exports.sendEmail = sendEmail;

--- a/server/utils/email/sendInBlueEmail.js
+++ b/server/utils/email/sendInBlueEmail.js
@@ -2,20 +2,8 @@ const SibApiV3Sdk = require('sib-api-v3-sdk');
 const config = require('../../config/config');
 const defaultClient = SibApiV3Sdk.ApiClient.instance;
 
-// Configure API key authorization: api-key
 const apiKey = defaultClient.authentications['api-key'];
 apiKey.apiKey = config.get('sendInBlue.apiKey');
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//apiKey.apiKeyPrefix['api-key'] = "Token"
-
-// getAccount(): Get your account information, plan and credits details
-// const api = new SibApiV3Sdk.AccountApi()
-// api.getAccount().then(function(data) {
-//   console.log('API called successfully. Returned data: ' + data);
-// }, function(error) {
-//   console.error(error);
-// });
-
 
 const sendEmail = async (to, templateId, params) => {
   try {

--- a/server/utils/email/sendInBlueEmail.js
+++ b/server/utils/email/sendInBlueEmail.js
@@ -16,10 +16,10 @@ apiKey.apiKey = config.get('sendInBlue.apiKey');
 //   console.error(error);
 // });
 
-const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();
 
 const sendEmail = async (to, templateId, params) => {
   try {
+    const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();
     const sendSmtpEmail = new SibApiV3Sdk.SendSmtpEmail();
 
     sendSmtpEmail.to = [to];


### PR DESCRIPTION
#### Changes
- Add Send In Blue SDK
- Update `createCampaign` endpoint to send emails

#### Notes
- Changed named imports in order to stub using `sinon`

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
