### PR TITLE
Fix/bu admin skip completed banner

### DIFF
--- a/src/app/features/bulk-upload-v2/bulk-upload-references/bulk-upload-references.directive.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/bulk-upload-references.directive.ts
@@ -182,9 +182,9 @@ export class BulkUploadReferencesDirective implements AfterViewInit {
     this.backService.setBackLink(returnTo);
   }
 
-  protected nextMissingPage(url, skipped: boolean = false): void {
+  protected nextMissingPage(url, missingReferencesLeft: boolean = false): void {
     this.router.navigate(url).then(() => {
-      if (url[url.length - 1] === '/bulk-upload' && !skipped) {
+      if (url[url.length - 1] === '/bulk-upload' && !missingReferencesLeft) {
         this.alertService.addAlert({
           type: 'success',
           message: 'All workplace and staff references have been added.',

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/bulk-upload-references.directive.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/bulk-upload-references.directive.ts
@@ -177,12 +177,14 @@ export class BulkUploadReferencesDirective implements AfterViewInit {
   protected anyFilledReferences(): boolean {
     return this.references.some((reference) => reference.localIdentifier !== null);
   }
+
   protected setBackLink(returnTo): void {
     this.backService.setBackLink(returnTo);
   }
-  protected nextMissingPage(url): void {
+
+  protected nextMissingPage(url, skipped: boolean = false): void {
     this.router.navigate(url).then(() => {
-      if (url[url.length - 1] === '/bulk-upload') {
+      if (url[url.length - 1] === '/bulk-upload' && !skipped) {
         this.alertService.addAlert({
           type: 'success',
           message: 'All workplace and staff references have been added.',

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/missing-staff-references/missing-staff-references-page.component.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/missing-staff-references/missing-staff-references-page.component.ts
@@ -92,7 +92,7 @@ export class MissingStaffReferencesComponent extends BulkUploadReferencesDirecti
     const currentEstablishmentIndex = this.establishmentsWithMissingReferences.findIndex(
       (establishment) => establishment.uid === this.establishmentUid,
     );
-    this.nextMissingPage(this.bulkUploadService.nextMissingReferencesNavigation(currentEstablishmentIndex + 1));
+    this.nextMissingPage(this.bulkUploadService.nextMissingReferencesNavigation(currentEstablishmentIndex + 1), true);
   }
 
   protected save(): void {

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/missing-staff-references/missing-staff-references-page.component.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/missing-staff-references/missing-staff-references-page.component.ts
@@ -32,6 +32,7 @@ export class MissingStaffReferencesComponent extends BulkUploadReferencesDirecti
   public workplaceName: string;
   public showMissing = true;
   private establishmentsWithMissingReferences: [EstablishmentList];
+  private currentEstablishmentIndex: number;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -73,6 +74,9 @@ export class MissingStaffReferencesComponent extends BulkUploadReferencesDirecti
       this.setupForm();
       this.setWorkerServerErrors();
       this.showToggles = this.anyFilledReferences();
+      this.currentEstablishmentIndex = this.establishmentsWithMissingReferences.findIndex(
+        (establishment) => establishment.uid === this.establishmentUid,
+      );
     });
   }
 
@@ -89,10 +93,10 @@ export class MissingStaffReferencesComponent extends BulkUploadReferencesDirecti
 
   public skipPage(): void {
     this.bulkUploadService.setMissingReferencesNavigation(this.establishmentsWithMissingReferences);
-    const currentEstablishmentIndex = this.establishmentsWithMissingReferences.findIndex(
-      (establishment) => establishment.uid === this.establishmentUid,
+    this.nextMissingPage(
+      this.bulkUploadService.nextMissingReferencesNavigation(this.currentEstablishmentIndex + 1),
+      true,
     );
-    this.nextMissingPage(this.bulkUploadService.nextMissingReferencesNavigation(currentEstablishmentIndex + 1), true);
   }
 
   protected save(): void {
@@ -102,9 +106,13 @@ export class MissingStaffReferencesComponent extends BulkUploadReferencesDirecti
         .pipe(take(1))
         .subscribe(
           () => {
-            this.establishmentsWithMissingReferences.shift();
+            this.establishmentsWithMissingReferences.splice(this.currentEstablishmentIndex, 1);
+            const missingReferencesLeft = this.establishmentsWithMissingReferences.length > 0;
             this.bulkUploadService.setMissingReferencesNavigation(this.establishmentsWithMissingReferences);
-            this.nextMissingPage(this.bulkUploadService.nextMissingReferencesNavigation());
+            this.nextMissingPage(
+              this.bulkUploadService.nextMissingReferencesNavigation(this.currentEstablishmentIndex),
+              missingReferencesLeft,
+            );
           },
           (error: HttpErrorResponse) => this.onError(error),
         ),

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/missing-workplace-references/missing-workplace-references-page.component.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/missing-workplace-references/missing-workplace-references-page.component.ts
@@ -55,7 +55,7 @@ export class MissingWorkplaceReferencesComponent extends BulkUploadReferencesDir
 
   public skipPage(): void {
     this.bulkUploadService.setMissingReferencesNavigation(this.establishmentsWithMissingReferences);
-    this.nextMissingPage(this.bulkUploadService.nextMissingReferencesNavigation());
+    this.nextMissingPage(this.bulkUploadService.nextMissingReferencesNavigation(), true);
   }
 
   protected save(): void {


### PR DESCRIPTION
#### Changes

- Pass in whether there are establishments with missing references left to nextMissingPage to stop _All references added_ banner from appearing after admin skipping
- Change save in missing-staff-references to remove the current establishment instead of the first one(removes bug where admin fills in a references page after having skipped and gets taken to the wrong references page)

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
