### PR TITLE
Fix: 24 months plus inactive

### DIFF
--- a/server/services/email-campaigns/inactive-workplaces/nextEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/nextEmail.js
@@ -7,18 +7,30 @@ const templates = {
   sixMonths: {
     lastUpdated: lastMonth.clone().subtract(6, 'months'),
     template: config.get('sendInBlue.templates.sixMonthsInactive'),
+    matches: function (lastUpdated) {
+      return lastUpdated.isSame(this.lastUpdated, 'month');
+    },
   },
   twelveMonths: {
     lastUpdated: lastMonth.clone().subtract(12, 'months'),
     template: config.get('sendInBlue.templates.twelveMonthsInactive'),
+    matches: function (lastUpdated) {
+      return lastUpdated.isSame(this.lastUpdated, 'month');
+    },
   },
   eighteenMonths: {
     lastUpdated: lastMonth.clone().subtract(18, 'months'),
     template: config.get('sendInBlue.templates.eighteenMonthsInactive'),
+    matches: function (lastUpdated) {
+      return lastUpdated.isSame(this.lastUpdated, 'month');
+    },
   },
   twentyFourMonths: {
     lastUpdated: lastMonth.clone().subtract(24, 'months'),
     template: config.get('sendInBlue.templates.twentyFourMonthsInactive'),
+    matches: function (lastUpdated) {
+      return this.lastUpdated.isSameOrAfter(lastUpdated, 'month');
+    },
   },
 };
 
@@ -29,7 +41,7 @@ const getTemplate = (inactiveWorkplace) => {
     const nextTemplate = month.template;
     const notReceivedTemplate = inactiveWorkplace.LastTemplate !== nextTemplate.id;
 
-    if (lastUpdated.isSame(month.lastUpdated, 'month') && notReceivedTemplate) {
+    if (month.matches(lastUpdated) && notReceivedTemplate) {
       return nextTemplate;
     }
   }

--- a/server/services/email-campaigns/inactive-workplaces/nextEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/nextEmail.js
@@ -29,7 +29,7 @@ const templates = {
     lastUpdated: lastMonth.clone().subtract(24, 'months'),
     template: config.get('sendInBlue.templates.twentyFourMonthsInactive'),
     matches: function (lastUpdated) {
-      return this.lastUpdated.isSameOrAfter(lastUpdated, 'month');
+      return lastUpdated.isSameOrBefore(this.lastUpdated, 'month');
     },
   },
 };

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
@@ -36,6 +36,11 @@ describe('nextEmailTemplate', () => {
       LastUpdated: endOfLastMonth.clone().subtract(24, 'months'),
       NextTemplate: twentyFourMonthTemplateId,
     },
+    {
+      inactiveMonths: 25,
+      LastUpdated: endOfLastMonth.clone().subtract(25, 'months'),
+      NextTemplate: twentyFourMonthTemplateId,
+    },
   ].forEach(({ inactiveMonths, LastUpdated, NextTemplate }) => {
     it(`should return the correct template when ${inactiveMonths} months inactive`, async () => {
       const inactiveWorkplace = {
@@ -74,12 +79,6 @@ describe('nextEmailTemplate', () => {
       LastTemplate: eighteenMonthTemplateId,
       NextTemplate: twentyFourMonthTemplateId,
     },
-    {
-      inactiveMonths: 25,
-      LastUpdated: endOfLastMonth.clone().subtract(25, 'months'),
-      LastTemplate: twentyFourMonthTemplateId,
-      NextTemplate: null,
-    },
   ].forEach(({ inactiveMonths, LastUpdated, LastTemplate, NextTemplate }) => {
     it(`should return the next template when ${inactiveMonths} months inactive`, async () => {
       const inactiveWorkplace = {
@@ -94,6 +93,9 @@ describe('nextEmailTemplate', () => {
       };
 
       const emailTemplate = nextEmail.getTemplate(inactiveWorkplace);
+
+      console.log({ emailTemplate });
+      console.log({ NextTemplate });
 
       expect(emailTemplate ? emailTemplate.id : emailTemplate).to.equal(NextTemplate);
     });
@@ -161,12 +163,6 @@ describe('nextEmailTemplate', () => {
     {
       inactiveMonths: 20,
       LastUpdated: endOfLastMonth.clone().subtract(20, 'months'),
-      LastTemplate: null,
-      NextTemplate: null,
-    },
-    {
-      inactiveMonths: 26,
-      LastUpdated: endOfLastMonth.clone().subtract(26, 'months'),
       LastTemplate: null,
       NextTemplate: null,
     },

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/nextEmail.spec.js
@@ -94,9 +94,6 @@ describe('nextEmailTemplate', () => {
 
       const emailTemplate = nextEmail.getTemplate(inactiveWorkplace);
 
-      console.log({ emailTemplate });
-      console.log({ NextTemplate });
-
       expect(emailTemplate ? emailTemplate.id : emailTemplate).to.equal(NextTemplate);
     });
   });


### PR DESCRIPTION
**Issue**

- If a workplace had been more than 24 months inactive, they were not being included in the report.

**Work done**

- Added a `matches` function to each of the templates
- Refactored `getTemplate` to use `matches` function
- 
#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
