### PR TITLE
Feat: Keep workplaces active - Calculate inactive workplaces

### DIFF
--- a/migrations/20210302141451-create_last_updated_establishments_view.js
+++ b/migrations/20210302141451-create_last_updated_establishments_view.js
@@ -1,0 +1,61 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW cqc."LastUpdatedEstablishments" AS (
+        SELECT e."EstablishmentID",
+           e."NameValue",
+           e."ParentID",
+           e."IsParent",
+           e."NmdsID",
+           e."DataOwner",
+           ( SELECT u."FullNameValue"
+                  FROM cqc."User" u
+                 WHERE u."IsPrimary" = true AND (e."EstablishmentID" = u."EstablishmentID" OR u."EstablishmentID" = e."ParentID") AND u."Archived" = false
+                LIMIT 1) AS "PrimaryUserName",
+           ( SELECT u."EmailValue"
+                  FROM cqc."User" u
+                 WHERE u."IsPrimary" = true AND (e."EstablishmentID" = u."EstablishmentID" OR u."EstablishmentID" = e."ParentID") AND u."Archived" = false
+                LIMIT 1) AS "PrimaryUserEmail",
+           GREATEST(e.updated, ( SELECT w.updated
+                  FROM cqc."Worker" w
+                 WHERE w."EstablishmentFK" = e."EstablishmentID" AND w."Archived" = false
+                 ORDER BY w.updated DESC
+                LIMIT 1)) AS "LastUpdated"
+          FROM cqc."Establishment" e
+       );
+    `);
+
+    await queryInterface.addIndex({
+      tableName: 'EmailCampaignHistories',
+      schema: 'cqc',
+    },
+    {
+      fields: ['establishmentID', 'createdAt'],
+    });
+
+    await queryInterface.addIndex({
+      tableName: 'EmailCampaigns',
+      schema: 'cqc',
+    },
+    {
+      fields: ['type', 'id'],
+    });
+
+    await queryInterface.addIndex({
+      tableName: 'LastUpdatedEstablishments',
+      schema: 'cqc',
+    },
+    {
+      fields: ['ParentID', 'IsParent', 'LastUpdated'],
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`DROP INDEX cqc."email_campaign_histories_establishment_i_d_created_at"`);
+    await queryInterface.sequelize.query(`DROP INDEX cqc."email_campaigns_type_id"`);
+
+    return queryInterface.sequelize.query(`DROP MATERIALIZED VIEW "cqc"."LastUpdatedEstablishments"`);
+  }
+};

--- a/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 
-const models = require('../../../../models');
+const models = require('../../index');
 
 const findInactiveWorkplaces = async () => {
   await models.sequelize.query('REFRESH MATERIALIZED VIEW cqc."LastUpdatedEstablishments"');

--- a/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const models = require('../../../../models');
 
 const findInactiveWorkplaces = async () => {
-  const lastUpdated = moment().subtract(6, 'months').format('YYYY-MM-DD');
+  await models.sequelize.query('REFRESH MATERIALIZED VIEW cqc."LastUpdatedEstablishments"');
 
   const inactiveWorkplaces = await models.sequelize.query(
     `
@@ -49,7 +49,7 @@ const findInactiveWorkplaces = async () => {
 					AND ech. "establishmentID" = e. "EstablishmentID");`,
     {
       type: models.sequelize.QueryTypes.SELECT,
-      replacements: { lastUpdated },
+      replacements: { lastUpdated: moment().subtract(6, 'months').format('YYYY-MM-DD') },
     },
   );
 

--- a/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -49,23 +49,23 @@ const findInactiveWorkplaces = async () => {
 					AND ech. "establishmentID" = e. "EstablishmentID");`,
     {
       type: models.sequelize.QueryTypes.SELECT,
-      replacements: { lastUpdated }
+      replacements: { lastUpdated },
     },
   );
 
-  return inactiveWorkplaces.map(inactiveWorkplace => {
+  return inactiveWorkplaces.map((inactiveWorkplace) => {
     return {
       id: inactiveWorkplace.EstablishmentID,
       name: inactiveWorkplace.NameValue,
       nmdsId: inactiveWorkplace.NmdsID,
       lastUpdated: inactiveWorkplace.LastUpdated,
-      emailTemplateId: 6,
+      emailTemplateId: 13,
       dataOwner: inactiveWorkplace.DataOwner,
       user: {
         name: inactiveWorkplace.PrimaryUserName,
         email: inactiveWorkplace.PrimaryUserEmail,
-      }
-    }
+      },
+    };
   });
 };
 

--- a/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -1,6 +1,10 @@
+const moment = require('moment');
+
 const models = require('../../../../models');
 
 const findInactiveWorkplaces = async () => {
+  const lastUpdated = moment().subtract(6, 'months').format('YYYY-MM-DD');
+
   const inactiveWorkplaces = await models.sequelize.query(
     `
   SELECT
@@ -32,7 +36,7 @@ const findInactiveWorkplaces = async () => {
 		WHERE
       "ParentID" IS NULL
       AND "IsParent" = FALSE
-			AND "LastUpdated" < '2020-08-01'
+			AND "LastUpdated" < :lastUpdated
 			AND NOT EXISTS (
 				SELECT
 					ech. "establishmentID"
@@ -41,10 +45,11 @@ const findInactiveWorkplaces = async () => {
         JOIN cqc."EmailCampaigns" ec ON ec."id" = ech."emailCampaignID"
 				WHERE
           ec."type" = 'inactiveWorkplaces'
-					AND ech."createdAt" > '2020-08-01'
+					AND ech."createdAt" > :lastUpdated
 					AND ech. "establishmentID" = e. "EstablishmentID");`,
     {
       type: models.sequelize.QueryTypes.SELECT,
+      replacements: { lastUpdated }
     },
   );
 

--- a/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -42,9 +42,7 @@ const findInactiveWorkplaces = async () => {
 				WHERE
           ec."type" = 'inactiveWorkplaces'
 					AND ech."createdAt" > '2020-08-01'
-					AND ech. "establishmentID" = e. "EstablishmentID")
-			ORDER BY
-				EmailCount DESC;`,
+					AND ech. "establishmentID" = e. "EstablishmentID");`,
     {
       type: models.sequelize.QueryTypes.SELECT,
     },

--- a/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -5,6 +5,7 @@ const findInactiveWorkplaces = async () => {
     `
   SELECT
 	"EstablishmentID",
+  "NameValue",
   "NmdsID",
   "DataOwner",
   "PrimaryUserName",
@@ -52,6 +53,7 @@ const findInactiveWorkplaces = async () => {
   return inactiveWorkplaces.map(inactiveWorkplace => {
     return {
       id: inactiveWorkplace.EstablishmentID,
+      name: inactiveWorkplace.NameValue,
       nmdsId: inactiveWorkplace.NmdsID,
       lastUpdated: inactiveWorkplace.LastUpdated,
       emailTemplateId: 6,

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const moment = require('moment');
 
 const models = require('../../../../models');
-const findInactiveWorkplaces = require('./findInactiveWorkplaces');
+const findInactiveWorkplaces = require('../../../../models/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
 const sendEmail = require('./sendEmail');
 
 const getInactiveWorkplaces = async (_, res) => {

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -39,7 +39,7 @@ const createCampaign = async (req, res) => {
       };
     });
 
-    models.EmailCampaignHistory.bulkCreate(history);
+    await models.EmailCampaignHistory.bulkCreate(history);
     inactiveWorkplaces.map(sendEmail.sendEmail);
 
     return res.json({

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -12,7 +12,7 @@ const getInactiveWorkplaces = async (_, res) => {
   return res.json({
     inactiveWorkplaces: inactiveWorkplaces.length,
   });
-}
+};
 
 const createCampaign = async (req, res) => {
   try {
@@ -50,7 +50,7 @@ const createCampaign = async (req, res) => {
     console.error(err);
     return res.status(503).json();
   }
-}
+};
 
 const getHistory = async (_, res) => {
   const type = models.EmailCampaign.types().INACTIVE_WORKPLACES;
@@ -66,7 +66,7 @@ const getHistory = async (_, res) => {
   });
 
   return res.json(history);
-}
+};
 
 router.route('/').get(getInactiveWorkplaces);
 router.route('/').post(createCampaign);

--- a/server/routes/admin/email-campaigns/inactive-workplaces/report.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/report.js
@@ -1,7 +1,7 @@
 const excelJS = require('exceljs');
 const express = require('express');
 const moment = require('moment');
-const findInactiveWorkplaces = require('./findInactiveWorkplaces');
+const findInactiveWorkplaces = require('../../../../models/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
 const excelUtils = require('../../../../utils/excelUtils');
 
 const printRow = (worksheet, item) => {

--- a/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
@@ -8,10 +8,7 @@ const sendEmail = async (workplace) => {
     },
     workplace.emailTemplateId,
     {
-      name: workplace.name,
-      workplaceId: workplace.nmdsId,
-      lastUpdated: workplace.lastUpdated,
-      nameOfUser: workplace.user.name,
+      WORKPLACE_ID: workplace.nmdsId,
     },
   );
 };

--- a/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
@@ -14,5 +14,5 @@ const sendEmail = async (workplace) => {
 };
 
 module.exports = {
-  sendEmail
+  sendEmail,
 };

--- a/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
+++ b/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
@@ -1,0 +1,69 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const models = require('../../../../../models');
+const findInactiveWorkplaces = require('../../../../../models/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
+
+describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const dummyInactiveWorkplaces = [
+    {
+      id: 478,
+      name: 'Workplace Name',
+      nmdsId: 'J1234567',
+      lastUpdated: '2020-06-01',
+      emailTemplateId: 13,
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Test Name',
+        email: 'test@example.com',
+      },
+    },
+    {
+      id: 479,
+      name: 'Second Workplace Name',
+      nmdsId: 'A0012345',
+      lastUpdated: '2020-01-01',
+      emailTemplateId: 13,
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Name McName',
+        email: 'name@mcname.com',
+      },
+    },
+  ];
+
+  it('should return inactive workplaces', async () => {
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 478,
+        NameValue: 'Workplace Name',
+        NmdsID: 'J1234567',
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Name',
+        PrimaryUserEmail: 'test@example.com',
+        LastUpdated: '2020-06-01',
+        LastEmailedDate: '2020-12-01',
+        EmailCount: 1,
+      },
+      {
+        EstablishmentID: 479,
+        NameValue: 'Second Workplace Name',
+        NmdsID: 'A0012345',
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Name McName',
+        PrimaryUserEmail: 'name@mcname.com',
+        LastUpdated: '2020-01-01',
+        LastEmailedDate: '2020-06-01',
+        EmailCount: 1,
+      },
+    ]);
+
+    const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
+
+    expect(inactiveWorkplaces).to.deep.equal(dummyInactiveWorkplaces);
+  });
+});

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -56,37 +56,6 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
     expect(response.inactiveWorkplaces).to.deep.equal(2);
   });
 
-  it('should return inactive workplaces', async () => {
-    sinon.stub(models.sequelize, 'query').returns([
-      {
-        EstablishmentID: 478,
-        NameValue: 'Workplace Name',
-        NmdsID: 'J1234567',
-        DataOwner: 'Workplace',
-        PrimaryUserName: 'Test Name',
-        PrimaryUserEmail: 'test@example.com',
-        LastUpdated: '2020-06-01',
-        LastEmailedDate: '2020-12-01',
-        EmailCount: 1,
-      },
-      {
-        EstablishmentID: 479,
-        NameValue: 'Second Workplace Name',
-        NmdsID: 'A0012345',
-        DataOwner: 'Workplace',
-        PrimaryUserName: 'Name McName',
-        PrimaryUserEmail: 'name@mcname.com',
-        LastUpdated: '2020-01-01',
-        LastEmailedDate: '2020-06-01',
-        EmailCount: 1,
-      },
-    ]);
-
-    const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
-
-    expect(inactiveWorkplaces).to.deep.equal(dummyInactiveWorkplaces);
-  });
-
   describe('createCampaign', async () => {
     it('should create a campaign', async () => {
       sinon.stub(findInactiveWorkplaces, 'findInactiveWorkplaces').returns(dummyInactiveWorkplaces);

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -18,7 +18,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       name: 'Workplace Name',
       nmdsId: 'J1234567',
       lastUpdated: '2020-06-01',
-      emailTemplateId: 6,
+      emailTemplateId: 13,
       dataOwner: 'Workplace',
       user: {
         name: 'Test Name',
@@ -30,7 +30,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       name: 'Second Workplace Name',
       nmdsId: 'A0012345',
       lastUpdated: '2020-01-01',
-      emailTemplateId: 6,
+      emailTemplateId: 13,
       dataOwner: 'Workplace',
       user: {
         name: 'Name McName',

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -57,32 +57,30 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
   });
 
   it('should return inactive workplaces', async () => {
-    sinon
-      .stub(models.sequelize, 'query')
-      .returns([
-        {
-          EstablishmentID: 478,
-          NameValue: 'Workplace Name',
-          NmdsID: 'J1234567',
-          DataOwner: 'Workplace',
-          PrimaryUserName: 'Test Name',
-          PrimaryUserEmail: 'test@example.com',
-          LastUpdated: '2020-06-01',
-          LastEmailedDate: '2020-12-01',
-          EmailCount: 1,
-        },
-        {
-          EstablishmentID: 479,
-          NameValue: 'Second Workplace Name',
-          NmdsID: 'A0012345',
-          DataOwner: 'Workplace',
-          PrimaryUserName: 'Name McName',
-          PrimaryUserEmail: 'name@mcname.com',
-          LastUpdated: '2020-01-01',
-          LastEmailedDate: '2020-06-01',
-          EmailCount: 1,
-        },
-      ]);
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 478,
+        NameValue: 'Workplace Name',
+        NmdsID: 'J1234567',
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Name',
+        PrimaryUserEmail: 'test@example.com',
+        LastUpdated: '2020-06-01',
+        LastEmailedDate: '2020-12-01',
+        EmailCount: 1,
+      },
+      {
+        EstablishmentID: 479,
+        NameValue: 'Second Workplace Name',
+        NmdsID: 'A0012345',
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Name McName',
+        PrimaryUserEmail: 'name@mcname.com',
+        LastUpdated: '2020-01-01',
+        LastEmailedDate: '2020-06-01',
+        EmailCount: 1,
+      },
+    ]);
 
     const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
 

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -3,7 +3,7 @@ const httpMocks = require('node-mocks-http');
 const sinon = require('sinon');
 
 const models = require('../../../../../../models');
-const findInactiveWorkplaces = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
+const findInactiveWorkplaces = require('../../../../../../models/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
 const sendEmail = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/sendEmail');
 const inactiveWorkplaceRoutes = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces');
 

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -30,16 +30,18 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       name: 'Second Workplace Name',
       nmdsId: 'A0012345',
       lastUpdated: '2020-01-01',
-      emailTemplateId: 12,
+      emailTemplateId: 6,
       dataOwner: 'Workplace',
       user: {
         name: 'Name McName',
         email: 'name@mcname.com',
       },
-    }
-  ]
+    },
+  ];
 
   it('should get the number of inactive workplaces', async () => {
+    sinon.stub(findInactiveWorkplaces, 'findInactiveWorkplaces').returns(dummyInactiveWorkplaces);
+
     const req = httpMocks.createRequest({
       method: 'GET',
       url: '/api/admin/email-campaigns/inactive-workplaces',
@@ -55,6 +57,33 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
   });
 
   it('should return inactive workplaces', async () => {
+    sinon
+      .stub(models.sequelize, 'query')
+      .returns([
+        {
+          EstablishmentID: 478,
+          NameValue: 'Workplace Name',
+          NmdsID: 'J1234567',
+          DataOwner: 'Workplace',
+          PrimaryUserName: 'Test Name',
+          PrimaryUserEmail: 'test@example.com',
+          LastUpdated: '2020-06-01',
+          LastEmailedDate: '2020-12-01',
+          EmailCount: 1,
+        },
+        {
+          EstablishmentID: 479,
+          NameValue: 'Second Workplace Name',
+          NmdsID: 'A0012345',
+          DataOwner: 'Workplace',
+          PrimaryUserName: 'Name McName',
+          PrimaryUserEmail: 'name@mcname.com',
+          LastUpdated: '2020-01-01',
+          LastEmailedDate: '2020-06-01',
+          EmailCount: 1,
+        },
+      ]);
+
     const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
 
     expect(inactiveWorkplaces).to.deep.equal(dummyInactiveWorkplaces);
@@ -110,8 +139,8 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
               id: 1,
               createdAt: '2021-01-05 09:00:00',
               emails: 1356,
-            }
-          }
+            };
+          },
         },
         {
           toJSON: () => {
@@ -119,8 +148,8 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
               id: 2,
               createdAt: '2020-12-05 10:00:00',
               emails: 278,
-            }
-          }
+            };
+          },
         },
       ]);
 

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
@@ -1,9 +1,41 @@
 const expect = require('chai').expect;
 const httpMocks = require('node-mocks-http');
+const sinon = require('sinon');
+
 const { generateReport } = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/report');
+const findInactiveWorkplaces = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
 
 describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () => {
+  const dummyInactiveWorkplaces = [
+    {
+      id: 478,
+      name: 'Workplace Name',
+      nmdsId: 'J1234567',
+      lastUpdated: '2020-06-01',
+      emailTemplateId: 6,
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Test Name',
+        email: 'test@example.com',
+      },
+    },
+    {
+      id: 479,
+      name: 'Second Workplace Name',
+      nmdsId: 'A0012345',
+      lastUpdated: '2020-01-01',
+      emailTemplateId: 6,
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Name McName',
+        email: 'name@mcname.com',
+      },
+    },
+  ];
+
   it('should generate a report', async () => {
+    sinon.stub(findInactiveWorkplaces, 'findInactiveWorkplaces').returns(dummyInactiveWorkplaces);
+
     const req = httpMocks.createRequest({
       method: 'GET',
       url: `/api/admin/email-campaigns/inactive-workplaces/report`,

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
@@ -12,7 +12,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () =>
       name: 'Workplace Name',
       nmdsId: 'J1234567',
       lastUpdated: '2020-06-01',
-      emailTemplateId: 6,
+      emailTemplateId: 13,
       dataOwner: 'Workplace',
       user: {
         name: 'Test Name',
@@ -24,7 +24,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () =>
       name: 'Second Workplace Name',
       nmdsId: 'A0012345',
       lastUpdated: '2020-01-01',
-      emailTemplateId: 6,
+      emailTemplateId: 13,
       dataOwner: 'Workplace',
       user: {
         name: 'Name McName',

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
@@ -3,7 +3,7 @@ const httpMocks = require('node-mocks-http');
 const sinon = require('sinon');
 
 const { generateReport } = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/report');
-const findInactiveWorkplaces = require('../../../../../../routes/admin/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
+const findInactiveWorkplaces = require('../../../../../../models/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
 
 describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () => {
   const dummyInactiveWorkplaces = [

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
@@ -48,8 +48,6 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () =>
     await generateReport(req, res);
 
     expect(res.statusCode).to.equal(200);
-    expect(res._headers['content-type']).to.equal(
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    );
+    expect(res._headers['content-type']).to.equal('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
   });
 });

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -30,7 +30,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
         email: 'test@example.com',
         name: 'Test Name',
       },
-      6,
+      13,
       {
         WORKPLACE_ID: 'J1234567',
       },

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -32,10 +32,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
       },
       6,
       {
-        name: 'Workplace Name',
-        workplaceId: 'J1234567',
-        lastUpdated: '2020-06-01',
-        nameOfUser: 'Test Name',
+        WORKPLACE_ID: 'J1234567',
       },
     );
   });

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -12,7 +12,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
       name: 'Workplace Name',
       nmdsId: 'J1234567',
       lastUpdated: '2020-06-01',
-      emailTemplateId: 6,
+      emailTemplateId: 13,
       dataOwner: 'Workplace',
       user: {
         name: 'Test Name',

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -8,24 +8,24 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
   });
 
   it('should call sendEmails for inactive workplace', async () => {
-    const inactiveWorkplace =
-      {
-        name: 'Workplace Name',
-        nmdsId: 'J1234567',
-        lastUpdated: '2020-06-01',
-        emailTemplateId: 6,
-        dataOwner: 'Workplace',
-        user: {
-          name: 'Test Name',
-          email: 'test@example.com',
-        },
-      };
+    const inactiveWorkplace = {
+      name: 'Workplace Name',
+      nmdsId: 'J1234567',
+      lastUpdated: '2020-06-01',
+      emailTemplateId: 6,
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Test Name',
+        email: 'test@example.com',
+      },
+    };
 
     const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
 
     await sendEmail.sendEmail(inactiveWorkplace);
 
-    sinon.assert.calledWith(sendEmailStub,
+    sinon.assert.calledWith(
+      sendEmailStub,
       {
         email: 'test@example.com',
         name: 'Test Name',

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -9,9 +9,7 @@ import { saveAs } from 'file-saver';
 import { Subscription } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
-import {
-  SendEmailsConfirmationDialogComponent,
-} from './dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component';
+import { SendEmailsConfirmationDialogComponent } from './dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component';
 
 @Component({
   selector: 'app-emails',


### PR DESCRIPTION
**Work done**

- Added `LastUpdatedEstablishments ` view to store Workplace information and when they were last updated
- Implemented `findInactiveWorkplaces`
- Updated `sendEmails` function to use `switchMap` in order to get latest # of inactive workplaces after creating the campaign
- Fixed issue where API would respond before finishing inserting campaign history (this was a bug that meant the UI would not update when re-sending a request)

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
