### PR TITLE
Accessibility audit: Fix shade of orange banners

### DIFF
--- a/src/assets/scss/components/_summary-list.scss
+++ b/src/assets/scss/components/_summary-list.scss
@@ -74,7 +74,7 @@
   .govuk-summary-list__row--warning {
     dt,
     dd {
-      background: rgba(govuk-colour('orange'), 0.15);
+      background: rgba(govuk-colour('orange'), 0.12);
     }
     @include govuk-media-query($from: desktop) {
       .govuk-summary-list__value {
@@ -106,7 +106,7 @@
 }
 
 .asc-warning-banner {
-  background-color: rgba(govuk-colour('orange'), 0.25);
+  background-color: rgba(govuk-colour('orange'), 0.12);
 
   @include govuk-media-query($from: desktop) {
     .govuk-summary-list__value {


### PR DESCRIPTION
Fix the shade of a couple of the orange warning banners that were missed

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
