### PR TITLE
Feat: Replace template id with name in the inactive workplace report

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -470,7 +470,7 @@ const config = convict({
           default: 13,
         },
         name: {
-          doc: 'Template Name for the 12 month inactive email',
+          doc: 'Template Name for the 6 month inactive email',
           format: String,
           default: '6 months',
         },

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -464,26 +464,54 @@ const config = convict({
     },
     templates: {
       sixMonthsInactive: {
-        doc: 'Template ID for the 6 month inactive email',
-        format: Number,
-        default: 13
+        id: {
+          doc: 'Template ID for the 6 month inactive email',
+          format: Number,
+          default: 13,
+        },
+        name: {
+          doc: 'Template Name for the 12 month inactive email',
+          format: String,
+          default: '6 months',
+        },
       },
       twelveMonthsInactive: {
-        doc: 'Template ID for the 12 month inactive email',
-        format: Number,
-        default: 14
+        id: {
+          doc: 'Template ID for the 12 month inactive email',
+          format: Number,
+          default: 14,
+        },
+        name: {
+          doc: 'Template Name for the 12 month inactive email',
+          format: String,
+          default: '12 months',
+        },
       },
       eighteenMonthsInactive: {
-        doc: 'Template ID for the 18 month inactive email',
-        format: Number,
-        default: 10
+        id: {
+          doc: 'Template ID for the 18 month inactive email',
+          format: Number,
+          default: 10
+        },
+        name: {
+          doc: 'Template Name for the 18 month inactive email',
+          format: String,
+          default: '18 months',
+        },
       },
       twentyFourMonthsInactive: {
-        doc: 'Template ID for the 24 month inactive email',
-        format: Number,
-        default: 12
+        id: {
+          doc: 'Template ID for the 24 month inactive email',
+          format: Number,
+          default: 12
+        },
+        name: {
+          doc: 'Template Name for the 24 month inactive email',
+          format: String,
+          default: '24 months',
+        },
       },
-    }
+    },
   },
 });
 

--- a/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -12,27 +12,39 @@ const nextEmailTemplate = (inactiveWorkplace) => {
   const twentyFourMonths = moment().startOf('day').subtract(24, 'months');
 
   if (lastUpdated.isSameOrBefore(sixMonths) && lastUpdated.isAfter(twelveMonths)) {
-    const nextTemplate = config.get('sendInBlue.templates.sixMonthsInactive');
+    const nextTemplate = {
+      id: config.get('sendInBlue.templates.sixMonthsInactive'),
+      name: '6 months',
+    }
 
-    return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
+    return inactiveWorkplace.LastTemplate !== nextTemplate.id ? nextTemplate : null;
   }
 
   if (lastUpdated.isSameOrBefore(twelveMonths) && lastUpdated.isAfter(eighteenMonths)) {
-    const nextTemplate = config.get('sendInBlue.templates.twelveMonthsInactive');
+    const nextTemplate = {
+      id: config.get('sendInBlue.templates.twelveMonthsInactive'),
+      name: '12 months',
+    }
 
-    return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
+    return inactiveWorkplace.LastTemplate !== nextTemplate.id ? nextTemplate : null;
   }
 
   if (lastUpdated.isBefore(twelveMonths) && lastUpdated.isSameOrAfter(eighteenMonths)) {
-    const nextTemplate = config.get('sendInBlue.templates.eighteenMonthsInactive');
+    const nextTemplate = {
+      id: config.get('sendInBlue.templates.eighteenMonthsInactive'),
+      name: '18 months',
+    }
 
-    return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
+    return inactiveWorkplace.LastTemplate !== nextTemplate.id ? nextTemplate : null;
   }
 
   if (lastUpdated.isSameOrBefore(twentyFourMonths)) {
-    const nextTemplate = config.get('sendInBlue.templates.twentyFourMonthsInactive');
+    const nextTemplate = {
+      id: config.get('sendInBlue.templates.twentyFourMonthsInactive'),
+      name: '24 months',
+    }
 
-    return inactiveWorkplace.LastTemplate !== nextTemplate ? nextTemplate : null;
+    return inactiveWorkplace.LastTemplate !== nextTemplate.id ? nextTemplate : null;
   }
 
   return null;
@@ -89,12 +101,17 @@ const findInactiveWorkplaces = async () => {
       return nextEmailTemplate(inactiveWorkplace) !== null;
     })
     .map((inactiveWorkplace) => {
+      const { id, name } = nextEmailTemplate(inactiveWorkplace);
+
       return {
         id: inactiveWorkplace.EstablishmentID,
         name: inactiveWorkplace.NameValue,
         nmdsId: inactiveWorkplace.NmdsID,
         lastUpdated: inactiveWorkplace.LastUpdated,
-        emailTemplateId: nextEmailTemplate(inactiveWorkplace),
+        emailTemplate: {
+          id,
+          name,
+        },
         dataOwner: inactiveWorkplace.DataOwner,
         user: {
           name: inactiveWorkplace.PrimaryUserName,

--- a/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.js
@@ -12,37 +12,25 @@ const nextEmailTemplate = (inactiveWorkplace) => {
   const twentyFourMonths = moment().startOf('day').subtract(24, 'months');
 
   if (lastUpdated.isSameOrBefore(sixMonths) && lastUpdated.isAfter(twelveMonths)) {
-    const nextTemplate = {
-      id: config.get('sendInBlue.templates.sixMonthsInactive'),
-      name: '6 months',
-    }
+    const nextTemplate = config.get('sendInBlue.templates.sixMonthsInactive');
 
     return inactiveWorkplace.LastTemplate !== nextTemplate.id ? nextTemplate : null;
   }
 
   if (lastUpdated.isSameOrBefore(twelveMonths) && lastUpdated.isAfter(eighteenMonths)) {
-    const nextTemplate = {
-      id: config.get('sendInBlue.templates.twelveMonthsInactive'),
-      name: '12 months',
-    }
+    const nextTemplate = config.get('sendInBlue.templates.twelveMonthsInactive');
 
     return inactiveWorkplace.LastTemplate !== nextTemplate.id ? nextTemplate : null;
   }
 
   if (lastUpdated.isBefore(twelveMonths) && lastUpdated.isSameOrAfter(eighteenMonths)) {
-    const nextTemplate = {
-      id: config.get('sendInBlue.templates.eighteenMonthsInactive'),
-      name: '18 months',
-    }
+    const nextTemplate = config.get('sendInBlue.templates.eighteenMonthsInactive');
 
     return inactiveWorkplace.LastTemplate !== nextTemplate.id ? nextTemplate : null;
   }
 
   if (lastUpdated.isSameOrBefore(twentyFourMonths)) {
-    const nextTemplate = {
-      id: config.get('sendInBlue.templates.twentyFourMonthsInactive'),
-      name: '24 months',
-    }
+    const nextTemplate = config.get('sendInBlue.templates.twentyFourMonthsInactive');
 
     return inactiveWorkplace.LastTemplate !== nextTemplate.id ? nextTemplate : null;
   }

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -29,7 +29,7 @@ const createCampaign = async (req, res) => {
       return {
         emailCampaignID: emailCampaign.id,
         establishmentID: workplace.id,
-        template: workplace.emailTemplateId,
+        template: workplace.emailTemplate.id,
         data: {
           dataOwner: workplace.dataOwner,
           lastUpdated: workplace.lastUpdated,

--- a/server/routes/admin/email-campaigns/inactive-workplaces/report.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/report.js
@@ -9,7 +9,7 @@ const printRow = (worksheet, item) => {
       workplace: item.name,
       workplaceId: item.nmdsId,
       lastUpdated: item.lastUpdated,
-      emailTemplate: item.emailTemplateId,
+      emailTemplate: item.emailTemplate.name,
       dataOwner: item.dataOwner,
       nameOfUser: item.user.name,
       userEmail: item.user.email,

--- a/server/routes/admin/email-campaigns/inactive-workplaces/report.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/report.js
@@ -9,7 +9,7 @@ const printRow = (worksheet, item) => {
       workplace: item.name,
       workplaceId: item.nmdsId,
       lastUpdated: item.lastUpdated,
-      emailTemplate: item.emailTemplate,
+      emailTemplate: item.emailTemplateId,
       dataOwner: item.dataOwner,
       nameOfUser: item.user.name,
       userEmail: item.user.email,
@@ -55,3 +55,4 @@ router.route('/').get(generateReport);
 
 module.exports = router;
 module.exports.generateReport = generateReport;
+module.exports.printRow = printRow;

--- a/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/sendEmail.js
@@ -6,7 +6,7 @@ const sendEmail = async (workplace) => {
       email: workplace.user.email,
       name: workplace.user.name,
     },
-    workplace.emailTemplateId,
+    workplace.emailTemplate.id,
     {
       WORKPLACE_ID: workplace.nmdsId,
     },

--- a/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
+++ b/server/test/unit/models/email-campaigns/inactive-workplaces/findInactiveWorkplaces.spec.js
@@ -16,7 +16,10 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       name: 'Workplace Name',
       nmdsId: 'J1234567',
       lastUpdated: moment().subtract(6, 'months').format('YYYY-MM-DD'),
-      emailTemplateId: 13,
+      emailTemplate: {
+        id: 13,
+        name: '6 months',
+      },
       dataOwner: 'Workplace',
       user: {
         name: 'Test Name',
@@ -28,7 +31,10 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       name: 'Second Workplace Name',
       nmdsId: 'A0012345',
       lastUpdated: moment().subtract(12, 'months').format('YYYY-MM-DD'),
-      emailTemplateId: 14,
+      emailTemplate: {
+        id: 14,
+        name: '12 months',
+      },
       dataOwner: 'Workplace',
       user: {
         name: 'Name McName',
@@ -142,9 +148,9 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
           LastTemplate: null,
         };
 
-        const emailTemplateId = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
+        const emailTemplate = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
 
-        expect(emailTemplateId).to.equal(NextTemplate);
+        expect(emailTemplate.id).to.equal(NextTemplate);
       });
     });
 
@@ -192,9 +198,9 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
           LastTemplate: LastTemplate,
         };
 
-        const emailTemplateId = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
+        const emailTemplate = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
 
-        expect(emailTemplateId).to.equal(NextTemplate);
+        expect(emailTemplate ? emailTemplate.id : emailTemplate).to.equal(NextTemplate);
       });
     });
 
@@ -232,9 +238,9 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
           LastTemplate: LastTemplate,
         };
 
-        const emailTemplateId = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
+        const emailTemplate = await findInactiveWorkplaces.nextEmailTemplate(inactiveWorkplace);
 
-        expect(emailTemplateId).to.equal(null);
+        expect(emailTemplate).to.equal(null);
       });
     });
   });

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -18,7 +18,9 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       name: 'Workplace Name',
       nmdsId: 'J1234567',
       lastUpdated: '2020-06-01',
-      emailTemplateId: 13,
+      emailTemplate: {
+        id: 13,
+      },
       dataOwner: 'Workplace',
       user: {
         name: 'Test Name',
@@ -30,7 +32,9 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       name: 'Second Workplace Name',
       nmdsId: 'A0012345',
       lastUpdated: '2020-01-01',
-      emailTemplateId: 13,
+      emailTemplate: {
+        id: 13,
+      },
       dataOwner: 'Workplace',
       user: {
         name: 'Name McName',

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
@@ -13,7 +13,9 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () =>
       name: 'Workplace Name',
       nmdsId: 'J1234567',
       lastUpdated: '2020-06-01',
-      emailTemplateId: 13,
+      emailTemplate: {
+        id: 13,
+      },
       dataOwner: 'Workplace',
       user: {
         name: 'Test Name',
@@ -25,7 +27,9 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () =>
       name: 'Second Workplace Name',
       nmdsId: 'A0012345',
       lastUpdated: '2020-01-01',
-      emailTemplateId: 13,
+      emailTemplate: {
+        id: 13,
+      },
       dataOwner: 'Workplace',
       user: {
         name: 'Name McName',
@@ -58,7 +62,10 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () =>
       name: 'Workplace Name',
       nmdsId: 'J1234567',
       lastUpdated: '2020-06-01',
-      emailTemplateId: 13,
+      emailTemplate: {
+        id: 13,
+        name: '6 months',
+      },
       dataOwner: 'Workplace',
       user: {
         name: 'Test Name',
@@ -74,13 +81,13 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () =>
     report.printRow(worksheet, workplace);
 
     sinon.assert.calledWith(addRow, {
-      workplace: workplace.name,
-      workplaceId: workplace.nmdsId,
-      lastUpdated: workplace.lastUpdated,
-      emailTemplate: workplace.emailTemplateId,
-      dataOwner: workplace.dataOwner,
-      nameOfUser: workplace.user.name,
-      userEmail: workplace.user.email,
+      workplace: 'Workplace Name',
+      workplaceId: 'J1234567',
+      lastUpdated: '2020-06-01',
+      emailTemplate: '6 months',
+      dataOwner: 'Workplace',
+      nameOfUser: 'Test Name',
+      userEmail: 'test@example.com',
     });
   });
 });

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -12,7 +12,9 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
       name: 'Workplace Name',
       nmdsId: 'J1234567',
       lastUpdated: '2020-06-01',
-      emailTemplateId: 13,
+      emailTemplate: {
+        id: 13,
+      },
       dataOwner: 'Workplace',
       user: {
         name: 'Test Name',


### PR DESCRIPTION
**Issue**

The template column in the Inactive Workplaces report was the ID for Send in Blue which wasn't helpful.

**Work done**

- Replaced the ID of the template with the name of the template

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
