### PR TITLE
Bug: WDF Eligibility

### DIFF
--- a/migrations/20210607093353-WdfEligibilityColumn.js
+++ b/migrations/20210607093353-WdfEligibilityColumn.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const table = {
+  tableName: 'Worker',
+  schema: 'cqc',
+};
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      try {
+        await Promise.all(
+          [
+            queryInterface.addColumn(
+              table,
+              'WdfEligible',
+              {
+                type: Sequelize.DataTypes.BOOLEAN,
+                allowNull: false,
+                defaultValue: false
+              },
+              { transaction },
+            ),
+          ]
+        )
+        return Promise.resolve();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await Promise.all(
+        queryInterface.removeColumn(table, 'WdfEligible'),
+    )
+  }
+};

--- a/migrations/20210607093353-WdfEligibilityColumn.js
+++ b/migrations/20210607093353-WdfEligibilityColumn.js
@@ -21,6 +21,10 @@ module.exports = {
               },
               { transaction },
             ),
+            queryInterface.sequelize.query(`
+            ALTER TABLE cqc."Worker"
+            DROP COLUMN IF EXISTS "CurrentWdfEligibiity";
+          `),
           ]
         )
         return Promise.resolve();

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -626,9 +626,7 @@ class Worker extends EntityValidator {
           // every time the worker is saved, need to calculate
           //  it's current WDF Eligibility, and if it is eligible, update
           //  the last WDF Eligibility status
-          let wdfAudit = null;
-
-          this.setWdfProperties(modifedCreationDocument, updatedTimestamp, wdfAudit, savedBy);
+          const wdfAudit = await this.setWdfProperties(modifedCreationDocument, updatedTimestamp, savedBy);
 
           // now save the document
           const creation = await models.worker.create(modifedCreationDocument, { transaction: thisTransaction });

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -722,9 +722,7 @@ class Worker extends EntityValidator {
           // every time the worker is saved, need to calculate
           //  it's current WDF Eligibility, and if it is eligible, update
           //  the last WDF Eligibility status
-          let wdfAudit = null;
-
-          await this.setWdfProperties(updateDocument, updatedTimestamp, wdfAudit, savedBy);
+          const wdfAudit = await this.setWdfProperties(updateDocument, updatedTimestamp, savedBy);
 
           // now save the document
           const [updatedRecordCount, updatedRows] = await models.worker.update(updateDocument, {
@@ -864,7 +862,7 @@ class Worker extends EntityValidator {
     return mustSave;
   }
 
-  async setWdfProperties(document, updatedTimestamp, wdfAudit, savedBy) {
+  async setWdfProperties(document, updatedTimestamp, savedBy) {
     const currentWdfEligibility = await this.isWdfEligible(WdfCalculator.effectiveDate);
     const effectiveDateTime = WdfCalculator.effectiveTime;
 
@@ -875,10 +873,12 @@ class Worker extends EntityValidator {
       (this._lastWdfEligibility === null || this._lastWdfEligibility.getTime() < effectiveDateTime)
     ) {
       document.lastWdfEligibility = updatedTimestamp;
-      wdfAudit = {
+     return {
         username: savedBy.toLowerCase(),
         type: 'wdfEligible',
       };
+    } else {
+      return null;
     }
   }
 

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -61,6 +61,7 @@ class Worker extends EntityValidator {
     // local attributes
     this._reason = null;
     this._lastWdfEligibility = null;
+    this._wdfEligible = null;
 
     // associated entities
     this._qualificationsEntities = [];
@@ -625,21 +626,9 @@ class Worker extends EntityValidator {
           // every time the worker is saved, need to calculate
           //  it's current WDF Eligibility, and if it is eligible, update
           //  the last WDF Eligibility status
-          const currentWdfEligibiity = await this.isWdfEligible(WdfCalculator.effectiveDate);
-
-          const effectiveDateTime = WdfCalculator.effectiveTime;
-
           let wdfAudit = null;
-          if (
-            currentWdfEligibiity.isEligible &&
-            (this._lastWdfEligibility === null || this._lastWdfEligibility.getTime() < effectiveDateTime)
-          ) {
-            modifedCreationDocument.lastWdfEligibility = updatedTimestamp;
-            wdfAudit = {
-              username: savedBy.toLowerCase(),
-              type: 'wdfEligible',
-            };
-          }
+
+          this.setWdfProperties(modifedCreationDocument, updatedTimestamp, wdfAudit, savedBy);
 
           // now save the document
           const creation = await models.worker.create(modifedCreationDocument, { transaction: thisTransaction });
@@ -733,21 +722,9 @@ class Worker extends EntityValidator {
           // every time the worker is saved, need to calculate
           //  it's current WDF Eligibility, and if it is eligible, update
           //  the last WDF Eligibility status
-          const currentWdfEligibiity = await this.isWdfEligible(WdfCalculator.effectiveDate);
-
-          const effectiveDateTime = WdfCalculator.effectiveTime;
-
           let wdfAudit = null;
-          if (
-            currentWdfEligibiity.isEligible &&
-            (this._lastWdfEligibility === null || this._lastWdfEligibility.getTime() < effectiveDateTime)
-          ) {
-            updateDocument.lastWdfEligibility = updatedTimestamp;
-            wdfAudit = {
-              username: savedBy.toLowerCase(),
-              type: 'wdfEligible',
-            };
-          }
+
+          await this.setWdfProperties(updateDocument, updatedTimestamp, wdfAudit, savedBy);
 
           // now save the document
           const [updatedRecordCount, updatedRows] = await models.worker.update(updateDocument, {
@@ -887,6 +864,24 @@ class Worker extends EntityValidator {
     return mustSave;
   }
 
+  async setWdfProperties(document, updatedTimestamp, wdfAudit, savedBy) {
+    const currentWdfEligibility = await this.isWdfEligible(WdfCalculator.effectiveDate);
+    const effectiveDateTime = WdfCalculator.effectiveTime;
+
+    document.wdfEligible = currentWdfEligibility.isEligible;
+
+    if (
+      currentWdfEligibility.isEligible &&
+      (this._lastWdfEligibility === null || this._lastWdfEligibility.getTime() < effectiveDateTime)
+    ) {
+      document.lastWdfEligibility = updatedTimestamp;
+      wdfAudit = {
+        username: savedBy.toLowerCase(),
+        type: 'wdfEligible',
+      };
+    }
+  }
+
   // loads the Worker (with given id) from DB, but only if it belongs to the given Establishment
   // returns true on success; false if no Worker
   // Can throw WorkerRestoreException exception.
@@ -977,6 +972,7 @@ class Worker extends EntityValidator {
         this._updated = fetchResults.updated;
         this._updatedBy = fetchResults.updatedBy;
         this._lastWdfEligibility = fetchResults.lastWdfEligibility;
+        this._wdfEligible = fetchResults.wdfEligible;
 
         // if history of the Worker is also required; attach the association
         //  and order in reverse chronological - note, order on id (not when)
@@ -1867,47 +1863,6 @@ class Worker extends EntityValidator {
     } catch (err) {
       console.error('Worker::bulkUpdateLocalIdentifiers error: ', err);
       throw err;
-    }
-  }
-
-  static async recalcWdf(username, establishmentId, workerUid, externalTransaction) {
-    try {
-      const thisWorker = new Worker(establishmentId);
-      await thisWorker.restore(workerUid);
-
-      // only try to update if not yet eligible
-      if (thisWorker._lastWdfEligibility === null) {
-        const wdfEligibility = await thisWorker.wdfToJson();
-        if (wdfEligibility.isEligible) {
-          const updatedWorker = await models.worker.update(
-            {
-              lastWdfEligibility: new Date(),
-            },
-            {
-              where: {
-                uid: workerUid,
-              },
-              returning: true,
-              plain: true,
-              transaction: externalTransaction,
-            },
-          );
-
-          await models.workerAudit.create(
-            {
-              workerFk: updatedWorker[1].dataValues.ID,
-              username,
-              type: 'wdfEligible',
-            },
-            { transaction: externalTransaction },
-          );
-        }
-      } // end if _lastWdfEligibility
-
-      return true;
-    } catch (err) {
-      console.error('Worker::recalcWdf error: ', err);
-      return false;
     }
   }
 }

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -79,6 +79,10 @@ module.exports = function (sequelize, DataTypes) {
         allowNull: true,
         field: '"LastWdfEligibility"',
       },
+      wdfEligible: {
+        type: DataTypes.BOOLEAN,
+        field: '"WdfEligible"',
+      },
       NameOrIdValue: {
         type: DataTypes.TEXT,
         allowNull: false,
@@ -1286,6 +1290,7 @@ module.exports = function (sequelize, DataTypes) {
         'updated',
         'updatedBy',
         'lastWdfEligibility',
+        'wdfEligible',
         [
           sequelize.literal('(SELECT COUNT(0) FROM cqc."WorkerTraining" WHERE "WorkerFK" = "worker"."ID")'),
           'trainingCount',

--- a/server/routes/establishments/worker.js
+++ b/server/routes/establishments/worker.js
@@ -271,7 +271,7 @@ const viewAllWorkers = async (req, res) => {
               updated: worker.updated,
               updatedBy: worker.updatedBy,
               effectiveFrom: effectiveFromIso,
-              wdfEligible: moment(worker.lastWdfEligibility).isAfter(effectiveFromIso),
+              wdfEligible: worker.wdfEligible && moment(worker.lastWdfEligibility).isAfter(effectiveFromIso),
               wdfEligibilityLastUpdated: worker.lastWdfEligibility
                 ? worker.lastWdfEligibility.toISOString()
                 : undefined,

--- a/server/test/unit/routes/establishments/worker.spec.js
+++ b/server/test/unit/routes/establishments/worker.spec.js
@@ -202,7 +202,7 @@ describe('worker route', () => {
         updated: worker.updated,
         updatedBy: worker.updatedBy,
         effectiveFrom: effectiveFrom,
-        wdfEligible: moment(worker.lastWdfEligibility).isAfter(effectiveFrom),
+        wdfEligible: worker.wdfEligible && moment(worker.lastWdfEligibility).isAfter(effectiveFrom),
         wdfEligibilityLastUpdated: worker.lastWdfEligibility.toISOString(),
       });
       expect(res._getData().workers[0].mainJob).to.contains({


### PR DESCRIPTION
#### Work done
- Add new `wdfEligible` column to the database and remove `currentWdfEligibiity` column
- Refactor save and load functions in `worker.js` to use `setWdfProperties`
- Use `wdfEligible` from database to determine if a worker is eligible for WDF for `viewAllWorkers` endpoint
- Delete unused function `recalcWdf` from `worker.js`

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
