### PR TITLE
Keep Workplaces Active - Parent Report

### DIFF
--- a/server/reports/inactive-workplaces/index.js
+++ b/server/reports/inactive-workplaces/index.js
@@ -1,0 +1,48 @@
+const excelJS = require('exceljs');
+const excelUtils = require('../../utils/excelUtils');
+
+const findInactiveWorkplaces = require('../../services/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
+const findParentWorkplaces = require('../../services/email-campaigns/inactive-workplaces/findParentWorkplaces');
+
+const workplaceWorksheetBuilder = require('./workplaces');
+const parentWorksheetBuilder = require('./parents');
+const subsidiaryWorksheetBuilder = require('./subsidiaries');
+
+const generate = async () => {
+  const workbook = new excelJS.Workbook();
+
+  workbook.creator = 'Skills-For-Care';
+  workbook.properties.date1904 = true;
+
+  // Build inactive worksheet
+  const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
+
+  const inactiveWorksheet = workplaceWorksheetBuilder.addWorksheet(workbook);
+  const inactiveWorkplaceRows = workplaceWorksheetBuilder.buildRows(inactiveWorkplaces);
+  inactiveWorksheet.addRows(inactiveWorkplaceRows);
+
+  // Build parent worksheet
+  const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
+
+  const parentWorksheet = parentWorksheetBuilder.addWorksheet(workbook);
+  const parentRows = parentWorksheetBuilder.buildRows(parentWorkplaces);
+  parentWorksheet.addRows(parentRows);
+
+  // Build subsidiary worksheet
+  const subsidiaryWorksheet = subsidiaryWorksheetBuilder.addWorksheet(workbook);
+
+  parentWorkplaces.map((workplace) => {
+    const subsidiaryRows = subsidiaryWorksheetBuilder.buildRows(workplace, workplace.subsidiaries);
+    subsidiaryWorksheet.addRows(subsidiaryRows);
+  });
+
+  workbook.eachSheet((sheet) => {
+    excelUtils.fitColumnsToSize(sheet);
+  });
+
+  return workbook;
+};
+
+module.exports = {
+  generate,
+};

--- a/server/reports/inactive-workplaces/parents.js
+++ b/server/reports/inactive-workplaces/parents.js
@@ -1,0 +1,40 @@
+const buildRow = (workplace) => {
+  return {
+    workplace: workplace.name,
+    workplaceId: workplace.nmdsId,
+    lastUpdated: workplace.lastUpdated,
+    emailTemplate: workplace.emailTemplate.name,
+    dataOwner: workplace.dataOwner,
+    nameOfUser: workplace.user.name,
+    userEmail: workplace.user.email,
+    totalSubs: workplace.subsidiaries.length,
+  };
+};
+
+const buildRows = (parentWorkplaces) => {
+  return parentWorkplaces.map(buildRow);
+};
+
+const addWorksheet = (workbook) => {
+  const worksheet = workbook.addWorksheet('Parent workplaces');
+  worksheet.columns = [
+    { header: 'Workplace name', key: 'workplace' },
+    { header: 'Workplace ID', key: 'workplaceId' },
+    { header: 'Date last updated', key: 'lastUpdated' },
+    { header: 'Email template', key: 'emailTemplate' },
+    { header: 'Data owner', key: 'dataOwner' },
+    { header: 'Name of user', key: 'nameOfUser' },
+    { header: 'User email', key: 'userEmail' },
+    { header: 'Total inactive subsidiaries', key: 'totalSubs' },
+  ];
+
+  const parentHeaderRow = worksheet.getRow(1);
+  parentHeaderRow.font = { bold: true, name: 'Calibri' };
+
+  return worksheet;
+};
+
+module.exports = {
+  addWorksheet,
+  buildRows,
+};

--- a/server/reports/inactive-workplaces/subsidiaries.js
+++ b/server/reports/inactive-workplaces/subsidiaries.js
@@ -1,0 +1,37 @@
+const buildRow = (parent, subsidiary) => {
+  return {
+    parentWorkplaceId: parent.nmdsId,
+    workplace: subsidiary.name,
+    workplaceId: subsidiary.nmdsId,
+    lastUpdated: subsidiary.lastUpdated,
+    dataOwner: subsidiary.dataOwner,
+  };
+};
+
+const buildRows = (parent, subsidiaries) => {
+  return subsidiaries.map((subsidiary) => {
+    return buildRow(parent, subsidiary);
+  });
+};
+
+const addWorksheet = (workbook) => {
+  const subsidiaryWorksheet = workbook.addWorksheet('Subsidiary workplaces');
+  subsidiaryWorksheet.columns = [
+    { header: 'Parent Workplace ID', key: 'parentWorkplaceId' },
+    { header: 'Workplace name', key: 'workplace' },
+    { header: 'Workplace ID', key: 'workplaceId' },
+    { header: 'Date last updated', key: 'lastUpdated' },
+    { header: 'Email template', key: 'emailTemplate' },
+    { header: 'Data owner', key: 'dataOwner' },
+  ];
+
+  const subsidiaryHeaderRow = subsidiaryWorksheet.getRow(1);
+  subsidiaryHeaderRow.font = { bold: true, name: 'Calibri' };
+
+  return subsidiaryWorksheet;
+};
+
+module.exports = {
+  addWorksheet,
+  buildRows,
+};

--- a/server/reports/inactive-workplaces/workplaces.js
+++ b/server/reports/inactive-workplaces/workplaces.js
@@ -1,0 +1,38 @@
+const buildRow = (workplace) => {
+  return {
+    workplace: workplace.name,
+    workplaceId: workplace.nmdsId,
+    lastUpdated: workplace.lastUpdated,
+    emailTemplate: workplace.emailTemplate.name,
+    dataOwner: workplace.dataOwner,
+    nameOfUser: workplace.user.name,
+    userEmail: workplace.user.email,
+  };
+};
+
+const buildRows = (workplaces) => {
+  return workplaces.map(buildRow);
+};
+
+const addWorksheet = (workbook) => {
+  const worksheet = workbook.addWorksheet('Inactive workplaces');
+  worksheet.columns = [
+    { header: 'Workplace name', key: 'workplace' },
+    { header: 'Workplace ID', key: 'workplaceId' },
+    { header: 'Date last updated', key: 'lastUpdated' },
+    { header: 'Email template', key: 'emailTemplate' },
+    { header: 'Data owner', key: 'dataOwner' },
+    { header: 'Name of user', key: 'nameOfUser' },
+    { header: 'User email', key: 'userEmail' },
+  ];
+
+  const headerRow = worksheet.getRow(1);
+  headerRow.font = { bold: true, name: 'Calibri' };
+
+  return worksheet;
+};
+
+module.exports = {
+  addWorksheet,
+  buildRows,
+};

--- a/server/routes/admin/email-campaigns/inactive-workplaces/report.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/report.js
@@ -1,55 +1,18 @@
-const excelJS = require('exceljs');
 const express = require('express');
 const moment = require('moment');
-const findInactiveWorkplaces = require('../../../../services/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
-const excelUtils = require('../../../../utils/excelUtils');
 
-const printRow = (worksheet, item) => {
-  worksheet.addRow({
-    workplace: item.name,
-    workplaceId: item.nmdsId,
-    lastUpdated: item.lastUpdated,
-    emailTemplate: item.emailTemplate.name,
-    dataOwner: item.dataOwner,
-    nameOfUser: item.user.name,
-    userEmail: item.user.email,
-  });
-};
+const inactiveWorkplacesReport = require('../../../../reports/inactive-workplaces');
 
 const generateReport = async (_req, res) => {
-  const workbook = new excelJS.Workbook();
-
-  workbook.creator = 'Skills-For-Care';
-  workbook.properties.date1904 = true;
-
-  const worksheet = workbook.addWorksheet('Inactive workplaces');
-  worksheet.columns = [
-    { header: 'Workplace name', key: 'workplace' },
-    { header: 'Workplace ID', key: 'workplaceId' },
-    { header: 'Date last updated', key: 'lastUpdated' },
-    { header: 'Email template', key: 'emailTemplate' },
-    { header: 'Data owner', key: 'dataOwner' },
-    { header: 'Name of user', key: 'nameOfUser' },
-    { header: 'User email', key: 'userEmail' },
-  ];
-
-  const headerRow = worksheet.getRow(1);
-  headerRow.font = { bold: true, name: 'Calibri' };
-
-  const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
-  inactiveWorkplaces.forEach((workplace) => {
-    printRow(worksheet, workplace);
-  });
-
-  excelUtils.fitColumnsToSize(worksheet);
-
   res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
   res.setHeader(
     'Content-Disposition',
     'attachment; filename=' + moment().format('DD-MM-YYYY') + '-inactiveWorkplaces.xlsx',
   );
 
+  const workbook = await inactiveWorkplacesReport.generate();
   await workbook.xlsx.write(res);
+
   return res.status(200).end();
 };
 
@@ -58,4 +21,3 @@ router.route('/').get(generateReport);
 
 module.exports = router;
 module.exports.generateReport = generateReport;
-module.exports.printRow = printRow;

--- a/server/test/unit/reports/inactive-workplaces/parents.spec.js
+++ b/server/test/unit/reports/inactive-workplaces/parents.spec.js
@@ -1,0 +1,54 @@
+const expect = require('chai').expect;
+
+const parentWorksheetBuilder = require('../../../../reports/inactive-workplaces/parents');
+
+describe('reports/inactive-workplaces/parents.js', () => {
+  it('should add Parent Workplaces to the worksheet', () => {
+    const workplace = {
+      id: 1,
+      name: 'Test Name',
+      nmdsId: 'A1234567',
+      lastUpdated: '2021-03-01',
+      emailTemplate: {
+        id: 15,
+        name: 'Parent',
+      },
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Test Person',
+        email: 'test@example.com',
+      },
+      subsidiaries: [
+        {
+          id: 2,
+          name: 'Test Name 2',
+          nmdsId: 'J231466',
+          lastUpdated: '3 months ago',
+          dataOwner: 'Parent',
+        },
+        {
+          id: 3,
+          name: 'Test Name 3',
+          nmdsId: 'H2345678',
+          lastUpdated: '6 months ago',
+          dataOwner: 'Parent',
+        },
+      ],
+    };
+
+    const rows = parentWorksheetBuilder.buildRows([workplace]);
+
+    expect(rows).to.deep.equal([
+      {
+        workplace: 'Test Name',
+        workplaceId: 'A1234567',
+        lastUpdated: '2021-03-01',
+        emailTemplate: 'Parent',
+        dataOwner: 'Workplace',
+        nameOfUser: 'Test Person',
+        userEmail: 'test@example.com',
+        totalSubs: 2,
+      },
+    ]);
+  });
+});

--- a/server/test/unit/reports/inactive-workplaces/subsidiaries.spec.js
+++ b/server/test/unit/reports/inactive-workplaces/subsidiaries.spec.js
@@ -1,0 +1,58 @@
+const expect = require('chai').expect;
+
+const subsidiariesWorksheetBuilder = require('../../../../reports/inactive-workplaces/subsidiaries');
+
+describe('reports/inactive-workplaces/parents.js', () => {
+  it('should add Subsidiary Workplaces to the worksheet', () => {
+    const workplace = {
+      id: 1,
+      name: 'Test Name',
+      nmdsId: 'A1234567',
+      lastUpdated: '2021-03-01',
+      emailTemplate: {
+        id: 15,
+        name: 'Parent',
+      },
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Test Person',
+        email: 'test@example.com',
+      },
+      subsidiaries: [
+        {
+          id: 2,
+          name: 'Test Name 2',
+          nmdsId: 'J231466',
+          lastUpdated: '2020-09-10',
+          dataOwner: 'Parent',
+        },
+        {
+          id: 3,
+          name: 'Test Name 3',
+          nmdsId: 'H2345678',
+          lastUpdated: '2020-03-10',
+          dataOwner: 'Parent',
+        },
+      ],
+    };
+
+    const rows = subsidiariesWorksheetBuilder.buildRows(workplace, workplace.subsidiaries);
+
+    expect(rows).to.deep.equal([
+      {
+        parentWorkplaceId: 'A1234567',
+        workplace: 'Test Name 2',
+        workplaceId: 'J231466',
+        lastUpdated: '2020-09-10',
+        dataOwner: 'Parent',
+      },
+      {
+        parentWorkplaceId: 'A1234567',
+        workplace: 'Test Name 3',
+        workplaceId: 'H2345678',
+        lastUpdated: '2020-03-10',
+        dataOwner: 'Parent',
+      },
+    ]);
+  });
+});

--- a/server/test/unit/reports/inactive-workplaces/workplaces.spec.js
+++ b/server/test/unit/reports/inactive-workplaces/workplaces.spec.js
@@ -1,0 +1,37 @@
+const expect = require('chai').expect;
+
+const workplaceWorksheetBuilder = require('../../../../reports/inactive-workplaces/workplaces');
+
+describe('reports/inactive-workplaces/workplaces.js', () => {
+  it('should add Workplace to the worksheet', () => {
+    const workplace = {
+      id: 478,
+      name: 'Workplace Name',
+      nmdsId: 'J1234567',
+      lastUpdated: '2020-06-01',
+      emailTemplate: {
+        id: 13,
+        name: '6 months',
+      },
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Test Name',
+        email: 'test@example.com',
+      },
+    };
+
+    const rows = workplaceWorksheetBuilder.buildRows([workplace]);
+
+    expect(rows).to.deep.equal([
+      {
+        workplace: 'Workplace Name',
+        workplaceId: 'J1234567',
+        lastUpdated: '2020-06-01',
+        emailTemplate: '6 months',
+        dataOwner: 'Workplace',
+        nameOfUser: 'Test Name',
+        userEmail: 'test@example.com',
+      },
+    ]);
+  });
+});

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/report.spec.js
@@ -1,4 +1,3 @@
-const excelJS = require('exceljs');
 const expect = require('chai').expect;
 const httpMocks = require('node-mocks-http');
 const sinon = require('sinon');
@@ -38,6 +37,10 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () =>
     },
   ];
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should generate a report', async () => {
     sinon.stub(findInactiveWorkplaces, 'findInactiveWorkplaces').returns(dummyInactiveWorkplaces);
 
@@ -54,40 +57,5 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/report', () =>
 
     expect(res.statusCode).to.equal(200);
     expect(res._headers['content-type']).to.equal('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-  });
-
-  it('should add Workplace to the worksheet', () => {
-    const workplace = {
-      id: 478,
-      name: 'Workplace Name',
-      nmdsId: 'J1234567',
-      lastUpdated: '2020-06-01',
-      emailTemplate: {
-        id: 13,
-        name: '6 months',
-      },
-      dataOwner: 'Workplace',
-      user: {
-        name: 'Test Name',
-        email: 'test@example.com',
-      },
-    };
-
-    const workbook = new excelJS.Workbook();
-    const worksheet = workbook.addWorksheet('Inactive workplaces');
-
-    const addRow = sinon.spy(worksheet, 'addRow');
-
-    report.printRow(worksheet, workplace);
-
-    sinon.assert.calledWith(addRow, {
-      workplace: 'Workplace Name',
-      workplaceId: 'J1234567',
-      lastUpdated: '2020-06-01',
-      emailTemplate: '6 months',
-      dataOwner: 'Workplace',
-      nameOfUser: 'Test Name',
-      userEmail: 'test@example.com',
-    });
   });
 });


### PR DESCRIPTION
**Work done**

- Added parents and subsidiaries worksheets to the Inactive Workplaces report
- Moved the code needed to build the report to `server/reports/inactive-workplaces`

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
