### PR TITLE
Feat: Calculate which email template to send

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -462,6 +462,28 @@ const config = convict({
       sensitive: true,
       env: 'SEND_IN_BLUE_KEY',
     },
+    templates: {
+      sixMonthsInactive: {
+        doc: 'Template ID for the 6 month inactive email',
+        format: Number,
+        default: 13
+      },
+      twelveMonthsInactive: {
+        doc: 'Template ID for the 12 month inactive email',
+        format: Number,
+        default: 14
+      },
+      eighteenMonthsInactive: {
+        doc: 'Template ID for the 18 month inactive email',
+        format: Number,
+        default: 10
+      },
+      twentyFourMonthsInactive: {
+        doc: 'Template ID for the 24 month inactive email',
+        format: Number,
+        default: 12
+      },
+    }
   },
 });
 

--- a/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -34,6 +34,8 @@ const nextEmailTemplate = (inactiveWorkplace) => {
 
     return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
   }
+
+  return null;
 };
 
 const findInactiveWorkplaces = async () => {

--- a/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 
+const config = require('../../../config/config');
 const models = require('../../index');
 
 const nextEmailTemplate = (inactiveWorkplace) => {
@@ -10,16 +11,28 @@ const nextEmailTemplate = (inactiveWorkplace) => {
   const eighteenMonths = moment().startOf('day').subtract(18, 'months');
   const twentyFourMonths = moment().startOf('day').subtract(24, 'months');
 
-  if (lastUpdated.isSameOrBefore(sixMonths) && lastUpdated.isSameOrAfter(twelveMonths)) {
-    return inactiveWorkplace.LastTemplate !== 13 ? 13 : null;
+  if (lastUpdated.isSameOrBefore(sixMonths) && lastUpdated.isAfter(twelveMonths)) {
+    const nextTemplate = config.get('sendInBlue.templates.sixMonthsInactive');
+
+    return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
+  }
+
+  if (lastUpdated.isSameOrBefore(twelveMonths) && lastUpdated.isAfter(eighteenMonths)) {
+    const nextTemplate = config.get('sendInBlue.templates.twelveMonthsInactive');
+
+    return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
   }
 
   if (lastUpdated.isBefore(twelveMonths) && lastUpdated.isSameOrAfter(eighteenMonths)) {
-    return inactiveWorkplace.LastTemplate !== 10 ? 10 : null;
+    const nextTemplate = config.get('sendInBlue.templates.eighteenMonthsInactive');
+
+    return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
   }
 
-  if (lastUpdated.isSameOrAfter(twentyFourMonths)) {
-    return inactiveWorkplace.LastTemplate !== 12 ? 12 : null;
+  if (lastUpdated.isSameOrBefore(twentyFourMonths)) {
+    const nextTemplate = config.get('sendInBlue.templates.twentyFourMonthsInactive');
+
+    return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
   }
 };
 

--- a/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -44,23 +44,7 @@ const findInactiveWorkplaces = async () => {
 		WHERE
 			ech. "establishmentID" = e. "EstablishmentID"
     ORDER BY ech. "createdAt" DESC
-    LIMIT 1) AS "LastTemplate",
-	(
-		SELECT
-			MAX(ech. "createdAt")
-		FROM
-			cqc."EmailCampaignHistories" ech
-		WHERE
-			ech. "establishmentID" = e. "EstablishmentID") AS "LastEmailedDate", (
-			SELECT
-				COUNT(*)
-			FROM
-				cqc."EmailCampaignHistories" ech
-      JOIN cqc."EmailCampaigns" ec ON ec."id" = ech."emailCampaignID"
-			WHERE
-				ec."type" = 'inactiveWorkplaces'
-				AND ech."establishmentID" = e."EstablishmentID"
-				AND ech."createdAt" > "LastUpdated") AS EmailCount
+    LIMIT 1) AS "LastTemplate"
 		FROM
 			cqc. "LastUpdatedEstablishments" e
 		WHERE

--- a/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
+++ b/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
@@ -48,8 +48,6 @@ describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         PrimaryUserEmail: 'test@example.com',
         LastUpdated: moment().subtract(6, 'months').format('YYYY-MM-DD'),
         LastTemplate: null,
-        LastEmailedDate: '2020-12-01',
-        EmailCount: 1,
       },
       {
         EstablishmentID: 479,
@@ -60,8 +58,6 @@ describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         PrimaryUserEmail: 'name@mcname.com',
         LastUpdated: moment().subtract(12, 'months').format('YYYY-MM-DD'),
         LastTemplate: null,
-        LastEmailedDate: '2020-06-01',
-        EmailCount: 1,
       },
     ]);
 
@@ -100,8 +96,6 @@ describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         DataOwner: 'Workplace',
         PrimaryUserName: 'Test Name',
         PrimaryUserEmail: 'test@example.com',
-        LastEmailedDate: '2020-12-01',
-        EmailCount: 2,
         LastUpdated: LastUpdated,
         LastTemplate: LastTemplate,
       }]);
@@ -121,8 +115,6 @@ describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         PrimaryUserName: 'Test Name',
         PrimaryUserEmail: 'test@example.com',
         LastUpdated: moment().subtract(6, 'months'),
-        LastEmailedDate: '2020-12-01',
-        EmailCount: 0,
       };
 
       const emailTemplateId = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
@@ -139,8 +131,6 @@ describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         PrimaryUserName: 'Test Name',
         PrimaryUserEmail: 'test@example.com',
         LastUpdated: moment().subtract(12, 'months'),
-        LastEmailedDate: '2020-12-01',
-        EmailCount: 1,
       };
 
       const emailTemplateId = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
@@ -157,8 +147,6 @@ describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         PrimaryUserName: 'Test Name',
         PrimaryUserEmail: 'test@example.com',
         LastUpdated: moment().subtract(18, 'months'),
-        LastEmailedDate: '2020-12-01',
-        EmailCount: 2,
       };
 
       const emailTemplateId = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
@@ -175,8 +163,6 @@ describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         PrimaryUserName: 'Test Name',
         PrimaryUserEmail: 'test@example.com',
         LastUpdated: moment().subtract(24, 'months'),
-        LastEmailedDate: '2020-12-01',
-        EmailCount: 2,
       };
 
       const emailTemplateId = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
@@ -214,8 +200,6 @@ describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
           DataOwner: 'Workplace',
           PrimaryUserName: 'Test Name',
           PrimaryUserEmail: 'test@example.com',
-          LastEmailedDate: '2020-12-01',
-          EmailCount: 2,
           LastUpdated: LastUpdated,
           LastTemplate: LastTemplate,
         };

--- a/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
+++ b/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const models = require('../../../../../models');
 const findInactiveWorkplaces = require('../../../../../models/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
 
-describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
+describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
   afterEach(() => {
     sinon.restore();
   });

--- a/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
+++ b/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
@@ -1,10 +1,11 @@
 const expect = require('chai').expect;
+const moment = require('moment');
 const sinon = require('sinon');
 
 const models = require('../../../../../models');
 const findInactiveWorkplaces = require('../../../../../models/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
 
-describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
+describe.only('server/routes/admin/email-campaigns/inactive-workplaces', () => {
   afterEach(() => {
     sinon.restore();
   });
@@ -14,7 +15,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       id: 478,
       name: 'Workplace Name',
       nmdsId: 'J1234567',
-      lastUpdated: '2020-06-01',
+      lastUpdated: moment().subtract(6, 'months').format('YYYY-MM-DD'),
       emailTemplateId: 13,
       dataOwner: 'Workplace',
       user: {
@@ -26,7 +27,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       id: 479,
       name: 'Second Workplace Name',
       nmdsId: 'A0012345',
-      lastUpdated: '2020-01-01',
+      lastUpdated: moment().subtract(12, 'months').format('YYYY-MM-DD'),
       emailTemplateId: 13,
       dataOwner: 'Workplace',
       user: {
@@ -45,7 +46,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         DataOwner: 'Workplace',
         PrimaryUserName: 'Test Name',
         PrimaryUserEmail: 'test@example.com',
-        LastUpdated: '2020-06-01',
+        LastUpdated: moment().subtract(6, 'months').format('YYYY-MM-DD'),
         LastEmailedDate: '2020-12-01',
         EmailCount: 1,
       },
@@ -56,7 +57,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         DataOwner: 'Workplace',
         PrimaryUserName: 'Name McName',
         PrimaryUserEmail: 'name@mcname.com',
-        LastUpdated: '2020-01-01',
+        LastUpdated: moment().subtract(12, 'months').format('YYYY-MM-DD'),
         LastEmailedDate: '2020-06-01',
         EmailCount: 1,
       },
@@ -65,5 +66,85 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
     const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
 
     expect(inactiveWorkplaces).to.deep.equal(dummyInactiveWorkplaces);
+  });
+
+  it('should return the correct template when 6 months inactive', async () => {
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 478,
+        NameValue: 'Workplace Name',
+        NmdsID: 'J1234567',
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Name',
+        PrimaryUserEmail: 'test@example.com',
+        LastUpdated: moment().subtract(6, 'months'),
+        LastEmailedDate: '2020-12-01',
+        EmailCount: 0,
+      }
+    ]);
+
+    const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
+
+    expect(inactiveWorkplaces[0].emailTemplateId).to.equal(13);
+  });
+
+  it('should return the correct template when 12 months inactive', async () => {
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 478,
+        NameValue: 'Workplace Name',
+        NmdsID: 'J1234567',
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Name',
+        PrimaryUserEmail: 'test@example.com',
+        LastUpdated: moment().subtract(12, 'months'),
+        LastEmailedDate: '2020-12-01',
+        EmailCount: 1,
+      }
+    ]);
+
+    const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
+
+    expect(inactiveWorkplaces[0].emailTemplateId).to.equal(13);
+  });
+
+  it('should return the correct template when 18 months inactive', async () => {
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 478,
+        NameValue: 'Workplace Name',
+        NmdsID: 'J1234567',
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Name',
+        PrimaryUserEmail: 'test@example.com',
+        LastUpdated: moment().subtract(18, 'months'),
+        LastEmailedDate: '2020-12-01',
+        EmailCount: 2,
+      }
+    ]);
+
+    const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
+
+    expect(inactiveWorkplaces[0].emailTemplateId).to.equal(10);
+  });
+
+  it('should return the correct template when 24 months inactive', async () => {
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 478,
+        NameValue: 'Workplace Name',
+        NmdsID: 'J1234567',
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Name',
+        PrimaryUserEmail: 'test@example.com',
+        LastUpdated: moment().subtract(24, 'months'),
+        LastEmailedDate: '2020-12-01',
+        EmailCount: 2,
+      }
+    ]);
+
+    const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
+
+    expect(inactiveWorkplaces[0].emailTemplateId).to.equal(12);
   });
 });


### PR DESCRIPTION
**Work done**

- Added function to calculate next email template
- Filter workplaces who have already been sent an email
- Removed  `LastEmailedDate` and `EmailCount` as these are no longer needed

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
