### PR TITLE
Fix: Subsidiaries undefined error

### DIFF
--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -8,12 +8,16 @@ const findParentWorkplaces = require('../../../../services/email-campaigns/inact
 const sendEmail = require('../../../../services/email-campaigns/inactive-workplaces/sendEmail');
 
 const getInactiveWorkplaces = async (_req, res) => {
-  const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
-  const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
+  try {
+    const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
+    const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
 
-  return res.json({
-    inactiveWorkplaces: inactiveWorkplaces.length + parentWorkplaces.length,
-  });
+    return res.json({
+      inactiveWorkplaces: inactiveWorkplaces.length + parentWorkplaces.length,
+    });
+  } catch (err) {
+    return res.status(503).json({});
+  }
 };
 
 const createCampaign = async (req, res) => {
@@ -29,7 +33,7 @@ const createCampaign = async (req, res) => {
     const inactiveWorkplaces = await findInactiveWorkplaces.findInactiveWorkplaces();
     const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
 
-    const totalInactiveWorkplaces = inactiveWorkplaces.concat(parentWorkplaces)
+    const totalInactiveWorkplaces = inactiveWorkplaces.concat(parentWorkplaces);
     const history = totalInactiveWorkplaces.map((workplace) => {
       return {
         emailCampaignID: emailCampaign.id,

--- a/server/services/email-campaigns/inactive-workplaces/findParentWorkplaces.js
+++ b/server/services/email-campaigns/inactive-workplaces/findParentWorkplaces.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+
 const config = require('../../../config/config');
 const { getParentWorkplaces } = require('../../../models/email-campaigns/inactive-workplaces/getParentWorkplaces');
 
@@ -15,7 +16,8 @@ const buildWorkplaces = (workplaces) => {
       return acc;
     }
 
-    const subsidiaries = (acc[workplace.ParentID].subsidiaries || (acc[workplace.ParentID].subsidiaries = []));
+    const parent = acc[workplace.ParentID] || (acc[workplace.ParentID] = {});
+    const subsidiaries = parent.subsidiaries || (parent.subsidiaries = []);
 
     if (moment(workplace.LastUpdated) <= lastMonth.clone().subtract(6, 'months')) {
       subsidiaries.push(workplace);

--- a/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/inactive-workplaces/index.spec.js
@@ -84,22 +84,44 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces', () => {
     },
   ];
 
-  it('should get the number of inactive workplaces', async () => {
-    sinon.stub(findInactiveWorkplaces, 'findInactiveWorkplaces').returns(dummyInactiveWorkplaces);
-    sinon.stub(findParentWorkplaces, 'findParentWorkplaces').returns(dummyParentWorkplaces);
+  describe('getInactiveWorkplaces', () => {
+    it('should get the number of inactive workplaces', async () => {
+      sinon.stub(findInactiveWorkplaces, 'findInactiveWorkplaces').returns(dummyInactiveWorkplaces);
+      sinon.stub(findParentWorkplaces, 'findParentWorkplaces').returns(dummyParentWorkplaces);
 
-    const req = httpMocks.createRequest({
-      method: 'GET',
-      url: '/api/admin/email-campaigns/inactive-workplaces',
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: '/api/admin/email-campaigns/inactive-workplaces',
+      });
+
+      req.role = 'Admin';
+
+      const res = httpMocks.createResponse();
+      await inactiveWorkplaceRoutes.getInactiveWorkplaces(req, res);
+      const response = res._getJSONData();
+
+      expect(response.inactiveWorkplaces).to.deep.equal(3);
     });
 
-    req.role = 'Admin';
+    it('should return an error if inactive workplaces throws an exception', async () => {
+      sinon.stub(findInactiveWorkplaces, 'findInactiveWorkplaces').rejects();
+      sinon.stub(findParentWorkplaces, 'findParentWorkplaces').rejects();
 
-    const res = httpMocks.createResponse();
-    await inactiveWorkplaceRoutes.getInactiveWorkplaces(req, res);
-    const response = res._getJSONData();
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: '/api/admin/email-campaigns/inactive-workplaces',
+      });
 
-    expect(response.inactiveWorkplaces).to.deep.equal(3);
+      req.role = 'Admin';
+
+      const res = httpMocks.createResponse();
+      await inactiveWorkplaceRoutes.getInactiveWorkplaces(req, res);
+
+      const response = res._getJSONData();
+
+      expect(res.statusCode).to.equal(503);
+      expect(response).to.deep.equal({});
+    });
   });
 
   describe('createCampaign', async () => {

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/findParentWorkplaces.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/findParentWorkplaces.spec.js
@@ -6,7 +6,6 @@ const models = require('../../../../../models');
 const findParentWorkplaces = require('../../../../../services/email-campaigns/inactive-workplaces/findParentWorkplaces');
 
 describe('server/routes/admin/email-campaigns/inactive-workplaces/findParentWorkplaces', () => {
-
   afterEach(() => {
     sinon.restore();
   });
@@ -71,7 +70,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/findParentWork
     expect(parentWorkplaces).to.deep.equal(dummyParentWorkplaces);
   });
 
-  it('should only return parent workplaces of subs that haven\'t updated for at least 6 months', async () => {
+  it("should only return parent workplaces of subs that haven't updated for at least 6 months", async () => {
     sinon.stub(models.sequelize, 'query').returns([
       {
         EstablishmentID: 1,
@@ -155,7 +154,7 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/findParentWork
     expect(parentWorkplaces).to.deep.equal([]);
   });
 
-  it('should return parent workplaces if they are inactive and their subs aren\'t', async () => {
+  it("should return parent workplaces if they are inactive and their subs aren't", async () => {
     sinon.stub(models.sequelize, 'query').returns([
       {
         EstablishmentID: 1,
@@ -201,5 +200,35 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/findParentWork
         subsidiaries: [],
       },
     ]);
+  });
+
+  it("should group subs when the parent isn't the first workplace in the list", async () => {
+    sinon.stub(models.sequelize, 'query').returns([
+      {
+        EstablishmentID: 2,
+        NameValue: 'Workplace Name',
+        ParentID: 1,
+        IsParent: false,
+        NmdsID: 'A0045232',
+        LastUpdated: endOfLastMonth.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Parent',
+        PrimaryUserName: 'Test Person',
+        PrimaryUserEmail: 'test@example.com',
+      },
+      {
+        EstablishmentID: 1,
+        NameValue: 'Test Name',
+        ParentID: null,
+        IsParent: true,
+        NmdsID: 'A1234567',
+        LastUpdated: endOfLastMonth.clone().subtract(6, 'months').format('YYYY-MM-DD'),
+        DataOwner: 'Workplace',
+        PrimaryUserName: 'Test Person',
+        PrimaryUserEmail: 'test@example.com',
+      },
+    ]);
+
+    const parentWorkplaces = await findParentWorkplaces.findParentWorkplaces();
+    expect(parentWorkplaces).to.deep.equal(dummyParentWorkplaces);
   });
 });


### PR DESCRIPTION
**Issue**

When the query from the database returns a subsidiary and then a parent, the server returns `Cannot read property 'subsidiaries' of undefined` because we are trying to add it to the parent object in the array which doesn't exist yet.

The reason Back to admin didn't work is because the endpoint wasn't using `try/catch` and so it just hung around waiting for a response.

**Work done**

- Updated `buildWorkplaces ` to use `||` in order to set the object before accessing it.
- Updated `api/admin/email-campaigns/inactive-workplaces` endpoint to use `try/catch` so that the request returns a 503 when a promise is rejected

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
