### PR TITLE
Feat: WDF Staff Record - Meeting with changes

### DIFF
--- a/server/test/factories/models.js
+++ b/server/test/factories/models.js
@@ -79,6 +79,9 @@ const workerBuilder = build('Worker', {
       }),
     ],
     wdfEligible: false,
+    wdf: {
+      isEligible: false
+    }
   },
 });
 

--- a/src/app/core/test-utils/MockFeatureFlagService.ts
+++ b/src/app/core/test-utils/MockFeatureFlagService.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { IConfigCatClient, SettingKeyValue } from 'configcat-common/lib/ConfigCatClient';
+
+@Injectable()
+export class MockFeatureFlagsService extends FeatureFlagsService {
+  public configCatClient = {
+    dispose: () => {},
+    getValue: () => {},
+    forceRefresh: () => {},
+    forceRefreshAsync: () => {
+      return new Promise((resolve) => {
+        return '';
+      });
+    },
+    getAllKeys: () => {},
+    getAllKeysAsync: () => {
+      return new Promise((resolve) => {
+        return [];
+      });
+    },
+    getVariationId: () => {},
+    getVariationIdAsync: () => {
+      return new Promise((resolve) => {
+        return '';
+      });
+    },
+    getAllVariationIds: () => {},
+    getAllVariationIdsAsync: () => {
+      return new Promise((resolve) => {
+        return '';
+      });
+    },
+    getKeyAndValue: () => {},
+    getKeyAndValueAsync: () => {
+      return new Promise((resolve) => {
+        return new SettingKeyValue();
+      });
+    },
+    getAllValues: () => {},
+    getAllValuesAsync: () => {
+      return new Promise((resolve) => {
+        return new SettingKeyValue();
+      });
+    },
+    getValueAsync: () => {
+      return new Promise((resolve) => {
+        return false;
+      });
+    },
+  } as IConfigCatClient;
+}

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -12,11 +12,13 @@ import { WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { MockAuthService } from '@core/test-utils/MockAuthService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockNotificationsService } from '@core/test-utils/MockNotificationsService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
 import { DashboardComponent } from '@features/dashboard/dashboard.component';
 import { HomeTabComponent } from '@features/dashboard/home-tab/home-tab.component';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 import { of } from 'rxjs';
@@ -68,11 +70,13 @@ describe('DashboardComponent', () => {
           deps: [HttpClient, Router, EstablishmentService, UserService, PermissionsService],
         },
         { provide: WindowToken, useValue: MockWindow },
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
       ],
     });
 
     const injector = getTestBed();
     const establishmentService = injector.inject(EstablishmentService) as EstablishmentService;
+
     const router = injector.inject(Router) as Router;
 
     return {

--- a/src/app/features/wdf/wdf-overview/wdf-overview.component.spec.ts
+++ b/src/app/features/wdf/wdf-overview/wdf-overview.component.spec.ts
@@ -37,21 +37,21 @@ describe('WdfOverviewComponent', () => {
       const { getByText } = await setup();
       const timeframeSentence = 'Your data has met the WDF 2021 to 2022 requirements';
 
-      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();;
+      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
 
     it('should display the correct date for when WDF eligibility is valid until', async () => {
       const { getByText } = await setup();
       const timeframeSentence = 'continues to meet them until 31 March 2022';
 
-      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();;
+      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
 
     it('should display the correct date for when the user became eligible', async () => {
       const { getByText } = await setup();
       const timeframeSentence = 'Your data met the requirements on 21 July 2021';
 
-      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();;
+      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
   });
 
@@ -77,9 +77,9 @@ describe('WdfOverviewComponent', () => {
       component.overallWdfEligibility = false;
       fixture.detectChanges();
 
-      expect(getByText(requirementsNotMetSentence, { exact: false })).toBeTruthy();;
-      expect(getByText(viewWdfLink, { exact: false })).toBeTruthy();;
-      expect(getByText(viewWdfSentence, { exact: false })).toBeTruthy();;
+      expect(getByText(requirementsNotMetSentence, { exact: false })).toBeTruthy();
+      expect(getByText(viewWdfLink, { exact: false })).toBeTruthy();
+      expect(getByText(viewWdfSentence, { exact: false })).toBeTruthy();
     });
   });
 });

--- a/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.html
+++ b/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.html
@@ -1,1 +1,16 @@
-<h4 class="govuk-heading-s govuk-!-margin-bottom-8">Update this staff record to save yourself time next year</h4>
+<span class="govuk-!-margin-bottom-6 govuk__flex govuk__nowrap">
+  <ng-container *ngIf="overallWdfEligibility && !worker.wdfEligible">
+    <h4 class="govuk-heading-s">
+      <img class="govuk-!-margin-right-1 govuk-util__vertical-align-top" src="/assets/images/flag-orange.svg" alt="" />
+      <span class="govuk-visually-hidden">Orange warning flag</span>Update this staff record to save yourself time next
+      year
+    </h4>
+  </ng-container>
+  <ng-container *ngIf="!overallWdfEligibility && !worker.wdfEligible">
+    <h4 class="govuk-heading-s">
+      <img class="govuk-!-margin-right-1 govuk-util__vertical-align-top" src="/assets/images/cross-icon.svg" alt="" />
+      <span class="govuk-visually-hidden">Red cross</span>Not meeting the WDF {{ wdfStartDate | date: 'yyyy' }} to
+      {{ wdfEndDate | date: 'yyyy' }} requirements
+    </h4>
+  </ng-container>
+</span>

--- a/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.html
+++ b/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.html
@@ -1,0 +1,1 @@
+<h4 class="govuk-heading-s govuk-!-margin-bottom-8">Update this staff record to save yourself time next year</h4>

--- a/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.ts
+++ b/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-wdf-staff-record-status-message',
+  templateUrl: './wdf-staff-record-status-message.component.html',
+})
+export class WdfStaffRecordStatusMessageComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.ts
+++ b/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.ts
@@ -1,11 +1,14 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
+
+import { Worker } from '../../../core/model/worker.model';
 
 @Component({
   selector: 'app-wdf-staff-record-status-message',
   templateUrl: './wdf-staff-record-status-message.component.html',
 })
-export class WdfStaffRecordStatusMessageComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit(): void {}
+export class WdfStaffRecordStatusMessageComponent {
+  @Input() overallWdfEligibility: boolean;
+  @Input() worker: Worker;
+  @Input() wdfStartDate: string;
+  @Input() wdfEndDate: string;
 }

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
@@ -12,14 +12,14 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-!-margin-bottom-4" *ngIf="!isEligible">
+      <ng-container *ngIf="!worker.wdf.isEligible">
         <app-wdf-staff-record-status-message
           [overallWdfEligibility]="overallWdfEligibility"
           [worker]="worker"
           [wdfStartDate]="wdfStartDate"
           [wdfEndDate]="wdfEndDate"
         ></app-wdf-staff-record-status-message>
-      </p>
+      </ng-container>
     </div>
   </div>
 

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
@@ -28,6 +28,7 @@
     [workplace]="workplace"
     [worker]="worker"
     [wdfView]="true"
+    [overallWdfEligibility]="overallWdfEligibility"
   ></app-staff-record-summary>
 
   <a class="govuk-button govuk-!-margin-top-3" [routerLink]="exitUrl.url" [fragment]="exitUrl.fragment"

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-!-margin-bottom-4" *ngIf="!isEligible">
-        <app-eligibility-icon [eligible]="isEligible"></app-eligibility-icon>
+        <app-wdf-staff-record-status-message></app-wdf-staff-record-status-message>
       </p>
     </div>
   </div>

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
@@ -12,14 +12,13 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <ng-container *ngIf="!worker.wdf.isEligible">
-        <app-wdf-staff-record-status-message
-          [overallWdfEligibility]="overallWdfEligibility"
-          [worker]="worker"
-          [wdfStartDate]="wdfStartDate"
-          [wdfEndDate]="wdfEndDate"
-        ></app-wdf-staff-record-status-message>
-      </ng-container>
+      <app-wdf-staff-record-status-message
+        *ngIf="!worker.wdf.isEligible"
+        [overallWdfEligibility]="overallWdfEligibility"
+        [worker]="worker"
+        [wdfStartDate]="wdfStartDate"
+        [wdfEndDate]="wdfEndDate"
+      ></app-wdf-staff-record-status-message>
     </div>
   </div>
 

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="worker">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-5">
         <span class="govuk-caption-xl">{{ worker.nameOrId }}</span>
         Staff record
       </h1>
@@ -13,7 +13,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-!-margin-bottom-4" *ngIf="!isEligible">
-        <app-wdf-staff-record-status-message></app-wdf-staff-record-status-message>
+        <app-wdf-staff-record-status-message
+          [overallWdfEligibility]="overallWdfEligibility"
+          [worker]="worker"
+          [wdfStartDate]="wdfStartDate"
+          [wdfEndDate]="wdfEndDate"
+        ></app-wdf-staff-record-status-message>
       </p>
     </div>
   </div>

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.spec.ts
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.spec.ts
@@ -11,10 +11,10 @@ import { MockWorkerService } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
+import { workerBuilder } from '../../../../../server/test/factories/models';
 import { WdfModule } from '../wdf.module.js';
 import { WdfStaffRecordComponent } from './wdf-staff-record.component';
 
-// import { workerBuilder } from '../../../../../server/test/factories/models.js';
 describe('WdfStaffRecordComponent', () => {
   const setup = async () => {
     const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(WdfStaffRecordComponent, {
@@ -45,27 +45,33 @@ describe('WdfStaffRecordComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // it('should display the "update staff record" message and orange flag when user meets WDF requirements overall but current staff record does not', async () => {
-  //   const { component, fixture, getByText } = await setup();
-  //   const expectedStatusMessage = 'Update this staff record to save yourself time next year';
-  //   const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
+  it('should display the "update staff record" message and orange flag when user meets WDF requirements overall but current staff record does not', async () => {
+    const { component, fixture, getByText } = await setup();
+    const expectedStatusMessage = 'Update this staff record to save yourself time next year';
+    const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
-  //   component.worker = workerBuilder();
-  //   fixture.detectChanges();
+    component.worker = workerBuilder();
+    component.exitUrl = { url: [] };
+    component.overallWdfEligibility = true;
+    fixture.detectChanges();
 
-  //   expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-  //   expect(getByText(expectedStatusMessage, { exact: false })).toBeTruthy();
-  // });
+    expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
+    expect(getByText(expectedStatusMessage, { exact: false })).toBeTruthy();
+  });
 
-  // it('should display the "not meeting requirements" message and red cross when user does not meet WDF requirements overall and current staff record does not', async () => {
-  //   const { component, fixture, getByText } = await setup();
-  //   const expectedStatusMessage = 'Not meeting the WDF 2021 to 2022 requirements';
-  //   const redCrossVisuallyHiddenMessage = 'Red cross';
+  it('should display the "not meeting requirements" message and red cross when user does not meet WDF requirements overall and current staff record does not', async () => {
+    const { component, fixture, getByText } = await setup();
+    const expectedStatusMessage = 'Not meeting the WDF 2021 to 2022 requirements';
+    const redCrossVisuallyHiddenMessage = 'Red cross';
 
-  //   component.worker = workerBuilder();
-  //   fixture.detectChanges();
+    component.worker = workerBuilder();
+    component.exitUrl = { url: [] };
+    component.overallWdfEligibility = false;
+    component.wdfStartDate = '2021-01-01';
+    component.wdfEndDate = '2022-01-01';
+    fixture.detectChanges();
 
-  //   expect(getByText(redCrossVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-  //   expect(getByText(expectedStatusMessage, { exact: false })).toBeTruthy();
-  // });
+    expect(getByText(redCrossVisuallyHiddenMessage, { exact: false })).toBeTruthy();
+    expect(getByText(expectedStatusMessage, { exact: false })).toBeTruthy();
+  });
 });

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.spec.ts
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.spec.ts
@@ -1,20 +1,55 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkerService } from '@core/services/worker.service';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockWorkerService } from '@core/test-utils/MockWorkerService';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
 
+import { WdfModule } from '../wdf.module.js';
 import { WdfStaffRecordComponent } from './wdf-staff-record.component';
 
 describe('WdfStaffRecordComponent', () => {
-  let component: WdfStaffRecordComponent;
-  let fixture: ComponentFixture<WdfStaffRecordComponent>;
+  const setup = async () => {
+    const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(WdfStaffRecordComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule],
+      providers: [
+        { provide: BreadcrumbService, useClass: MockBreadcrumbService },
+        { provide: EstablishmentService, useClass: MockEstablishmentService },
+        { provide: WorkerService, useClass: MockWorkerService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              params: {
+                id: '123',
+              },
+            },
+          },
+        },
+      ],
+    });
+    const component = fixture.componentInstance;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [WdfStaffRecordComponent],
-    }).compileComponents();
+    return { component, fixture, getByText, getAllByText, getByTestId, queryByText };
+  };
+
+  it('should render a WdfStaffRecordComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
   });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(WdfStaffRecordComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  // it('should display the "update staff record message" and orange flag when user meets WDF requirements overall but current staff record does not', async () => {
+  //   const { component, fixture, getByText } = await setup();
+  //   component.worker = workerBuilder();
+  //   fixture.detectChanges();
+
+  //   const expectedStatusMessage = 'Update this staff record to save yourself time next year';
+  //   expect(getByText(expectedStatusMessage, { exact: false })).toBeTruthy();
+  // });
 });

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.spec.ts
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.spec.ts
@@ -14,6 +14,7 @@ import { render } from '@testing-library/angular';
 import { WdfModule } from '../wdf.module.js';
 import { WdfStaffRecordComponent } from './wdf-staff-record.component';
 
+// import { workerBuilder } from '../../../../../server/test/factories/models.js';
 describe('WdfStaffRecordComponent', () => {
   const setup = async () => {
     const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(WdfStaffRecordComponent, {
@@ -44,12 +45,27 @@ describe('WdfStaffRecordComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // it('should display the "update staff record message" and orange flag when user meets WDF requirements overall but current staff record does not', async () => {
+  // it('should display the "update staff record" message and orange flag when user meets WDF requirements overall but current staff record does not', async () => {
   //   const { component, fixture, getByText } = await setup();
+  //   const expectedStatusMessage = 'Update this staff record to save yourself time next year';
+  //   const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
+
   //   component.worker = workerBuilder();
   //   fixture.detectChanges();
 
-  //   const expectedStatusMessage = 'Update this staff record to save yourself time next year';
+  //   expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
+  //   expect(getByText(expectedStatusMessage, { exact: false })).toBeTruthy();
+  // });
+
+  // it('should display the "not meeting requirements" message and red cross when user does not meet WDF requirements overall and current staff record does not', async () => {
+  //   const { component, fixture, getByText } = await setup();
+  //   const expectedStatusMessage = 'Not meeting the WDF 2021 to 2022 requirements';
+  //   const redCrossVisuallyHiddenMessage = 'Red cross';
+
+  //   component.worker = workerBuilder();
+  //   fixture.detectChanges();
+
+  //   expect(getByText(redCrossVisuallyHiddenMessage, { exact: false })).toBeTruthy();
   //   expect(getByText(expectedStatusMessage, { exact: false })).toBeTruthy();
   // });
 });

--- a/src/app/features/wdf/wdf.module.ts
+++ b/src/app/features/wdf/wdf.module.ts
@@ -11,9 +11,10 @@ import { WdfStaffRecordComponent } from './wdf-staff-record/wdf-staff-record.com
 import { WdfStaffSummaryComponent } from './wdf-staff-summary/wdf-staff-summary.component';
 import { WdfRequirementsStateComponent } from './wdf-requirements-state/wdf-requirements-state.component';
 import { WdfStatusMessageComponent } from './wdf-status-message/wdf-status-message.component';
+import { WdfStaffRecordStatusMessageComponent } from './wdf-staff-record-status-message/wdf-staff-record-status-message.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, WdfRoutingModule],
-  declarations: [WdfOverviewComponent, WdfDataComponent, WdfStaffSummaryComponent, WdfStaffRecordComponent, WdfRequirementsStateComponent, WdfStatusMessageComponent],
+  declarations: [WdfOverviewComponent, WdfDataComponent, WdfStaffSummaryComponent, WdfStaffRecordComponent, WdfRequirementsStateComponent, WdfStatusMessageComponent, WdfStaffRecordStatusMessageComponent],
 })
 export class WdfModule {}

--- a/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
+++ b/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
@@ -6,11 +6,13 @@ import { Establishment } from '@core/model/establishment.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockWorkerService } from '@core/test-utils/MockWorkerService';
 import { EligibilityIconComponent } from '@shared/components/eligibility-icon/eligibility-icon.component';
 import { InsetTextComponent } from '@shared/components/inset-text/inset-text.component';
 import { BasicRecordComponent } from '@shared/components/staff-record-summary/basic-record/basic-record.component';
 import { SummaryRecordValueComponent } from '@shared/components/summary-record-value/summary-record-value.component';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
@@ -56,6 +58,7 @@ describe('MandatoryDetailsComponent', () => {
           provide: PermissionsService,
           useValue: mockPermissionsService,
         },
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/features/workplace/view-workplace/view-workplace.component.spec.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.spec.ts
@@ -13,10 +13,12 @@ import { WindowRef } from '@core/services/window.ref';
 import { MockAuthService } from '@core/test-utils/MockAuthService';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockNotificationsService } from '@core/test-utils/MockNotificationsService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
 import { ViewWorkplaceComponent } from '@features/workplace/view-workplace/view-workplace.component';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 import { of } from 'rxjs';
@@ -66,6 +68,7 @@ describe('view-workplace', () => {
           provide: BreadcrumbService,
           useClass: MockBreadcrumbService,
         },
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
       ],
     });
 

--- a/src/app/shared/components/eligibility-icon/eligibility-icon.component.html
+++ b/src/app/shared/components/eligibility-icon/eligibility-icon.component.html
@@ -2,5 +2,5 @@
   <ng-container *ngIf="num !== null">
     <strong class="govuk-line-height__normal govuk-!-margin-right-1">{{ num }}</strong>
   </ng-container>
-  <img class="govuk-!-margin-right-1" src="/assets/images/{{ icon }}-icon.svg" alt="" /> {{ label }}
+  <img class="govuk-!-margin-right-1" src="/assets/images/{{ icon }}.svg" alt="" /> {{ label }}
 </span>

--- a/src/app/shared/components/eligibility-icon/eligibility-icon.component.html
+++ b/src/app/shared/components/eligibility-icon/eligibility-icon.component.html
@@ -1,4 +1,4 @@
-<span class="govuk-!-margin-bottom-0 govuk__flex govuk__nowrap">
+<span class="govuk-!-margin-bottom-0 govuk-!-margin-top-1 govuk__flex govuk__nowrap">
   <ng-container *ngIf="num !== null">
     <strong class="govuk-line-height__normal govuk-!-margin-right-1">{{ num }}</strong>
   </ng-container>

--- a/src/app/shared/components/eligibility-icon/eligibility-icon.component.spec.ts
+++ b/src/app/shared/components/eligibility-icon/eligibility-icon.component.spec.ts
@@ -1,27 +1,61 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
 
 import { EligibilityIconComponent } from './eligibility-icon.component';
 
 describe('EligibilityIconComponent', () => {
-  let component: EligibilityIconComponent;
-  let fixture: ComponentFixture<EligibilityIconComponent>;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [EligibilityIconComponent],
+  const setup = async (overallEligibility: boolean, currentRowEligible: boolean) => {
+    const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(EligibilityIconComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
       providers: [{ provide: FeatureFlagsService, useClass: MockFeatureFlagsService }],
-    }).compileComponents();
-  }));
+      componentProperties: { overallEligibility: overallEligibility, eligible: currentRowEligible },
+    });
+    const component = fixture.componentInstance;
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(EligibilityIconComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    return { component, fixture, getByText, getAllByText, getByTestId, queryByText };
+  };
+
+  it('should render a EligibilityIconComponent', async () => {
+    const { component } = await setup(true, true);
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should not display a message when user meets WDF requirements overall and the current row is eligible', async () => {
+    const { component, fixture } = await setup(true, true);
+
+    component.displayCorrectIcon(true);
+    fixture.detectChanges();
+
+    expect(component.label).toEqual('');
+    expect(component.icon).toEqual('');
+  });
+
+  it('should display the "You need to add this information" message and orange flag when user meets WDF requirements overall but current row is empty', async () => {
+    const { component, fixture } = await setup(true, false);
+    const expectedMessage = 'You need to add this information';
+    const orangeFlagIcon = 'flag-orange';
+
+    component.displayCorrectIcon(true);
+    fixture.detectChanges();
+
+    expect(component.label).toEqual(expectedMessage);
+    expect(component.icon).toEqual(orangeFlagIcon);
+  });
+
+  it('should display the "You need to add this information" message and orange flag when user meets WDF requirements overall but current row is empty', async () => {
+    const { component, fixture } = await setup(false, false);
+    const expectedMessage = 'You need to add this information';
+    const redCrossIcon = 'cross-icon';
+
+    component.displayCorrectIcon(true);
+    fixture.detectChanges();
+
+    expect(component.label).toEqual(expectedMessage);
+    expect(component.icon).toEqual(redCrossIcon);
   });
 });

--- a/src/app/shared/components/eligibility-icon/eligibility-icon.component.spec.ts
+++ b/src/app/shared/components/eligibility-icon/eligibility-icon.component.spec.ts
@@ -1,4 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 import { EligibilityIconComponent } from './eligibility-icon.component';
 
@@ -8,9 +10,9 @@ describe('EligibilityIconComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ EligibilityIconComponent ]
-    })
-    .compileComponents();
+      declarations: [EligibilityIconComponent],
+      providers: [{ provide: FeatureFlagsService, useClass: MockFeatureFlagsService }],
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/shared/components/eligibility-icon/eligibility-icon.component.ts
+++ b/src/app/shared/components/eligibility-icon/eligibility-icon.component.ts
@@ -18,22 +18,19 @@ export class EligibilityIconComponent implements OnInit {
 
   ngOnInit() {
     this.featureFlagsService.configCatClient.getValueAsync('wdfNewDesign', false).then((value) => {
-      this.calc(value);
+      this.displayCorrectIcon(value);
     });
   }
 
-  public calc(newDesign): void {
+  public displayCorrectIcon(newDesign): void {
     if (newDesign) {
       if (!this.eligible && this.overallEligibility) {
         this.icon = 'flag-orange';
+        this.label = 'You need to add this information';
       } else if (!this.eligible && !this.overallEligibility) {
         this.icon = 'cross-icon';
+        this.label = 'You need to add this information';
       }
-      this.label = this.check
-        ? 'Check and confirm'
-        : this.eligible
-        ? 'Meeting requirements'
-        : 'Not meeting requirements';
     } else {
       this.icon = this.eligible ? 'tick-icon' : 'cross-icon';
       this.label = this.check

--- a/src/app/shared/components/eligibility-icon/eligibility-icon.component.ts
+++ b/src/app/shared/components/eligibility-icon/eligibility-icon.component.ts
@@ -1,10 +1,12 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
   selector: 'app-eligibility-icon',
   templateUrl: './eligibility-icon.component.html',
 })
 export class EligibilityIconComponent implements OnInit {
+  @Input() overallEligibility = false;
   @Input() eligible: boolean;
   @Input() check: boolean;
   @Input() num: number = null;
@@ -12,8 +14,33 @@ export class EligibilityIconComponent implements OnInit {
   public icon: string;
   public label: string;
 
+  constructor(private featureFlagsService: FeatureFlagsService) {}
+
   ngOnInit() {
-    this.icon = this.eligible ? 'tick' : 'cross';
-    this.label = this.check ? 'Check and confirm' : this.eligible ? 'Meeting requirements' : 'Not meeting requirements';
+    this.featureFlagsService.configCatClient.getValueAsync('wdfNewDesign', false).then((value) => {
+      this.calc(value);
+    });
+  }
+
+  public calc(newDesign): void {
+    if (newDesign) {
+      if (!this.eligible && this.overallEligibility) {
+        this.icon = 'flag-orange';
+      } else if (!this.eligible && !this.overallEligibility) {
+        this.icon = 'cross-icon';
+      }
+      this.label = this.check
+        ? 'Check and confirm'
+        : this.eligible
+        ? 'Meeting requirements'
+        : 'Not meeting requirements';
+    } else {
+      this.icon = this.eligible ? 'tick-icon' : 'cross-icon';
+      this.label = this.check
+        ? 'Check and confirm'
+        : this.eligible
+        ? 'Meeting requirements'
+        : 'Not meeting requirements';
+    }
   }
 }

--- a/src/app/shared/components/eligibility-icon/eligibility-icon.component.ts
+++ b/src/app/shared/components/eligibility-icon/eligibility-icon.component.ts
@@ -11,8 +11,8 @@ export class EligibilityIconComponent implements OnInit {
   @Input() check: boolean;
   @Input() num: number = null;
 
-  public icon: string;
-  public label: string;
+  public icon = '';
+  public label = '';
 
   constructor(private featureFlagsService: FeatureFlagsService) {}
 

--- a/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
+++ b/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
@@ -1,9 +1,7 @@
 <h2 class="govuk-heading-m">{{ basicTitle }}</h2>
 <dl class="govuk-summary-list govuk-summary-list--no-border asc-summarylist-border-top asc-summarylist-border-bottom">
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Name or ID number
-    </dt>
+    <dt class="govuk-summary-list__key">Name or ID number</dt>
     <dd class="govuk-summary-list__value">
       {{ worker.nameOrId }}
     </dd>
@@ -18,11 +16,13 @@
   </div>
 
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Main job role
-    </dt>
+    <dt class="govuk-summary-list__key">Main job role</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.mainJob">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.mainJob"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         <ng-container *ngIf="worker.mainJob.other; else title">
           <span>{{ worker.mainJob.other }}</span>
         </ng-container>
@@ -34,11 +34,13 @@
   </div>
 
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Contract type
-    </dt>
+    <dt class="govuk-summary-list__key">Contract type</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.contract">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.contract"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.contract }}
       </app-summary-record-value>
     </dd>

--- a/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.ts
+++ b/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.ts
@@ -8,5 +8,6 @@ import { StaffRecordSummaryComponent } from '../staff-record-summary.component';
 })
 export class BasicRecordComponent extends StaffRecordSummaryComponent {
   @Input() public wdfView = false;
-  @Input() public basicTitle: string = 'Mandatory details';
+  @Input() public basicTitle = 'Mandatory details';
+  @Input() public overallWdfEligibility: boolean;
 }

--- a/src/app/shared/components/staff-record-summary/employment/employment.component.html
+++ b/src/app/shared/components/staff-record-summary/employment/employment.component.html
@@ -18,7 +18,11 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Date started</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.mainJobStartDate">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.mainJobStartDate"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.mainJobStartDate ? mainStartDate : '-' }}
       </app-summary-record-value>
     </dd>
@@ -117,11 +121,15 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Recruited from</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.recruitedFrom">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.recruitedFrom"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{
-        worker.recruitedFrom?.from?.from !== null
-          ? worker.recruitedFrom?.from?.from
-          : (worker.recruitedFrom?.value | openEndedAnswer)
+          worker.recruitedFrom?.from?.from !== null
+            ? worker.recruitedFrom?.from?.from
+            : (worker.recruitedFrom?.value | openEndedAnswer)
         }}
       </app-summary-record-value>
     </dd>
@@ -139,9 +147,9 @@
     <dt class="govuk-summary-list__key">Worked in adult social care</dt>
     <dd class="govuk-summary-list__value">
       {{
-      worker.socialCareStartDate?.year
-        ? worker.socialCareStartDate?.year
-        : (worker.socialCareStartDate?.value | openEndedAnswer)
+        worker.socialCareStartDate?.year
+          ? worker.socialCareStartDate?.year
+          : (worker.socialCareStartDate?.value | openEndedAnswer)
       }}
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -157,7 +165,11 @@
   <div class="govuk-summary-list__row" *ngIf="displayDaysSickness">
     <dt class="govuk-summary-list__key">Sickness in last 12 months</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.daysSick">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.daysSick"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.daysSick | workerDays | openEndedAnswer }}
       </app-summary-record-value>
     </dd>
@@ -174,7 +186,11 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Zero hours contract</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.zeroHoursContract">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.zeroHoursContract"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.zeroHoursContract || '-' | closedEndedAnswer }}
       </app-summary-record-value>
     </dd>
@@ -191,11 +207,15 @@
   <div class="govuk-summary-list__row" *ngIf="displayAverageWeeklyHours">
     <dt class="govuk-summary-list__key">Average weekly working hours</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.weeklyHoursAverage">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.weeklyHoursAverage"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{
-        isNumber(worker.weeklyHoursAverage?.hours)
-          ? worker.weeklyHoursAverage?.hours
-          : (worker.weeklyHoursAverage?.value | openEndedAnswer)
+          isNumber(worker.weeklyHoursAverage?.hours)
+            ? worker.weeklyHoursAverage?.hours
+            : (worker.weeklyHoursAverage?.value | openEndedAnswer)
         }}
       </app-summary-record-value>
     </dd>
@@ -212,11 +232,15 @@
   <div class="govuk-summary-list__row" *ngIf="displayWeeklyContractedHours">
     <dt class="govuk-summary-list__key">Contracted weekly hours</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.weeklyHoursContracted">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.weeklyHoursContracted"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{
-        isNumber(worker.weeklyHoursContracted?.hours)
-          ? worker.weeklyHoursContracted?.hours
-          : (worker.weeklyHoursContracted?.value | openEndedAnswer)
+          isNumber(worker.weeklyHoursContracted?.hours)
+            ? worker.weeklyHoursContracted?.hours
+            : (worker.weeklyHoursContracted?.value | openEndedAnswer)
         }}
       </app-summary-record-value>
     </dd>
@@ -234,7 +258,11 @@
     <dt class="govuk-summary-list__key">Salary</dt>
 
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.annualHourlyPay">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.annualHourlyPay"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.annualHourlyPay | workerPay | closedEndedAnswer }}
       </app-summary-record-value>
     </dd>

--- a/src/app/shared/components/staff-record-summary/employment/employment.component.ts
+++ b/src/app/shared/components/staff-record-summary/employment/employment.component.ts
@@ -17,6 +17,7 @@ import { StaffRecordSummaryComponent } from '../staff-record-summary.component';
 })
 export class EmploymentComponent extends StaffRecordSummaryComponent {
   @Input() wdfView = false;
+  @Input() overallWdfEligibility: boolean;
 
   constructor(
     location: Location,

--- a/src/app/shared/components/staff-record-summary/personal-details/personal-details.component.html
+++ b/src/app/shared/components/staff-record-summary/personal-details/personal-details.component.html
@@ -45,7 +45,11 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Date of birth</dt>
     <dd class="govuk-summary-list__value govuk-list--inline">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.dateOfBirth">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.dateOfBirth"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         <div class="govuk-!-display-inline-block govuk-!-width-one-third">
           <ng-container *ngIf="!worker.dateOfBirth; else hasDob">-</ng-container>
           <ng-template #hasDob>{{ dobHidden ? '*********' : dob }}</ng-template>
@@ -86,7 +90,11 @@
     <dt class="govuk-summary-list__key">Gender</dt>
 
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.gender">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.gender"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.gender || '-' | closedEndedAnswer }}
       </app-summary-record-value>
     </dd>
@@ -133,7 +141,11 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Nationality</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.nationality">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.nationality"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{
           worker.nationality?.other?.nationality !== null
             ? worker.nationality?.other?.nationality

--- a/src/app/shared/components/staff-record-summary/personal-details/personal-details.component.ts
+++ b/src/app/shared/components/staff-record-summary/personal-details/personal-details.component.ts
@@ -10,6 +10,7 @@ import { StaffRecordSummaryComponent } from '../staff-record-summary.component';
 })
 export class PersonalDetailsComponent extends StaffRecordSummaryComponent {
   @Input() wdfView = false;
+  @Input() overallWdfEligibility: boolean;
   public ninoHidden = true;
   public dobHidden = true;
 

--- a/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
+++ b/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
@@ -1,11 +1,13 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Started or completed Care Certificate
-    </dt>
+    <dt class="govuk-summary-list__key">Started or completed Care Certificate</dt>
 
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.careCertificate">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.careCertificate"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.careCertificate || '-' }}
       </app-summary-record-value>
     </dd>
@@ -21,11 +23,13 @@
   </div>
 
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Any social care qualification
-    </dt>
+    <dt class="govuk-summary-list__key">Any social care qualification</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.qualificationInSocialCare">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.qualificationInSocialCare"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.qualificationInSocialCare || '-' | closedEndedAnswer }}
       </app-summary-record-value>
     </dd>
@@ -40,11 +44,13 @@
   </div>
 
   <div class="govuk-summary-list__row" *ngIf="displaySocialCareQualifications">
-    <dt class="govuk-summary-list__key">
-      Highest level of social care qualification
-    </dt>
+    <dt class="govuk-summary-list__key">Highest level of social care qualification</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.socialCareQualification">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.socialCareQualification"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.socialCareQualification?.title | closedEndedAnswer }}
       </app-summary-record-value>
     </dd>
@@ -59,11 +65,13 @@
   </div>
 
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Non-social care qualification
-    </dt>
+    <dt class="govuk-summary-list__key">Non-social care qualification</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.otherQualification">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.otherQualification"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.otherQualification || '-' | closedEndedAnswer }}
       </app-summary-record-value>
     </dd>
@@ -78,11 +86,13 @@
   </div>
 
   <div class="govuk-summary-list__row" *ngIf="displayOtherQualifications">
-    <dt class="govuk-summary-list__key">
-      Highest level of non-social care qualification
-    </dt>
+    <dt class="govuk-summary-list__key">Highest level of non-social care qualification</dt>
     <dd class="govuk-summary-list__value">
-      <app-summary-record-value [wdfView]="wdfView" [wdfValue]="worker.wdf?.highestQualification">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.highestQualification"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
         {{ worker.highestQualification?.title || '-' }}
       </app-summary-record-value>
     </dd>
@@ -97,9 +107,7 @@
   </div>
 
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Completing apprenticeship training
-    </dt>
+    <dt class="govuk-summary-list__key">Completing apprenticeship training</dt>
     <dd class="govuk-summary-list__value">
       {{ worker.apprenticeshipTraining || '-' | closedEndedAnswer }}
     </dd>

--- a/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.ts
+++ b/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.ts
@@ -8,6 +8,7 @@ import { StaffRecordSummaryComponent } from '../staff-record-summary.component';
 })
 export class QualificationsAndTrainingComponent extends StaffRecordSummaryComponent {
   @Input() wdfView = false;
+  @Input() overallWdfEligibility: boolean;
 
   get displaySocialCareQualifications() {
     return this.worker.qualificationInSocialCare === 'Yes';

--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.html
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.html
@@ -1,14 +1,28 @@
-<app-basic-record [workplace]="workplace" [worker]="worker" [return]="returnTo" [wdfView]="wdfView"></app-basic-record>
+<app-basic-record
+  [workplace]="workplace"
+  [worker]="worker"
+  [return]="returnTo"
+  [wdfView]="wdfView"
+  [overallWdfEligibility]="overallWdfEligibility"
+></app-basic-record>
 <app-personal-details
   [workplace]="workplace"
   [worker]="worker"
   [return]="returnTo"
   [wdfView]="wdfView"
+  [overallWdfEligibility]="overallWdfEligibility"
 ></app-personal-details>
-<app-employment [workplace]="workplace" [worker]="worker" [return]="returnTo" [wdfView]="wdfView"></app-employment>
+<app-employment
+  [workplace]="workplace"
+  [worker]="worker"
+  [return]="returnTo"
+  [wdfView]="wdfView"
+  [overallWdfEligibility]="overallWdfEligibility"
+></app-employment>
 <app-qualifications-and-training
   [workplace]="workplace"
   [worker]="worker"
   [return]="returnTo"
   [wdfView]="wdfView"
+  [overallWdfEligibility]="overallWdfEligibility"
 ></app-qualifications-and-training>

--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
@@ -23,6 +23,7 @@ export class StaffRecordSummaryComponent implements OnInit {
   @Input() workplace: Establishment;
   @Input() return: URLStructure;
   @Input() wdfView = false;
+  @Input() overallWdfEligibility: boolean;
 
   private _worker: Worker;
   private workplaceUid: string;

--- a/src/app/shared/components/summary-record-change/summary-record-change.component.html
+++ b/src/app/shared/components/summary-record-change/summary-record-change.component.html
@@ -1,9 +1,8 @@
 <a [routerLink]="link" (click)="setReturn()">
   <ng-container *ngIf="!hasData">
-    Provide information
+    Add information
     <span class="govuk-visually-hidden"> for</span>
   </ng-container>
   <ng-container *ngIf="hasData"> Change</ng-container>
-  <span class="govuk-visually-hidden">{{explanationText}}</span>
+  <span class="govuk-visually-hidden">{{ explanationText }}</span>
 </a>
-

--- a/src/app/shared/components/summary-record-change/summary-record-change.component.spec.ts
+++ b/src/app/shared/components/summary-record-change/summary-record-change.component.spec.ts
@@ -33,10 +33,12 @@ describe('SummaryRecordChangeComponent', () => {
     const { component } = await setup(' test', [], true);
     expect(component.queryByText).toBeTruthy();
   });
-  it('should render Provide information when it  doesnt has data', async () => {
+
+  it('should render Add information when it doesnt has data', async () => {
     const { component } = await setup(' test', [], false);
     expect(component.queryByText('Add information')).toBeTruthy();
   });
+
   it('should render the screen reader text', async () => {
     const { component } = await setup(' test', [], false);
     expect(component.queryByText('test')).toBeTruthy();

--- a/src/app/shared/components/summary-record-change/summary-record-change.component.spec.ts
+++ b/src/app/shared/components/summary-record-change/summary-record-change.component.spec.ts
@@ -7,8 +7,7 @@ import { render } from '@testing-library/angular';
 import { SummaryRecordChangeComponent } from './summary-record-change.component';
 
 describe('SummaryRecordChangeComponent', () => {
-  async function setup(explanationText = '',link=[],hasData=false) {
-
+  async function setup(explanationText = '', link = [], hasData = false) {
     const component = await render(SummaryRecordChangeComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [],
@@ -31,16 +30,15 @@ describe('SummaryRecordChangeComponent', () => {
   });
 
   it('should render Change when it has data', async () => {
-    const { component } = await setup(' test',[],true);
+    const { component } = await setup(' test', [], true);
     expect(component.queryByText).toBeTruthy();
   });
   it('should render Provide information when it  doesnt has data', async () => {
-    const { component } = await setup(' test',[],false);
-    expect(component.queryByText("Provide information")).toBeTruthy();
+    const { component } = await setup(' test', [], false);
+    expect(component.queryByText('Add information')).toBeTruthy();
   });
   it('should render the screen reader text', async () => {
-    const { component } = await setup(' test',[],false);
-    expect(component.queryByText("test")).toBeTruthy();
+    const { component } = await setup(' test', [], false);
+    expect(component.queryByText('test')).toBeTruthy();
   });
-
 });

--- a/src/app/shared/components/summary-record-value/summary-record-value.component.html
+++ b/src/app/shared/components/summary-record-value/summary-record-value.component.html
@@ -1,3 +1,4 @@
+<ng-content></ng-content>
 <ng-container *ngIf="wdfNewDesign; else wdfOldDesign">
   <ng-container *ngIf="wdfView && wdfValue?.isEligible === ELIGIBILITY.NO; else answer">
     <app-eligibility-icon [overallEligibility]="true" [eligible]="false"></app-eligibility-icon>
@@ -15,7 +16,6 @@
         wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES
       "
     >
-      <ng-content></ng-content>
       <div
         *ngIf="wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES"
         class="govuk-!-margin-top-2"

--- a/src/app/shared/components/summary-record-value/summary-record-value.component.html
+++ b/src/app/shared/components/summary-record-value/summary-record-value.component.html
@@ -1,12 +1,15 @@
-<ng-content></ng-content>
 <ng-container *ngIf="wdfNewDesign; else wdfOldDesign">
-  <ng-container *ngIf="wdfView && overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; else answer">
+  <ng-container *ngIf="wdfView && overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; else response">
     <app-eligibility-icon [overallEligibility]="true" [eligible]="false"></app-eligibility-icon>
   </ng-container>
 
-  <ng-container *ngIf="wdfView && !overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; else answer">
+  <ng-container *ngIf="wdfView && !overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; else response">
     <app-eligibility-icon [overallEligibility]="false" [eligible]="false"></app-eligibility-icon>
   </ng-container>
+
+  <ng-template #response>
+    <ng-content></ng-content>
+  </ng-template>
 </ng-container>
 
 <ng-template #wdfOldDesign>
@@ -20,6 +23,7 @@
         wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES
       "
     >
+      <ng-content></ng-content>
       <div
         *ngIf="wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES"
         class="govuk-!-margin-top-2"

--- a/src/app/shared/components/summary-record-value/summary-record-value.component.html
+++ b/src/app/shared/components/summary-record-value/summary-record-value.component.html
@@ -1,19 +1,27 @@
-<ng-container *ngIf="wdfView && wdfValue?.isEligible === ELIGIBILITY.NO; else answer">
-  <app-eligibility-icon [eligible]="false"></app-eligibility-icon>
+<ng-container *ngIf="wdfNewDesign; else wdfOldDesign">
+  <ng-container *ngIf="wdfView && wdfValue?.isEligible === ELIGIBILITY.NO; else answer">
+    <app-eligibility-icon [overallEligibility]="true" [eligible]="false"></app-eligibility-icon>
+  </ng-container>
 </ng-container>
 
-<ng-template #answer>
-  <div
-    [class.govuk-util__bold]="
-      wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES
-    "
-  >
-    <ng-content></ng-content>
+<ng-template #wdfOldDesign>
+  <ng-container *ngIf="wdfView && wdfValue?.isEligible === ELIGIBILITY.NO; else answer">
+    <app-eligibility-icon [eligible]="false"></app-eligibility-icon>
+  </ng-container>
+
+  <ng-template #answer>
     <div
-      *ngIf="wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES"
-      class="govuk-!-margin-top-2"
+      [class.govuk-util__bold]="
+        wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES
+      "
     >
-      <app-eligibility-icon [eligible]="false" [check]="true"></app-eligibility-icon>
+      <ng-content></ng-content>
+      <div
+        *ngIf="wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES"
+        class="govuk-!-margin-top-2"
+      >
+        <app-eligibility-icon [eligible]="false" [check]="true"></app-eligibility-icon>
+      </div>
     </div>
-  </div>
+  </ng-template>
 </ng-template>

--- a/src/app/shared/components/summary-record-value/summary-record-value.component.html
+++ b/src/app/shared/components/summary-record-value/summary-record-value.component.html
@@ -1,14 +1,20 @@
 <ng-container *ngIf="wdfNewDesign; else wdfOldDesign">
-  <ng-container *ngIf="wdfView && overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; else response">
-    <app-eligibility-icon [overallEligibility]="true" [eligible]="false"></app-eligibility-icon>
-  </ng-container>
+  <ng-container
+    *ngIf="wdfView && overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; then orangeFlags; else redFlags"
+  ></ng-container>
 
-  <ng-container *ngIf="wdfView && !overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; else response">
-    <app-eligibility-icon [overallEligibility]="false" [eligible]="false"></app-eligibility-icon>
-  </ng-container>
+  <ng-template #orangeFlags>
+    <app-eligibility-icon [overallEligibility]="true" [eligible]="false"></app-eligibility-icon>
+  </ng-template>
+
+  <ng-template #redFlags>
+    <ng-container *ngIf="wdfView && !overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; else response">
+      <app-eligibility-icon [overallEligibility]="false" [eligible]="false"></app-eligibility-icon>
+    </ng-container>
+  </ng-template>
 
   <ng-template #response>
-    <ng-content></ng-content>
+    <ng-container *ngTemplateOutlet="content"></ng-container>
   </ng-template>
 </ng-container>
 
@@ -23,7 +29,7 @@
         wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES
       "
     >
-      <ng-content></ng-content>
+      <ng-container *ngTemplateOutlet="content"></ng-container>
       <div
         *ngIf="wdfView && !wdfValue?.updatedSinceEffectiveDate && wdfValue?.isEligible === ELIGIBILITY.YES"
         class="govuk-!-margin-top-2"
@@ -33,3 +39,5 @@
     </div>
   </ng-template>
 </ng-template>
+
+<ng-template #content><ng-content></ng-content></ng-template>

--- a/src/app/shared/components/summary-record-value/summary-record-value.component.html
+++ b/src/app/shared/components/summary-record-value/summary-record-value.component.html
@@ -1,7 +1,11 @@
 <ng-content></ng-content>
 <ng-container *ngIf="wdfNewDesign; else wdfOldDesign">
-  <ng-container *ngIf="wdfView && wdfValue?.isEligible === ELIGIBILITY.NO; else answer">
+  <ng-container *ngIf="wdfView && overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; else answer">
     <app-eligibility-icon [overallEligibility]="true" [eligible]="false"></app-eligibility-icon>
+  </ng-container>
+
+  <ng-container *ngIf="wdfView && !overallWdfEligibility && wdfValue?.isEligible === ELIGIBILITY.NO; else answer">
+    <app-eligibility-icon [overallEligibility]="false" [eligible]="false"></app-eligibility-icon>
   </ng-container>
 </ng-container>
 

--- a/src/app/shared/components/summary-record-value/summary-record-value.component.spec.ts
+++ b/src/app/shared/components/summary-record-value/summary-record-value.component.spec.ts
@@ -1,15 +1,18 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 import { EligibilityIconComponent } from '../eligibility-icon/eligibility-icon.component';
 import { SummaryRecordValueComponent } from './summary-record-value.component';
 
-describe('StaffRecordValueComponent', () => {
+describe('SummaryRecordValueComponent', () => {
   let component: SummaryRecordValueComponent;
   let fixture: ComponentFixture<SummaryRecordValueComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SummaryRecordValueComponent, EligibilityIconComponent],
+      providers: [{ provide: FeatureFlagsService, useClass: MockFeatureFlagsService }],
     }).compileComponents();
   }));
 

--- a/src/app/shared/components/summary-record-value/summary-record-value.component.ts
+++ b/src/app/shared/components/summary-record-value/summary-record-value.component.ts
@@ -1,12 +1,22 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Eligibility, WDFValue } from '@core/model/wdf.model';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
   selector: 'app-summary-record-value',
   templateUrl: './summary-record-value.component.html',
 })
-export class SummaryRecordValueComponent {
+export class SummaryRecordValueComponent implements OnInit {
+  public wdfNewDesign: boolean;
   @Input() wdfView: boolean;
   @Input() wdfValue: WDFValue;
   public ELIGIBILITY = Eligibility;
+
+  constructor(private featureFlagsService: FeatureFlagsService) {}
+
+  ngOnInit() {
+    this.featureFlagsService.configCatClient.getValueAsync('wdfNewDesign', false).then((value) => {
+      this.wdfNewDesign = value;
+    });
+  }
 }

--- a/src/app/shared/components/summary-record-value/summary-record-value.component.ts
+++ b/src/app/shared/components/summary-record-value/summary-record-value.component.ts
@@ -7,9 +7,10 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
   templateUrl: './summary-record-value.component.html',
 })
 export class SummaryRecordValueComponent implements OnInit {
-  public wdfNewDesign: boolean;
   @Input() wdfView: boolean;
   @Input() wdfValue: WDFValue;
+  @Input() overallWdfEligibility: boolean;
+  public wdfNewDesign: boolean;
   public ELIGIBILITY = Eligibility;
 
   constructor(private featureFlagsService: FeatureFlagsService) {}

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -5,8 +5,10 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { NumericAnswerPipe } from '@shared/pipes/numeric-answer.pipe';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { within } from '@testing-library/angular';
 
 import { Establishment } from '../../../../mockdata/establishment';
@@ -35,6 +37,7 @@ describe('WorkplaceSummaryComponent', () => {
           useFactory: MockPermissionsService.factory(),
           deps: [HttpClient, Router, UserService],
         },
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
       ],
     }).compileComponents();
   }));
@@ -107,7 +110,6 @@ describe('WorkplaceSummaryComponent', () => {
     fixture.detectChanges();
     const moreRecords = within(document.body).queryByTestId('morerecords');
     expect(moreRecords.innerHTML).toContain("You've more staff than staff records");
-
   });
 
   it("should not show banner if you don't have permission to list workers", async () => {

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.spec.ts
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.spec.ts
@@ -1,12 +1,15 @@
+import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { SharedModule } from '@shared/shared.module';
-import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { SharedModule } from '@shared/shared.module';
+
 import { Establishment } from '../../../../mockdata/establishment';
 import { WorkplaceTabComponent } from './workplace-tab.component';
 
@@ -16,16 +19,14 @@ describe('WorkplaceTabComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [
-        SharedModule,
-        RouterTestingModule,
-        HttpClientTestingModule],
+      imports: [SharedModule, RouterTestingModule, HttpClientTestingModule],
       providers: [
         {
           provide: PermissionsService,
           useFactory: MockPermissionsService.factory(),
-          deps: [HttpClient, Router, UserService]
+          deps: [HttpClient, Router, UserService],
         },
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
       ],
     }).compileComponents();
   }));

--- a/src/app/shared/services/feature-flags.service.ts
+++ b/src/app/shared/services/feature-flags.service.ts
@@ -1,23 +1,19 @@
-import { Injectable } from '@angular/core';
-import * as configcat from 'configcat-js';
-import { IConfigCatClient } from 'configcat-common/lib/ConfigCatClient';
 import { LogLevel } from 'configcat-common';
-import { environment } from '../../../environments/environment';
+import { IConfigCatClient } from 'configcat-common/lib/ConfigCatClient';
+import * as configcat from 'configcat-js';
 
+import { environment } from '../../../environments/environment';
 
 export class FeatureFlagsService {
   public configCatClient: IConfigCatClient;
   public logger = configcat.createConsoleLogger(LogLevel.Info);
 
-  constructor(
-  ) {}
+  constructor() {}
 
-  start(){
-    this.configCatClient = configcat.createClientWithAutoPoll(environment.configCatKey,
-      {
-        pollIntervalSeconds: 2,
-        logger: this.logger
-      });
+  start() {
+    this.configCatClient = configcat.createClientWithAutoPoll(environment.configCatKey, {
+      pollIntervalSeconds: 2,
+      logger: this.logger,
+    });
   }
-
 }


### PR DESCRIPTION
#### Work done
- Added `FeatureFlagsService` to determine whether to show new WDF view or not
- Created a status message component for staff records page
- Updated tests to use `MockFeatureFlagsService` if they use the same staff summary components
- Updated `EligibilityIconComponent` to display correct icons and messages for new WDF view
- Added `overallWdfEligibility` to staff summary components so that it can be used by `SummaryRecordValueComponent`

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
