### PR TITLE
Bug: Back buttons

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -208,18 +208,6 @@ const routes: Routes = [
         loadChildren: () => import('@features/notifications/notifications.module').then((m) => m.NotificationsModule),
       },
       {
-        path: 'add-mandatory-training',
-        loadChildren: () =>
-          import('@features/add-mandatory-training/add-mandatory-training.module').then(
-            (m) => m.AddMandatoryTrainingModule,
-          ),
-        canActivate: [CheckPermissionsGuard],
-        data: {
-          permissions: ['canAddEstablishment'],
-          title: 'Add Mandatory Training',
-        },
-      },
-      {
         path: 'registration-survey',
         loadChildren: () =>
           import('@features/registration-survey/registration-survey.module').then((m) => m.RegistrationSurveyModule),

--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.spec.ts
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.spec.ts
@@ -1,0 +1,84 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AlertService } from '@core/services/alert.service';
+import { BackService } from '@core/services/back.service';
+import { DialogService } from '@core/services/dialog.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { TrainingService } from '@core/services/training.service';
+import { WindowRef } from '@core/services/window.ref';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { AddMandatoryTrainingComponent } from './add-mandatory-training.component';
+import { AddMandatoryTrainingModule } from './add-mandatory-training.module';
+
+describe('AddMandatoryTrainingComponent', () => {
+  async function setup() {
+    const component = await render(AddMandatoryTrainingComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, AddMandatoryTrainingModule, HttpClientTestingModule],
+      declarations: [],
+      providers: [
+        AlertService,
+        BackService,
+        DialogService,
+        TrainingService,
+        {
+          provide: WindowRef,
+          useClass: WindowRef,
+        },
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            parent: {
+              snapshot: {
+                data: {
+                  establishment: {
+                    uid: '123',
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+    return {
+      component,
+    };
+  }
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  describe('setBackLink', async () => {
+    it('should return to dashboard when the workplace is the primary workplace', async () => {
+      const { component } = await setup();
+      const expectedReturnUrl = { url: ['/dashboard'], fragment: 'training-and-qualifications' };
+
+      component.fixture.componentInstance.primaryWorkplace.uid = '123';
+      component.fixture.componentInstance.setBackLink();
+      component.fixture.detectChanges();
+
+      expect(component.fixture.componentInstance.return).toEqual(expectedReturnUrl);
+    });
+
+    it('should return to subsidiary dashboard when the workplace is not the primary workplace', async () => {
+      const { component } = await setup();
+      const expectedReturnUrl = { url: ['/workplace', '123'], fragment: 'training-and-qualifications' };
+
+      component.fixture.componentInstance.primaryWorkplace.uid = '125';
+      component.fixture.componentInstance.setBackLink();
+      component.fixture.detectChanges();
+
+      expect(component.fixture.componentInstance.return).toEqual(expectedReturnUrl);
+    });
+  });
+});

--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
@@ -98,7 +98,7 @@ export class AddMandatoryTrainingComponent implements OnInit {
     );
   }
 
-  private setBackLink(): void {
+  public setBackLink(): void {
     const url =
       this.establishment.uid === this.primaryWorkplace.uid ? ['/dashboard'] : ['/workplace', this.establishment.uid];
     this.return = { url: url, fragment: 'training-and-qualifications' };

--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
@@ -71,9 +71,8 @@ export class AddMandatoryTrainingComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.return = { url: ['/dashboard'], fragment: 'training-and-qualifications' };
+    this.primaryWorkplace = this.establishmentService.primaryWorkplace;
 
-    this.setBackLink();
     this.getAllTrainingCategories();
     this.getAlJobs();
     this.setupForm();
@@ -82,6 +81,7 @@ export class AddMandatoryTrainingComponent implements OnInit {
     this.subscriptions.add(
       this.establishmentService.establishment$.subscribe((establishment) => {
         this.establishment = establishment;
+        this.setBackLink();
         this.establishmentService.getAllMandatoryTrainings(this.establishment.uid).subscribe(
           (trainings) => {
             this.existingMandatoryTrainings = trainings;
@@ -98,6 +98,9 @@ export class AddMandatoryTrainingComponent implements OnInit {
   }
 
   private setBackLink(): void {
+    const url =
+      this.establishment.uid === this.primaryWorkplace.uid ? ['/dashboard'] : ['/workplace', this.establishment.uid];
+    this.return = { url: url, fragment: 'training-and-qualifications' };
     this.backService.setBackLink(this.return);
   }
 

--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import {
   allMandatoryTrainingCategories,
@@ -60,6 +60,7 @@ export class AddMandatoryTrainingComponent implements OnInit {
     protected establishmentService: EstablishmentService,
     private jobService: JobService,
     protected router: Router,
+    private route: ActivatedRoute,
   ) {}
 
   get categoriesArray(): FormArray {
@@ -72,6 +73,8 @@ export class AddMandatoryTrainingComponent implements OnInit {
 
   ngOnInit(): void {
     this.primaryWorkplace = this.establishmentService.primaryWorkplace;
+    this.establishment = this.route.parent.snapshot.data.establishment;
+    this.setBackLink();
 
     this.getAllTrainingCategories();
     this.getAlJobs();
@@ -80,8 +83,6 @@ export class AddMandatoryTrainingComponent implements OnInit {
     this.setupServerErrorsMap();
     this.subscriptions.add(
       this.establishmentService.establishment$.subscribe((establishment) => {
-        this.establishment = establishment;
-        this.setBackLink();
         this.establishmentService.getAllMandatoryTrainings(this.establishment.uid).subscribe(
           (trainings) => {
             this.existingMandatoryTrainings = trainings;

--- a/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -102,7 +102,7 @@
           <a (click)="becomeAParent($event)" href="#">Become a parent organisation</a>
         </li>
         <li *ngIf="canAddWorker">
-          <a [routerLink]="['/add-mandatory-training']">Manage mandatory training</a>
+          <a [routerLink]="['/workplace', workplace.uid, 'add-mandatory-training']">Manage mandatory training</a>
         </li>
       </ul>
     </ng-container>

--- a/src/app/features/workers/main-job-start-date/main-job-start-date.component.ts
+++ b/src/app/features/workers/main-job-start-date/main-job-start-date.component.ts
@@ -23,7 +23,7 @@ export class MainJobStartDateComponent extends QuestionComponent {
     protected route: ActivatedRoute,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
-    protected workerService: WorkerService
+    protected workerService: WorkerService,
   ) {
     super(formBuilder, router, route, backService, errorSummaryService, workerService);
 
@@ -50,9 +50,7 @@ export class MainJobStartDateComponent extends QuestionComponent {
     }
 
     this.next = this.getRoutePath('other-job-roles');
-    this.previous = this.workerService.addStaffRecordInProgress$.value
-      ? this.getRoutePath('staff-details')
-      : ['/dashboard'];
+    this.previous = this.getReturnPath();
   }
 
   public setupFormErrorsMap(): void {
@@ -88,5 +86,15 @@ export class MainJobStartDateComponent extends QuestionComponent {
     }
 
     return { mainJobStartDate: null };
+  }
+
+  private getReturnPath() {
+    if (this.workerService.addStaffRecordInProgress$.value) {
+      return this.getRoutePath('staff-details');
+    }
+    if (this.workplace.uid === this.primaryWorkplace.uid) {
+      return ['/dashboard'];
+    }
+    return [`/workplace/${this.workplace.uid}`];
   }
 }

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -359,6 +359,18 @@ const routes: Routes = [
           permissions: ['canViewBenchmarks'],
         },
       },
+      {
+        path: 'add-mandatory-training',
+        loadChildren: () =>
+          import('@features/add-mandatory-training/add-mandatory-training.module').then(
+            (m) => m.AddMandatoryTrainingModule,
+          ),
+        canActivate: [CheckPermissionsGuard],
+        data: {
+          permissions: ['canAddEstablishment'],
+          title: 'Add Mandatory Training',
+        },
+      },
     ],
   },
 ];

--- a/src/app/shared/components/training-link-panel/training-link-panel.component.html
+++ b/src/app/shared/components/training-link-panel/training-link-panel.component.html
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-one-third">
     <a
       class="govuk-list govuk-list--inline govuk-!-margin-right-5"
-      [routerLink]="['/add-mandatory-training']"
+      [routerLink]="['/workplace', workplace.uid, 'add-mandatory-training']"
       >Manage mandatory training
     </a>
   </div>


### PR DESCRIPTION
#### Work done
- Fix back button in `AddMandatoryTrainingComponent` to return to dashboard if the workplace is the primary workplace, or subsidiary's dashboard if not
- Same for `MainJobStartDateComponent`
- Moved routing for mandatory training to `workplace-routing.module`
- Added tests for `AddMandatoryTrainingComponent`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [x] No, I found it difficult to test (for `MainJobStartDateComponent`)
- [ ] No, they are not required for this change
