### PR TITLE
Feat: WDF Staff Summary - meeting with changes

### DIFF
--- a/src/app/core/model/wdf.model.ts
+++ b/src/app/core/model/wdf.model.ts
@@ -14,3 +14,9 @@ export interface WDFValue {
   isEligible: Eligibility;
   updatedSinceEffectiveDate: boolean;
 }
+
+export interface WdfEligibilityStatus {
+  overall?: boolean;
+  currentStaff?: boolean;
+  currentWorkplace?: boolean;
+}

--- a/src/app/features/wdf/wdf-data/wdf-data.component.html
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.html
@@ -8,7 +8,12 @@
 </div>
 
 <h4 class="govuk-heading-s govuk-!-margin-bottom-8">
-  Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
+  <ng-container *ngIf="overallWdfEligibility && !(workplaceWdfEligibility && staffWdfEligibility)">
+    Keeping your data up to date will save you time next year
+  </ng-container>
+  <ng-container *ngIf="overallWdfEligibility && workplaceWdfEligibility && staffWdfEligibility">
+    Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
+  </ng-container>
 </h4>
 
 <app-tabs>

--- a/src/app/features/wdf/wdf-data/wdf-data.component.html
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.html
@@ -12,11 +12,7 @@
 </h4>
 
 <app-tabs>
-  <app-tab
-    [greenTick]="overallWdfEligibility && workplaceWdfEligibility"
-    [alert]="overallWdfEligibility && !workplaceWdfEligibility"
-    [title]="'Workplace'"
-  >
+  <app-tab [greenTick]="showGreenTickOnWorkplaceTab()" [alert]="showOrangeFlagOnWorkplaceTab()" [title]="'Workplace'">
     <app-workplace-summary
       *ngIf="workplace"
       [workplace]="workplace"
@@ -27,8 +23,8 @@
   </app-tab>
   <app-tab
     *ngIf="canViewWorker"
-    [greenTick]="overallWdfEligibility && staffWdfEligibility"
-    [alert]="overallWdfEligibility && !staffWdfEligibility"
+    [greenTick]="showGreenTickOnStaffTab()"
+    [alert]="showOrangeFlagOnStaffTab()"
     [title]="'Staff records'"
   >
     <app-wdf-staff-summary

--- a/src/app/features/wdf/wdf-data/wdf-data.component.html
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.html
@@ -7,14 +7,13 @@
   </div>
 </div>
 
-<h4 class="govuk-heading-s govuk-!-margin-bottom-8">
-  <ng-container *ngIf="overallWdfEligibility && !(workplaceWdfEligibility && staffWdfEligibility)">
-    Keeping your data up to date will save you time next year
-  </ng-container>
-  <ng-container *ngIf="overallWdfEligibility && workplaceWdfEligibility && staffWdfEligibility">
-    Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
-  </ng-container>
-</h4>
+<app-wdf-status-message
+  [wdfStartDate]="wdfStartDate"
+  [wdfEndDate]="wdfEndDate"
+  [overallWdfEligibility]="overallWdfEligibility"
+  [staffWdfEligibility]="staffWdfEligibility"
+  [workplaceWdfEligibility]="workplaceWdfEligibility"
+></app-wdf-status-message>
 
 <app-tabs>
   <app-tab [greenTick]="showGreenTickOnWorkplaceTab()" [alert]="showOrangeFlagOnWorkplaceTab()" [title]="'Workplace'">

--- a/src/app/features/wdf/wdf-data/wdf-data.component.html
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.html
@@ -10,9 +10,7 @@
 <app-wdf-status-message
   [wdfStartDate]="wdfStartDate"
   [wdfEndDate]="wdfEndDate"
-  [overallWdfEligibility]="overallWdfEligibility"
-  [staffWdfEligibility]="staffWdfEligibility"
-  [workplaceWdfEligibility]="workplaceWdfEligibility"
+  [wdfEligibilityStatus]="wdfEligibilityStatus"
 ></app-wdf-status-message>
 
 <app-tabs>

--- a/src/app/features/wdf/wdf-data/wdf-data.component.html
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
       <span class="govuk-caption-xl">Workforce Development Fund (WDF)</span>
       WDF data
     </h1>
@@ -14,7 +14,11 @@
 ></app-wdf-status-message>
 
 <app-tabs>
-  <app-tab [greenTick]="showGreenTickOnWorkplaceTab()" [alert]="showOrangeFlagOnWorkplaceTab()" [title]="'Workplace'">
+  <app-tab
+    [greenTick]="wdfEligibilityStatus.overall && wdfEligibilityStatus.currentWorkplace"
+    [alert]="wdfEligibilityStatus.overall && !wdfEligibilityStatus.currentWorkplace"
+    [title]="'Workplace'"
+  >
     <app-workplace-summary
       *ngIf="workplace"
       [workplace]="workplace"
@@ -25,8 +29,8 @@
   </app-tab>
   <app-tab
     *ngIf="canViewWorker"
-    [greenTick]="showGreenTickOnStaffTab()"
-    [alert]="showOrangeFlagOnStaffTab()"
+    [greenTick]="wdfEligibilityStatus.overall && wdfEligibilityStatus.currentStaff"
+    [alert]="wdfEligibilityStatus.overall && !wdfEligibilityStatus.currentStaff"
     [title]="'Staff records'"
   >
     <app-wdf-staff-summary

--- a/src/app/features/wdf/wdf-data/wdf-data.component.html
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.html
@@ -22,11 +22,10 @@
     ></app-workplace-summary>
   </app-tab>
   <app-tab *ngIf="canViewWorker" [greenTick]="true" [title]="'Staff records'">
-    <app-staff-summary
+    <app-wdf-staff-summary
       *ngIf="workers && workplace"
       [workplace]="workplace"
       [workers]="workers"
-      [wdfView]="true"
-    ></app-staff-summary>
+    ></app-wdf-staff-summary>
   </app-tab>
 </app-tabs>

--- a/src/app/features/wdf/wdf-data/wdf-data.component.html
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.html
@@ -12,7 +12,11 @@
 </h4>
 
 <app-tabs>
-  <app-tab [greenTick]="true" [title]="'Workplace'">
+  <app-tab
+    [greenTick]="overallWdfEligibility && workplaceWdfEligibility"
+    [alert]="overallWdfEligibility && !workplaceWdfEligibility"
+    [title]="'Workplace'"
+  >
     <app-workplace-summary
       *ngIf="workplace"
       [workplace]="workplace"

--- a/src/app/features/wdf/wdf-data/wdf-data.component.html
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.html
@@ -25,7 +25,12 @@
       [wdfView]="true"
     ></app-workplace-summary>
   </app-tab>
-  <app-tab *ngIf="canViewWorker" [greenTick]="true" [title]="'Staff records'">
+  <app-tab
+    *ngIf="canViewWorker"
+    [greenTick]="overallWdfEligibility && staffWdfEligibility"
+    [alert]="overallWdfEligibility && !staffWdfEligibility"
+    [title]="'Staff records'"
+  >
     <app-wdf-staff-summary
       *ngIf="workers && workplace"
       [workplace]="workplace"

--- a/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
@@ -46,11 +46,28 @@ describe('WdfDataComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display the correct timeframe for meeting WDF requirements', async () => {
-    const { getByText } = await setup();
+  it('should display the correct message and timeframe if meeting WDF requirements', async () => {
+    const { component, fixture, getByText } = await setup();
     const timeframeSentence = 'Your data meets the WDF 2021 to 2022 requirements';
 
+    component.overallWdfEligibility = true;
+    component.workplaceWdfEligibility = true;
+    component.staffWdfEligibility = true;
+    fixture.detectChanges();
+
     expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
+  });
+
+  it('should display the "Keeping data up to date" message if meeting WDF requirements with data changes', async () => {
+    const { component, fixture, getByText } = await setup();
+    const keepUpToDateMessage = 'Keeping your data up to date will save you time next year';
+
+    component.overallWdfEligibility = true;
+    component.workplaceWdfEligibility = true;
+    component.staffWdfEligibility = false;
+    fixture.detectChanges();
+
+    expect(getByText(keepUpToDateMessage, { exact: false })).toBeTruthy();
   });
 
   it('should display a green tick on the workplace tab when the user has qualified for WDF and workplace is still eligible', async () => {

--- a/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
@@ -51,4 +51,14 @@ describe('WdfDataComponent', () => {
 
     expect(getByText(greenTickVisuallyHiddenMessage, { exact: false })).toBeTruthy();
   });
+
+  it('should display an orange flag on the workplace tab when the user has qualified for WDF but workplace is no longer eligible', async () => {
+    const { component, fixture, getByText } = await setup();
+    const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
+
+    component.workplaceWdfEligibility = false;
+    fixture.detectChanges();
+
+    expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
+  });
 });

--- a/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
@@ -17,12 +17,13 @@ import { MockWorkerService, workerBuilder } from '@core/test-utils/MockWorkerSer
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
+import { WdfModule } from '../wdf.module.js';
 import { WdfDataComponent } from './wdf-data.component';
 
 describe('WdfDataComponent', () => {
   const setup = async () => {
     const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(WdfDataComponent, {
-      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
+      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule],
       providers: [
         { provide: BreadcrumbService, useClass: MockBreadcrumbService },
         { provide: EstablishmentService, useClass: MockEstablishmentService },
@@ -120,7 +121,7 @@ describe('WdfDataComponent', () => {
 
   describe('getStaffWdfEligibility', () => {
     it('should return true when all workers are WDF eligible', async () => {
-      const { component, fixture, getAllByText } = await setup();
+      const { component, fixture } = await setup();
 
       component.workers = [workerBuilder(), workerBuilder(), workerBuilder()];
       component.workers[0].wdfEligible = true;
@@ -128,11 +129,11 @@ describe('WdfDataComponent', () => {
       component.workers[2].wdfEligible = true;
       fixture.detectChanges();
 
-      expect(component.getStaffWdfEligibility()).toBeTrue();
+      expect(component.getStaffWdfEligibility(component.workers)).toBeTrue();
     });
 
     it('should return false when any worker is not WDF eligible', async () => {
-      const { component, fixture, getAllByText } = await setup();
+      const { component, fixture } = await setup();
 
       component.workers = [workerBuilder(), workerBuilder(), workerBuilder()];
       component.workers[0].wdfEligible = true;
@@ -140,7 +141,7 @@ describe('WdfDataComponent', () => {
       component.workers[2].wdfEligible = true;
       fixture.detectChanges();
 
-      expect(component.getStaffWdfEligibility()).toBeFalse();
+      expect(component.getStaffWdfEligibility(component.workers)).toBeFalse();
     });
   });
 });

--- a/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
@@ -46,94 +46,72 @@ describe('WdfDataComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display the correct message and timeframe if meeting WDF requirements', async () => {
-    const { component, fixture, getByText } = await setup();
-    const timeframeSentence = 'Your data meets the WDF 2021 to 2022 requirements';
+  describe('Tab icons', async () => {
+    it('should display a green tick on the workplace tab when the user has qualified for WDF and workplace is still eligible', async () => {
+      const { component, fixture, getByText } = await setup();
+      const greenTickVisuallyHiddenMessage = 'Green tick';
 
-    component.overallWdfEligibility = true;
-    component.workplaceWdfEligibility = true;
-    component.staffWdfEligibility = true;
-    fixture.detectChanges();
+      component.workplaceWdfEligibility = true;
+      component.staffWdfEligibility = false;
+      fixture.detectChanges();
 
-    expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
-  });
+      expect(getByText(greenTickVisuallyHiddenMessage, { exact: false })).toBeTruthy();
+    });
 
-  it('should display the "Keeping data up to date" message if meeting WDF requirements with data changes', async () => {
-    const { component, fixture, getByText } = await setup();
-    const keepUpToDateMessage = 'Keeping your data up to date will save you time next year';
+    it('should display a green tick in staff tab when the user has qualified for WDF and is still eligible', async () => {
+      const { component, fixture, getByText } = await setup();
+      const greenTickVisuallyHiddenMessage = 'Green tick';
 
-    component.overallWdfEligibility = true;
-    component.workplaceWdfEligibility = true;
-    component.staffWdfEligibility = false;
-    fixture.detectChanges();
+      component.workplaceWdfEligibility = false;
+      component.staffWdfEligibility = true;
+      fixture.detectChanges();
 
-    expect(getByText(keepUpToDateMessage, { exact: false })).toBeTruthy();
-  });
+      expect(getByText(greenTickVisuallyHiddenMessage, { exact: false })).toBeTruthy();
+    });
 
-  it('should display a green tick on the workplace tab when the user has qualified for WDF and workplace is still eligible', async () => {
-    const { component, fixture, getByText } = await setup();
-    const greenTickVisuallyHiddenMessage = 'Green tick';
+    it('should display a green tick on the staff tab and the workplace tab when the user has qualified for WDF and staff records and workplace are still eligible', async () => {
+      const { component, fixture, getAllByText } = await setup();
+      const greenTickVisuallyHiddenMessage = 'Green tick';
 
-    component.workplaceWdfEligibility = true;
-    component.staffWdfEligibility = false;
-    fixture.detectChanges();
+      component.workplaceWdfEligibility = true;
+      component.staffWdfEligibility = true;
+      fixture.detectChanges();
 
-    expect(getByText(greenTickVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-  });
+      expect(getAllByText(greenTickVisuallyHiddenMessage, { exact: false }).length).toBe(2);
+    });
 
-  it('should display a green tick in staff tab when the user has qualified for WDF and is still eligible', async () => {
-    const { component, fixture, getByText } = await setup();
-    const greenTickVisuallyHiddenMessage = 'Green tick';
+    it('should display an orange flag on the workplace tab when the user has qualified for WDF but workplace is no longer eligible', async () => {
+      const { component, fixture, getByText } = await setup();
+      const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
-    component.workplaceWdfEligibility = false;
-    component.staffWdfEligibility = true;
-    fixture.detectChanges();
+      component.workplaceWdfEligibility = false;
+      component.staffWdfEligibility = true;
+      fixture.detectChanges();
 
-    expect(getByText(greenTickVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-  });
+      expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
+    });
 
-  it('should display a green tick on the staff tab and the workplace tab when the user has qualified for WDF and staff records and workplace are still eligible', async () => {
-    const { component, fixture, getAllByText } = await setup();
-    const greenTickVisuallyHiddenMessage = 'Green tick';
+    it('should display an orange flag on the staff tab when the user has qualified for WDF but staff records are no longer eligible', async () => {
+      const { component, fixture, getByText } = await setup();
+      const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
-    component.workplaceWdfEligibility = true;
-    component.staffWdfEligibility = true;
-    fixture.detectChanges();
+      component.workplaceWdfEligibility = true;
+      component.staffWdfEligibility = false;
+      fixture.detectChanges();
 
-    expect(getAllByText(greenTickVisuallyHiddenMessage, { exact: false }).length).toBe(2);
-  });
+      expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
+    });
 
-  it('should display an orange flag on the workplace tab when the user has qualified for WDF but workplace is no longer eligible', async () => {
-    const { component, fixture, getByText } = await setup();
-    const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
+    it('should display an orange flag on the staff tab and workplace tab when the user has qualified for WDF but staff records and workplace are no longer eligible', async () => {
+      const { component, fixture, getAllByText } = await setup();
+      const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
-    component.workplaceWdfEligibility = false;
-    component.staffWdfEligibility = true;
-    fixture.detectChanges();
+      component.workplaceWdfEligibility = false;
+      component.staffWdfEligibility = false;
+      fixture.detectChanges();
 
-    expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-  });
-
-  it('should display an orange flag on the staff tab when the user has qualified for WDF but staff records are no longer eligible', async () => {
-    const { component, fixture, getByText } = await setup();
-    const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
-
-    component.workplaceWdfEligibility = true;
-    component.staffWdfEligibility = false;
-    fixture.detectChanges();
-
-    expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-  });
-
-  it('should display an orange flag on the staff tab and workplace tab when the user has qualified for WDF but staff records and workplace are no longer eligible', async () => {
-    const { component, fixture, getAllByText } = await setup();
-    const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
-
-    component.workplaceWdfEligibility = false;
-    component.staffWdfEligibility = false;
-    fixture.detectChanges();
-
-    expect(getAllByText(orangeFlagVisuallyHiddenMessage, { exact: false }).length).toBe(2);
+      expect(getAllByText(orangeFlagVisuallyHiddenMessage, { exact: false }).length).toBe(2);
+    });
   });
 
   describe('getStaffWdfEligibility', () => {
@@ -159,6 +137,32 @@ describe('WdfDataComponent', () => {
       fixture.detectChanges();
 
       expect(component.getStaffWdfEligibility(component.workers)).toBeFalse();
+    });
+  });
+
+  describe('WdfStatusMessageComponent', async () => {
+    it('should display the correct message and timeframe if meeting WDF requirements', async () => {
+      const { component, fixture, getByText } = await setup();
+      const timeframeSentence = 'Your data meets the WDF 2021 to 2022 requirements';
+
+      component.overallWdfEligibility = true;
+      component.workplaceWdfEligibility = true;
+      component.staffWdfEligibility = true;
+      fixture.detectChanges();
+
+      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
+    });
+
+    it('should display the "Keeping data up to date" message if meeting WDF requirements with data changes', async () => {
+      const { component, fixture, getByText } = await setup();
+      const keepUpToDateMessage = 'Keeping your data up to date will save you time next year';
+
+      component.overallWdfEligibility = true;
+      component.workplaceWdfEligibility = true;
+      component.staffWdfEligibility = false;
+      fixture.detectChanges();
+
+      expect(getByText(keepUpToDateMessage, { exact: false })).toBeTruthy();
     });
   });
 });

--- a/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
@@ -13,7 +13,7 @@ import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockReportService } from '@core/test-utils/MockReportService';
-import { MockWorkerService } from '@core/test-utils/MockWorkerService';
+import { MockWorkerService, workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
@@ -42,7 +42,6 @@ describe('WdfDataComponent', () => {
 
   it('should render a WdfDataComponent', async () => {
     const { component } = await setup();
-    console.log(component.workers);
     expect(component).toBeTruthy();
   });
 
@@ -117,5 +116,31 @@ describe('WdfDataComponent', () => {
     fixture.detectChanges();
 
     expect(getAllByText(orangeFlagVisuallyHiddenMessage, { exact: false }).length).toBe(2);
+  });
+
+  describe('getStaffWdfEligibility', () => {
+    it('should return true when all workers are WDF eligible', async () => {
+      const { component, fixture, getAllByText } = await setup();
+
+      component.workers = [workerBuilder(), workerBuilder(), workerBuilder()];
+      component.workers[0].wdfEligible = true;
+      component.workers[1].wdfEligible = true;
+      component.workers[2].wdfEligible = true;
+      fixture.detectChanges();
+
+      expect(component.getStaffWdfEligibility()).toBeTrue();
+    });
+
+    it('should return false when any worker is not WDF eligible', async () => {
+      const { component, fixture, getAllByText } = await setup();
+
+      component.workers = [workerBuilder(), workerBuilder(), workerBuilder()];
+      component.workers[0].wdfEligible = true;
+      component.workers[1].wdfEligible = false;
+      component.workers[2].wdfEligible = true;
+      fixture.detectChanges();
+
+      expect(component.getStaffWdfEligibility()).toBeFalse();
+    });
   });
 });

--- a/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
@@ -51,8 +51,8 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getByText } = await setup();
       const greenTickVisuallyHiddenMessage = 'Green tick';
 
-      component.workplaceWdfEligibility = true;
-      component.staffWdfEligibility = false;
+      component.wdfEligibilityStatus.currentWorkplace = true;
+      component.wdfEligibilityStatus.currentStaff = false;
       fixture.detectChanges();
 
       expect(getByText(greenTickVisuallyHiddenMessage, { exact: false })).toBeTruthy();
@@ -62,8 +62,8 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getByText } = await setup();
       const greenTickVisuallyHiddenMessage = 'Green tick';
 
-      component.workplaceWdfEligibility = false;
-      component.staffWdfEligibility = true;
+      component.wdfEligibilityStatus.currentWorkplace = false;
+      component.wdfEligibilityStatus.currentStaff = true;
       fixture.detectChanges();
 
       expect(getByText(greenTickVisuallyHiddenMessage, { exact: false })).toBeTruthy();
@@ -73,8 +73,8 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getAllByText } = await setup();
       const greenTickVisuallyHiddenMessage = 'Green tick';
 
-      component.workplaceWdfEligibility = true;
-      component.staffWdfEligibility = true;
+      component.wdfEligibilityStatus.currentWorkplace = true;
+      component.wdfEligibilityStatus.currentStaff = true;
       fixture.detectChanges();
 
       expect(getAllByText(greenTickVisuallyHiddenMessage, { exact: false }).length).toBe(2);
@@ -84,8 +84,8 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getByText } = await setup();
       const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
-      component.workplaceWdfEligibility = false;
-      component.staffWdfEligibility = true;
+      component.wdfEligibilityStatus.currentWorkplace = false;
+      component.wdfEligibilityStatus.currentStaff = true;
       fixture.detectChanges();
 
       expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
@@ -95,8 +95,8 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getByText } = await setup();
       const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
-      component.workplaceWdfEligibility = true;
-      component.staffWdfEligibility = false;
+      component.wdfEligibilityStatus.currentWorkplace = true;
+      component.wdfEligibilityStatus.currentStaff = false;
       fixture.detectChanges();
 
       expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
@@ -106,8 +106,8 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getAllByText } = await setup();
       const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
-      component.workplaceWdfEligibility = false;
-      component.staffWdfEligibility = false;
+      component.wdfEligibilityStatus.currentWorkplace = false;
+      component.wdfEligibilityStatus.currentStaff = false;
       fixture.detectChanges();
 
       expect(getAllByText(orangeFlagVisuallyHiddenMessage, { exact: false }).length).toBe(2);
@@ -145,9 +145,9 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getByText } = await setup();
       const timeframeSentence = 'Your data meets the WDF 2021 to 2022 requirements';
 
-      component.overallWdfEligibility = true;
-      component.workplaceWdfEligibility = true;
-      component.staffWdfEligibility = true;
+      component.wdfEligibilityStatus.overall = true;
+      component.wdfEligibilityStatus.currentWorkplace = true;
+      component.wdfEligibilityStatus.currentStaff = true;
       fixture.detectChanges();
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
@@ -157,9 +157,9 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getByText } = await setup();
       const keepUpToDateMessage = 'Keeping your data up to date will save you time next year';
 
-      component.overallWdfEligibility = true;
-      component.workplaceWdfEligibility = true;
-      component.staffWdfEligibility = false;
+      component.wdfEligibilityStatus.overall = true;
+      component.wdfEligibilityStatus.currentWorkplace = true;
+      component.wdfEligibilityStatus.currentStaff = false;
       fixture.detectChanges();
 
       expect(getByText(keepUpToDateMessage, { exact: false })).toBeTruthy();

--- a/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
@@ -42,6 +42,7 @@ describe('WdfDataComponent', () => {
 
   it('should render a WdfDataComponent', async () => {
     const { component } = await setup();
+    console.log(component.workers);
     expect(component).toBeTruthy();
   });
 
@@ -90,6 +91,7 @@ describe('WdfDataComponent', () => {
     const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
     component.workplaceWdfEligibility = false;
+    component.staffWdfEligibility = true;
     fixture.detectChanges();
 
     expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();

--- a/src/app/features/wdf/wdf-data/wdf-data.component.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.ts
@@ -92,7 +92,7 @@ export class WdfDataComponent implements OnInit {
           .pipe(take(1))
           .subscribe((workers) => {
             this.workers = sortBy(workers, ['wdfEligible']);
-            this.staffWdfEligibility = this.getStaffWdfEligibility();
+            this.staffWdfEligibility = this.getStaffWdfEligibility(workers);
           }),
       );
     }
@@ -102,7 +102,6 @@ export class WdfDataComponent implements OnInit {
     this.subscriptions.add(
       this.reportService.getWDFReport(this.workplaceUid).subscribe((report) => {
         this.report = report;
-        console.log(report);
         this.setDates(report);
         this.setWdfEligibility(report);
       }),
@@ -127,7 +126,7 @@ export class WdfDataComponent implements OnInit {
     this.workplaceWdfEligibility = report.wdf.workplace;
   }
 
-  public getStaffWdfEligibility(): boolean {
-    return this.workers.every((worker) => worker.wdfEligible === true);
+  public getStaffWdfEligibility(workers: Worker[]): boolean {
+    return workers.every((worker) => worker.wdfEligible === true);
   }
 }

--- a/src/app/features/wdf/wdf-data/wdf-data.component.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.ts
@@ -58,22 +58,6 @@ export class WdfDataComponent implements OnInit {
     this.subscriptions.unsubscribe();
   }
 
-  public showGreenTickOnWorkplaceTab(): boolean {
-    return this.wdfEligibilityStatus.overall && this.wdfEligibilityStatus.currentWorkplace;
-  }
-
-  public showOrangeFlagOnWorkplaceTab(): boolean {
-    return this.wdfEligibilityStatus.overall && !this.wdfEligibilityStatus.currentWorkplace;
-  }
-
-  public showGreenTickOnStaffTab(): boolean {
-    return this.wdfEligibilityStatus.overall && this.wdfEligibilityStatus.currentStaff;
-  }
-
-  public showOrangeFlagOnStaffTab(): boolean {
-    return this.wdfEligibilityStatus.overall && !this.wdfEligibilityStatus.currentStaff;
-  }
-
   private setWorkplace(): void {
     this.subscriptions.add(
       this.establishmentService.getEstablishment(this.workplaceUid, true).subscribe((workplace) => {

--- a/src/app/features/wdf/wdf-data/wdf-data.component.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.ts
@@ -27,6 +27,9 @@ export class WdfDataComponent implements OnInit {
   public wdfStartDate: string;
   public wdfEndDate: string;
   public returnUrl: URLStructure;
+  public overallWdfEligibility: boolean;
+  public workplaceWdfEligibility: boolean;
+  public staffWdfEligibility: boolean;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -78,6 +81,7 @@ export class WdfDataComponent implements OnInit {
       this.reportService.getWDFReport(this.workplaceUid).subscribe((report) => {
         this.report = report;
         this.setDates(report);
+        this.setWdfEligibility(report);
       }),
     );
   }
@@ -93,5 +97,11 @@ export class WdfDataComponent implements OnInit {
   private setDates(report: WDFReport): void {
     this.wdfStartDate = moment(report.effectiveFrom).format('D MMMM YYYY');
     this.wdfEndDate = moment(report.effectiveFrom).add(1, 'years').format('D MMMM YYYY');
+  }
+
+  private setWdfEligibility(report: WDFReport): void {
+    this.overallWdfEligibility = report.wdf.overall;
+    this.workplaceWdfEligibility = report.wdf.workplace;
+    this.staffWdfEligibility = report.wdf.staff;
   }
 }

--- a/src/app/features/wdf/wdf-data/wdf-data.component.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.ts
@@ -13,6 +13,7 @@ import * as moment from 'moment';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
+import { WdfEligibilityStatus } from '../../../core/model/wdf.model';
 import { Worker } from '../../../core/model/worker.model';
 
 @Component({
@@ -29,9 +30,7 @@ export class WdfDataComponent implements OnInit {
   public wdfStartDate: string;
   public wdfEndDate: string;
   public returnUrl: URLStructure;
-  public overallWdfEligibility: boolean;
-  public workplaceWdfEligibility: boolean;
-  public staffWdfEligibility: boolean;
+  public wdfEligibilityStatus: WdfEligibilityStatus = {};
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -60,19 +59,19 @@ export class WdfDataComponent implements OnInit {
   }
 
   public showGreenTickOnWorkplaceTab(): boolean {
-    return this.overallWdfEligibility && this.workplaceWdfEligibility;
+    return this.wdfEligibilityStatus.overall && this.wdfEligibilityStatus.currentWorkplace;
   }
 
   public showOrangeFlagOnWorkplaceTab(): boolean {
-    return this.overallWdfEligibility && !this.workplaceWdfEligibility;
+    return this.wdfEligibilityStatus.overall && !this.wdfEligibilityStatus.currentWorkplace;
   }
 
   public showGreenTickOnStaffTab(): boolean {
-    return this.overallWdfEligibility && this.staffWdfEligibility;
+    return this.wdfEligibilityStatus.overall && this.wdfEligibilityStatus.currentStaff;
   }
 
   public showOrangeFlagOnStaffTab(): boolean {
-    return this.overallWdfEligibility && !this.staffWdfEligibility;
+    return this.wdfEligibilityStatus.overall && !this.wdfEligibilityStatus.currentStaff;
   }
 
   private setWorkplace(): void {
@@ -92,7 +91,7 @@ export class WdfDataComponent implements OnInit {
           .pipe(take(1))
           .subscribe((workers) => {
             this.workers = sortBy(workers, ['wdfEligible']);
-            this.staffWdfEligibility = this.getStaffWdfEligibility(workers);
+            this.wdfEligibilityStatus.currentStaff = this.getStaffWdfEligibility(workers);
           }),
       );
     }
@@ -122,8 +121,8 @@ export class WdfDataComponent implements OnInit {
   }
 
   private setWdfEligibility(report: WDFReport): void {
-    this.overallWdfEligibility = report.wdf.overall;
-    this.workplaceWdfEligibility = report.wdf.workplace;
+    this.wdfEligibilityStatus.overall = report.wdf.overall;
+    this.wdfEligibilityStatus.currentWorkplace = report.wdf.workplace;
   }
 
   public getStaffWdfEligibility(workers: Worker[]): boolean {

--- a/src/app/features/wdf/wdf-data/wdf-data.component.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.ts
@@ -67,6 +67,22 @@ export class WdfDataComponent implements OnInit {
     this.subscriptions.unsubscribe();
   }
 
+  public showGreenTickOnWorkplaceTab(): boolean {
+    return this.overallWdfEligibility && this.workplaceWdfEligibility;
+  }
+
+  public showOrangeFlagOnWorkplaceTab(): boolean {
+    return this.overallWdfEligibility && !this.workplaceWdfEligibility;
+  }
+
+  public showGreenTickOnStaffTab(): boolean {
+    return this.overallWdfEligibility && this.staffWdfEligibility;
+  }
+
+  public showOrangeFlagOnStaffTab(): boolean {
+    return this.overallWdfEligibility && !this.staffWdfEligibility;
+  }
+
   private setWorkplace() {
     this.subscriptions.add(
       this.establishmentService.getEstablishment(this.workplaceUid, true).subscribe((workplace) => {

--- a/src/app/features/wdf/wdf-data/wdf-data.component.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.ts
@@ -127,7 +127,7 @@ export class WdfDataComponent implements OnInit {
     this.workplaceWdfEligibility = report.wdf.workplace;
   }
 
-  private getStaffWdfEligibility(): boolean {
-    return this.workers.some((worker) => worker.wdfEligible === false);
+  public getStaffWdfEligibility(): boolean {
+    return this.workers.every((worker) => worker.wdfEligible === true);
   }
 }

--- a/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.html
+++ b/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.html
@@ -1,0 +1,11 @@
+<span class="govuk-!-margin-bottom-0 govuk__flex govuk__nowrap">
+  <ng-container *ngIf="showMeetingRequirementsMessage()">
+    <span class="govuk-visually-hidden">{{ worker.nameOrId }} is</span>
+    <img class="govuk-!-margin-right-1" src="/assets/images/tick-icon.svg" alt="" />
+    <span class="govuk-visually-hidden">Green tick</span>Meeting requirements
+  </ng-container>
+  <ng-container *ngIf="showCheckStaffRecordMessage()">
+    <img class="govuk-!-margin-right-1" src="/assets/images/flag-orange.svg" alt="" />
+    <span class="govuk-visually-hidden">Orange warning flag</span>Check this staff record
+  </ng-container>
+</span>

--- a/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.html
+++ b/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.html
@@ -1,10 +1,10 @@
 <span class="govuk-!-margin-bottom-0 govuk__flex govuk__nowrap">
-  <ng-container *ngIf="showMeetingRequirementsMessage()">
+  <ng-container *ngIf="overallWdfEligibility && worker.wdfEligible">
     <span class="govuk-visually-hidden">{{ worker.nameOrId }} is</span>
     <img class="govuk-!-margin-right-1" src="/assets/images/tick-icon.svg" alt="" />
     <span class="govuk-visually-hidden">Green tick</span>Meeting requirements
   </ng-container>
-  <ng-container *ngIf="showCheckStaffRecordMessage()">
+  <ng-container *ngIf="overallWdfEligibility && !worker.wdfEligible">
     <img class="govuk-!-margin-right-1" src="/assets/images/flag-orange.svg" alt="" />
     <span class="govuk-visually-hidden">Orange warning flag</span>Check this staff record
   </ng-container>

--- a/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.ts
+++ b/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.ts
@@ -9,12 +9,4 @@ import { Worker } from '../../../core/model/worker.model';
 export class WdfRequirementsStateComponent {
   @Input() overallWdfEligibility: boolean;
   @Input() worker: Worker;
-
-  public showMeetingRequirementsMessage(): boolean {
-    return this.overallWdfEligibility && this.worker.wdfEligible;
-  }
-
-  public showCheckStaffRecordMessage(): boolean {
-    return this.overallWdfEligibility && !this.worker.wdfEligible;
-  }
 }

--- a/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.ts
+++ b/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core';
+
+import { Worker } from '../../../core/model/worker.model';
+
+@Component({
+  selector: 'app-wdf-requirements-state',
+  templateUrl: './wdf-requirements-state.component.html',
+})
+export class WdfRequirementsStateComponent {
+  @Input() overallWdfEligibility: boolean;
+  @Input() worker: Worker;
+
+  public showMeetingRequirementsMessage(): boolean {
+    return this.overallWdfEligibility && this.worker.wdfEligible;
+  }
+
+  public showCheckStaffRecordMessage(): boolean {
+    return this.overallWdfEligibility && !this.worker.wdfEligible;
+  }
+}

--- a/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.html
+++ b/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.html
@@ -33,8 +33,20 @@
         <span class="govuk__nowrap">{{ lastUpdated(worker.updated) }}</span>
       </td>
       <td class="govuk-table__cell">
-        <span class="govuk-visually-hidden">{{ worker.nameOrId }} is</span>
-        <app-eligibility-icon [eligible]="worker.wdfEligible"></app-eligibility-icon>
+        <ng-container *ngIf="overallWdfEligibility && !worker.wdfEligible">
+          <span class="govuk-visually-hidden">{{ worker.nameOrId }} is</span>
+          <span class="govuk-!-margin-bottom-0 govuk__flex govuk__nowrap">
+            <img class="govuk-!-margin-right-1" src="/assets/images/flag-orange.svg" alt="" />
+            <span class="govuk-visually-hidden">Orange warning flag</span>Check this staff record
+          </span>
+        </ng-container>
+        <ng-container *ngIf="overallWdfEligibility && worker.wdfEligible">
+          <span class="govuk-visually-hidden">{{ worker.nameOrId }} is</span>
+          <span class="govuk-!-margin-bottom-0 govuk__flex govuk__nowrap">
+            <img class="govuk-!-margin-right-1" src="/assets/images/tick-icon.svg" alt="" />
+            <span class="govuk-visually-hidden">Green tick</span>Meeting requirements
+          </span>
+        </ng-container>
       </td>
     </tr>
   </tbody>

--- a/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.html
+++ b/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.html
@@ -33,20 +33,10 @@
         <span class="govuk__nowrap">{{ lastUpdated(worker.updated) }}</span>
       </td>
       <td class="govuk-table__cell">
-        <ng-container *ngIf="overallWdfEligibility && !worker.wdfEligible">
-          <span class="govuk-visually-hidden">{{ worker.nameOrId }} is</span>
-          <span class="govuk-!-margin-bottom-0 govuk__flex govuk__nowrap">
-            <img class="govuk-!-margin-right-1" src="/assets/images/flag-orange.svg" alt="" />
-            <span class="govuk-visually-hidden">Orange warning flag</span>Check this staff record
-          </span>
-        </ng-container>
-        <ng-container *ngIf="overallWdfEligibility && worker.wdfEligible">
-          <span class="govuk-visually-hidden">{{ worker.nameOrId }} is</span>
-          <span class="govuk-!-margin-bottom-0 govuk__flex govuk__nowrap">
-            <img class="govuk-!-margin-right-1" src="/assets/images/tick-icon.svg" alt="" />
-            <span class="govuk-visually-hidden">Green tick</span>Meeting requirements
-          </span>
-        </ng-container>
+        <app-wdf-requirements-state
+          [overallWdfEligibility]="overallWdfEligibility"
+          [worker]="worker"
+        ></app-wdf-requirements-state>
       </td>
     </tr>
   </tbody>

--- a/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.html
+++ b/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.html
@@ -1,0 +1,41 @@
+<div class="govuk-form-group">
+  <label class="govuk-label" for="sortByStaff"> Sort by </label>
+  <select class="govuk-select" id="sortByStaff" name="sortByStaff" (change)="sortByColumn($event.target.value)">
+    <option *ngFor="let sortStaffOption of sortStaffOptions | keyvalue" value="{{ sortStaffOption.key }}">
+      {{ sortStaffOption.value }}
+    </option>
+  </select>
+</div>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Staff name</th>
+      <th class="govuk-table__header" scope="col">Job role</th>
+      <th class="govuk-table__header" scope="col">Last updated</th>
+      <th class="govuk-table__header" scope="col">WDF requirements</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row" *ngFor="let worker of workers">
+      <td class="govuk-table__cell govuk-!-font-weight-regular">
+        <ng-container *ngIf="canViewWorker; else nameOrId">
+          <a [routerLink]="getWorkerRecordPath(worker)">
+            {{ worker.nameOrId }}
+          </a>
+        </ng-container>
+        <ng-template #nameOrId>
+          {{ worker.nameOrId }}
+        </ng-template>
+      </td>
+      <td class="govuk-table__cell">{{ worker.jobRole }}</td>
+      <td class="govuk-table__cell">
+        <span class="govuk-visually-hidden">last updated</span>
+        <span class="govuk__nowrap">{{ lastUpdated(worker.updated) }}</span>
+      </td>
+      <td class="govuk-table__cell">
+        <span class="govuk-visually-hidden">{{ worker.nameOrId }} is</span>
+        <app-eligibility-icon [eligible]="worker.wdfEligible"></app-eligibility-icon>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.spec.ts
+++ b/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.spec.ts
@@ -1,0 +1,53 @@
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { UserService } from '@core/services/user.service';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+import { workers } from 'node:cluster';
+
+import { establishmentBuilder, workerBuilder } from '../../../../../server/test/factories/models.js';
+import { WdfStaffSummaryComponent } from './wdf-staff-summary.component';
+
+describe('WdfStaffSummaryComponent', () => {
+  const setup = async () => {
+    const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(WdfStaffSummaryComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
+      providers: [
+        {
+          provide: PermissionsService,
+          useFactory: MockPermissionsService.factory(['canViewWorker']),
+          deps: [HttpClient, Router, UserService],
+        },
+      ],
+      componentProperties: {
+        workplace: establishmentBuilder() as Establishment,
+        workers: [workerBuilder(), workerBuilder(), workerBuilder()],
+      },
+    });
+    const component = fixture.componentInstance;
+
+    return { component, fixture, getByText, getAllByText, getByTestId, queryByText };
+  };
+
+  it('should render a WdfStaffSummaryComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  // it('should display an orange flag on staff record when the user has qualified for WDF but 1 staff record is no longer eligible', async () => {
+  //   const { component, fixture, getByText } = await setup();
+  //   const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
+
+  //   // component.workplaceWdfEligibility = true;
+  //   // component.staffWdfEligibility = false;
+  //   // fixture.detectChanges();
+
+  //   expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
+  // });
+});

--- a/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.spec.ts
+++ b/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.spec.ts
@@ -14,12 +14,13 @@ import { render } from '@testing-library/angular';
 import { workers } from 'node:cluster';
 
 import { establishmentBuilder, workerBuilder } from '../../../../../server/test/factories/models.js';
+import { WdfModule } from '../wdf.module.js';
 import { WdfStaffSummaryComponent } from './wdf-staff-summary.component';
 
 describe('WdfStaffSummaryComponent', () => {
   const setup = async () => {
     const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(WdfStaffSummaryComponent, {
-      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
+      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule],
       providers: [
         { provide: ReportService, useClass: MockReportService },
         {

--- a/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.ts
+++ b/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.ts
@@ -1,0 +1,78 @@
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Establishment, WdfSortStaffOptions } from '@core/model/establishment.model';
+import { Worker } from '@core/model/worker.model';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { orderBy } from 'lodash';
+import * as moment from 'moment';
+
+@Component({
+  selector: 'app-wdf-staff-summary',
+  templateUrl: './wdf-staff-summary.component.html',
+})
+export class WdfStaffSummaryComponent implements OnInit, OnChanges {
+  @Input() workplace: Establishment;
+  @Input() workers: Array<Worker>;
+  public canViewWorker: boolean;
+  public canEditWorker: boolean;
+  public sortStaffOptions;
+  public workersOrderBy: Array<Worker>;
+
+  constructor(private permissionsService: PermissionsService) {}
+
+  public lastUpdated(timestamp: string): string {
+    const lastUpdated: moment.Moment = moment(timestamp);
+    const isToday: boolean = moment().isSame(lastUpdated, 'day');
+    return isToday ? 'Today' : lastUpdated.format('D MMMM YYYY');
+  }
+
+  public getWorkerRecordPath(worker: Worker) {
+    return ['/wdf'];
+  }
+
+  ngOnInit() {
+    this.canViewWorker = this.permissionsService.can(this.workplace.uid, 'canViewWorker');
+    this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
+    this.sortStaffOptions = WdfSortStaffOptions;
+  }
+
+  ngOnChanges() {
+    this.workers = this.workers.map((worker) => {
+      worker.jobRole = worker.mainJob.other ? worker.mainJob.other : worker.mainJob.title;
+      return worker;
+    });
+    this.workers = orderBy(this.workers, [(worker) => worker.nameOrId.toLowerCase()], ['asc']);
+  }
+
+  public sortByColumn(selectedColumn: any) {
+    switch (selectedColumn) {
+      case '0_asc': {
+        this.workers = orderBy(this.workers, [(worker) => worker.nameOrId.toLowerCase()], ['asc']);
+        break;
+      }
+      case '0_dsc': {
+        this.workers = orderBy(this.workers, [(worker) => worker.nameOrId.toLowerCase()], ['desc']);
+        break;
+      }
+      case '1_asc': {
+        this.workers = orderBy(this.workers, [(worker) => worker.jobRole.toLowerCase()], ['asc']);
+        break;
+      }
+      case '1_dsc': {
+        this.workers = orderBy(this.workers, [(worker) => worker.jobRole.toLowerCase()], ['desc']);
+        break;
+      }
+      case '2_meeting': {
+        this.workers = orderBy(this.workers, [(worker) => worker.wdfEligible], ['desc']);
+        break;
+      }
+      case '2_not_meeting': {
+        this.workers = orderBy(this.workers, [(worker) => worker.wdfEligible], ['asc']);
+        break;
+      }
+      default: {
+        this.workers = orderBy(this.workers, [(worker) => worker.nameOrId.toLowerCase()], ['asc']);
+        break;
+      }
+    }
+  }
+}

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
@@ -1,0 +1,8 @@
+<h4 class="govuk-heading-s govuk-!-margin-bottom-8">
+  <ng-container *ngIf="overallWdfEligibility && !(workplaceWdfEligibility && staffWdfEligibility)">
+    Keeping your data up to date will save you time next year
+  </ng-container>
+  <ng-container *ngIf="overallWdfEligibility && workplaceWdfEligibility && staffWdfEligibility">
+    Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
+  </ng-container>
+</h4>

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
@@ -1,8 +1,8 @@
 <h4 class="govuk-heading-s govuk-!-margin-bottom-8">
-  <ng-container *ngIf="overallWdfEligibility && !(workplaceWdfEligibility && staffWdfEligibility)">
+  <ng-container *ngIf="showMeetingWithChangesMessage()">
     Keeping your data up to date will save you time next year
   </ng-container>
-  <ng-container *ngIf="overallWdfEligibility && workplaceWdfEligibility && staffWdfEligibility">
+  <ng-container *ngIf="showMeetingMessage()">
     Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
   </ng-container>
 </h4>

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
@@ -1,8 +1,14 @@
 <h4 class="govuk-heading-s govuk-!-margin-bottom-8">
-  <ng-container *ngIf="showMeetingWithChangesMessage()">
+  <ng-container
+    *ngIf="
+      wdfEligibilityStatus.overall && !(wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff)
+    "
+  >
     Keeping your data up to date will save you time next year
   </ng-container>
-  <ng-container *ngIf="showMeetingMessage()">
+  <ng-container
+    *ngIf="wdfEligibilityStatus.overall && wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff"
+  >
     Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
   </ng-container>
 </h4>

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
@@ -10,19 +10,4 @@ export class WdfStatusMessageComponent {
   @Input() wdfStartDate: string;
   @Input() wdfEndDate: string;
   @Input() wdfEligibilityStatus: WdfEligibilityStatus;
-
-  public showMeetingMessage(): boolean {
-    return (
-      this.wdfEligibilityStatus.overall &&
-      this.wdfEligibilityStatus.currentWorkplace &&
-      this.wdfEligibilityStatus.currentStaff
-    );
-  }
-
-  public showMeetingWithChangesMessage(): boolean {
-    return (
-      this.wdfEligibilityStatus.overall &&
-      !(this.wdfEligibilityStatus.currentWorkplace && this.wdfEligibilityStatus.currentStaff)
-    );
-  }
 }

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
 
+import { WdfEligibilityStatus } from '../../../core/model/wdf.model';
+
 @Component({
   selector: 'app-wdf-status-message',
   templateUrl: './wdf-status-message.component.html',
@@ -7,15 +9,20 @@ import { Component, Input } from '@angular/core';
 export class WdfStatusMessageComponent {
   @Input() wdfStartDate: string;
   @Input() wdfEndDate: string;
-  @Input() overallWdfEligibility: boolean;
-  @Input() workplaceWdfEligibility: boolean;
-  @Input() staffWdfEligibility: boolean;
+  @Input() wdfEligibilityStatus: WdfEligibilityStatus;
 
   public showMeetingMessage(): boolean {
-    return this.overallWdfEligibility && this.workplaceWdfEligibility && this.staffWdfEligibility;
+    return (
+      this.wdfEligibilityStatus.overall &&
+      this.wdfEligibilityStatus.currentWorkplace &&
+      this.wdfEligibilityStatus.currentStaff
+    );
   }
 
   public showMeetingWithChangesMessage(): boolean {
-    return this.overallWdfEligibility && !(this.workplaceWdfEligibility && this.staffWdfEligibility);
+    return (
+      this.wdfEligibilityStatus.overall &&
+      !(this.wdfEligibilityStatus.currentWorkplace && this.wdfEligibilityStatus.currentStaff)
+    );
   }
 }

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
@@ -10,4 +10,12 @@ export class WdfStatusMessageComponent {
   @Input() overallWdfEligibility: boolean;
   @Input() workplaceWdfEligibility: boolean;
   @Input() staffWdfEligibility: boolean;
+
+  public showMeetingMessage(): boolean {
+    return this.overallWdfEligibility && this.workplaceWdfEligibility && this.staffWdfEligibility;
+  }
+
+  public showMeetingWithChangesMessage(): boolean {
+    return this.overallWdfEligibility && !(this.workplaceWdfEligibility && this.staffWdfEligibility);
+  }
 }

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-wdf-status-message',
+  templateUrl: './wdf-status-message.component.html',
+})
+export class WdfStatusMessageComponent {
+  @Input() wdfStartDate: string;
+  @Input() wdfEndDate: string;
+  @Input() overallWdfEligibility: boolean;
+  @Input() workplaceWdfEligibility: boolean;
+  @Input() staffWdfEligibility: boolean;
+}

--- a/src/app/features/wdf/wdf.module.ts
+++ b/src/app/features/wdf/wdf.module.ts
@@ -7,9 +7,10 @@ import { SharedModule } from '@shared/shared.module';
 import { WdfOverviewComponent } from './wdf-overview/wdf-overview.component';
 import { WdfRoutingModule } from './wdf-routing.module';
 import { WdfDataComponent } from './wdf-data/wdf-data.component';
+import { WdfStaffSummaryComponent } from './wdf-staff-summary/wdf-staff-summary.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, WdfRoutingModule],
-  declarations: [WdfOverviewComponent, WdfDataComponent],
+  declarations: [WdfOverviewComponent, WdfDataComponent, WdfStaffSummaryComponent],
 })
 export class WdfModule {}

--- a/src/app/features/wdf/wdf.module.ts
+++ b/src/app/features/wdf/wdf.module.ts
@@ -10,9 +10,10 @@ import { WdfRoutingModule } from './wdf-routing.module';
 import { WdfStaffRecordComponent } from './wdf-staff-record/wdf-staff-record.component';
 import { WdfStaffSummaryComponent } from './wdf-staff-summary/wdf-staff-summary.component';
 import { WdfRequirementsStateComponent } from './wdf-requirements-state/wdf-requirements-state.component';
+import { WdfStatusMessageComponent } from './wdf-status-message/wdf-status-message.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, WdfRoutingModule],
-  declarations: [WdfOverviewComponent, WdfDataComponent, WdfStaffSummaryComponent, WdfStaffRecordComponent, WdfRequirementsStateComponent],
+  declarations: [WdfOverviewComponent, WdfDataComponent, WdfStaffSummaryComponent, WdfStaffRecordComponent, WdfRequirementsStateComponent, WdfStatusMessageComponent],
 })
 export class WdfModule {}

--- a/src/app/features/wdf/wdf.module.ts
+++ b/src/app/features/wdf/wdf.module.ts
@@ -9,9 +9,10 @@ import { WdfOverviewComponent } from './wdf-overview/wdf-overview.component';
 import { WdfRoutingModule } from './wdf-routing.module';
 import { WdfStaffRecordComponent } from './wdf-staff-record/wdf-staff-record.component';
 import { WdfStaffSummaryComponent } from './wdf-staff-summary/wdf-staff-summary.component';
+import { WdfRequirementsStateComponent } from './wdf-requirements-state/wdf-requirements-state.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, WdfRoutingModule],
-  declarations: [WdfOverviewComponent, WdfDataComponent, WdfStaffSummaryComponent, WdfStaffRecordComponent],
+  declarations: [WdfOverviewComponent, WdfDataComponent, WdfStaffSummaryComponent, WdfStaffRecordComponent, WdfRequirementsStateComponent],
 })
 export class WdfModule {}


### PR DESCRIPTION
#### Work done
- Create new `wdfStaffSummaryComponent`
- Add conditional rendering of WDF eligibility status message
- Add conditional rendering of green ticks and orange flags on tabs and staff summary table
- Create `wdfEligibilityStatus` interface

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
