### PR TITLE
Fix: Remove Archived workplaces from the KWA view 

### DIFF
--- a/migrations/20210316155005-update_last_updated_establishments_view.js
+++ b/migrations/20210316155005-update_last_updated_establishments_view.js
@@ -1,0 +1,45 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query('DROP MATERIALIZED VIEW cqc."LastUpdatedEstablishments"');
+
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW cqc."LastUpdatedEstablishments" AS (
+        SELECT e."EstablishmentID",
+           e."NameValue",
+           e."ParentID",
+           e."IsParent",
+           e."NmdsID",
+           e."DataOwner",
+           ( SELECT u."FullNameValue"
+                  FROM cqc."User" u
+                 WHERE u."IsPrimary" = true AND (e."EstablishmentID" = u."EstablishmentID" OR u."EstablishmentID" = e."ParentID") AND u."Archived" = false
+                LIMIT 1) AS "PrimaryUserName",
+           ( SELECT u."EmailValue"
+                  FROM cqc."User" u
+                 WHERE u."IsPrimary" = true AND (e."EstablishmentID" = u."EstablishmentID" OR u."EstablishmentID" = e."ParentID") AND u."Archived" = false
+                LIMIT 1) AS "PrimaryUserEmail",
+           GREATEST(e.updated, ( SELECT w.updated
+                  FROM cqc."Worker" w
+                 WHERE w."EstablishmentFK" = e."EstablishmentID" AND w."Archived" = false
+                 ORDER BY w.updated DESC
+                LIMIT 1)) AS "LastUpdated"
+          FROM cqc."Establishment" e
+          WHERE e."Archived" = false
+       );
+    `);
+
+    await queryInterface.addIndex({
+      tableName: 'LastUpdatedEstablishments',
+      schema: 'cqc',
+    },
+    {
+      fields: ['ParentID', 'IsParent', 'LastUpdated'],
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.query('DROP MATERIALIZED VIEW "cqc"."LastUpdatedEstablishments"');
+  }
+};


### PR DESCRIPTION
**Issue**

We use a Materialized View to store the list of workplaces and their last updated date / who to email etc.

However they were also including workplaces that have been archived

Given Sequelize adds `"Archived" = false` as a default scope for all of the queries so we don't have to think about that, it didn't register!

**Work done**

- Re-created `LastUpdatedEstablishments` view to only include Workplaces who are not archived.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
