### PR TITLE
Feat: WDF parent staff records - happy path

### DIFF
--- a/src/app/core/breadcrumb/journey.wdf.ts
+++ b/src/app/core/breadcrumb/journey.wdf.ts
@@ -3,9 +3,10 @@ import { JourneyRoute } from './breadcrumb.model';
 enum Path {
   OVERVIEW = '/wdf',
   DATA = '/wdf/data',
-  STAFF_RECORD = 'wdf/data/staffrecord/:id',
+  STAFF_RECORD = 'wdf/data/staff-record/:id',
   WORKPLACES = 'wdf/workplaces',
-  PARENT_DATA = 'wdf/:id/data',
+  PARENT_DATA = 'wdf/workplaces/:establishmentuid',
+  PARENT_STAFF_RECORD = 'wdf/workplaces/:establishmentuid/staff-record/:id',
 }
 
 export const wdfJourney: JourneyRoute = {
@@ -42,7 +43,12 @@ export const wdfParentJourney: JourneyRoute = {
             {
               title: 'WDF data',
               path: Path.PARENT_DATA,
-              children: [],
+              children: [
+                {
+                  title: 'Staff record',
+                  path: Path.PARENT_STAFF_RECORD,
+                },
+              ],
             },
           ],
         },

--- a/src/app/features/wdf/wdf-data/wdf-data.component.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.ts
@@ -34,7 +34,6 @@ export class WdfDataComponent implements OnInit {
   public wdfEndDate: string;
   public returnUrl: URLStructure;
   public wdfEligibilityStatus: WdfEligibilityStatus = {};
-  public isParent: boolean;
   public isStandalone = true;
   private subscriptions: Subscription = new Subscription();
 
@@ -58,9 +57,6 @@ export class WdfDataComponent implements OnInit {
       this.returnUrl = { url: ['/wdf', 'data'] };
     }
 
-    this.isParent = this.checkIfParent();
-    this.isParent ? this.breadcrumbService.show(JourneyType.WDF_PARENT) : this.breadcrumbService.show(JourneyType.WDF);
-
     this.canViewWorker = this.permissionsService.can(this.workplaceUid, 'canViewWorker');
     this.canEditWorker = this.permissionsService.can(this.workplaceUid, 'canEditWorker');
 
@@ -79,6 +75,7 @@ export class WdfDataComponent implements OnInit {
       this.establishmentService.getEstablishment(this.workplaceUid, true).subscribe((workplace) => {
         this.workplace = workplace;
         this.isStandalone = this.checkIfStandalone();
+        this.setBreadcrumbs();
         this.establishmentService.setState(workplace);
       }),
     );
@@ -130,9 +127,12 @@ export class WdfDataComponent implements OnInit {
     return workers.every((worker) => worker.wdfEligible === true);
   }
 
-  private checkIfParent(): boolean {
-    return this.primaryWorkplaceUid === this.workplaceUid ? true : false;
+  private setBreadcrumbs(): void {
+    this.isStandalone
+      ? this.breadcrumbService.show(JourneyType.WDF)
+      : this.breadcrumbService.show(JourneyType.WDF_PARENT);
   }
+
   private checkIfStandalone(): boolean {
     if (this.workplace) {
       if (this.primaryWorkplaceUid !== this.workplaceUid) {

--- a/src/app/features/wdf/wdf-overview/wdf-overview.component.html
+++ b/src/app/features/wdf/wdf-overview/wdf-overview.component.html
@@ -19,7 +19,7 @@
           Your data met the requirements on {{ overallEligibilityDate }} and will continue to meet them until 31 March
           {{ wdfEndDate | date: 'yyyy' }}.
         </p>
-        <p><a [routerLink]="['/wdf/workplaces']">Keep your WDF data up to date</a>, it will save you time next year.</p>
+        <p><a [routerLink]="['/wdf/data']">Keep your WDF data up to date</a>, it will save you time next year.</p>
       </ng-container>
 
       <ng-template #notEligible>

--- a/src/app/features/wdf/wdf-routing.module.ts
+++ b/src/app/features/wdf/wdf-routing.module.ts
@@ -34,9 +34,19 @@ const routes: Routes = [
       },
       {
         path: ':establishmentuid',
-        component: WdfDataComponent,
-        canActivate: [HasPermissionsGuard],
-        data: { permissions: ['canViewWdfReport'], title: 'WDF data' },
+        children: [
+          {
+            path: '',
+            component: WdfDataComponent,
+            canActivate: [HasPermissionsGuard],
+            data: { permissions: ['canViewWdfReport'], title: 'WDF data' },
+          },
+          {
+            path: 'staff-record/:id',
+            component: WdfStaffRecordComponent,
+            data: { title: 'WDF Staff Record' },
+          },
+        ],
       },
     ],
   },

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.ts
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.ts
@@ -43,11 +43,6 @@ export class WdfStaffRecordComponent implements OnInit {
     this.primaryWorkplaceUid = this.establishmentService.primaryWorkplace.uid;
     this.setExitUrl();
 
-    this.isStandalone = this.checkIfStandalone();
-    this.isStandalone
-      ? this.breadcrumbService.show(JourneyType.WDF)
-      : this.breadcrumbService.show(JourneyType.WDF_PARENT);
-
     this.refreshSubscription();
     this.getEstablishment();
     this.getWorker(this.route.snapshot.params);
@@ -67,6 +62,8 @@ export class WdfStaffRecordComponent implements OnInit {
     this.subscriptions.add(
       this.establishmentService.getEstablishment(this.workplaceUid, true).subscribe((workplace) => {
         this.workplace = workplace;
+        this.isStandalone = this.checkIfStandalone();
+        this.setBreadcrumbs();
         this.establishmentService.setState(workplace);
       }),
     );
@@ -109,6 +106,12 @@ export class WdfStaffRecordComponent implements OnInit {
       return !this.workplace.isParent;
     }
     return true;
+  }
+
+  private setBreadcrumbs(): void {
+    this.isStandalone
+      ? this.breadcrumbService.show(JourneyType.WDF)
+      : this.breadcrumbService.show(JourneyType.WDF_PARENT);
   }
 
   private refreshSubscription() {

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.ts
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.ts
@@ -20,13 +20,14 @@ export class WdfStaffRecordComponent implements OnInit {
   public worker: Worker;
   public workplace: Establishment;
   public workplaceUid: string;
+  public primaryWorkplaceUid: string;
   public isEligible: boolean;
   public exitUrl: URLStructure;
   public overallWdfEligibility: boolean;
   public wdfStartDate: string;
   public wdfEndDate: string;
   public workerList: string[];
-
+  public isStandalone: boolean;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -39,8 +40,14 @@ export class WdfStaffRecordComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.breadcrumbService.show(JourneyType.WDF);
-    this.workplaceUid = this.establishmentService.primaryWorkplace.uid;
+    this.primaryWorkplaceUid = this.establishmentService.primaryWorkplace.uid;
+    this.setExitUrl();
+
+    this.isStandalone = this.checkIfStandalone();
+    this.isStandalone
+      ? this.breadcrumbService.show(JourneyType.WDF)
+      : this.breadcrumbService.show(JourneyType.WDF_PARENT);
+
     this.refreshSubscription();
     this.getEstablishment();
     this.getWorker(this.route.snapshot.params);
@@ -52,8 +59,8 @@ export class WdfStaffRecordComponent implements OnInit {
     this.subscriptions.unsubscribe();
   }
 
-  public getListOfWorkers(){
-    this.workerList = JSON.parse(localStorage.getItem("ListOfWorkers"));
+  public getListOfWorkers() {
+    this.workerList = JSON.parse(localStorage.getItem('ListOfWorkers'));
   }
 
   public getEstablishment() {
@@ -70,7 +77,6 @@ export class WdfStaffRecordComponent implements OnInit {
       this.workerService.getWorker(this.workplaceUid, data.id, true).subscribe((worker) => {
         this.worker = worker;
         this.isEligible = this.worker.wdf.isEligible && this.worker.wdf.currentEligibility;
-        this.exitUrl = { url: ['/wdf', 'data'], fragment: 'staff-records' };
       }),
     );
   }
@@ -85,13 +91,32 @@ export class WdfStaffRecordComponent implements OnInit {
     );
   }
 
-  private refreshSubscription(){
+  private setExitUrl(): void {
+    if (this.route.snapshot.params.establishmentuid) {
+      this.workplaceUid = this.route.snapshot.params.establishmentuid;
+      this.exitUrl = { url: ['/wdf', 'workplaces', this.workplaceUid], fragment: 'staff-records' };
+    } else {
+      this.workplaceUid = this.establishmentService.primaryWorkplace.uid;
+      this.exitUrl = { url: ['/wdf', 'data'], fragment: 'staff-records' };
+    }
+  }
+
+  private checkIfStandalone(): boolean {
+    if (this.workplace) {
+      if (this.primaryWorkplaceUid !== this.workplaceUid) {
+        return false;
+      }
+      return !this.workplace.isParent;
+    }
+    return true;
+  }
+
+  private refreshSubscription() {
     this.route.params.subscribe((data) => {
       this.getEstablishment();
       this.getWorker(data);
       this.getOverallWdfEligibility();
       this.getListOfWorkers();
-
     });
     this.subscriptions.add(
       this.router.events

--- a/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.spec.ts
+++ b/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.spec.ts
@@ -4,16 +4,18 @@ import { BrowserModule } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { ReportService } from '@core/services/report.service.js';
 import { UserService } from '@core/services/user.service';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { MockReportService } from '@core/test-utils/MockReportService.js';
+import { MockReportService } from '@core/test-utils/MockReportService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
-import { establishmentBuilder, workerBuilder } from '../../../../../server/test/factories/models.js';
-import { WdfModule } from '../wdf.module.js';
+import { establishmentBuilder, workerBuilder } from '../../../../../server/test/factories/models';
+import { WdfModule } from '../wdf.module';
 import { WdfStaffSummaryComponent } from './wdf-staff-summary.component';
 
 describe('WdfStaffSummaryComponent', () => {
@@ -27,6 +29,7 @@ describe('WdfStaffSummaryComponent', () => {
           useFactory: MockPermissionsService.factory(['canViewWorker']),
           deps: [HttpClient, Router, UserService],
         },
+        { provide: EstablishmentService, useClass: MockEstablishmentService },
       ],
       componentProperties: {
         workplace: establishmentBuilder() as Establishment,

--- a/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.ts
+++ b/src/app/features/wdf/wdf-staff-summary/wdf-staff-summary.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Establishment, WdfSortStaffOptions } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { ReportService } from '@core/services/report.service';
 import { orderBy } from 'lodash';
@@ -15,13 +17,20 @@ export class WdfStaffSummaryComponent implements OnInit, OnChanges {
   @Input() workplace: Establishment;
   @Input() workers: Array<Worker>;
   @Input() canEditWorker: boolean;
+  public workplaceUid: string;
+  public primaryWorkplaceUid: string;
   public canViewWorker: boolean;
   public sortStaffOptions;
   public sortBy: string;
   public overallWdfEligibility: boolean;
   private subscriptions: Subscription = new Subscription();
 
-  constructor(private permissionsService: PermissionsService, private reportService: ReportService) {}
+  constructor(
+    private permissionsService: PermissionsService,
+    private reportService: ReportService,
+    private route: ActivatedRoute,
+    private establishmentService: EstablishmentService,
+  ) {}
 
   public lastUpdated(timestamp: string): string {
     const lastUpdated: moment.Moment = moment(timestamp);
@@ -30,7 +39,13 @@ export class WdfStaffSummaryComponent implements OnInit, OnChanges {
   }
 
   public getWorkerRecordPath(worker: Worker) {
-    return ['/wdf', 'staff-record', worker.uid];
+    if (this.route.snapshot.params.establishmentuid) {
+      this.workplaceUid = this.route.snapshot.params.establishmentuid;
+      return ['/wdf', 'workplaces', this.workplaceUid, 'staff-record', worker.uid];
+    } else {
+      this.workplaceUid = this.establishmentService.primaryWorkplace.uid;
+      return ['/wdf', 'staff-record', worker.uid];
+    }
   }
 
   ngOnInit() {
@@ -49,10 +64,12 @@ export class WdfStaffSummaryComponent implements OnInit, OnChanges {
     this.restoreSortBy();
     this.saveWorkerList();
   }
+
   public saveWorkerList() {
     const listOfWorkerUids = this.workers.map((worker) => worker.uid);
     localStorage.setItem('ListOfWorkers', JSON.stringify(listOfWorkerUids));
   }
+
   public restoreSortBy() {
     this.sortBy = localStorage.getItem('SortBy');
     if (this.sortBy) {

--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
@@ -67,7 +67,14 @@ export class StaffRecordSummaryComponent implements OnInit {
   }
 
   private setNewWdfReturn(): void {
-    this.returnTo = { url: ['/wdf', 'staff-record', this.worker.uid] };
+    if (this.route.snapshot.params.establishmentuid) {
+      this.returnTo = {
+        url: ['/wdf', 'workplaces', this.workplaceUid, 'staff-record', this.worker.uid],
+        fragment: 'staff-records',
+      };
+    } else {
+      this.returnTo = { url: ['/wdf', 'staff-record', this.worker.uid] };
+    }
   }
 
   public getRoutePath(name: string) {


### PR DESCRIPTION
#### Work done
- Added staff records to parent breadcrumb journey
- Fix breadcrumbs for parents on WDF data page (parents were seeing breadcrumbs for standalone workplaces when viewing their own workplace)
- Set `exitUrl` and breadcrumbs on staff record page depending on if parent or standalone workplace

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [x] No, I found it difficult to test
- [ ] No, they are not required for this change
