### PR TITLE
Feat: WDF Parent - Workplaces summary page

### DIFF
--- a/src/app/core/breadcrumb/journey.wdf.ts
+++ b/src/app/core/breadcrumb/journey.wdf.ts
@@ -4,6 +4,7 @@ enum Path {
   OVERVIEW = '/wdf',
   DATA = '/wdf/data',
   STAFF_RECORD = 'wdf/data/staffrecord/:id',
+  WORKPLACES = 'wdf/workplaces',
 }
 
 export const wdfJourney: JourneyRoute = {
@@ -12,6 +13,11 @@ export const wdfJourney: JourneyRoute = {
       title: 'WDF',
       path: Path.OVERVIEW,
       children: [
+        {
+          title: 'Workplaces',
+          path: Path.WORKPLACES,
+          children: [],
+        },
         {
           title: 'WDF data',
           path: Path.DATA,

--- a/src/app/core/model/establishment.model.ts
+++ b/src/app/core/model/establishment.model.ts
@@ -223,6 +223,15 @@ export enum WdfSortStaffOptions {
   '2_not_meeting' = 'WDF requirements (not meeting)',
 }
 
+export enum WdfParentSortStaffOptions {
+  '0_asc' = 'Staff name (A to Z)',
+  '0_dsc' = 'Staff name (Z to A)',
+  '1_asc' = 'Job role (A to Z)',
+  '1_dsc' = 'Job role (Z to A)',
+  '2_meeting' = 'WDF requirements (meeting)',
+  '2_not_meeting' = 'WDF requirements (not meeting)',
+}
+
 export enum SortTrainingAndQualsOptionsWorker {
   '0_expired' = 'Expired',
   '1_expires_soon' = 'Expires soon',

--- a/src/app/core/model/establishment.model.ts
+++ b/src/app/core/model/establishment.model.ts
@@ -223,13 +223,11 @@ export enum WdfSortStaffOptions {
   '2_not_meeting' = 'WDF requirements (not meeting)',
 }
 
-export enum WdfParentSortStaffOptions {
-  '0_asc' = 'Staff name (A to Z)',
-  '0_dsc' = 'Staff name (Z to A)',
-  '1_asc' = 'Job role (A to Z)',
-  '1_dsc' = 'Job role (Z to A)',
+export enum WdfParentSortWorkplacesOptions {
+  '1_not_meeting' = 'WDF requirements (not meeting)',
   '2_meeting' = 'WDF requirements (meeting)',
-  '2_not_meeting' = 'WDF requirements (not meeting)',
+  '3_asc' = 'Workplace name (A to Z)',
+  '4_dsc' = 'Workplace name (Z to A)',
 }
 
 export enum SortTrainingAndQualsOptionsWorker {

--- a/src/app/features/wdf/wdf-overview/wdf-overview.component.html
+++ b/src/app/features/wdf/wdf-overview/wdf-overview.component.html
@@ -53,7 +53,10 @@
           Your workplaces' data met the requirements on {{ parentOverallEligibilityDate }} and will continue to meet
           them until 31 March {{ wdfEndDate | date: 'yyyy' }}.
         </p>
-        <p><a [routerLink]="['']">View your workplaces</a> and keep your data up to date to save time next year.</p>
+        <p>
+          <a [routerLink]="['/wdf/workplaces']">View your workplaces</a> and keep your data up to date to save time next
+          year.
+        </p>
       </ng-container>
 
       <ng-template #parentNotEligible>
@@ -68,7 +71,7 @@
           </h2>
         </span>
         <p>
-          <a [routerLink]="['/wdf/data']">View your workplaces</a> to see which have data that does not meet the
+          <a [routerLink]="['/wdf/workplaces']">View your workplaces</a> to see which have data that does not meet the
           requirements.
         </p>
       </ng-template>

--- a/src/app/features/wdf/wdf-overview/wdf-overview.component.spec.ts
+++ b/src/app/features/wdf/wdf-overview/wdf-overview.component.spec.ts
@@ -165,7 +165,7 @@ describe('WdfOverviewComponent', () => {
     });
   });
 
-  describe('getParentsAndSubs', async () => {
+  describe('getParentAndSubs', async () => {
     it('should calculate parentOverallWdfEligibility to be true if all workplaces are eligible', async () => {
       const { component, fixture } = await setup();
 

--- a/src/app/features/wdf/wdf-overview/wdf-overview.component.ts
+++ b/src/app/features/wdf/wdf-overview/wdf-overview.component.ts
@@ -53,10 +53,10 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
   private getParentAndSubs(): void {
     this.subscriptions.add(
       this.userService.getEstablishments(true).subscribe((workplaces: GetWorkplacesResponse) => {
-        this.workplaces.push(workplaces.primary);
         if (workplaces.subsidaries) {
           this.workplaces = workplaces.subsidaries.establishments.filter((item) => item.ustatus !== 'PENDING');
         }
+        this.workplaces.push(workplaces.primary);
         this.workplaces = orderBy(this.workplaces, ['wdf.overall', 'updated'], ['asc', 'desc']);
         this.getParentOverallWdfEligibility();
         this.getLastOverallEligibilityDate();

--- a/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.html
+++ b/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.html
@@ -1,14 +1,13 @@
 <span class="govuk-!-margin-bottom-0 govuk__flex govuk__nowrap">
-  <ng-container *ngIf="worker.wdfEligible">
-    <span class="govuk-visually-hidden">{{ worker.nameOrId }} is</span>
+  <ng-container *ngIf="currentWdfEligibility">
     <img class="govuk-!-margin-right-1" src="/assets/images/tick-icon.svg" alt="" />
     <span class="govuk-visually-hidden">Green tick</span>Meeting
   </ng-container>
-  <ng-container *ngIf="overallWdfEligibility && !worker.wdfEligible">
+  <ng-container *ngIf="overallWdfEligibility && !currentWdfEligibility">
     <img class="govuk-!-margin-right-1" src="/assets/images/flag-orange.svg" alt="" />
     <span class="govuk-visually-hidden">Orange warning flag</span>Not meeting
   </ng-container>
-  <ng-container *ngIf="!overallWdfEligibility && !worker.wdfEligible">
+  <ng-container *ngIf="!overallWdfEligibility && !currentWdfEligibility">
     <img class="govuk-!-margin-right-1" src="/assets/images/cross-icon.svg" alt="" />
     <span class="govuk-visually-hidden">Red cross</span>Not meeting
   </ng-container>

--- a/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.ts
+++ b/src/app/features/wdf/wdf-requirements-state/wdf-requirements-state.component.ts
@@ -1,12 +1,10 @@
 import { Component, Input } from '@angular/core';
 
-import { Worker } from '../../../core/model/worker.model';
-
 @Component({
   selector: 'app-wdf-requirements-state',
   templateUrl: './wdf-requirements-state.component.html',
 })
 export class WdfRequirementsStateComponent {
   @Input() overallWdfEligibility: boolean;
-  @Input() worker: Worker;
+  @Input() currentWdfEligibility: boolean;
 }

--- a/src/app/features/wdf/wdf-routing.module.ts
+++ b/src/app/features/wdf/wdf-routing.module.ts
@@ -4,6 +4,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { WdfDataComponent } from './wdf-data/wdf-data.component';
 import { WdfOverviewComponent } from './wdf-overview/wdf-overview.component';
 import { WdfStaffRecordComponent } from './wdf-staff-record/wdf-staff-record.component';
+import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary/wdf-workplaces-summary.component';
 
 const routes: Routes = [
   {
@@ -20,6 +21,11 @@ const routes: Routes = [
     path: 'staff-record/:id',
     component: WdfStaffRecordComponent,
     data: { title: 'WDF Staff Record' },
+  },
+  {
+    path: 'workplaces',
+    component: WdfWorkplacesSummaryComponent,
+    data: { title: 'WDF Workplaces' },
   },
 ];
 

--- a/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.html
+++ b/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.html
@@ -1,7 +1,11 @@
 <div class="govuk-form-group">
   <label class="govuk-label" for="sortByStaff"> Sort by </label>
   <select class="govuk-select" id="sortByStaff" name="sortByStaff" (change)="sortByColumn($event.target.value)">
-    <option *ngFor="let sortStaffOption of sortStaffOptions | keyvalue" value="{{ sortStaffOption.key }}" [selected]="sortStaffOption.key == this.sortBy">
+    <option
+      *ngFor="let sortStaffOption of sortStaffOptions | keyvalue"
+      value="{{ sortStaffOption.key }}"
+      [selected]="sortStaffOption.key == this.sortBy"
+    >
       {{ sortStaffOption.value }}
     </option>
   </select>
@@ -35,7 +39,7 @@
       <td class="govuk-table__cell">
         <app-wdf-requirements-state
           [overallWdfEligibility]="overallWdfEligibility"
-          [worker]="worker"
+          [currentWdfEligibility]="worker.wdfEligible"
         ></app-wdf-requirements-state>
       </td>
     </tr>

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
@@ -1,5 +1,5 @@
-<h4 class="govuk-heading-s govuk-!-margin-bottom-8">
-  <ng-container *ngIf="!isParent; else parent">
+<ng-container *ngIf="!isParent; else parent">
+  <h4 class="govuk-heading-s govuk-!-margin-bottom-8">
     <ng-container *ngIf="!wdfEligibilityStatus.overall">
       Your data does not meet the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
     </ng-container>
@@ -15,10 +15,12 @@
     >
       Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
     </ng-container>
-  </ng-container>
+  </h4>
+</ng-container>
 
-  <ng-template #parent>
+<ng-template #parent>
+  <h4 class="govuk-heading-s">
     All your workplaces' data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to
     {{ wdfEndDate | date: 'yyyy' }} requirements
-  </ng-template>
-</h4>
+  </h4>
+</ng-template>

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.html
@@ -1,17 +1,24 @@
 <h4 class="govuk-heading-s govuk-!-margin-bottom-8">
-  <ng-container *ngIf="!wdfEligibilityStatus.overall">
-    Your data does not meet the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
+  <ng-container *ngIf="!isParent; else parent">
+    <ng-container *ngIf="!wdfEligibilityStatus.overall">
+      Your data does not meet the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
+    </ng-container>
+    <ng-container
+      *ngIf="
+        wdfEligibilityStatus.overall && !(wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff)
+      "
+    >
+      Keeping your data up to date will save you time next year
+    </ng-container>
+    <ng-container
+      *ngIf="wdfEligibilityStatus.overall && wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff"
+    >
+      Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
+    </ng-container>
   </ng-container>
-  <ng-container
-    *ngIf="
-      wdfEligibilityStatus.overall && !(wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff)
-    "
-  >
-    Keeping your data up to date will save you time next year
-  </ng-container>
-  <ng-container
-    *ngIf="wdfEligibilityStatus.overall && wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff"
-  >
-    Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
-  </ng-container>
+
+  <ng-template #parent>
+    All your workplaces' data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to
+    {{ wdfEndDate | date: 'yyyy' }} requirements
+  </ng-template>
 </h4>

--- a/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
+++ b/src/app/features/wdf/wdf-status-message/wdf-status-message.component.ts
@@ -10,4 +10,5 @@ export class WdfStatusMessageComponent {
   @Input() wdfStartDate: string;
   @Input() wdfEndDate: string;
   @Input() wdfEligibilityStatus: WdfEligibilityStatus;
+  @Input() isParent = false;
 }

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.html
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.html
@@ -2,11 +2,11 @@
   <label class="govuk-label" for="sortByStaff"> Sort by </label>
   <select class="govuk-select" id="sortByStaff" name="sortByStaff" (change)="sortByColumn($event.target.value)">
     <option
-      *ngFor="let sortStaffOption of sortStaffOptions | keyvalue"
-      value="{{ sortStaffOption.key }}"
-      [selected]="sortStaffOption.key == this.sortBy"
+      *ngFor="let sortWorkplaceOption of sortWorkplacesOptions | keyvalue"
+      value="{{ sortWorkplaceOption.key }}"
+      [selected]="sortWorkplaceOption.key == this.sortBy"
     >
-      {{ sortStaffOption.value }}
+      {{ sortWorkplaceOption.value }}
     </option>
   </select>
 </div>

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.html
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.html
@@ -27,12 +27,17 @@
         </a>
       </td>
       <td class="govuk-table__cell">
-        <!-- <app-wdf-requirements-state
+        <app-wdf-requirements-state
           [overallWdfEligibility]="workplace.wdf.overall"
           [currentWdfEligibility]="workplace.wdf.workplace"
-        ></app-wdf-requirements-state> -->
+        ></app-wdf-requirements-state>
       </td>
-      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell">
+        <app-wdf-requirements-state
+          [overallWdfEligibility]="workplace.wdf.overall"
+          [currentWdfEligibility]="workplace.wdf.staff"
+        ></app-wdf-requirements-state>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.html
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.html
@@ -1,0 +1,20 @@
+<table *ngIf="workplaces.length" class="govuk-table govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Workplace name</th>
+      <th scope="col" class="govuk-table__header">WDF requirements (workplace)</th>
+      <th scope="col" class="govuk-table__header">WDF requirements (staff records)</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr *ngFor="let workplace of workplaces" class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <a [routerLink]="[]">
+          {{ workplace.name }}
+        </a>
+      </td>
+      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+  </tbody>
+</table>

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.html
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.html
@@ -1,3 +1,16 @@
+<div class="govuk-form-group">
+  <label class="govuk-label" for="sortByStaff"> Sort by </label>
+  <select class="govuk-select" id="sortByStaff" name="sortByStaff" (change)="sortByColumn($event.target.value)">
+    <option
+      *ngFor="let sortStaffOption of sortStaffOptions | keyvalue"
+      value="{{ sortStaffOption.key }}"
+      [selected]="sortStaffOption.key == this.sortBy"
+    >
+      {{ sortStaffOption.value }}
+    </option>
+  </select>
+</div>
+
 <table *ngIf="workplaces.length" class="govuk-table govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
@@ -13,7 +26,12 @@
           {{ workplace.name }}
         </a>
       </td>
-      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell">
+        <!-- <app-wdf-requirements-state
+          [overallWdfEligibility]="workplace.wdf.overall"
+          [currentWdfEligibility]="workplace.wdf.workplace"
+        ></app-wdf-requirements-state> -->
+      </td>
       <td class="govuk-table__cell"></td>
     </tr>
   </tbody>

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.spec.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WdfWorkplacesSummaryTableComponent } from './wdf-workplaces-summary-table.component';
+
+describe('WdfWorkplacesSummaryTableComponent', () => {
+  let component: WdfWorkplacesSummaryTableComponent;
+  let fixture: ComponentFixture<WdfWorkplacesSummaryTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ WdfWorkplacesSummaryTableComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WdfWorkplacesSummaryTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.spec.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.spec.ts
@@ -1,25 +1,54 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
 
+import { WdfModule } from '../wdf.module.js';
 import { WdfWorkplacesSummaryTableComponent } from './wdf-workplaces-summary-table.component';
 
 describe('WdfWorkplacesSummaryTableComponent', () => {
-  let component: WdfWorkplacesSummaryTableComponent;
-  let fixture: ComponentFixture<WdfWorkplacesSummaryTableComponent>;
+  const workplace = {
+    name: 'Workplace name',
+    wdf: {
+      overall: true,
+      staff: true,
+      workplace: true,
+    },
+  };
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ WdfWorkplacesSummaryTableComponent ]
-    })
-    .compileComponents();
-  });
+  const setup = async () => {
+    const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(
+      WdfWorkplacesSummaryTableComponent,
+      {
+        imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule],
+        providers: [],
+        componentProperties: {
+          workplaces: [workplace],
+        },
+      },
+    );
+    const component = fixture.componentInstance;
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(WdfWorkplacesSummaryTableComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    return { component, fixture, getByText, getAllByText, getByTestId, queryByText };
+  };
 
-  it('should create', () => {
+  it('should render a WdfWorkplacesSummaryTableComponent', async () => {
+    const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should display two green ticks when the workplace has qualified for WDF and the workplace and staff records are eligible', async () => {
+    const { component, fixture, getAllByText } = await setup();
+    const greenTickVisuallyHiddenMessage = 'Green tick';
+    const meetingMessage = 'Meeting';
+
+    component.workplaces[0].wdf.overall = true;
+    component.workplaces[0].wdf.workplace = true;
+    component.workplaces[0].wdf.staff = true;
+    fixture.detectChanges();
+
+    expect(getAllByText(greenTickVisuallyHiddenMessage, { exact: false }).length).toBe(2);
+    expect(getAllByText(meetingMessage, { exact: true }).length).toBe(2);
   });
 });

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-wdf-workplaces-summary-table',
+  templateUrl: './wdf-workplaces-summary-table.component.html',
+})
+export class WdfWorkplacesSummaryTableComponent implements OnInit {
+  @Input() workplaces = [];
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
@@ -18,11 +18,10 @@ export class WdfWorkplacesSummaryTableComponent implements OnInit {
   }
 
   ngOnChanges() {
-    this.workplaces = this.workplaces.map((worker) => {
-      worker.jobRole = worker.mainJob.other ? worker.mainJob.other : worker.mainJob.title;
-      return worker;
+    this.workplaces = this.workplaces.map((workplace) => {
+      return workplace;
     });
-    this.workplaces = orderBy(this.workplaces, [(worker) => worker.nameOrId.toLowerCase()], ['asc']);
+    this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.name.toLowerCase()], ['asc']);
   }
 
   public sortByColumn(selectedColumn: any) {

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
@@ -1,4 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { WdfParentSortStaffOptions } from '@core/model/establishment.model';
+import { orderBy } from 'lodash';
 
 @Component({
   selector: 'app-wdf-workplaces-summary-table',
@@ -6,7 +8,54 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class WdfWorkplacesSummaryTableComponent implements OnInit {
   @Input() workplaces = [];
+  public sortStaffOptions;
+  public sortBy: string;
+
   constructor() {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.sortStaffOptions = WdfParentSortStaffOptions;
+  }
+
+  ngOnChanges() {
+    this.workplaces = this.workplaces.map((worker) => {
+      worker.jobRole = worker.mainJob.other ? worker.mainJob.other : worker.mainJob.title;
+      return worker;
+    });
+    this.workplaces = orderBy(this.workplaces, [(worker) => worker.nameOrId.toLowerCase()], ['asc']);
+  }
+
+  public sortByColumn(selectedColumn: any) {
+    localStorage.setItem('SortBy', selectedColumn);
+    switch (selectedColumn) {
+      case '0_asc': {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.nameOrId.toLowerCase()], ['asc']);
+        break;
+      }
+      case '0_dsc': {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.nameOrId.toLowerCase()], ['desc']);
+        break;
+      }
+      case '1_asc': {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.jobRole.toLowerCase()], ['asc']);
+        break;
+      }
+      case '1_dsc': {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.jobRole.toLowerCase()], ['desc']);
+        break;
+      }
+      case '2_meeting': {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.wdfEligible], ['desc']);
+        break;
+      }
+      case '2_not_meeting': {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.wdfEligible], ['asc']);
+        break;
+      }
+      default: {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.nameOrId.toLowerCase()], ['asc']);
+        break;
+      }
+    }
+  }
 }

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { WdfParentSortStaffOptions } from '@core/model/establishment.model';
+import { WdfParentSortWorkplacesOptions } from '@core/model/establishment.model';
 import { orderBy } from 'lodash';
 
 @Component({
@@ -8,13 +8,11 @@ import { orderBy } from 'lodash';
 })
 export class WdfWorkplacesSummaryTableComponent implements OnInit {
   @Input() workplaces = [];
-  public sortStaffOptions;
+  public sortWorkplacesOptions;
   public sortBy: string;
 
-  constructor() {}
-
   ngOnInit(): void {
-    this.sortStaffOptions = WdfParentSortStaffOptions;
+    this.sortWorkplacesOptions = WdfParentSortWorkplacesOptions;
   }
 
   ngOnChanges() {
@@ -25,34 +23,25 @@ export class WdfWorkplacesSummaryTableComponent implements OnInit {
   }
 
   public sortByColumn(selectedColumn: any) {
-    localStorage.setItem('SortBy', selectedColumn);
     switch (selectedColumn) {
-      case '0_asc': {
-        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.nameOrId.toLowerCase()], ['asc']);
-        break;
-      }
-      case '0_dsc': {
-        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.nameOrId.toLowerCase()], ['desc']);
-        break;
-      }
-      case '1_asc': {
-        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.jobRole.toLowerCase()], ['asc']);
-        break;
-      }
-      case '1_dsc': {
-        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.jobRole.toLowerCase()], ['desc']);
+      case '1_not_meeting': {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.name.toLowerCase()], ['asc']);
         break;
       }
       case '2_meeting': {
-        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.wdfEligible], ['desc']);
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.name.toLowerCase()], ['desc']);
         break;
       }
-      case '2_not_meeting': {
-        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.wdfEligible], ['asc']);
+      case '3_asc': {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.name.toLowerCase()], ['asc']);
+        break;
+      }
+      case '4_dsc': {
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.name.toLowerCase()], ['desc']);
         break;
       }
       default: {
-        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.nameOrId.toLowerCase()], ['asc']);
+        this.workplaces = orderBy(this.workplaces, [(workplace) => workplace.name.toLowerCase()], ['asc']);
         break;
       }
     }

--- a/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.html
+++ b/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.html
@@ -14,7 +14,7 @@
   [isParent]="true"
 ></app-wdf-status-message>
 
-<ul class="govuk-list govuk-list--inline govuk-list--download govuk-!-margin-bottom-8">
+<ul class="govuk-list govuk-list--inline govuk-list--download govuk-!-margin-bottom-5">
   <li>
     <a
       href="/download/{{ now | date: 'yyyy-MM-dd' }}-sfc-wdf-parent-report.xls"
@@ -23,3 +23,5 @@
     >
   </li>
 </ul>
+
+<app-wdf-workplaces-summary-table [workplaces]="workplaces"></app-wdf-workplaces-summary-table>

--- a/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.html
+++ b/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.html
@@ -13,3 +13,13 @@
   [wdfEligibilityStatus]="parentWdfEligibilityStatus"
   [isParent]="true"
 ></app-wdf-status-message>
+
+<ul class="govuk-list govuk-list--inline govuk-list--download govuk-!-margin-bottom-8">
+  <li>
+    <a
+      href="/download/{{ now | date: 'yyyy-MM-dd' }}-sfc-wdf-parent-report.xls"
+      (click)="downloadWdfParentReport($event)"
+      >Download your WDF report PDF</a
+    >
+  </li>
+</ul>

--- a/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.html
+++ b/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.html
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+      <span class="govuk-caption-xl">Workforce Development Fund (WDF)</span>
+      Workplaces
+    </h1>
+  </div>
+</div>
+
+<app-wdf-status-message
+  [wdfStartDate]="wdfStartDate"
+  [wdfEndDate]="wdfEndDate"
+  [wdfEligibilityStatus]="parentWdfEligibilityStatus"
+  [isParent]="true"
+></app-wdf-status-message>

--- a/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
@@ -1,0 +1,60 @@
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { ReportService } from '@core/services/report.service';
+import { UserService } from '@core/services/user.service';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { MockReportService } from '@core/test-utils/MockReportService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { WdfModule } from '../wdf.module.js';
+import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary.component';
+
+describe('WdfWorkplacesSummaryComponent', () => {
+  const setup = async () => {
+    const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(WdfWorkplacesSummaryComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule],
+      providers: [
+        { provide: BreadcrumbService, useClass: MockBreadcrumbService },
+        { provide: EstablishmentService, useClass: MockEstablishmentService },
+        { provide: ReportService, useClass: MockReportService },
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+        {
+          provide: PermissionsService,
+          useFactory: MockPermissionsService.factory(['canViewWorker']),
+          deps: [HttpClient, Router, UserService],
+        },
+      ],
+    });
+    const component = fixture.componentInstance;
+
+    return { component, fixture, getByText, getAllByText, getByTestId, queryByText };
+  };
+
+  it('should render a WdfWorkplacesSummaryComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  describe('WdfStatusMessageComponent', async () => {
+    it('should display the correct message and timeframe if meeting WDF requirements', async () => {
+      const { component, fixture, getByText } = await setup();
+      const timeframeSentence = "All your workplaces' data meets the WDF 2021 to 2022 requirements";
+
+      component.parentWdfEligibilityStatus = true;
+      fixture.detectChanges();
+
+      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
+    });
+  });
+});

--- a/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -15,12 +16,13 @@ import { MockPermissionsService } from '@core/test-utils/MockPermissionsService'
 import { MockReportService } from '@core/test-utils/MockReportService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
+import { of } from 'rxjs';
 
 import { WdfModule } from '../wdf.module.js';
 import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary.component';
 
-describe('WdfWorkplacesSummaryComponent', () => {
+fdescribe('WdfWorkplacesSummaryComponent', () => {
   const setup = async () => {
     const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(WdfWorkplacesSummaryComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule],
@@ -44,6 +46,19 @@ describe('WdfWorkplacesSummaryComponent', () => {
   it('should render a WdfWorkplacesSummaryComponent', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should download a WDF report when the download link is clicked', async () => {
+    const { fixture, getByText } = await setup();
+
+    const reportService = TestBed.inject(ReportService);
+    const getReport = spyOn(reportService, 'getParentWDFReport').and.callFake(() => of(null));
+    const saveAs = spyOn(fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+
+    fireEvent.click(getByText('Download your WDF report PDF', { exact: false }));
+
+    expect(getReport).toHaveBeenCalled();
+    expect(saveAs).toHaveBeenCalled();
   });
 
   describe('WdfStatusMessageComponent', async () => {

--- a/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
@@ -22,7 +22,7 @@ import { of } from 'rxjs';
 import { WdfModule } from '../wdf.module.js';
 import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary.component';
 
-fdescribe('WdfWorkplacesSummaryComponent', () => {
+describe('WdfWorkplacesSummaryComponent', () => {
   const setup = async () => {
     const { fixture, getByText, getAllByText, getByTestId, queryByText } = await render(WdfWorkplacesSummaryComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule],

--- a/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.ts
@@ -53,7 +53,6 @@ export class WdfWorkplacesSummaryComponent implements OnInit {
         }
         this.workplaces = orderBy(this.workplaces, ['wdf.overall', 'updated'], ['asc', 'desc']);
         this.getParentOverallWdfEligibility();
-        console.log(this.workplaces);
       }),
     );
   }
@@ -83,7 +82,7 @@ export class WdfWorkplacesSummaryComponent implements OnInit {
     this.subscriptions.add(
       this.reportService.getParentWDFReport(this.workplaceUid).subscribe(
         (response) => this.saveFile(response),
-        () => {},
+        (error) => console.error(error),
       ),
     );
   }

--- a/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.ts
@@ -47,10 +47,10 @@ export class WdfWorkplacesSummaryComponent implements OnInit {
   private getParentAndSubs(): void {
     this.subscriptions.add(
       this.userService.getEstablishments(true).subscribe((workplaces: GetWorkplacesResponse) => {
-        this.workplaces.push(workplaces.primary);
         if (workplaces.subsidaries) {
           this.workplaces = workplaces.subsidaries.establishments.filter((item) => item.ustatus !== 'PENDING');
         }
+        this.workplaces.push(workplaces.primary);
         this.workplaces = orderBy(this.workplaces, ['wdf.overall', 'updated'], ['asc', 'desc']);
         this.getParentOverallWdfEligibility();
       }),

--- a/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary/wdf-workplaces-summary.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from '@angular/core';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { WDFReport } from '@core/model/reports.model';
+import { URLStructure } from '@core/model/url.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { ReportService } from '@core/services/report.service';
+import * as moment from 'moment';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-wdf-workplaces-summary',
+  templateUrl: './wdf-workplaces-summary.component.html',
+})
+export class WdfWorkplacesSummaryComponent implements OnInit {
+  public workplaceUid: string;
+  public wdfStartDate: string;
+  public wdfEndDate: string;
+  public returnUrl: URLStructure;
+  public report: WDFReport;
+  public parentWdfEligibilityStatus: boolean;
+  private subscriptions: Subscription = new Subscription();
+
+  constructor(
+    private establishmentService: EstablishmentService,
+    private reportService: ReportService,
+    private breadcrumbService: BreadcrumbService,
+  ) {}
+
+  ngOnInit(): void {
+    this.breadcrumbService.show(JourneyType.WDF);
+    this.returnUrl = { url: ['/wdf', 'workplaces'] };
+
+    this.workplaceUid = this.establishmentService.primaryWorkplace.uid;
+    this.getWdfReport();
+  }
+
+  private getWdfReport() {
+    this.subscriptions.add(
+      this.reportService.getWDFReport(this.workplaceUid).subscribe((report) => {
+        this.report = report;
+        this.setDates(report);
+      }),
+    );
+  }
+
+  private setDates(report: WDFReport): void {
+    this.wdfStartDate = moment(report.effectiveFrom).format('D MMMM YYYY');
+    this.wdfEndDate = moment(report.effectiveFrom).add(1, 'years').format('D MMMM YYYY');
+  }
+}

--- a/src/app/features/wdf/wdf.module.ts
+++ b/src/app/features/wdf/wdf.module.ts
@@ -6,16 +6,29 @@ import { SharedModule } from '@shared/shared.module';
 
 import { WdfDataComponent } from './wdf-data/wdf-data.component';
 import { WdfOverviewComponent } from './wdf-overview/wdf-overview.component';
+import { WdfRequirementsStateComponent } from './wdf-requirements-state/wdf-requirements-state.component';
 import { WdfRoutingModule } from './wdf-routing.module';
+import {
+  WdfStaffRecordStatusMessageComponent,
+} from './wdf-staff-record-status-message/wdf-staff-record-status-message.component';
+import { WdfPaginationComponent } from './wdf-staff-record/wdf-pagination/wdf-pagination.component';
 import { WdfStaffRecordComponent } from './wdf-staff-record/wdf-staff-record.component';
 import { WdfStaffSummaryComponent } from './wdf-staff-summary/wdf-staff-summary.component';
-import { WdfRequirementsStateComponent } from './wdf-requirements-state/wdf-requirements-state.component';
 import { WdfStatusMessageComponent } from './wdf-status-message/wdf-status-message.component';
-import { WdfStaffRecordStatusMessageComponent } from './wdf-staff-record-status-message/wdf-staff-record-status-message.component';
-import { WdfPaginationComponent } from './wdf-staff-record/wdf-pagination/wdf-pagination.component';
+import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary/wdf-workplaces-summary.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, WdfRoutingModule],
-  declarations: [WdfOverviewComponent, WdfDataComponent, WdfStaffSummaryComponent, WdfStaffRecordComponent, WdfRequirementsStateComponent, WdfStatusMessageComponent, WdfStaffRecordStatusMessageComponent, WdfPaginationComponent],
+  declarations: [
+    WdfOverviewComponent,
+    WdfDataComponent,
+    WdfStaffSummaryComponent,
+    WdfStaffRecordComponent,
+    WdfRequirementsStateComponent,
+    WdfStatusMessageComponent,
+    WdfStaffRecordStatusMessageComponent,
+    WdfPaginationComponent,
+    WdfWorkplacesSummaryComponent,
+  ],
 })
 export class WdfModule {}

--- a/src/app/features/wdf/wdf.module.ts
+++ b/src/app/features/wdf/wdf.module.ts
@@ -15,6 +15,7 @@ import { WdfPaginationComponent } from './wdf-staff-record/wdf-pagination/wdf-pa
 import { WdfStaffRecordComponent } from './wdf-staff-record/wdf-staff-record.component';
 import { WdfStaffSummaryComponent } from './wdf-staff-summary/wdf-staff-summary.component';
 import { WdfStatusMessageComponent } from './wdf-status-message/wdf-status-message.component';
+import { WdfWorkplacesSummaryTableComponent } from './wdf-workplaces-summary-table/wdf-workplaces-summary-table.component';
 import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary/wdf-workplaces-summary.component';
 
 @NgModule({
@@ -29,6 +30,7 @@ import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary/wdf-work
     WdfStaffRecordStatusMessageComponent,
     WdfPaginationComponent,
     WdfWorkplacesSummaryComponent,
+    WdfWorkplacesSummaryTableComponent,
   ],
 })
 export class WdfModule {}


### PR DESCRIPTION
#### Work done
- Add sort by options for workplaces
- Refactor WDF requirements state component so it can be used for workplaces
- Add new message for parents in WDF status message component
- New workplaces summary page and workplaces summary table component

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
