### PR TITLE
Fix: Remove email template column from subsidiaries

### DIFF
--- a/server/reports/inactive-workplaces/subsidiaries.js
+++ b/server/reports/inactive-workplaces/subsidiaries.js
@@ -21,7 +21,6 @@ const addWorksheet = (workbook) => {
     { header: 'Workplace name', key: 'workplace' },
     { header: 'Workplace ID', key: 'workplaceId' },
     { header: 'Date last updated', key: 'lastUpdated' },
-    { header: 'Email template', key: 'emailTemplate' },
     { header: 'Data owner', key: 'dataOwner' },
   ];
 


### PR DESCRIPTION
**Issue**

We don't need the email template column for the subsidiaries worksheet as they'll be included in the parent email

**Work done**

- Removed email template column from subsidiaries worksheet

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
