### PR TITLE
Fix: Send in Blue whitelist not being set from AWS secrets

### DIFF
--- a/server/aws/secrets.js
+++ b/server/aws/secrets.js
@@ -33,6 +33,7 @@ const initialiseSecrets = async (region, wallet) => {
         SENTRY_DSN: mySecrets.SENTRY_DSN,
         HONEYCOMB_WRITE_KEY: mySecrets.HONEYCOMB_WRITE_KEY,
         SEND_IN_BLUE_KEY: mySecrets.SEND_IN_BLUE_KEY,
+        SEND_IN_BLUE_WHITELIST: mySecrets.SEND_IN_BLUE_WHITELIST,
       };
     }
   } catch (err) {


### PR DESCRIPTION
**Issue**

`SEND_IN_BLUE_WHITELIST` was missing from `myLocalSecrets` object.

Not sure why `myLocalSecrets` can't be set to `mySecrets` - it's a 1-1 mapping, but it may be intentional.

**Work done**

- Added `mySecrets.SEND_IN_BLUE_WHITELIST` to `myLocalSecrets`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
