### PR TITLE
fix(staffRecordQuestionsAndLabels): Change phrasing for social care q…

### DIFF
--- a/src/app/features/workers/social-care-qualification/social-care-qualification.component.html
+++ b/src/app/features/workers/social-care-qualification/social-care-qualification.component.html
@@ -9,9 +9,7 @@
       >
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">
-              Do they hold a qualification relevant to social care?
-            </h1>
+            <h1 class="govuk-fieldset__heading">Do they have a qualification relevant to social care?</h1>
           </legend>
           <div class="govuk-radios">
             <div *ngFor="let answer of answersAvailable; let idx = index" class="govuk-radios__item">

--- a/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
+++ b/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
@@ -160,7 +160,7 @@
   </div>
 
   <div class="govuk-summary-list__row" *ngIf="displayOtherQualifications">
-    <dt class="govuk-summary-list__key">Highest level of non-social care qualification</dt>
+    <dt class="govuk-summary-list__key">Highest level of other qualifications</dt>
     <dd class="govuk-summary-list__value">
       <app-summary-record-value
         [wdfView]="wdfView"


### PR DESCRIPTION
#### Changes
- Change staff record label to ‘Highest level of other qualifications’ from ‘Highest level of non-social care qualification’
- Change social care qualification question to ‘Do they have a qualification relevant to social care?’

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
