### PR TITLE
Fix: use TRIM to remove whitespace from either side of Workplace ID

### DIFF
--- a/server/models/email-campaigns/inactive-workplaces/getInactiveWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/getInactiveWorkplaces.js
@@ -17,7 +17,7 @@ const getInactiveWorkplaces = async () => {
   SELECT
 	"EstablishmentID",
   "NameValue",
-  "NmdsID",
+  TRIM("NmdsID"),
   "DataOwner",
   "PrimaryUserName",
   "PrimaryUserEmail",


### PR DESCRIPTION
**Issue**

The Workplace ID in the Inactive Workplace report has spaces in it, which makes it hard to cross reference with other reports (like the deletion report etc)

**Work done**

- Removed spaces from either side of the Workplace ID by using `TRIM`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
