### PR TITLE
Feat: WDF Parent - meeting with changes/not meeting

### DIFF
--- a/src/app/features/wdf/wdf-data-status-message/wdf-data-status-message.component.html
+++ b/src/app/features/wdf/wdf-data-status-message/wdf-data-status-message.component.html
@@ -1,17 +1,36 @@
-<h4 class="govuk-heading-s govuk-!-margin-bottom-8">
-  <ng-container *ngIf="!wdfEligibilityStatus.overall">
-    Your data does not meet the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
-  </ng-container>
+<h4 class="govuk-heading-s govuk-!-margin-bottom-3">
   <ng-container
     *ngIf="
-      wdfEligibilityStatus.overall && !(wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff)
+      wdfEligibilityStatus.overall && wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff;
+      then meeting;
+      else meetingWithChanges
     "
-  >
-    Keeping your data up to date will save you time next year
-  </ng-container>
-  <ng-container
-    *ngIf="wdfEligibilityStatus.overall && wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff"
-  >
+  ></ng-container>
+
+  <ng-template #meeting>
     Your data meets the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
-  </ng-container>
+  </ng-template>
+
+  <ng-template #meetingWithChanges>
+    <ng-container
+      *ngIf="
+        wdfEligibilityStatus.overall && !(wdfEligibilityStatus.currentWorkplace && wdfEligibilityStatus.currentStaff);
+        else notMeeting
+      "
+    >
+      <ng-container *ngIf="isStandalone; else parent">
+        Keeping your data up to date will save you time next year
+      </ng-container>
+      <ng-template #parent>
+        Your workplace met the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements,
+        but keeping your data up to date will save you time next year
+      </ng-template>
+    </ng-container>
+  </ng-template>
+
+  <ng-template #notMeeting>
+    <ng-container *ngIf="!wdfEligibilityStatus.overall">
+      Your data does not meet the WDF {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
+    </ng-container>
+  </ng-template>
 </h4>

--- a/src/app/features/wdf/wdf-data-status-message/wdf-data-status-message.component.ts
+++ b/src/app/features/wdf/wdf-data-status-message/wdf-data-status-message.component.ts
@@ -10,5 +10,5 @@ export class WdfDataStatusMessageComponent {
   @Input() public wdfStartDate: string;
   @Input() public wdfEndDate: string;
   @Input() public wdfEligibilityStatus: WdfEligibilityStatus;
-  @Input() public isParent = false;
+  @Input() public isStandalone = true;
 }

--- a/src/app/features/wdf/wdf-data-status-message/wdf-data-status-message.component.ts
+++ b/src/app/features/wdf/wdf-data-status-message/wdf-data-status-message.component.ts
@@ -10,5 +10,5 @@ export class WdfDataStatusMessageComponent {
   @Input() public wdfStartDate: string;
   @Input() public wdfEndDate: string;
   @Input() public wdfEligibilityStatus: WdfEligibilityStatus;
-  @Input() public isStandalone = true;
+  @Input() public isStandalone: boolean;
 }

--- a/src/app/features/wdf/wdf-data/wdf-data.component.html
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.html
@@ -1,17 +1,17 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
       <span class="govuk-caption-xl">Workforce Development Fund (WDF)</span>
       WDF data<ng-container *ngIf="workplace && !isStandalone">: {{ workplace.name }}</ng-container>
     </h1>
+    <app-wdf-data-status-message
+      [wdfStartDate]="wdfStartDate"
+      [wdfEndDate]="wdfEndDate"
+      [wdfEligibilityStatus]="wdfEligibilityStatus"
+      [isStandalone]="isStandalone"
+    ></app-wdf-data-status-message>
   </div>
 </div>
-
-<app-wdf-data-status-message
-  [wdfStartDate]="wdfStartDate"
-  [wdfEndDate]="wdfEndDate"
-  [wdfEligibilityStatus]="wdfEligibilityStatus"
-></app-wdf-data-status-message>
 
 <app-tabs>
   <app-tab

--- a/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
@@ -192,11 +192,12 @@ describe('WdfDataComponent', () => {
     });
   });
 
-  describe('WdfStatusMessageComponent', async () => {
+  describe('WdfDataStatusMessageComponent', async () => {
     it('should display the correct message and timeframe if meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
       const timeframeSentence = 'Your data meets the WDF 2021 to 2022 requirements';
 
+      component.isStandalone = true;
       component.wdfEligibilityStatus.overall = true;
       component.wdfEligibilityStatus.currentWorkplace = true;
       component.wdfEligibilityStatus.currentStaff = true;
@@ -209,6 +210,7 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getByText } = await setup();
       const keepUpToDateMessage = 'Keeping your data up to date will save you time next year';
 
+      component.isStandalone = true;
       component.wdfEligibilityStatus.overall = true;
       component.wdfEligibilityStatus.currentWorkplace = true;
       component.wdfEligibilityStatus.currentStaff = false;
@@ -221,6 +223,45 @@ describe('WdfDataComponent', () => {
       const { component, fixture, getByText } = await setup();
       const notMeetingMessage = 'Your data does not meet the WDF 2021 to 2022 requirements';
 
+      component.isStandalone = true;
+      component.wdfEligibilityStatus.overall = false;
+      fixture.detectChanges();
+
+      expect(getByText(notMeetingMessage, { exact: false })).toBeTruthy();
+    });
+
+    it('should display the correct message and timeframe for parents if meeting WDF requirements', async () => {
+      const { component, fixture, getByText } = await setup();
+      const timeframeSentence = 'Your data meets the WDF 2021 to 2022 requirements';
+
+      component.isStandalone = false;
+      component.wdfEligibilityStatus.overall = true;
+      component.wdfEligibilityStatus.currentWorkplace = true;
+      component.wdfEligibilityStatus.currentStaff = true;
+      fixture.detectChanges();
+
+      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
+    });
+
+    it('should display the "keeping data up to date" message for parents if meeting WDF requirements with data changes', async () => {
+      const { component, fixture, getByText } = await setup();
+      const keepUpToDateMessage =
+        'Your workplace met the WDF 2021 to 2022 requirements, but keeping your data up to date will save you time next year';
+
+      component.isStandalone = false;
+      component.wdfEligibilityStatus.overall = true;
+      component.wdfEligibilityStatus.currentWorkplace = false;
+      component.wdfEligibilityStatus.currentStaff = false;
+      fixture.detectChanges();
+
+      expect(getByText(keepUpToDateMessage, { exact: false })).toBeTruthy();
+    });
+
+    it('should display the not meeting message for parents if not meeting WDF requirements overall', async () => {
+      const { component, fixture, getByText } = await setup();
+      const notMeetingMessage = 'Your data does not meet the WDF 2021 to 2022 requirements';
+
+      component.isStandalone = false;
       component.wdfEligibilityStatus.overall = false;
       fixture.detectChanges();
 

--- a/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.html
+++ b/src/app/features/wdf/wdf-staff-record-status-message/wdf-staff-record-status-message.component.html
@@ -9,8 +9,8 @@
   <ng-container *ngIf="!overallWdfEligibility && !worker.wdfEligible">
     <h4 class="govuk-heading-s">
       <img class="govuk-!-margin-right-1 govuk-util__vertical-align-top" src="/assets/images/cross-icon.svg" alt="" />
-      <span class="govuk-visually-hidden">Red cross</span>Not meeting the WDF {{ wdfStartDate | date: 'yyyy' }} to
-      {{ wdfEndDate | date: 'yyyy' }} requirements
+      <span class="govuk-visually-hidden">Red cross</span>This record does not meet the WDF
+      {{ wdfStartDate | date: 'yyyy' }} to {{ wdfEndDate | date: 'yyyy' }} requirements
     </h4>
   </ng-container>
 </span>

--- a/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.spec.ts
+++ b/src/app/features/wdf/wdf-staff-record/wdf-staff-record.component.spec.ts
@@ -71,7 +71,7 @@ describe('WdfStaffRecordComponent', () => {
 
   it('should display the "not meeting requirements" message and red cross when user does not meet WDF requirements overall and current staff record does not', async () => {
     const { component, fixture, getByText } = await setup();
-    const expectedStatusMessage = 'Not meeting the WDF 2021 to 2022 requirements';
+    const expectedStatusMessage = 'This record does not meet the WDF 2021 to 2022 requirements';
     const redCrossVisuallyHiddenMessage = 'Red cross';
 
     component.worker = workerBuilder();

--- a/src/app/shared/components/staff-record-summary/personal-details/personal-details.component.html
+++ b/src/app/shared/components/staff-record-summary/personal-details/personal-details.component.html
@@ -63,7 +63,7 @@
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
       <app-summary-record-change
-        *ngIf="!(wdfView && wdfNewDesign)"
+        *ngIf="!(wdfView && wdfNewDesign && !!worker.dateOfBirth)"
         [explanationText]="' date of birth'"
         [link]="getRoutePath('date-of-birth')"
         [hasData]="!!worker.dateOfBirth"
@@ -101,7 +101,7 @@
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
       <app-summary-record-change
-        *ngIf="!(wdfView && wdfNewDesign)"
+        *ngIf="!(wdfView && wdfNewDesign && !!worker.gender)"
         [explanationText]="' gender'"
         [link]="getRoutePath('gender')"
         [hasData]="!!worker.gender"

--- a/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.html
+++ b/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.html
@@ -3,6 +3,6 @@
 </span>
 <span class="govuk__nowrap">
   Either change the total or
-  <a href="" [routerLink]="staffRecordsUrl.url" [fragment]="staffRecordsUrl.fragment">view staff records</a> to add more
+  <a [routerLink]="staffRecordsUrl.url" [fragment]="staffRecordsUrl.fragment">view staff records</a> to add more
   records.
 </span>

--- a/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.html
+++ b/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.html
@@ -2,5 +2,7 @@
   <img class="govuk-!-margin-right-1" src="/assets/images/{{ icon }}.svg" alt="" />{{ staffMismatchMessage }}
 </span>
 <span class="govuk__nowrap">
-  Either change the total or <a href="dashboard#staff-records">view staff records</a> to add more records.
+  Either change the total or
+  <a href="" [routerLink]="staffRecordsUrl.url" [fragment]="staffRecordsUrl.fragment">view staff records</a> to add more
+  records.
 </span>

--- a/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.spec.ts
+++ b/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.spec.ts
@@ -1,6 +1,8 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
@@ -13,6 +15,7 @@ describe('WdfStaffMismatchMessageComponent', () => {
       WdfStaffMismatchMessageComponent,
       {
         imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
+        providers: [{ provide: EstablishmentService, useClass: MockEstablishmentService }],
         componentProperties: { workplace: establishmentBuilder(), workerCount: 1 },
       },
     );

--- a/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.ts
+++ b/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.ts
@@ -1,18 +1,28 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
+import { URLStructure } from '@core/model/url.model';
+import { EstablishmentService } from '@core/services/establishment.service';
 
 @Component({
   selector: 'app-wdf-staff-mismatch-message',
   templateUrl: './wdf-staff-mismatch-message.component.html',
 })
 export class WdfStaffMismatchMessageComponent implements OnInit {
-  @Input() workplace: Establishment;
-  @Input() workerCount: number;
-  @Input() overallWdfEligibility: boolean;
+  @Input() public workplace: Establishment;
+  @Input() public workerCount: number;
+  @Input() public overallWdfEligibility: boolean;
   public staffMismatchMessage: string;
   public icon: string;
+  public staffRecordsUrl: URLStructure;
+  private primaryWorkplaceUid: string;
+
+  constructor(private route: ActivatedRoute, private establishmentService: EstablishmentService) {}
 
   ngOnInit() {
+    this.primaryWorkplaceUid = this.establishmentService.primaryWorkplace.uid;
+
+    this.setStaffRecordsUrl();
     this.setMessage();
     this.setIcon();
   }
@@ -41,6 +51,14 @@ export class WdfStaffMismatchMessageComponent implements OnInit {
     if (this.overallWdfEligibility == false) {
       this.icon = 'cross-icon';
       return;
+    }
+  }
+
+  private setStaffRecordsUrl(): void {
+    if (this.route.snapshot.params.establishmentuid && this.primaryWorkplaceUid !== this.workplace.uid) {
+      this.staffRecordsUrl = { url: ['/workplace', this.workplace.uid], fragment: 'staff-records' };
+    } else {
+      this.staffRecordsUrl = { url: ['/dashboard'], fragment: 'staff-records' };
     }
   }
 }

--- a/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.ts
+++ b/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.ts
@@ -15,7 +15,7 @@ export class WdfStaffMismatchMessageComponent implements OnInit {
   public staffMismatchMessage: string;
   public icon: string;
   public staffRecordsUrl: URLStructure;
-  private primaryWorkplaceUid: string;
+  public primaryWorkplaceUid: string;
 
   constructor(private route: ActivatedRoute, private establishmentService: EstablishmentService) {}
 
@@ -54,7 +54,7 @@ export class WdfStaffMismatchMessageComponent implements OnInit {
     }
   }
 
-  private setStaffRecordsUrl(): void {
+  public setStaffRecordsUrl(): void {
     if (this.route.snapshot.params.establishmentuid && this.primaryWorkplaceUid !== this.workplace.uid) {
       this.staffRecordsUrl = { url: ['/workplace', this.workplace.uid], fragment: 'staff-records' };
     } else {


### PR DESCRIPTION
#### Work done
- Add WDF data status messages for parents
- Update staff record status message
- Add logic to show the 'Add information' button when DOB and gender fields are empty
- Update 'view staff records' URL in staff mismatch message component depending on whether user is a parent or sub

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
