### PR TITLE
Fix: Date range for inactive workplaces

### DIFF
--- a/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -3,33 +3,35 @@ const moment = require('moment');
 const config = require('../../../config/config');
 const models = require('../../index');
 
+const endOfLastMonth = moment().subtract(1, 'months').endOf('month').endOf('day');
+
 const nextEmailTemplate = (inactiveWorkplace) => {
-  const lastUpdated = moment(inactiveWorkplace.LastUpdated).startOf('day');
+  const lastUpdated = moment(inactiveWorkplace.LastUpdated).endOf('day');
 
-  const sixMonths = moment().startOf('day').subtract(6, 'months');
-  const twelveMonths = moment().startOf('day').subtract(12, 'months');
-  const eighteenMonths = moment().startOf('day').subtract(18, 'months');
-  const twentyFourMonths = moment().startOf('day').subtract(24, 'months');
+  const sixMonths = endOfLastMonth.clone().subtract(6, 'months');
+  const twelveMonths = endOfLastMonth.clone().subtract(12, 'months');
+  const eighteenMonths = endOfLastMonth.clone().subtract(18, 'months');
+  const twentyFourMonths = endOfLastMonth.clone().subtract(24, 'months');
 
-  if (lastUpdated.isSameOrBefore(sixMonths) && lastUpdated.isAfter(twelveMonths)) {
+  if (lastUpdated.isSame(sixMonths, 'month')) {
     const nextTemplate = config.get('sendInBlue.templates.sixMonthsInactive');
 
     return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
   }
 
-  if (lastUpdated.isSameOrBefore(twelveMonths) && lastUpdated.isAfter(eighteenMonths)) {
+  if (lastUpdated.isSame(twelveMonths, 'month')) {
     const nextTemplate = config.get('sendInBlue.templates.twelveMonthsInactive');
 
     return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
   }
 
-  if (lastUpdated.isBefore(twelveMonths) && lastUpdated.isSameOrAfter(eighteenMonths)) {
+  if (lastUpdated.isSame(eighteenMonths, 'month')) {
     const nextTemplate = config.get('sendInBlue.templates.eighteenMonthsInactive');
 
     return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
   }
 
-  if (lastUpdated.isSameOrBefore(twentyFourMonths)) {
+  if (lastUpdated.isSame(twentyFourMonths, 'month')) {
     const nextTemplate = config.get('sendInBlue.templates.twentyFourMonthsInactive');
 
     return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
@@ -56,8 +58,11 @@ const findInactiveWorkplaces = async () => {
 			"template"
 		FROM
 			cqc."EmailCampaignHistories" ech
+    JOIN cqc."EmailCampaigns" ec ON ec."id" = ech."emailCampaignID"
 		WHERE
-			ech. "establishmentID" = e. "EstablishmentID"
+      ec."type" = 'inactiveWorkplaces'
+		  AND ech. "establishmentID" = e. "EstablishmentID"
+      AND ech."createdAt" >= e."LastUpdated"
     ORDER BY ech. "createdAt" DESC
     LIMIT 1) AS "LastTemplate"
 		FROM
@@ -65,7 +70,7 @@ const findInactiveWorkplaces = async () => {
 		WHERE
       "ParentID" IS NULL
       AND "IsParent" = FALSE
-			AND "LastUpdated" < :lastUpdated
+			AND "LastUpdated" <= :lastUpdated
 			AND NOT EXISTS (
 				SELECT
 					ech. "establishmentID"
@@ -74,12 +79,12 @@ const findInactiveWorkplaces = async () => {
         JOIN cqc."EmailCampaigns" ec ON ec."id" = ech."emailCampaignID"
 				WHERE
           ec."type" = 'inactiveWorkplaces'
-					AND ech."createdAt" > :lastUpdated
+					AND ech."createdAt" >= :lastUpdated
 					AND ech. "establishmentID" = e. "EstablishmentID");`,
     {
       type: models.sequelize.QueryTypes.SELECT,
       replacements: {
-        lastUpdated: moment().subtract(1, 'months').endOf('month').subtract(6, 'months').format('YYYY-MM-DD'),
+        lastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
       },
     },
   );

--- a/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
+++ b/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
@@ -10,12 +10,14 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
     sinon.restore();
   });
 
+  const endOfLastMonth = moment().subtract(1, 'months').endOf('month').endOf('day');
+
   const dummyInactiveWorkplaces = [
     {
       id: 478,
       name: 'Workplace Name',
       nmdsId: 'J1234567',
-      lastUpdated: moment().subtract(6, 'months').format('YYYY-MM-DD'),
+      lastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
       emailTemplateId: 13,
       dataOwner: 'Workplace',
       user: {
@@ -27,7 +29,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       id: 479,
       name: 'Second Workplace Name',
       nmdsId: 'A0012345',
-      lastUpdated: moment().subtract(12, 'months').format('YYYY-MM-DD'),
+      lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
       emailTemplateId: 14,
       dataOwner: 'Workplace',
       user: {
@@ -46,7 +48,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         DataOwner: 'Workplace',
         PrimaryUserName: 'Test Name',
         PrimaryUserEmail: 'test@example.com',
-        LastUpdated: moment().subtract(6, 'months').format('YYYY-MM-DD'),
+        LastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
         LastTemplate: null,
       },
       {
@@ -56,7 +58,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
         DataOwner: 'Workplace',
         PrimaryUserName: 'Name McName',
         PrimaryUserEmail: 'name@mcname.com',
-        LastUpdated: moment().subtract(12, 'months').format('YYYY-MM-DD'),
+        LastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
         LastTemplate: null,
       },
     ]);
@@ -69,22 +71,22 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
   [
     {
       inactiveMonths: 6,
-      LastUpdated: moment().subtract(6, 'months'),
+      LastUpdated: endOfLastMonth.clone().subtract(6, 'months'),
       LastTemplate: 13,
     },
     {
       inactiveMonths: 12,
-      LastUpdated: moment().subtract(12, 'months'),
+      LastUpdated: endOfLastMonth.clone().subtract(12, 'months'),
       LastTemplate: 14,
     },
     {
       inactiveMonths: 18,
-      LastUpdated: moment().subtract(18, 'months'),
+      LastUpdated: endOfLastMonth.clone().subtract(18, 'months'),
       LastTemplate: 10,
     },
     {
       inactiveMonths: 24,
-      LastUpdated: moment().subtract(24, 'months'),
+      LastUpdated: endOfLastMonth.clone().subtract(24, 'months'),
       LastTemplate: 12,
     },
   ].forEach(({ inactiveMonths, LastUpdated, LastTemplate }) => {
@@ -111,22 +113,22 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
     [
       {
         inactiveMonths: 6,
-        LastUpdated: moment().subtract(6, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(6, 'months'),
         NextTemplate: 13,
       },
       {
         inactiveMonths: 12,
-        LastUpdated: moment().subtract(12, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(12, 'months'),
         NextTemplate: 14,
       },
       {
         inactiveMonths: 18,
-        LastUpdated: moment().subtract(18, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(18, 'months'),
         NextTemplate: 10,
       },
       {
         inactiveMonths: 24,
-        LastUpdated: moment().subtract(24, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(24, 'months'),
         NextTemplate: 12,
       },
     ].forEach(({ inactiveMonths, LastUpdated, NextTemplate }) => {
@@ -150,32 +152,26 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
 
     [
       {
-        inactiveMonths: 5,
-        LastUpdated: moment().subtract(5, 'months'),
-        LastTemplate: null,
-        NextTemplate: null,
-      },
-      {
         inactiveMonths: 12,
-        LastUpdated: moment().subtract(12, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(12, 'months'),
         LastTemplate: 13,
         NextTemplate: 14,
       },
       {
         inactiveMonths: 18,
-        LastUpdated: moment().subtract(18, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(18, 'months'),
         LastTemplate: 14,
         NextTemplate: 10,
       },
       {
         inactiveMonths: 24,
-        LastUpdated: moment().subtract(24, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(24, 'months'),
         LastTemplate: 10,
         NextTemplate: 12,
       },
       {
         inactiveMonths: 25,
-        LastUpdated: moment().subtract(25, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(25, 'months'),
         LastTemplate: 12,
         NextTemplate: null,
       },
@@ -201,22 +197,22 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
     [
       {
         inactiveMonths: 6,
-        LastUpdated: moment().subtract(6, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(6, 'months'),
         LastTemplate: 13,
       },
       {
         inactiveMonths: 12,
-        LastUpdated: moment().subtract(12, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(12, 'months'),
         LastTemplate: 14,
       },
       {
         inactiveMonths: 18,
-        LastUpdated: moment().subtract(18, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(18, 'months'),
         LastTemplate: 10,
       },
       {
         inactiveMonths: 24,
-        LastUpdated: moment().subtract(24, 'months'),
+        LastUpdated: endOfLastMonth.clone().subtract(24, 'months'),
         LastTemplate: 12,
       },
     ].forEach(({ inactiveMonths, LastUpdated, LastTemplate }) => {
@@ -236,6 +232,56 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
 
         expect(emailTemplateId).to.equal(null);
       });
+    });
+  });
+
+  [
+    {
+      inactiveMonths: 5,
+      LastUpdated: endOfLastMonth.clone().subtract(5, 'months'),
+      LastTemplate: null,
+      NextTemplate: null,
+    },
+    {
+      inactiveMonths: 7,
+      LastUpdated: endOfLastMonth.clone().subtract(7, 'months'),
+      LastTemplate: null,
+      NextTemplate: null,
+    },
+    {
+      inactiveMonths: 14,
+      LastUpdated: endOfLastMonth.clone().subtract(14, 'months'),
+      LastTemplate: null,
+      NextTemplate: null,
+    },
+    {
+      inactiveMonths: 20,
+      LastUpdated: endOfLastMonth.clone().subtract(20, 'months'),
+      LastTemplate: null,
+      NextTemplate: null,
+    },
+    {
+      inactiveMonths: 26,
+      LastUpdated: endOfLastMonth.clone().subtract(26, 'months'),
+      LastTemplate: null,
+      NextTemplate: null,
+    },
+  ].forEach(({ inactiveMonths, LastUpdated, LastTemplate, NextTemplate }) => {
+    it(`should not return a template when ${inactiveMonths} months inactive as they are outside of the 6, 12, 18, 24 month`, async () => {
+      const inactiveWorkplace = {
+        EstablishmentID: 478,
+        NameValue: 'Workplace Name',
+        NmdsID: 'J1234567',
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Name',
+        PrimaryUserEmail: 'test@example.com',
+        LastUpdated: LastUpdated,
+        LastTemplate: LastTemplate,
+      };
+
+      const emailTemplateId = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
+
+      expect(emailTemplateId).to.equal(NextTemplate);
     });
   });
 });


### PR DESCRIPTION
**Issue**

The logic to determine whether an inactive workplace should be emailed also included those in-between 6/12/18/24 months

**Work done**

- Fixed logic to only include workplaces if they have been inactive in the same month & year as 6/12/18/24 months ago

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
