### PR TITLE
Fix: KWA Subsidiaries primary user being set to parent who may not own the data

### DIFF
--- a/migrations/20210422101858-update_last_updated_establishments_view.js
+++ b/migrations/20210422101858-update_last_updated_establishments_view.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query('DROP MATERIALIZED VIEW cqc."LastUpdatedEstablishments"');
+    await queryInterface.sequelize.query('DROP MATERIALIZED VIEW IF EXISTS cqc."LastUpdatedEstablishments"');
 
     await queryInterface.sequelize.query(`
       CREATE MATERIALIZED VIEW cqc."LastUpdatedEstablishments" AS (
@@ -36,6 +36,22 @@ module.exports = {
     },
     {
       fields: ['ParentID', 'IsParent', 'LastUpdated'],
+    });
+
+    await queryInterface.addIndex({
+      tableName: 'LastUpdatedEstablishments',
+      schema: 'cqc',
+    },
+    {
+      fields: ['IsParent', 'PrimaryUserEmail'],
+    });
+
+    await queryInterface.addIndex({
+      tableName: 'LastUpdatedEstablishments',
+      schema: 'cqc',
+    },
+    {
+      fields: ['IsParent', 'PrimaryUserEmail', 'LastUpdated', 'DataOwner'],
     });
   },
 

--- a/migrations/20210422101858-update_last_updated_establishments_view.js
+++ b/migrations/20210422101858-update_last_updated_establishments_view.js
@@ -1,0 +1,45 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query('DROP MATERIALIZED VIEW cqc."LastUpdatedEstablishments"');
+
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW cqc."LastUpdatedEstablishments" AS (
+        SELECT e."EstablishmentID",
+           e."NameValue",
+           e."ParentID",
+           e."IsParent",
+           e."NmdsID",
+           e."DataOwner",
+           ( SELECT u."FullNameValue"
+                  FROM cqc."User" u
+                 WHERE u."IsPrimary" = true AND (e."EstablishmentID" = u."EstablishmentID") AND u."Archived" = false
+                LIMIT 1) AS "PrimaryUserName",
+           ( SELECT u."EmailValue"
+                  FROM cqc."User" u
+                 WHERE u."IsPrimary" = true AND (e."EstablishmentID" = u."EstablishmentID") AND u."Archived" = false
+                LIMIT 1) AS "PrimaryUserEmail",
+           GREATEST(e.updated, ( SELECT w.updated
+                  FROM cqc."Worker" w
+                 WHERE w."EstablishmentFK" = e."EstablishmentID" AND w."Archived" = false
+                 ORDER BY w.updated DESC
+                LIMIT 1)) AS "LastUpdated"
+          FROM cqc."Establishment" e
+          WHERE e."Archived" = false
+       );
+    `);
+
+    await queryInterface.addIndex({
+      tableName: 'LastUpdatedEstablishments',
+      schema: 'cqc',
+    },
+    {
+      fields: ['ParentID', 'IsParent', 'LastUpdated'],
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.query('DROP MATERIALIZED VIEW "cqc"."LastUpdatedEstablishments"');
+  }
+};

--- a/server/models/email-campaigns/inactive-workplaces/getInactiveWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/getInactiveWorkplaces.js
@@ -40,6 +40,7 @@ const getInactiveWorkplaces = async () => {
       "IsParent" = FALSE
       AND "DataOwner" = 'Workplace'
 			AND "LastUpdated" <= :lastUpdated
+      AND "PrimaryUserEmail" IS NOT NULL
 			AND NOT EXISTS (
 				SELECT
 					ech. "establishmentID"

--- a/server/models/email-campaigns/inactive-workplaces/getParentWorkplaces.js
+++ b/server/models/email-campaigns/inactive-workplaces/getParentWorkplaces.js
@@ -21,6 +21,7 @@ const getParentWorkplaces = async () => {
     cqc. "LastUpdatedEstablishments" e
   WHERE
     "IsParent" = TRUE
+    AND "PrimaryUserEmail" IS NOT NULL
     AND NOT EXISTS (
       SELECT
         ech. "establishmentID"


### PR DESCRIPTION
**Issue**

The query to calculate the primary user was looking to the parent workplace if the subsidiary did not have a primary user.

This meant that we had a situation where parents would be emailed when a subsidiary owns their data but do not have a primary user

**Work done**

- Fixed `LastUpdatedEstablishments` view to not use the parent workplace primary user when there is no primary user for a subsidiary
- Updated queries to filter out workplaces where the primary user is empty 

**Note**

The reason we are filtering out empty primary users in our `SELECT` query is because the deletion report also uses the  `LastUpdatedEstablishments` view.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
