### PR TITLE
Feat: Keep Workplaces Active - Update endpoints for parents

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -511,6 +511,18 @@ const config = convict({
           default: '24 months',
         },
       },
+      parent: {
+        id: {
+          doc: 'Template ID for the parent workplace email',
+          format: Number,
+          default: 15,
+        },
+        name: {
+          doc: 'Template Name for the parent workplace email',
+          format: String,
+          default: 'Parent',
+        },
+      },
     },
   },
 });

--- a/server/models/email-campaigns/inactive-workplaces/getParentWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/getParentWorkplaces.js
@@ -8,7 +8,13 @@ const getParentWorkplaces = async () => {
   return models.sequelize.query(
     `
     SELECT
-    *
+      "EstablishmentID",
+      "NameValue",
+      TRIM("NmdsID"),
+      "DataOwner",
+      "PrimaryUserName",
+      "PrimaryUserEmail",
+      "LastUpdated"
   FROM
     cqc. "LastUpdatedEstablishments" e
   WHERE
@@ -25,7 +31,13 @@ const getParentWorkplaces = async () => {
         AND ech. "establishmentID" = e. "EstablishmentID")
     UNION
     SELECT
-      *
+      "EstablishmentID",
+      "NameValue",
+      TRIM("NmdsID"),
+      "DataOwner",
+      "PrimaryUserName",
+      "PrimaryUserEmail",
+      "LastUpdated"
     FROM
       cqc. "LastUpdatedEstablishments" e
     WHERE

--- a/server/models/email-campaigns/inactive-workplaces/getParentWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/getParentWorkplaces.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const models = require('../../index');
 
 const getParentWorkplaces = async () => {
-  const currentMonth = moment().startOf('month').format('YYYY-MM-DD');
+  const lastEmailDate = moment().subtract(5, 'months').startOf('month').format('YYYY-MM-DD');
 
   return models.sequelize.query(
     `
@@ -21,7 +21,7 @@ const getParentWorkplaces = async () => {
         JOIN cqc. "EmailCampaigns" ec ON ec. "id" = ech. "emailCampaignID"
       WHERE
         ec. "type" = 'inactiveWorkplaces'
-        AND ech. "createdAt" >= :currentMonth
+        AND ech. "createdAt" >= :lastEmailDate
         AND ech. "establishmentID" = e. "EstablishmentID")
     UNION
     SELECT
@@ -39,12 +39,12 @@ const getParentWorkplaces = async () => {
           JOIN cqc. "EmailCampaigns" ec ON ec. "id" = ech. "emailCampaignID"
         WHERE
           ec. "type" = 'inactiveWorkplaces'
-          AND ech. "createdAt" >= :currentMonth
+          AND ech. "createdAt" >= :lastEmailDate
           AND ech. "establishmentID" = e. "ParentID");`,
     {
       type: models.sequelize.QueryTypes.SELECT,
       replacements: {
-        currentMonth,
+        lastEmailDate,
       },
     },
   );

--- a/server/models/emailcampaign.js
+++ b/server/models/emailcampaign.js
@@ -47,7 +47,10 @@ module.exports = (sequelize, DataTypes) => {
       }],
       group: [
         'EmailCampaign.id',
-      ]
+      ],
+      order: [
+        ['createdAt', 'DESC'],
+      ],
     });
   }
 

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -46,7 +46,7 @@ const createCampaign = async (req, res) => {
     });
 
     await models.EmailCampaignHistory.bulkCreate(history);
-    inactiveWorkplaces.map(sendEmail.sendEmail);
+    totalInactiveWorkplaces.map(sendEmail.sendEmail);
 
     return res.json({
       date: emailCampaign.createdAt,

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -27,7 +27,10 @@ const createCampaign = async (req, res) => {
     });
 
     const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
-    const history = inactiveWorkplaces.map((workplace) => {
+    const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
+
+    const totalInactiveWorkplaces = inactiveWorkplaces.concat(parentWorkplaces)
+    const history = totalInactiveWorkplaces.map((workplace) => {
       return {
         emailCampaignID: emailCampaign.id,
         establishmentID: workplace.id,
@@ -35,6 +38,7 @@ const createCampaign = async (req, res) => {
         data: {
           dataOwner: workplace.dataOwner,
           lastUpdated: workplace.lastUpdated,
+          subsidiaries: workplace.subsidiaries ? workplace.subsidiaries : [],
         },
         sentToName: workplace.user.name,
         sentToEmail: workplace.user.email,
@@ -46,7 +50,7 @@ const createCampaign = async (req, res) => {
 
     return res.json({
       date: emailCampaign.createdAt,
-      emails: inactiveWorkplaces.length,
+      emails: totalInactiveWorkplaces.length,
     });
   } catch (err) {
     console.error(err);

--- a/server/services/email-campaigns/inactive-workplaces/findParentWorkplaces.js
+++ b/server/services/email-campaigns/inactive-workplaces/findParentWorkplaces.js
@@ -1,5 +1,5 @@
 const moment = require('moment');
-
+const config = require('../../../config/config');
 const { getParentWorkplaces } = require('../../../models/email-campaigns/inactive-workplaces/getParentWorkplaces');
 
 const lastMonth = moment().subtract(1, 'months');
@@ -28,10 +28,7 @@ const transformParentWorkplaces = async () => {
       const name = parentWorkplace.NameValue;
       const nmdsId = parentWorkplace.NmdsID;
       const lastUpdated = parentWorkplace.LastUpdated;
-      const emailTemplate = {
-        id: 15,
-        name: 'Parent',
-      };
+      const emailTemplate = config.get('sendInBlue.templates.parent');
       const dataOwner = parentWorkplace.DataOwner;
       const user = {
         name: parentWorkplace.PrimaryUserName,
@@ -53,7 +50,7 @@ const transformParentWorkplaces = async () => {
 
 const findParentWorkplaces = async () => {
   return (await transformParentWorkplaces()).filter((parent) => {
-    return parent.subsidiaries.length || (parent.lastUpdated <= lastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'));
+    return parent.subsidiaries.length || (moment(parent.lastUpdated) <= lastMonth.clone().subtract(6, 'months'));
   });
 };
 

--- a/server/services/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/sendEmail.js
@@ -1,17 +1,23 @@
 const sendInBlueEmail = require('../../../utils/email/sendInBlueEmail');
 
 const sendEmail = async (workplace) => {
+  const params = {
+    WORKPLACE_ID: workplace.nmdsId,
+      FULL_NAME: workplace.user.name,
+  };
+
+  if (workplace.subsidiaries) {
+    params.SUBSIDIARIES = workplace.subsidiaries;
+  };
+
   sendInBlueEmail.sendEmail(
     {
       email: workplace.user.email,
       name: workplace.user.name,
     },
     workplace.emailTemplate.id,
-    {
-      WORKPLACE_ID: workplace.nmdsId,
-      FULL_NAME: workplace.user.name,
-    },
-  );
+    params,
+  )
 };
 
 module.exports = {

--- a/server/services/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/sendEmail.js
@@ -1,4 +1,5 @@
 const sendInBlueEmail = require('../../../utils/email/sendInBlueEmail');
+const config = require('../../../config/config');
 
 const sendEmail = async (workplace) => {
   const params = {
@@ -6,7 +7,7 @@ const sendEmail = async (workplace) => {
       FULL_NAME: workplace.user.name,
   };
 
-  if (workplace.subsidiaries) {
+  if (workplace.emailTemplate.id === config.get('sendInBlue.templates.parent').id) {
     params.SUBSIDIARIES = workplace.subsidiaries;
   };
 

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -144,7 +144,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       });
       sinon.assert.calledWith(sendEmailMock, dummyInactiveWorkplaces[0]);
       sinon.assert.calledWith(sendEmailMock, dummyInactiveWorkplaces[1]);
-      // sinon.assert.calledWith(sendEmailMock, dummyParentWorkplaces[0]);
+      sinon.assert.calledWith(sendEmailMock, dummyParentWorkplaces[0]);
     });
 
     it('should get the email campaign history', async () => {

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -105,6 +105,8 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
   describe('createCampaign', async () => {
     it('should create a campaign', async () => {
       sinon.stub(findInactiveWorkplaces, 'findInactiveWorkplaces').returns(dummyInactiveWorkplaces);
+      sinon.stub(findParentWorkplaces, 'findParentWorkplaces').returns(dummyParentWorkplaces);
+
       const sendEmailMock = sinon.stub(sendEmail, 'sendEmail').returns();
       const userMock = sinon.stub(models.user, 'findByUUID').returns({
         id: 1,
@@ -131,7 +133,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
 
       expect(response).to.deep.equal({
         date: '2021-01-01',
-        emails: 2,
+        emails: 3,
       });
 
       sinon.assert.calledOnce(createEmailCampaignHistoryMock);
@@ -142,6 +144,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
       });
       sinon.assert.calledWith(sendEmailMock, dummyInactiveWorkplaces[0]);
       sinon.assert.calledWith(sendEmailMock, dummyInactiveWorkplaces[1]);
+      // sinon.assert.calledWith(sendEmailMock, dummyParentWorkplaces[0]);
     });
 
     it('should get the email campaign history', async () => {

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/findParentWorkplaces.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/findParentWorkplaces.spec.js
@@ -182,7 +182,6 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/findParentWork
     ]);
 
     const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
-    console.log(parentWorkplaces);
 
     expect(parentWorkplaces).to.deep.equal([
       {

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/findParentWorkplaces.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/findParentWorkplaces.spec.js
@@ -34,7 +34,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/findParentWork
           id: 2,
           name: 'Workplace Name',
           nmdsId: 'A0045232',
-          lastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
+          lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
           dataOwner: 'Parent',
         },
       ],
@@ -60,14 +60,147 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/findParentWork
         ParentID: 1,
         IsParent: false,
         NmdsID: 'A0045232',
-        LastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
+        LastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
         DataOwner: 'Parent',
         PrimaryUserName: 'Test Person',
         PrimaryUserEmail: 'test@example.com',
-      }
+      },
     ]);
     const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
 
     expect(parentWorkplaces).to.deep.equal(dummyParentWorkplaces);
+  });
+
+  it('should only return parent workplaces of subs that haven\'t updated for at least 6 months', async () => {
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 1,
+        NameValue: 'Test Name',
+        ParentID: null,
+        IsParent: true,
+        NmdsID: 'A1234567',
+        LastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Person',
+        PrimaryUserEmail: 'test@example.com',
+      },
+      {
+        EstablishmentID: 2,
+        NameValue: 'Workplace Name',
+        ParentID: 1,
+        IsParent: false,
+        NmdsID: 'A0045232',
+        LastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Parent',
+        PrimaryUserName: 'Test Person',
+        PrimaryUserEmail: 'test@example.com',
+      },
+      {
+        EstablishmentID: 3,
+        NameValue: 'Parent 2 Name',
+        ParentID: null,
+        IsParent: true,
+        NmdsID: 'A0011223',
+        LastUpdated: endOfLastMonth.clone().subtract(3, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test 2 Person',
+        PrimaryUserEmail: 'test2@example.com',
+      },
+      {
+        EstablishmentID: 4,
+        NameValue: 'Workplace 2 Name',
+        ParentID: 3,
+        IsParent: false,
+        NmdsID: 'H0205232',
+        LastUpdated: endOfLastMonth.clone().subtract(3, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Parent',
+        PrimaryUserName: 'Test 2 Person',
+        PrimaryUserEmail: 'test2@example.com',
+      },
+    ]);
+
+    const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
+
+    expect(parentWorkplaces).to.deep.equal(dummyParentWorkplaces);
+  });
+
+  it('should return an empty array when there are no inactive subs', async () => {
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 1,
+        NameValue: 'Parent Name',
+        ParentID: null,
+        IsParent: true,
+        NmdsID: 'A1234567',
+        LastUpdated: endOfLastMonth.clone().subtract(3, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Person',
+        PrimaryUserEmail: 'test@example.com',
+      },
+      {
+        EstablishmentID: 2,
+        NameValue: 'Workplace Name',
+        ParentID: 1,
+        IsParent: false,
+        NmdsID: 'A0045232',
+        LastUpdated: endOfLastMonth.clone().subtract(1, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Parent',
+        PrimaryUserName: 'Test Person',
+        PrimaryUserEmail: 'test@example.com',
+      },
+    ]);
+
+    const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
+
+    expect(parentWorkplaces).to.deep.equal([]);
+  });
+
+  it('should return parent workplaces if they are inactive and their subs aren\'t', async () => {
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 1,
+        NameValue: 'Test Name',
+        ParentID: null,
+        IsParent: true,
+        NmdsID: 'A1234567',
+        LastUpdated: endOfLastMonth.clone().subtract(13, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Person',
+        PrimaryUserEmail: 'test@example.com',
+      },
+      {
+        EstablishmentID: 2,
+        NameValue: 'Workplace Name',
+        ParentID: 1,
+        IsParent: false,
+        NmdsID: 'A0045232',
+        LastUpdated: endOfLastMonth.clone().subtract(1, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Parent',
+        PrimaryUserName: 'Test Person',
+        PrimaryUserEmail: 'test@example.com',
+      },
+    ]);
+
+    const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
+    console.log(parentWorkplaces);
+
+    expect(parentWorkplaces).to.deep.equal([
+      {
+        id: 1,
+        name: 'Test Name',
+        nmdsId: 'A1234567',
+        lastUpdated: endOfLastMonth.clone().subtract(13, 'months').format('YYYY-MM-DD'),
+        emailTemplate: {
+          id: parentTemplateId,
+          name: 'Parent',
+        },
+        dataOwner: 'Workplace',
+        user: {
+          name: 'Test Person',
+          email: 'test@example.com',
+        },
+        subsidiaries: [],
+      },
+    ]);
   });
 });

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -1,7 +1,9 @@
+const expect = require('chai').expect;
+const moment = require('moment');
 const sinon = require('sinon');
+
 const sendEmail = require('../../../../../services/email-campaigns/inactive-workplaces/sendEmail');
 const sendInBlueEmail = require('../../../../../utils/email/sendInBlueEmail');
-const moment = require('moment');
 
 describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', () => {
   afterEach(() => {
@@ -11,80 +13,56 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
   const endOfLastMonth = moment().subtract(1, 'months').endOf('month').endOf('day');
   const parentTemplateId = 15;
 
-  it('should call sendEmails for inactive workplace', async () => {
-    const inactiveWorkplace = {
-      name: 'Workplace Name',
-      nmdsId: 'J1234567',
-      lastUpdated: '2020-06-01',
-      emailTemplate: {
-        id: 13,
-      },
-      dataOwner: 'Workplace',
-      user: {
-        name: 'Test Name',
-        email: 'test@example.com',
-      },
-    };
-
-    const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
-
-    await sendEmail.sendEmail(inactiveWorkplace);
-
-    sinon.assert.calledWith(
-      sendEmailStub,
-      {
-        email: 'test@example.com',
-        name: 'Test Name',
-      },
-      13,
-      {
-        WORKPLACE_ID: 'J1234567',
-        FULL_NAME: 'Test Name',
-      },
-    );
-  });
-
-  it('should call sendEmails for parent workplaces', async () => {
-    const parentWorkplace = {
-      id: 1,
-      name: 'Test Name',
-      nmdsId: 'A1234567',
-      lastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
-      emailTemplate: {
-        id: parentTemplateId,
-        name: 'Parent',
-      },
-      dataOwner: 'Workplace',
-      user: {
-        name: 'Test Person',
-        email: 'test@example.com',
-      },
-      subsidiaries: [
-        {
-          id: 2,
-          name: 'Workplace Name',
-          nmdsId: 'A0045232',
-          lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
-          dataOwner: 'Parent',
+  describe('sendEmail', () => {
+    it('should call sendEmails for inactive workplace', async () => {
+      const inactiveWorkplace = {
+        name: 'Workplace Name',
+        nmdsId: 'J1234567',
+        lastUpdated: '2020-06-01',
+        emailTemplate: {
+          id: 13,
         },
-      ],
-    };
+        dataOwner: 'Workplace',
+        user: {
+          name: 'Test Name',
+          email: 'test@example.com',
+        },
+      };
 
-    const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
+      const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
 
-    await sendEmail.sendEmail(parentWorkplace);
+      await sendEmail.sendEmail(inactiveWorkplace);
 
-    sinon.assert.calledWith(
-      sendEmailStub,
-      {
-        email: 'test@example.com',
-        name: 'Test Person',
-      },
-      15,
-      {
-        WORKPLACE_ID: 'A1234567',
-        FULL_NAME: 'Test Person',
-        SUBSIDIARIES: [
+      sinon.assert.calledWith(
+        sendEmailStub,
+        {
+          email: 'test@example.com',
+          name: 'Test Name',
+        },
+        13,
+        {
+          WORKPLACE_ID: 'J1234567',
+          FULL_NAME: 'Test Name',
+        },
+      );
+    });
+
+    it('should call sendEmails for parent workplaces', async () => {
+      const parentWorkplace = {
+        id: 1,
+        name: 'Test Name',
+        nmdsId: 'A1234567',
+        lastUpdated: endOfLastMonth.clone().subtract(3, 'months').format('YYYY-MM-DD'),
+        emailTemplate: {
+          id: parentTemplateId,
+          name: 'Parent',
+        },
+        dataOwner: 'Workplace',
+        user: {
+          name: 'Test Person',
+          email: 'test@example.com',
+        },
+        subsidiaries: [
           {
             id: 2,
             name: 'Workplace Name',
@@ -93,7 +71,148 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
             dataOwner: 'Parent',
           },
         ],
-      },
-    );
+      };
+
+      const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
+
+      await sendEmail.sendEmail(parentWorkplace);
+
+      sinon.assert.calledWith(
+        sendEmailStub,
+        {
+          email: 'test@example.com',
+          name: 'Test Person',
+        },
+        15,
+        {
+          WORKPLACE_ID: 'A1234567',
+          FULL_NAME: 'Test Person',
+          WORKPLACES: [
+            {
+              id: 2,
+              name: 'Workplace Name',
+              nmdsId: 'A0045232',
+              lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+              dataOwner: 'Parent',
+            },
+          ],
+        },
+      );
+    });
+  });
+
+  describe('getParams', () => {
+    it('returns the right params for single workplaces', () => {
+      const inactiveWorkplace = {
+        name: 'Workplace Name',
+        nmdsId: 'J1234567',
+        lastUpdated: '2020-06-01',
+        emailTemplate: {
+          id: 13,
+        },
+        dataOwner: 'Workplace',
+        user: {
+          name: 'Test Name',
+          email: 'test@example.com',
+        },
+      };
+
+      const params = sendEmail.getParams(inactiveWorkplace);
+      expect(params).to.deep.equal({
+        WORKPLACE_ID: 'J1234567',
+        FULL_NAME: 'Test Name',
+      });
+    });
+
+    it('returns the right params for parent workplaces', () => {
+      const parentWorkplace = {
+        id: 1,
+        name: 'Test Name',
+        nmdsId: 'A1234567',
+        lastUpdated: endOfLastMonth.clone().subtract(3, 'months').format('YYYY-MM-DD'),
+        emailTemplate: {
+          id: parentTemplateId,
+          name: 'Parent',
+        },
+        dataOwner: 'Workplace',
+        user: {
+          name: 'Test Person',
+          email: 'test@example.com',
+        },
+        subsidiaries: [
+          {
+            id: 2,
+            name: 'Workplace Name',
+            nmdsId: 'A0045232',
+            lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+            dataOwner: 'Parent',
+          },
+        ],
+      };
+
+      const params = sendEmail.getParams(parentWorkplace);
+      expect(params).to.deep.equal({
+        WORKPLACE_ID: 'A1234567',
+        FULL_NAME: 'Test Person',
+        WORKPLACES: [
+          {
+            id: 2,
+            name: 'Workplace Name',
+            nmdsId: 'A0045232',
+            lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+            dataOwner: 'Parent',
+          },
+        ],
+      });
+    });
+
+    it('includes parent workplace in the WORKPLACES param if the parent is out of date', () => {
+      const parentWorkplace = {
+        id: 1,
+        name: 'Test Name',
+        nmdsId: 'A1234567',
+        lastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
+        emailTemplate: {
+          id: parentTemplateId,
+          name: 'Parent',
+        },
+        dataOwner: 'Workplace',
+        user: {
+          name: 'Test Person',
+          email: 'test@example.com',
+        },
+        subsidiaries: [
+          {
+            id: 2,
+            name: 'Workplace Name',
+            nmdsId: 'A0045232',
+            lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+            dataOwner: 'Parent',
+          },
+        ],
+      };
+
+      const params = sendEmail.getParams(parentWorkplace);
+      expect(params).to.deep.equal({
+        WORKPLACE_ID: 'A1234567',
+        FULL_NAME: 'Test Person',
+        WORKPLACES: [
+          {
+            id: 1,
+            name: 'Test Name',
+            nmdsId: 'A1234567',
+            lastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
+            dataOwner: 'Workplace',
+          },
+          {
+            id: 2,
+            name: 'Workplace Name',
+            nmdsId: 'A0045232',
+            lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+            dataOwner: 'Parent',
+          },
+        ],
+      });
+    });
   });
 });

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -1,11 +1,15 @@
 const sinon = require('sinon');
 const sendEmail = require('../../../../../services/email-campaigns/inactive-workplaces/sendEmail');
 const sendInBlueEmail = require('../../../../../utils/email/sendInBlueEmail');
+const moment = require('moment');
 
 describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', () => {
   afterEach(() => {
     sinon.restore();
   });
+
+  const endOfLastMonth = moment().subtract(1, 'months').endOf('month').endOf('day');
+  const parentTemplateId = 15;
 
   it('should call sendEmails for inactive workplace', async () => {
     const inactiveWorkplace = {
@@ -36,6 +40,59 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
       {
         WORKPLACE_ID: 'J1234567',
         FULL_NAME: 'Test Name',
+      },
+    );
+  });
+
+  it('should call sendEmails for parent workplaces', async () => {
+    const parentWorkplace = {
+      id: 1,
+      name: 'Test Name',
+      nmdsId: 'A1234567',
+      lastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
+      emailTemplate: {
+        id: parentTemplateId,
+        name: 'Parent',
+      },
+      dataOwner: 'Workplace',
+      user: {
+        name: 'Test Person',
+        email: 'test@example.com',
+      },
+      subsidiaries: [
+        {
+          id: 2,
+          name: 'Workplace Name',
+          nmdsId: 'A0045232',
+          lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+          dataOwner: 'Parent',
+        },
+      ],
+    };
+
+    const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
+
+    await sendEmail.sendEmail(parentWorkplace);
+
+    sinon.assert.calledWith(
+      sendEmailStub,
+      {
+        email: 'test@example.com',
+        name: 'Test Person',
+      },
+      15,
+      {
+        WORKPLACE_ID: 'A1234567',
+        FULL_NAME: 'Test Person',
+        SUBSIDIARIES: [
+          {
+            id: 2,
+            name: 'Workplace Name',
+            nmdsId: 'A0045232',
+            lastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+            dataOwner: 'Parent',
+          },
+        ],
       },
     );
   });

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -38,7 +38,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <tr class="govuk-table__row" *ngFor="let row of history.slice().reverse()">
+      <tr class="govuk-table__row" *ngFor="let row of history">
         <td class="govuk-table__cell">{{ row.date | date: 'dd/MM/yyyy' }}</td>
         <td class="govuk-table__cell">{{ row.emails | number }}</td>
       </tr>

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -38,7 +38,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <tr class="govuk-table__row" *ngFor="let row of history">
+      <tr class="govuk-table__row" *ngFor="let row of history.slice().reverse()">
         <td class="govuk-table__cell">{{ row.date | date: 'dd/MM/yyyy' }}</td>
         <td class="govuk-table__cell">{{ row.emails | number }}</td>
       </tr>


### PR DESCRIPTION
#### Changes
- Add parent template to config
- Update endpoints and `sendEmail` function to send email to both inactive and parent workplaces
- Filter out parent workplaces/subsidiaries that have updated in the last 6 months
- Add tests
- Reverse history table so that the newest campaign is shown first

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
