### PR TITLE
Live: Exclude Archived workplaces & add Send in Blue whitelist

### DIFF
--- a/migrations/20210316155005-update_last_updated_establishments_view.js
+++ b/migrations/20210316155005-update_last_updated_establishments_view.js
@@ -1,0 +1,45 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query('DROP MATERIALIZED VIEW cqc."LastUpdatedEstablishments"');
+
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW cqc."LastUpdatedEstablishments" AS (
+        SELECT e."EstablishmentID",
+           e."NameValue",
+           e."ParentID",
+           e."IsParent",
+           e."NmdsID",
+           e."DataOwner",
+           ( SELECT u."FullNameValue"
+                  FROM cqc."User" u
+                 WHERE u."IsPrimary" = true AND (e."EstablishmentID" = u."EstablishmentID" OR u."EstablishmentID" = e."ParentID") AND u."Archived" = false
+                LIMIT 1) AS "PrimaryUserName",
+           ( SELECT u."EmailValue"
+                  FROM cqc."User" u
+                 WHERE u."IsPrimary" = true AND (e."EstablishmentID" = u."EstablishmentID" OR u."EstablishmentID" = e."ParentID") AND u."Archived" = false
+                LIMIT 1) AS "PrimaryUserEmail",
+           GREATEST(e.updated, ( SELECT w.updated
+                  FROM cqc."Worker" w
+                 WHERE w."EstablishmentFK" = e."EstablishmentID" AND w."Archived" = false
+                 ORDER BY w.updated DESC
+                LIMIT 1)) AS "LastUpdated"
+          FROM cqc."Establishment" e
+          WHERE e."Archived" = false
+       );
+    `);
+
+    await queryInterface.addIndex({
+      tableName: 'LastUpdatedEstablishments',
+      schema: 'cqc',
+    },
+    {
+      fields: ['ParentID', 'IsParent', 'LastUpdated'],
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.query('DROP MATERIALIZED VIEW "cqc"."LastUpdatedEstablishments"');
+  }
+};

--- a/server/aws/secrets.js
+++ b/server/aws/secrets.js
@@ -171,6 +171,18 @@ const sendInBlueKey = () => {
   }
 };
 
+const sendInBlueWhitelist = () => {
+  if (myLocalSecrets !== null) {
+    if (!myLocalSecrets.SEND_IN_BLUE_WHITELIST) {
+      return '';
+    } else {
+      return myLocalSecrets.SEND_IN_BLUE_WHITELIST;
+    }
+  } else {
+    throw new Error('Unknown secrets');
+  }
+};
+
 const dbAppUserKey = () => {
   if (myLocalSecrets !== null) {
     if (!myLocalSecrets.DB_APP_USER_KEY) {
@@ -219,4 +231,5 @@ module.exports.datadogApiKey = datadogApiKey;
 module.exports.sentryDsn = sentryDsn;
 module.exports.honeycombWriteKey = honeycombWriteKey;
 module.exports.sendInBlueKey = sendInBlueKey;
+module.exports.sendInBlueWhitelist = sendInBlueWhitelist;
 module.exports.getAddressKey = getAddressKey;

--- a/server/aws/secrets.js
+++ b/server/aws/secrets.js
@@ -33,6 +33,7 @@ const initialiseSecrets = async (region, wallet) => {
         SENTRY_DSN: mySecrets.SENTRY_DSN,
         HONEYCOMB_WRITE_KEY: mySecrets.HONEYCOMB_WRITE_KEY,
         SEND_IN_BLUE_KEY: mySecrets.SEND_IN_BLUE_KEY,
+        SEND_IN_BLUE_WHITELIST: mySecrets.SEND_IN_BLUE_WHITELIST,
       };
     }
   } catch (err) {

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -462,6 +462,13 @@ const config = convict({
       sensitive: true,
       env: 'SEND_IN_BLUE_KEY',
     },
+    whitelist: {
+      doc: 'Send in Blue API Whitelist',
+      format: String,
+      default: '',
+      sensitive: true,
+      env: 'SEND_IN_BLUE_WHITELIST',
+    },
     templates: {
       sixMonthsInactive: {
         id: {
@@ -543,7 +550,10 @@ if (config.get('aws.secrets.use')) {
     //  config.set('datadog.api_key', AWSSecrets.datadogApiKey()); // Data dog is still work in progress, checking if we really need this
     config.set('sentry.dsn', AWSSecrets.sentryDsn());
     config.set('honeycomb.write_key', AWSSecrets.honeycombWriteKey());
+
+    // Send in Blue
     config.set('sendInBlue.apiKey', AWSSecrets.sendInBlueKey());
+    config.set('sendInBlue.whitelist', AWSSecrets.sendInBlueWhitelist())
 
     // token secret
     config.set('jwt.secret', AWSSecrets.jwtSecret());

--- a/server/services/email-campaigns/inactive-workplaces/nextEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/nextEmail.js
@@ -25,7 +25,7 @@ const templates = {
 const getTemplate = (inactiveWorkplace) => {
   const lastUpdated = moment(inactiveWorkplace.LastUpdated);
 
-  for (const [_key, month] of Object.entries(templates)) {
+  for (const [, month] of Object.entries(templates)) {
     const nextTemplate = month.template;
     const notReceivedTemplate = inactiveWorkplace.LastTemplate !== nextTemplate.id;
 
@@ -37,20 +37,11 @@ const getTemplate = (inactiveWorkplace) => {
   return null;
 };
 
-const isWhitelisted = (email) => {
-  if (!config.get('sendInBlue.whitelist')) {
-    return true;
-  }
-
-  return config.get('sendInBlue.whitelist').split(',').includes(email);
-}
-
 const shouldReceive = (inactiveWorkplace) => {
-  return isWhitelisted(inactiveWorkplace.PrimaryUserEmail) === true && getTemplate(inactiveWorkplace) !== null;
+  return getTemplate(inactiveWorkplace) !== null;
 };
 
 module.exports = {
   getTemplate,
-  isWhitelisted,
   shouldReceive,
 };

--- a/server/services/email-campaigns/inactive-workplaces/nextEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/nextEmail.js
@@ -37,11 +37,20 @@ const getTemplate = (inactiveWorkplace) => {
   return null;
 };
 
+const isWhitelisted = (email) => {
+  if (!config.get('sendInBlue.whitelist')) {
+    return true;
+  }
+
+  return config.get('sendInBlue.whitelist').split(',').includes(email);
+}
+
 const shouldReceive = (inactiveWorkplace) => {
-  return getTemplate(inactiveWorkplace) !== null;
+  return isWhitelisted(inactiveWorkplace.PrimaryUserEmail) === true && getTemplate(inactiveWorkplace) !== null;
 };
 
 module.exports = {
   getTemplate,
+  isWhitelisted,
   shouldReceive,
 };

--- a/server/services/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/sendEmail.js
@@ -1,6 +1,19 @@
+const config = require('../../../config/config');
 const sendInBlueEmail = require('../../../utils/email/sendInBlueEmail');
 
+const isWhitelisted = (email) => {
+  if (!config.get('sendInBlue.whitelist')) {
+    return true;
+  }
+
+  return config.get('sendInBlue.whitelist').split(',').includes(email);
+};
+
 const sendEmail = async (workplace) => {
+  if (!isWhitelisted(workplace.user.email)) {
+    return;
+  }
+
   sendInBlueEmail.sendEmail(
     {
       email: workplace.user.email,
@@ -16,4 +29,5 @@ const sendEmail = async (workplace) => {
 
 module.exports = {
   sendEmail,
+  isWhitelisted,
 };

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
@@ -2,7 +2,6 @@ const expect = require('chai').expect;
 const moment = require('moment');
 const sinon = require('sinon');
 
-const config = require('../../../../../config/config');
 const nextEmail = require('../../../../../services/email-campaigns/inactive-workplaces/nextEmail');
 
 describe('nextEmailTemplate', () => {
@@ -187,33 +186,6 @@ describe('nextEmailTemplate', () => {
       const emailTemplateId = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplateId).to.equal(NextTemplate);
-    });
-  });
-
-  describe('isWhitelisted', () => {
-    it ('should return true if there is no whitelist', () => {
-      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('');
-
-      const whitelisted =  nextEmail.isWhitelisted('test@test.com');
-
-      expect(whitelisted).to.equal(true);
-    });
-
-
-    it ('should return true if the email is whitelisted', () => {
-      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
-
-      const whitelisted =  nextEmail.isWhitelisted('test@test.com');
-
-      expect(whitelisted).to.equal(true);
-    });
-
-    it ('should return false if the email is not whitelisted', () => {
-      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
-
-      const whitelisted =  nextEmail.isWhitelisted('example@example.com');
-
-      expect(whitelisted).to.equal(false);
     });
   });
 });

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
@@ -2,6 +2,7 @@ const expect = require('chai').expect;
 const moment = require('moment');
 const sinon = require('sinon');
 
+const config = require('../../../../../config/config');
 const nextEmail = require('../../../../../services/email-campaigns/inactive-workplaces/nextEmail');
 
 describe('nextEmailTemplate', () => {
@@ -49,7 +50,7 @@ describe('nextEmailTemplate', () => {
         LastTemplate: null,
       };
 
-      const emailTemplate = await nextEmail.getTemplate(inactiveWorkplace);
+      const emailTemplate = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplate.id).to.equal(NextTemplate);
     });
@@ -93,7 +94,7 @@ describe('nextEmailTemplate', () => {
         LastTemplate: LastTemplate,
       };
 
-      const emailTemplate = await nextEmail.getTemplate(inactiveWorkplace);
+      const emailTemplate = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplate ? emailTemplate.id : emailTemplate).to.equal(NextTemplate);
     });
@@ -133,7 +134,7 @@ describe('nextEmailTemplate', () => {
         LastTemplate: LastTemplate,
       };
 
-      const emailTemplate = await nextEmail.getTemplate(inactiveWorkplace);
+      const emailTemplate = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplate).to.equal(null);
     });
@@ -183,9 +184,36 @@ describe('nextEmailTemplate', () => {
         LastTemplate: LastTemplate,
       };
 
-      const emailTemplateId = await nextEmail.getTemplate(inactiveWorkplace);
+      const emailTemplateId = nextEmail.getTemplate(inactiveWorkplace);
 
       expect(emailTemplateId).to.equal(NextTemplate);
+    });
+  });
+
+  describe('isWhitelisted', () => {
+    it ('should return true if there is no whitelist', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('');
+
+      const whitelisted =  nextEmail.isWhitelisted('test@test.com');
+
+      expect(whitelisted).to.equal(true);
+    });
+
+
+    it ('should return true if the email is whitelisted', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+      const whitelisted =  nextEmail.isWhitelisted('test@test.com');
+
+      expect(whitelisted).to.equal(true);
+    });
+
+    it ('should return false if the email is not whitelisted', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+      const whitelisted =  nextEmail.isWhitelisted('example@example.com');
+
+      expect(whitelisted).to.equal(false);
     });
   });
 });

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -1,4 +1,7 @@
+const expect = require('chai').expect;
 const sinon = require('sinon');
+
+const config = require('../../../../../config/config');
 const sendEmail = require('../../../../../services/email-campaigns/inactive-workplaces/sendEmail');
 const sendInBlueEmail = require('../../../../../utils/email/sendInBlueEmail');
 
@@ -38,5 +41,31 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
         FULL_NAME: 'Test Name',
       },
     );
+  });
+
+  describe('isWhitelisted', () => {
+    it('should return true if there is no whitelist', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('');
+
+      const whitelisted = sendEmail.isWhitelisted('test@test.com');
+
+      expect(whitelisted).to.equal(true);
+    });
+
+    it('should return true if the email is whitelisted', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+      const whitelisted = sendEmail.isWhitelisted('test@test.com');
+
+      expect(whitelisted).to.equal(true);
+    });
+
+    it('should return false if the email is not whitelisted', () => {
+      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+      const whitelisted = sendEmail.isWhitelisted('example@example.com');
+
+      expect(whitelisted).to.equal(false);
+    });
   });
 });


### PR DESCRIPTION
**Changes introduced**

- Add a Send in Blue whitelist for staging and pre-prod
- Filter out archived workplaces in the `LastUpdatedEstablishments` view

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
