### PR TITLE
Fix: WDF tab icon

### DIFF
--- a/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.spec.ts
@@ -190,6 +190,15 @@ describe('WdfDataComponent', () => {
 
       expect(component.getStaffWdfEligibility(component.workers)).toBeFalse();
     });
+
+    it('should return false when there are no workers', async () => {
+      const { component, fixture } = await setup();
+
+      component.workers = [];
+      fixture.detectChanges();
+
+      expect(component.getStaffWdfEligibility(component.workers)).toBeFalse();
+    });
   });
 
   describe('WdfDataStatusMessageComponent', async () => {

--- a/src/app/features/wdf/wdf-data/wdf-data.component.ts
+++ b/src/app/features/wdf/wdf-data/wdf-data.component.ts
@@ -124,6 +124,9 @@ export class WdfDataComponent implements OnInit {
   }
 
   public getStaffWdfEligibility(workers: Worker[]): boolean {
+    if (workers.length == 0) {
+      return false;
+    }
     return workers.every((worker) => worker.wdfEligible === true);
   }
 


### PR DESCRIPTION
#### Changes
- Fixed an issue where staff tab had a tick when there were no workers
- Set `staffWdfEligibility` to false when there are no workers

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
