### PR TITLE
Fix/second user banner

### DIFF
--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -86,8 +86,11 @@
         <app-benchmarks-tab class="asc-benchmarks-tab" [workplace]="workplace"></app-benchmarks-tab>
       </app-tab>
 
-      <app-tab *ngIf="workplace && canViewListOfUsers" [title]="'Users'" [alert]="showUsersTabFlag">
-        <app-user-accounts-summary [workplace]="workplace"></app-user-accounts-summary>
+      <app-tab *ngIf="workplace && canViewListOfUsers" [title]="'Users'" [alert]="showSecondUserBanner">
+        <app-user-accounts-summary
+          [workplace]="workplace"
+          [showSecondUserBanner]="showSecondUserBanner"
+        ></app-user-accounts-summary>
       </app-tab>
     </app-tabs>
   </div>

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -31,7 +31,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   public subsidiaryCount: number;
   public canViewBenchmarks: boolean;
   public workplaceUid: string | null;
-  public showUsersTabFlag: boolean;
+  public showSecondUserBanner: boolean;
   public canAddUser: boolean;
 
   constructor(
@@ -98,7 +98,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       );
       this.subscriptions.add(
         this.userService.getAllUsersForEstablishment(this.workplaceUid).subscribe((users) => {
-          this.showUsersTabFlag = this.canAddUser && users.length === 1;
+          this.showSecondUserBanner = this.canAddUser && users.length === 1;
         }),
       );
     }

--- a/src/app/features/workplace/view-workplace/view-workplace.component.html
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.html
@@ -44,8 +44,8 @@
       <app-tab *ngIf="canViewBenchmarks" [title]="'Benchmarks'">
         <app-benchmarks-tab class="asc-benchmarks-tab" [workplace]="workplace"></app-benchmarks-tab>
       </app-tab>
-      <app-tab *ngIf="canViewListOfUsers" [title]="'Users'">
-        <app-user-accounts-summary [workplace]="workplace"></app-user-accounts-summary>
+      <app-tab *ngIf="canViewListOfUsers" [title]="'Users'" [alert]="false">
+        <app-user-accounts-summary [workplace]="workplace" [showSecondUserBanner]="false"></app-user-accounts-summary>
       </app-tab>
     </app-tabs>
   </div>

--- a/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.html
+++ b/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.html
@@ -3,15 +3,11 @@
     <h2 class="govuk-heading-m">Users ({{ users.length }})</h2>
     <div *ngIf="canAddUser && users.length === 1">
       <app-inset-text [color]="'todo'">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <h3 class="govuk-heading-s">You should add a second user</h3>
-            <p>
-              Adding a second user will give Skills for Care another person to contact at your workplace should you be
-              unavailable.
-            </p>
-          </div>
-        </div>
+        <h3 class="govuk-heading-s">You should add a second user</h3>
+        <p>
+          Adding a second user will give Skills for Care another person to contact at your workplace should you be
+          unavailable.
+        </p>
       </app-inset-text>
     </div>
   </div>

--- a/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.html
+++ b/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.html
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Users ({{ users.length }})</h2>
-    <div *ngIf="canAddUser && users.length === 1">
+    <div *ngIf="showSecondUserBanner">
       <app-inset-text [color]="'todo'">
         <h3 class="govuk-heading-s">You should add a second user</h3>
         <p>

--- a/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.spec.ts
+++ b/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.spec.ts
@@ -20,11 +20,11 @@ import { render } from '@testing-library/angular';
 import { Establishment } from '../../../../mockdata/establishment';
 
 describe('UserAccountsSummaryComponent', () => {
-  const setup = async (isAdmin = true, subsidiaries = 0) => {
+  const setup = async (showBanner = false, isAdmin = true, subsidiaries = 0) => {
     const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(UserAccountsSummaryComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [],
-      componentProperties: { workplace: Establishment },
+      componentProperties: { workplace: Establishment, showSecondUserBanner: showBanner },
       providers: [
         {
           provide: WindowRef,
@@ -85,38 +85,18 @@ describe('UserAccountsSummaryComponent', () => {
     expect(component.canAddUser).toBeFalsy();
   });
 
-  it("should show add user banner if there's only 1 user for the workplace", async () => {
-    const { component, fixture, queryByText } = await setup();
+  it('should show add user banner if showSecondUserBanner is true', async () => {
+    const { component, fixture, queryByText } = await setup(true);
     const addUserText =
       'Adding a second user will give Skills for Care another person to contact at your workplace should you be unavailable.';
-
-    component.workplace.uid = '4698f4a4-ab82-4906-8b0e-3f4972375927';
-    component.ngOnInit();
-    fixture.detectChanges();
 
     expect(queryByText(addUserText, { exact: false })).toBeTruthy();
   });
 
-  it("should not show add user banner if there's more than 1 user for the workplace", async () => {
-    const { component, fixture, queryByText } = await setup();
+  it('should not show add user banner if showSecondUserBanner is false', async () => {
+    const { component, fixture, queryByText } = await setup(false);
     const addUserText =
       'Adding a second user will give Skills for Care another person to contact at your workplace should you be unavailable.';
-
-    component.workplace.uid = 'overLimit';
-    component.ngOnInit();
-    fixture.detectChanges();
-
-    expect(queryByText(addUserText, { exact: false })).toBeFalsy();
-  });
-
-  it("should not show add user banner if there's 1 user which can't add users for the workplace", async () => {
-    const { component, fixture, queryByText } = await setup();
-    const addUserText =
-      'Adding a second user will give Skills for Care another person to contact at your workplace should you be unavailable.';
-
-    component.workplace.uid = '4698f4a4-ab82-4906-8b0e-3f4972375927';
-    component.canAddUser = false;
-    fixture.detectChanges();
 
     expect(queryByText(addUserText, { exact: false })).toBeFalsy();
   });

--- a/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.spec.ts
+++ b/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.spec.ts
@@ -86,7 +86,7 @@ describe('UserAccountsSummaryComponent', () => {
   });
 
   it('should show add user banner if showSecondUserBanner is true', async () => {
-    const { component, fixture, queryByText } = await setup(true);
+    const { queryByText } = await setup(true);
     const addUserText =
       'Adding a second user will give Skills for Care another person to contact at your workplace should you be unavailable.';
 
@@ -94,7 +94,7 @@ describe('UserAccountsSummaryComponent', () => {
   });
 
   it('should not show add user banner if showSecondUserBanner is false', async () => {
-    const { component, fixture, queryByText } = await setup(false);
+    const { queryByText } = await setup(false);
     const addUserText =
       'Adding a second user will give Skills for Care another person to contact at your workplace should you be unavailable.';
 

--- a/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.ts
+++ b/src/app/shared/components/user-accounts-summary/user-accounts-summary.component.ts
@@ -13,6 +13,7 @@ import { Subscription } from 'rxjs';
 })
 export class UserAccountsSummaryComponent implements OnInit, OnDestroy {
   @Input() workplace: Establishment;
+  @Input() showSecondUserBanner: boolean;
 
   private subscriptions: Subscription = new Subscription();
   public users: Array<UserDetails> = [];


### PR DESCRIPTION
#### Changes 
- Change spacing on add second user banner
- Move logic for rendering banner out of user accounts summary component(into dashboard/view-workplace component)
- Set banner as false in view-workplace component as parent workplace should never see banner when viewing child workplaces

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
