### PR TITLE
Fix: AWS Secrets for Send in Blue

### DIFF
--- a/server/utils/email/sendInBlueEmail.js
+++ b/server/utils/email/sendInBlueEmail.js
@@ -1,9 +1,17 @@
 const SibApiV3Sdk = require('sib-api-v3-sdk');
+const AppConfig = require('../../config/appConfig');
 const config = require('../../config/config');
-const defaultClient = SibApiV3Sdk.ApiClient.instance;
 
+const defaultClient = SibApiV3Sdk.ApiClient.instance;
 const apiKey = defaultClient.authentications['api-key'];
-apiKey.apiKey = config.get('sendInBlue.apiKey');
+
+if (AppConfig.ready) {
+  apiKey.apiKey = config.get('sendInBlue.apiKey');
+}
+
+AppConfig.on(AppConfig.READY_EVENT, () => {
+  apiKey.apiKey = config.get('sendInBlue.apiKey');
+});
 
 const sendEmail = async (to, templateId, params) => {
   try {


### PR DESCRIPTION
**Issue**

The way in which JS requires code means that the API key for Send in Blue was being set before AWS Secrets Manager had responded with the config value.

We need to listen for `AppConfig's` `READY_EVENT` in order to set it after AWS has returned.

**Work done**

- Used `AppConfig` to update the API key once AWS has responded with the secrets

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
