### PR TITLE
Fix: Only email workplaces in the whitelist

### DIFF
--- a/server/aws/secrets.js
+++ b/server/aws/secrets.js
@@ -171,6 +171,18 @@ const sendInBlueKey = () => {
   }
 };
 
+const sendInBlueWhitelist = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.SEND_IN_BLUE_WHITELIST) {
+      return '';
+    } else {
+      return myLocalSecrets.SEND_IN_BLUE_WHITELIST;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+};
+
 const dbAppUserKey = () => {
   if (myLocalSecrets !== null) {
     if (!myLocalSecrets.DB_APP_USER_KEY) {
@@ -219,4 +231,5 @@ module.exports.datadogApiKey = datadogApiKey;
 module.exports.sentryDsn = sentryDsn;
 module.exports.honeycombWriteKey = honeycombWriteKey;
 module.exports.sendInBlueKey = sendInBlueKey;
+module.exports.sendInBlueWhitelist = sendInBlueWhitelist;
 module.exports.getAddressKey = getAddressKey;

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -462,6 +462,13 @@ const config = convict({
       sensitive: true,
       env: 'SEND_IN_BLUE_KEY',
     },
+    whitelist: {
+      doc: 'Send in Blue API Whitelist',
+      format: String,
+      default: '',
+      sensitive: true,
+      env: 'SEND_IN_BLUE_WHITELIST',
+    },
     templates: {
       sixMonthsInactive: {
         id: {
@@ -543,7 +550,10 @@ if (config.get('aws.secrets.use')) {
     //  config.set('datadog.api_key', AWSSecrets.datadogApiKey()); // Data dog is still work in progress, checking if we really need this
     config.set('sentry.dsn', AWSSecrets.sentryDsn());
     config.set('honeycomb.write_key', AWSSecrets.honeycombWriteKey());
+
+    // Send in Blue
     config.set('sendInBlue.apiKey', AWSSecrets.sendInBlueKey());
+    config.set('sendInBlue.whitelist', AWSSecrets.sendInBlueWhitelist())
 
     // token secret
     config.set('jwt.secret', AWSSecrets.jwtSecret());

--- a/server/services/email-campaigns/inactive-workplaces/nextEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/nextEmail.js
@@ -37,11 +37,20 @@ const getTemplate = (inactiveWorkplace) => {
   return null;
 };
 
+const isWhitelisted = (email) => {
+  if (!config.get('sendInBlue.whitelist')) {
+    return true;
+  }
+
+  return config.get('sendInBlue.whitelist').split(',').includes(email);
+}
+
 const shouldReceive = (inactiveWorkplace) => {
-  return getTemplate(inactiveWorkplace) !== null;
+  return isWhitelisted(inactiveWorkplace.PrimaryUserEmail) === true && getTemplate(inactiveWorkplace) !== null;
 };
 
 module.exports = {
   getTemplate,
+  isWhitelisted,
   shouldReceive,
 };

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
@@ -2,6 +2,7 @@ const expect = require('chai').expect;
 const moment = require('moment');
 const sinon = require('sinon');
 
+const config = require('../../../../../config/config');
 const nextEmail = require('../../../../../services/email-campaigns/inactive-workplaces/nextEmail');
 
 describe('nextEmailTemplate', () => {
@@ -49,7 +50,7 @@ describe('nextEmailTemplate', () => {
         LastTemplate: null,
       };
 
-      const emailTemplate = await nextEmail.getTemplate(inactiveWorkplace);
+      const emailTemplate = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplate.id).to.equal(NextTemplate);
     });
@@ -93,7 +94,7 @@ describe('nextEmailTemplate', () => {
         LastTemplate: LastTemplate,
       };
 
-      const emailTemplate = await nextEmail.getTemplate(inactiveWorkplace);
+      const emailTemplate = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplate ? emailTemplate.id : emailTemplate).to.equal(NextTemplate);
     });
@@ -133,7 +134,7 @@ describe('nextEmailTemplate', () => {
         LastTemplate: LastTemplate,
       };
 
-      const emailTemplate = await nextEmail.getTemplate(inactiveWorkplace);
+      const emailTemplate = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplate).to.equal(null);
     });
@@ -183,9 +184,36 @@ describe('nextEmailTemplate', () => {
         LastTemplate: LastTemplate,
       };
 
-      const emailTemplateId = await nextEmail.getTemplate(inactiveWorkplace);
+      const emailTemplateId = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplateId).to.equal(NextTemplate);
+    });
+  });
+
+  describe('isWhitelisted', () => {
+    it ('should return true if there is no whitelist', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('');
+
+      const whitelisted =  nextEmail.isWhitelisted('test@test.com');
+
+      expect(whitelisted).to.equal(true);
+    });
+
+
+    it ('should return true if the email is whitelisted', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+      const whitelisted =  nextEmail.isWhitelisted('test@test.com');
+
+      expect(whitelisted).to.equal(true);
+    });
+
+    it ('should return false if the email is not whitelisted', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+      const whitelisted =  nextEmail.isWhitelisted('example@example.com');
+
+      expect(whitelisted).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
**Issue**

In order to test Keep Workplaces Active, we don't want to send emails unless they have been whitelisted.

**Work done**

- Add send in blue whitelist config
- Only include emails in the whitelist if it has been set

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
