### PR TITLE
Fix(buAdminSkipToBulkUploadPage): Add adminSkipService to skip throug…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { TrainingService } from '@core/services/training.service';
 import { windowProvider, WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
+import { AdminSkipService } from '@features/bulk-upload-v2/admin-skip.service';
 import { DashboardComponent } from '@features/dashboard/dashboard.component';
 import { HomeTabComponent } from '@features/dashboard/home-tab/home-tab.component';
 import { ForgotYourPasswordConfirmationComponent } from '@features/forgot-your-password/confirmation/confirmation.component';
@@ -50,10 +51,10 @@ import { HighchartsChartModule } from 'highcharts-angular';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { MigratedUserTermsConditionsComponent } from './features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
-import { SentryErrorHandler } from './SentryErrorHandler.component';
-import { SatisfactionSurveyComponent } from './features/satisfaction-survey/satisfaction-survey.component';
 import { StaffMismatchBannerComponent } from './features/dashboard/home-tab/staff-mismatch-banner/staff-mismatch-banner.component';
+import { MigratedUserTermsConditionsComponent } from './features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
+import { SatisfactionSurveyComponent } from './features/satisfaction-survey/satisfaction-survey.component';
+import { SentryErrorHandler } from './SentryErrorHandler.component';
 
 @NgModule({
   declarations: [
@@ -95,6 +96,7 @@ import { StaffMismatchBannerComponent } from './features/dashboard/home-tab/staf
   ],
   providers: [
     AuthGuard,
+    AdminSkipService,
     BackService,
     CountryService,
     EstablishmentService,

--- a/src/app/core/guards/bulk-upload/bulk-upload-missing.guard.ts
+++ b/src/app/core/guards/bulk-upload/bulk-upload-missing.guard.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { CanActivate, Router, UrlTree } from '@angular/router';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { AdminSkipService } from '@features/bulk-upload-v2/admin-skip.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -13,6 +14,7 @@ export class BulkUploadMissingGuard implements CanActivate {
     private bulkUploadService: BulkUploadService,
     private establishmentService: EstablishmentService,
     private router: Router,
+    private adminSkipService: AdminSkipService,
   ) {}
 
   canActivate(): Observable<boolean | UrlTree> {
@@ -22,6 +24,10 @@ export class BulkUploadMissingGuard implements CanActivate {
 
     return this.bulkUploadService.getMissingRef(workplaceID).pipe(
       map((response) => {
+        if (this.adminSkipService.skippedWorkplaces.includes(workplaceID)) {
+          return true;
+        }
+
         if (response.establishment > 0 || response.worker > 0) {
           const redirect: UrlTree = this.router.parseUrl('/bulk-upload/missing');
           return redirect;

--- a/src/app/core/guards/bulk-upload/bulk-upload-start.guard.ts
+++ b/src/app/core/guards/bulk-upload/bulk-upload-start.guard.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { CanActivate, Router, UrlTree } from '@angular/router';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { AdminSkipService } from '@features/bulk-upload-v2/admin-skip.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -13,6 +14,7 @@ export class BulkUploadStartGuard implements CanActivate {
     private bulkUploadService: BulkUploadService,
     private establishmentService: EstablishmentService,
     private router: Router,
+    private adminSkipService: AdminSkipService,
   ) {}
 
   canActivate(): Observable<boolean | UrlTree> {
@@ -22,6 +24,10 @@ export class BulkUploadStartGuard implements CanActivate {
 
     return this.bulkUploadService.isFirstBulkUpload(workplaceID).pipe(
       map((response) => {
+        if (this.adminSkipService.skippedWorkplaces.includes(workplaceID)) {
+          return true;
+        }
+
         if (response.isFirstBulkUpload) {
           const redirect: UrlTree = this.router.parseUrl('/bulk-upload/start');
           return redirect;

--- a/src/app/features/bulk-upload-v2/admin-skip.service.ts
+++ b/src/app/features/bulk-upload-v2/admin-skip.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class AdminSkipService {
+  skippedWorkplaces: string[] = [];
+
+  add(workplaceId: string) {
+    if (!this.skippedWorkplaces.includes(workplaceId)) this.skippedWorkplaces.push(workplaceId);
+  }
+
+  clear() {
+    this.skippedWorkplaces = [];
+  }
+}

--- a/src/app/features/bulk-upload-v2/bulk-upload-missing/bulk-upload-missing-page.component.spec.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-missing/bulk-upload-missing-page.component.spec.ts
@@ -9,12 +9,12 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockBulkUploadService } from '@core/test-utils/MockBulkUploadService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { BulkUploadMissingPageComponent } from '@features/bulk-upload-v2/bulk-upload-missing/bulk-upload-missing-page.component';
 import { BulkUploadV2Module } from '@features/bulk-upload-v2/bulk-upload.module';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
-const { build, fake, sequence } = require('@jackfranklin/test-data-bot');
 
-import { BulkUploadMissingPageComponent } from '@features/bulk-upload-v2/bulk-upload-missing/bulk-upload-missing-page.component';
+import { AdminSkipService } from '../admin-skip.service';
 
 describe('BulkUploadMissingPageComponent', () => {
   async function setup() {
@@ -33,6 +33,7 @@ describe('BulkUploadMissingPageComponent', () => {
           provide: BreadcrumbService,
           useClass: MockBreadcrumbService,
         },
+        AdminSkipService,
         BackService,
       ],
     });
@@ -45,7 +46,7 @@ describe('BulkUploadMissingPageComponent', () => {
       component,
       establishmentService,
       router,
-      componentInstance
+      componentInstance,
     };
   }
 
@@ -55,49 +56,48 @@ describe('BulkUploadMissingPageComponent', () => {
   });
 
   it('should show pluralized workplace and staff when multiple', async () => {
-    const { component,componentInstance } = await setup();
+    const { component, componentInstance } = await setup();
 
     componentInstance.missingRefCount = {
-      establishment:2,
-      worker:2
+      establishment: 2,
+      worker: 2,
     };
     component.fixture.detectChanges();
-    const para = component.getByTestId("info");
-    expect(para.innerText).toContain("You still need to add 2 workplace references and 2 staff references.");
+    const para = component.getByTestId('info');
+    expect(para.innerText).toContain('You still need to add 2 workplace references and 2 staff references.');
   });
   it('should show singular workplace  when multiple', async () => {
-    const { component,componentInstance } = await setup();
+    const { component, componentInstance } = await setup();
 
     componentInstance.missingRefCount = {
-      establishment:1,
-      worker:1
+      establishment: 1,
+      worker: 1,
     };
     component.fixture.detectChanges();
-    const para = component.getByTestId("info");
-    expect(para.innerText).toContain("You still need to add 1 workplace reference and 1 staff reference.");
+    const para = component.getByTestId('info');
+    expect(para.innerText).toContain('You still need to add 1 workplace reference and 1 staff reference.');
   });
 
   it('should not show workplace when 0 ', async () => {
-    const { component,componentInstance } = await setup();
+    const { component, componentInstance } = await setup();
 
     componentInstance.missingRefCount = {
-      establishment:0,
-      worker:2
+      establishment: 0,
+      worker: 2,
     };
     component.fixture.detectChanges();
-    const para = component.getByTestId("info");
-    expect(para.innerText).toContain("You still need to add 2 staff references.");
+    const para = component.getByTestId('info');
+    expect(para.innerText).toContain('You still need to add 2 staff references.');
   });
   it('should not show staff when 0 ', async () => {
-    const { component,componentInstance } = await setup();
+    const { component, componentInstance } = await setup();
 
     componentInstance.missingRefCount = {
-      establishment:2,
-      worker:0
+      establishment: 2,
+      worker: 0,
     };
     component.fixture.detectChanges();
-    const para = component.getByTestId("info");
-    expect(para.innerText).toContain("You still need to add 2 workplace references.");
+    const para = component.getByTestId('info');
+    expect(para.innerText).toContain('You still need to add 2 workplace references.');
   });
-
 });

--- a/src/app/features/bulk-upload-v2/bulk-upload-page/bulk-upload-page.component.spec.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-page/bulk-upload-page.component.spec.ts
@@ -41,10 +41,7 @@ describe('BulkUploadPageV2Component', () => {
           provide: BreadcrumbService,
           useClass: MockBreadcrumbService,
         },
-        {
-          provide: AdminSkipService,
-          useClass: AdminSkipService,
-        },
+        AdminSkipService,
       ],
     });
 

--- a/src/app/features/bulk-upload-v2/bulk-upload-page/bulk-upload-page.component.spec.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-page/bulk-upload-page.component.spec.ts
@@ -1,20 +1,22 @@
-import { render } from '@testing-library/angular';
-import { SharedModule } from '@shared/shared.module';
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
 import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { HomeTabComponent } from '@features/dashboard/home-tab/home-tab.component';
-import { WindowRef } from '@core/services/window.ref';
-import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { HttpClient } from '@angular/common/http';
-import { UserService } from '@core/services/user.service';
-import { EstablishmentService } from '@core/services/establishment.service';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { getTestBed } from '@angular/core/testing';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { UserService } from '@core/services/user.service';
+import { WindowRef } from '@core/services/window.ref';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { BulkUploadPageV2Component } from '@features/bulk-upload-v2/bulk-upload-page/bulk-upload-page.component';
+import { HomeTabComponent } from '@features/dashboard/home-tab/home-tab.component';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { AdminSkipService } from '../admin-skip.service';
 
 describe('BulkUploadPageV2Component', () => {
   async function setup() {
@@ -38,6 +40,10 @@ describe('BulkUploadPageV2Component', () => {
         {
           provide: BreadcrumbService,
           useClass: MockBreadcrumbService,
+        },
+        {
+          provide: AdminSkipService,
+          useClass: AdminSkipService,
         },
       ],
     });

--- a/src/app/features/bulk-upload-v2/bulk-upload-page/bulk-upload-page.component.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-page/bulk-upload-page.component.ts
@@ -1,28 +1,35 @@
 import { I18nPluralPipe } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { BulkUploadService, BulkUploadServiceV2 } from '@core/services/bulk-upload.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 
+import { AdminSkipService } from '../admin-skip.service';
+
 @Component({
   selector: 'app-bulk-upload-page',
   templateUrl: './bulk-upload-page.component.html',
   providers: [I18nPluralPipe, { provide: BulkUploadService, useClass: BulkUploadServiceV2 }],
 })
-export class BulkUploadPageV2Component implements OnInit {
+export class BulkUploadPageV2Component implements OnInit, OnDestroy {
   public establishment: Establishment;
 
   constructor(
     private establishmentService: EstablishmentService,
     private bulkUploadService: BulkUploadService,
     private breadcrumbService: BreadcrumbService,
+    private adminSkipService: AdminSkipService,
   ) {}
 
   ngOnInit() {
     this.breadcrumbService.show(JourneyType.BULK_UPLOAD);
     this.establishment = this.establishmentService.primaryWorkplace;
     this.bulkUploadService.setReturnTo(null);
+  }
+
+  ngOnDestroy() {
+    this.adminSkipService.clear();
   }
 }

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/missing-staff-references/missing-staff-references-page.component.spec.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/missing-staff-references/missing-staff-references-page.component.spec.ts
@@ -19,6 +19,7 @@ import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockBulkUploadService } from '@core/test-utils/MockBulkUploadService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockWorkerService, workerBuilder } from '@core/test-utils/MockWorkerService';
+import { AdminSkipService } from '@features/bulk-upload-v2/admin-skip.service';
 import { BulkUploadV2Module } from '@features/bulk-upload-v2/bulk-upload.module';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
@@ -79,6 +80,7 @@ describe('MissingStaffReferencesComponent', () => {
         BackService,
         FormBuilder,
         ErrorSummaryService,
+        AdminSkipService,
       ],
     });
 

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/missing-staff-references/missing-staff-references-page.component.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/missing-staff-references/missing-staff-references-page.component.ts
@@ -12,6 +12,7 @@ import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkerService } from '@core/services/worker.service';
+import { AdminSkipService } from '@features/bulk-upload-v2/admin-skip.service';
 import { orderBy } from 'lodash';
 import { Subscription } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
@@ -44,6 +45,7 @@ export class MissingStaffReferencesComponent extends BulkUploadReferencesDirecti
     protected router: Router,
     protected alertService: AlertService,
     private workerService: WorkerService,
+    private adminSkipService: AdminSkipService,
   ) {
     super(errorSummaryService, formBuilder, alertService, backService, router);
   }
@@ -97,6 +99,7 @@ export class MissingStaffReferencesComponent extends BulkUploadReferencesDirecti
       this.bulkUploadService.nextMissingReferencesNavigation(this.currentEstablishmentIndex + 1),
       true,
     );
+    this.adminSkipService.add(this.establishmentUid);
   }
 
   protected save(): void {

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/missing-workplace-references/missing-workplace-references-page.component.spec.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/missing-workplace-references/missing-workplace-references-page.component.spec.ts
@@ -15,6 +15,7 @@ import { MockAuthService } from '@core/test-utils/MockAuthService';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockBulkUploadService } from '@core/test-utils/MockBulkUploadService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { AdminSkipService } from '@features/bulk-upload-v2/admin-skip.service';
 import { BulkUploadV2Module } from '@features/bulk-upload-v2/bulk-upload.module';
 import { bool, build, fake, sequence } from '@jackfranklin/test-data-bot';
 import { SharedModule } from '@shared/shared.module';
@@ -78,6 +79,7 @@ describe('MissingWorkplaceReferencesComponent', () => {
         BackService,
         FormBuilder,
         ErrorSummaryService,
+        AdminSkipService,
       ],
     });
 

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/missing-workplace-references/missing-workplace-references-page.component.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/missing-workplace-references/missing-workplace-references-page.component.ts
@@ -11,6 +11,7 @@ import { BackService } from '@core/services/back.service';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { AdminSkipService } from '@features/bulk-upload-v2/admin-skip.service';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -39,6 +40,7 @@ export class MissingWorkplaceReferencesComponent extends BulkUploadReferencesDir
     protected formBuilder: FormBuilder,
     protected router: Router,
     protected alertService: AlertService,
+    private adminSkipService: AdminSkipService,
   ) {
     super(errorSummaryService, formBuilder, alertService, backService, router);
   }
@@ -56,6 +58,7 @@ export class MissingWorkplaceReferencesComponent extends BulkUploadReferencesDir
   public skipPage(): void {
     this.bulkUploadService.setMissingReferencesNavigation(this.establishmentsWithMissingReferences);
     this.nextMissingPage(this.bulkUploadService.nextMissingReferencesNavigation(), true);
+    this.adminSkipService.add(this.primaryWorkplace.uid);
   }
 
   protected save(): void {

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/staff-references/staff-references-page.component.spec.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/staff-references/staff-references-page.component.spec.ts
@@ -8,17 +8,18 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockBulkUploadService } from '@core/test-utils/MockBulkUploadService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockWorkerService, workerBuilder } from '@core/test-utils/MockWorkerService';
+import { AdminSkipService } from '@features/bulk-upload-v2/admin-skip.service';
 import { BulkUploadV2Module } from '@features/bulk-upload-v2/bulk-upload.module';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
 import { StaffReferencesComponent } from './staff-references-page.component';
-import { WindowRef } from '@core/services/window.ref';
 
 describe('StaffReferencesComponent', () => {
   async function setup(references: Worker[] = []) {
@@ -43,7 +44,7 @@ describe('StaffReferencesComponent', () => {
         },
         {
           provide: WindowRef,
-          useClass: WindowRef
+          useClass: WindowRef,
         },
         {
           provide: ActivatedRoute,
@@ -64,6 +65,7 @@ describe('StaffReferencesComponent', () => {
         BackService,
         FormBuilder,
         ErrorSummaryService,
+        AdminSkipService,
       ],
     });
 

--- a/src/app/features/bulk-upload-v2/bulk-upload-references/workplace-references/workplace-references-page.component.spec.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-references/workplace-references/workplace-references-page.component.spec.ts
@@ -13,6 +13,7 @@ import { WindowRef } from '@core/services/window.ref';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockBulkUploadService } from '@core/test-utils/MockBulkUploadService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { AdminSkipService } from '@features/bulk-upload-v2/admin-skip.service';
 import { BulkUploadV2Module } from '@features/bulk-upload-v2/bulk-upload.module';
 import { bool, build, fake, sequence } from '@jackfranklin/test-data-bot';
 import { SharedModule } from '@shared/shared.module';
@@ -66,6 +67,7 @@ describe('WorkplaceReferencesComponent', () => {
         BackService,
         FormBuilder,
         ErrorSummaryService,
+        AdminSkipService,
       ],
     });
 

--- a/src/app/features/bulk-upload-v2/bulk-upload-start-page/bulk-upload-start-page.component.spec.ts
+++ b/src/app/features/bulk-upload-v2/bulk-upload-start-page/bulk-upload-start-page.component.spec.ts
@@ -5,6 +5,7 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { render } from '@testing-library/angular';
 
+import { AdminSkipService } from '../admin-skip.service';
 import { CodesAndGuidanceComponent } from '../codes-and-guidance/codes-and-guidance.component';
 import { BulkUploadStartPageComponent } from './bulk-upload-start-page.component';
 
@@ -12,7 +13,7 @@ describe('BulkUploadStartPage', () => {
   const setup = async () => {
     const { fixture, getByText } = await render(BulkUploadStartPageComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule],
-      providers: [{ provide: BreadcrumbService, useClass: MockBreadcrumbService }],
+      providers: [{ provide: BreadcrumbService, useClass: MockBreadcrumbService }, AdminSkipService],
       declarations: [BulkUploadStartPageComponent, CodesAndGuidanceComponent],
     });
     const component = fixture.componentInstance;


### PR DESCRIPTION
Add adminSkipService to skip through to bulk upload page after skipping through missing references

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
