### PR TITLE
Fix: Only whitelist when sending email

### DIFF
--- a/server/services/email-campaigns/inactive-workplaces/nextEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/nextEmail.js
@@ -37,20 +37,11 @@ const getTemplate = (inactiveWorkplace) => {
   return null;
 };
 
-const isWhitelisted = (email) => {
-  if (!config.get('sendInBlue.whitelist')) {
-    return true;
-  }
-
-  return config.get('sendInBlue.whitelist').split(',').includes(email);
-};
-
 const shouldReceive = (inactiveWorkplace) => {
-  return isWhitelisted(inactiveWorkplace.PrimaryUserEmail) === true && getTemplate(inactiveWorkplace) !== null;
+  return getTemplate(inactiveWorkplace) !== null;
 };
 
 module.exports = {
   getTemplate,
-  isWhitelisted,
   shouldReceive,
 };

--- a/server/services/email-campaigns/inactive-workplaces/nextEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/nextEmail.js
@@ -25,7 +25,7 @@ const templates = {
 const getTemplate = (inactiveWorkplace) => {
   const lastUpdated = moment(inactiveWorkplace.LastUpdated);
 
-  for (const [_key, month] of Object.entries(templates)) {
+  for (const [, month] of Object.entries(templates)) {
     const nextTemplate = month.template;
     const notReceivedTemplate = inactiveWorkplace.LastTemplate !== nextTemplate.id;
 
@@ -43,7 +43,7 @@ const isWhitelisted = (email) => {
   }
 
   return config.get('sendInBlue.whitelist').split(',').includes(email);
-}
+};
 
 const shouldReceive = (inactiveWorkplace) => {
   return isWhitelisted(inactiveWorkplace.PrimaryUserEmail) === true && getTemplate(inactiveWorkplace) !== null;

--- a/server/services/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/sendEmail.js
@@ -1,6 +1,19 @@
+const config = require('../../../config/config');
 const sendInBlueEmail = require('../../../utils/email/sendInBlueEmail');
 
+const isWhitelisted = (email) => {
+  if (!config.get('sendInBlue.whitelist')) {
+    return true;
+  }
+
+  return config.get('sendInBlue.whitelist').split(',').includes(email);
+};
+
 const sendEmail = async (workplace) => {
+  if (!isWhitelisted(workplace.user.email)) {
+    return;
+  }
+
   sendInBlueEmail.sendEmail(
     {
       email: workplace.user.email,
@@ -16,4 +29,5 @@ const sendEmail = async (workplace) => {
 
 module.exports = {
   sendEmail,
+  isWhitelisted,
 };

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
@@ -2,7 +2,6 @@ const expect = require('chai').expect;
 const moment = require('moment');
 const sinon = require('sinon');
 
-const config = require('../../../../../config/config');
 const nextEmail = require('../../../../../services/email-campaigns/inactive-workplaces/nextEmail');
 
 describe('nextEmailTemplate', () => {
@@ -187,33 +186,6 @@ describe('nextEmailTemplate', () => {
       const emailTemplateId = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplateId).to.equal(NextTemplate);
-    });
-  });
-
-  describe('isWhitelisted', () => {
-    it ('should return true if there is no whitelist', () => {
-      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('');
-
-      const whitelisted =  nextEmail.isWhitelisted('test@test.com');
-
-      expect(whitelisted).to.equal(true);
-    });
-
-
-    it ('should return true if the email is whitelisted', () => {
-      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
-
-      const whitelisted =  nextEmail.isWhitelisted('test@test.com');
-
-      expect(whitelisted).to.equal(true);
-    });
-
-    it ('should return false if the email is not whitelisted', () => {
-      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
-
-      const whitelisted =  nextEmail.isWhitelisted('example@example.com');
-
-      expect(whitelisted).to.equal(false);
     });
   });
 });

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -1,4 +1,7 @@
+const expect = require('chai').expect;
 const sinon = require('sinon');
+
+const config = require('../../../../../config/config');
 const sendEmail = require('../../../../../services/email-campaigns/inactive-workplaces/sendEmail');
 const sendInBlueEmail = require('../../../../../utils/email/sendInBlueEmail');
 
@@ -38,5 +41,31 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
         FULL_NAME: 'Test Name',
       },
     );
+  });
+
+  describe('isWhitelisted', () => {
+    it('should return true if there is no whitelist', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('');
+
+      const whitelisted = sendEmail.isWhitelisted('test@test.com');
+
+      expect(whitelisted).to.equal(true);
+    });
+
+    it('should return true if the email is whitelisted', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+      const whitelisted = sendEmail.isWhitelisted('test@test.com');
+
+      expect(whitelisted).to.equal(true);
+    });
+
+    it('should return false if the email is not whitelisted', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+      const whitelisted = sendEmail.isWhitelisted('example@example.com');
+
+      expect(whitelisted).to.equal(false);
+    });
   });
 });


### PR DESCRIPTION
**Issue**

We added the whitelisting logic to the place where we decide whether a workplace should be sent an email, but this meant that workplaces would be filtered out in the report etc.

**Work done**

- Moved the whitelisting logic to when the emails are actually sent

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
