### PR TITLE
Feat: Targeted emails

### DIFF
--- a/server/models/emailcampaign.js
+++ b/server/models/emailcampaign.js
@@ -57,6 +57,7 @@ module.exports = (sequelize, DataTypes) => {
   EmailCampaign.types = () => {
     return {
       INACTIVE_WORKPLACES: 'inactiveWorkplaces',
+      TARGETED_EMAILS: 'targetedEmails'
     }
   }
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -402,6 +402,7 @@ module.exports = function (sequelize, DataTypes) {
         {
           model: sequelize.models.establishment,
           attributes: [
+            'id',
             'nmdsId',
             'NameValue',
           ],

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -387,5 +387,28 @@ module.exports = function (sequelize, DataTypes) {
     });
   };
 
+  User.allPrimaryUsers = async function() {
+    return await this.findAll({
+      attributes: [
+        [sequelize.literal('DISTINCT ON ("user"."EmailValue") "user"."EmailValue"'), 'email'],
+        'id',
+        'FullNameValue',
+      ],
+      where: {
+        isPrimary: true,
+        archived: false,
+      },
+      include: [
+        {
+          model: sequelize.models.establishment,
+          attributes: [
+            'nmdsId',
+            'NameValue',
+          ],
+        }
+      ],
+    })
+  }
+
   return User;
 };

--- a/server/routes/admin/email-campaigns/inactive-workplaces/index.js
+++ b/server/routes/admin/email-campaigns/inactive-workplaces/index.js
@@ -1,12 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const moment = require('moment');
-const { pRateLimit } = require('p-ratelimit');
 
 const models = require('../../../../models');
 const findInactiveWorkplaces = require('../../../../services/email-campaigns/inactive-workplaces/findInactiveWorkplaces');
 const findParentWorkplaces = require('../../../../services/email-campaigns/inactive-workplaces/findParentWorkplaces');
 const sendEmail = require('../../../../services/email-campaigns/inactive-workplaces/sendEmail');
+const { limit } = require('../../../../services/email-campaigns/limit');
+
 
 const getInactiveWorkplaces = async (_req, res) => {
   try {
@@ -53,11 +54,6 @@ const createCampaign = async (req, res) => {
     });
 
     await models.EmailCampaignHistory.bulkCreate(history);
-
-    const limit = pRateLimit({
-      interval: 1000,
-      rate: 5, // 5 emails per second
-    });
 
     totalInactiveWorkplaces.map((inactiveWorkplace) => {
       return limit(() => sendEmail.sendEmail(inactiveWorkplace));

--- a/server/routes/admin/email-campaigns/index.js
+++ b/server/routes/admin/email-campaigns/index.js
@@ -2,5 +2,6 @@ const express = require('express');
 const router = express.Router();
 
 router.use('/inactive-workplaces', require('./inactive-workplaces'));
+router.use('/targeted-emails', require('./targeted-emails'));
 
 module.exports = router;

--- a/server/routes/admin/email-campaigns/targeted-emails/index.js
+++ b/server/routes/admin/email-campaigns/targeted-emails/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+
+const getTargetedUsers = async (req, res) => {
+  return res.status(200).send({totalUsers: 1500});
+}
+
+router.route('/').get(getTargetedUsers);
+
+module.exports.router = router;
+module.exports.getTargetedUsers = getTargetedUsers;

--- a/server/routes/admin/email-campaigns/targeted-emails/index.js
+++ b/server/routes/admin/email-campaigns/targeted-emails/index.js
@@ -2,10 +2,23 @@ const express = require('express');
 const router = express.Router();
 
 const getTargetedTotalEmails = async (req, res) => {
-  return res.status(200).send({totalEmails: 1500});
-}
+  return res.status(200).send({ totalEmails: 1500 });
+};
+
+const getTargetedEmailTemplates = async (req, res) => {
+  return res.status(200).send({
+    templates: [
+      {
+        id: 3,
+        name: 'Email about something important',
+      },
+    ],
+  });
+};
 
 router.route('/total').get(getTargetedTotalEmails);
+router.route('/templates').get(getTargetedEmailTemplates);
 
 module.exports = router;
 module.exports.getTargetedTotalEmails = getTargetedTotalEmails;
+module.exports.getTargetedEmailTemplates = getTargetedEmailTemplates;

--- a/server/routes/admin/email-campaigns/targeted-emails/index.js
+++ b/server/routes/admin/email-campaigns/targeted-emails/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const sendInBlue = require('../../../../utils/email/sendInBlueEmail');
+const models = require('../../../../models/');
 const router = express.Router();
 
 const templateOptions = {
@@ -10,7 +11,17 @@ const templateOptions = {
 };
 
 const getTargetedTotalEmails = async (req, res) => {
-  return res.status(200).send({ totalEmails: 1500 });
+  const groups = {
+    'primaryUsers': await models.user.allPrimaryUsers(),
+  };
+
+  try {
+    const users = groups[req.query.groupType];
+    return res.status(200).send({ totalEmails: users.length });
+  } catch(error) {
+    console.error(error);
+    return res.status(503).send();
+  }
 };
 
 const getTargetedEmailTemplates = async (req, res) => {

--- a/server/routes/admin/email-campaigns/targeted-emails/index.js
+++ b/server/routes/admin/email-campaigns/targeted-emails/index.js
@@ -16,9 +16,15 @@ const getTargetedEmailTemplates = async (req, res) => {
   });
 };
 
+const createTargetedEmailsCampaign = async (req, res) => {
+  return res.status(200).send({ success: true });
+};
+
 router.route('/total').get(getTargetedTotalEmails);
 router.route('/templates').get(getTargetedEmailTemplates);
+router.route('/').post(createTargetedEmailsCampaign);
 
 module.exports = router;
 module.exports.getTargetedTotalEmails = getTargetedTotalEmails;
 module.exports.getTargetedEmailTemplates = getTargetedEmailTemplates;
+module.exports.createTargetedEmailsCampaign = createTargetedEmailsCampaign;

--- a/server/routes/admin/email-campaigns/targeted-emails/index.js
+++ b/server/routes/admin/email-campaigns/targeted-emails/index.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { celebrate, Joi, errors, Segments } = require('celebrate');
 const sendInBlue = require('../../../../utils/email/sendInBlueEmail');
 const models = require('../../../../models/');
 const router = express.Router();
@@ -45,7 +46,16 @@ const createTargetedEmailsCampaign = async (req, res) => {
   return res.status(200).send({ success: true });
 };
 
-router.route('/total').get(getTargetedTotalEmails);
+router.route('/total').get(
+  celebrate({
+    [Segments.QUERY]: {
+      groupType: Joi.string().valid('primaryUsers'),
+    },
+  }),
+  getTargetedTotalEmails,
+);
+
+router.use('/total', errors());
 router.route('/templates').get(getTargetedEmailTemplates);
 router.route('/').post(createTargetedEmailsCampaign);
 

--- a/server/routes/admin/email-campaigns/targeted-emails/index.js
+++ b/server/routes/admin/email-campaigns/targeted-emails/index.js
@@ -1,11 +1,11 @@
 const express = require('express');
 const router = express.Router();
 
-const getTargetedUsers = async (req, res) => {
-  return res.status(200).send({totalUsers: 1500});
+const getTargetedTotalEmails = async (req, res) => {
+  return res.status(200).send({totalEmails: 1500});
 }
 
-router.route('/').get(getTargetedUsers);
+router.route('/total').get(getTargetedTotalEmails);
 
-module.exports.router = router;
-module.exports.getTargetedUsers = getTargetedUsers;
+module.exports = router;
+module.exports.getTargetedTotalEmails = getTargetedTotalEmails;

--- a/server/routes/admin/email-campaigns/targeted-emails/index.js
+++ b/server/routes/admin/email-campaigns/targeted-emails/index.js
@@ -1,19 +1,33 @@
 const express = require('express');
+const sendInBlue = require('../../../../utils/email/sendInBlueEmail');
 const router = express.Router();
+
+const templateOptions = {
+  templateStatus: true, // Boolean | Filter on the status of the template. Active = true, inactive = false
+  limit: 50, // Number | Number of documents returned per page
+  offset: 0, // Number | Index of the first document in the page
+  sort: 'desc', // String | Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+};
 
 const getTargetedTotalEmails = async (req, res) => {
   return res.status(200).send({ totalEmails: 1500 });
 };
 
 const getTargetedEmailTemplates = async (req, res) => {
-  return res.status(200).send({
-    templates: [
-      {
-        id: 3,
-        name: 'Email about something important',
-      },
-    ],
-  });
+  try {
+    const templates = await sendInBlue.getTemplates(templateOptions);
+    const formattedTemplates = templates.templates.map(({ id, name }) => {
+      return { id, name };
+    });
+
+    return res.status(200).send({
+      templates: formattedTemplates,
+    });
+  } catch (error) {
+    return res.status(200).send({
+      templates: [],
+    });
+  }
 };
 
 const createTargetedEmailsCampaign = async (req, res) => {
@@ -28,3 +42,4 @@ module.exports = router;
 module.exports.getTargetedTotalEmails = getTargetedTotalEmails;
 module.exports.getTargetedEmailTemplates = getTargetedEmailTemplates;
 module.exports.createTargetedEmailsCampaign = createTargetedEmailsCampaign;
+module.exports.templateOptions = templateOptions;

--- a/server/services/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/sendEmail.js
@@ -2,7 +2,7 @@ const moment = require('moment');
 
 const config = require('../../../config/config');
 const sendInBlueEmail = require('../../../utils/email/sendInBlueEmail');
-const { isWhitelisted } = require('../isWhitelisted');
+const isWhitelisted = require('../isWhitelisted');
 
 const endOfLastMonth = moment().subtract(1, 'months').endOf('month').endOf('day');
 
@@ -28,7 +28,7 @@ const getParams = (workplace) => {
 };
 
 const sendEmail = async (workplace) => {
-  if (!isWhitelisted(workplace.user.email)) {
+  if (!isWhitelisted.isWhitelisted(workplace.user.email)) {
     return;
   }
 

--- a/server/services/email-campaigns/inactive-workplaces/sendEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/sendEmail.js
@@ -2,6 +2,7 @@ const moment = require('moment');
 
 const config = require('../../../config/config');
 const sendInBlueEmail = require('../../../utils/email/sendInBlueEmail');
+const { isWhitelisted } = require('../isWhitelisted');
 
 const endOfLastMonth = moment().subtract(1, 'months').endOf('month').endOf('day');
 
@@ -26,14 +27,6 @@ const getParams = (workplace) => {
   return params;
 };
 
-const isWhitelisted = (email) => {
-  if (!config.get('sendInBlue.whitelist')) {
-    return true;
-  }
-
-  return config.get('sendInBlue.whitelist').split(',').includes(email);
-};
-
 const sendEmail = async (workplace) => {
   if (!isWhitelisted(workplace.user.email)) {
     return;
@@ -54,5 +47,4 @@ const sendEmail = async (workplace) => {
 module.exports = {
   sendEmail,
   getParams,
-  isWhitelisted,
 };

--- a/server/services/email-campaigns/isWhitelisted.js
+++ b/server/services/email-campaigns/isWhitelisted.js
@@ -1,0 +1,13 @@
+const config = require('../../config/config');
+
+const isWhitelisted = (email) => {
+  if (!config.get('sendInBlue.whitelist')) {
+    return true;
+  }
+
+  return config.get('sendInBlue.whitelist').split(',').includes(email);
+};
+
+module.exports = {
+  isWhitelisted,
+};

--- a/server/services/email-campaigns/limit.js
+++ b/server/services/email-campaigns/limit.js
@@ -2,7 +2,7 @@ const { pRateLimit } = require('p-ratelimit');
 
 const limit = pRateLimit({
       interval: 1000,
-      rate: 15, // 5 emails per second
+      rate: 15, // 15 emails per second
 });
 
 exports.limit = limit;

--- a/server/services/email-campaigns/limit.js
+++ b/server/services/email-campaigns/limit.js
@@ -1,0 +1,8 @@
+const { pRateLimit } = require('p-ratelimit');
+
+const limit = pRateLimit({
+      interval: 1000,
+      rate: 15, // 5 emails per second
+});
+
+exports.limit = limit;

--- a/server/services/email-campaigns/targeted-emails/sendEmail.js
+++ b/server/services/email-campaigns/targeted-emails/sendEmail.js
@@ -1,5 +1,5 @@
 const sendInBlueEmail = require('../../../utils/email/sendInBlueEmail');
-const { isWhitelisted } = require('../isWhitelisted');
+const isWhitelisted = require('../isWhitelisted');
 
 const getParams = (user) => {
   return {
@@ -9,7 +9,7 @@ const getParams = (user) => {
 };
 
 const sendEmail = async (user, templateId) => {
-  if (!isWhitelisted(user.get('email'))) {
+  if (!isWhitelisted.isWhitelisted(user.get('email'))) {
     return;
   }
 

--- a/server/services/email-campaigns/targeted-emails/sendEmail.js
+++ b/server/services/email-campaigns/targeted-emails/sendEmail.js
@@ -1,0 +1,31 @@
+const sendInBlueEmail = require('../../../utils/email/sendInBlueEmail');
+const { isWhitelisted } = require('../isWhitelisted');
+
+const getParams = (user) => {
+  return {
+    FULL_NAME: user.FullNameValue,
+    WORKPLACE_ID: user.establishment.nmdsId,
+  };
+};
+
+const sendEmail = async (user, templateId) => {
+  if (!isWhitelisted(user.get('email'))) {
+    return;
+  }
+
+  const params = getParams(user);
+
+  sendInBlueEmail.sendEmail(
+    {
+      email: user.get('email'),
+      name: user.FullNameValue,
+    },
+    templateId,
+    params,
+  );
+};
+
+module.exports = {
+  sendEmail,
+  getParams,
+};

--- a/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
@@ -11,11 +11,12 @@ const user = build('User', {
   fields: {
     FullNameValue: fake((f) => f.name.findName()),
     email: fake((f) => f.internet.email()),
+    get: () => fake((f) => f.internet.email()),
     establishment: {
       id: sequence(),
       NameValue: fake((f) => f.lorem.sentence()),
       nmdsId: fake((f) => f.helpers.replaceSymbols('?#####'))
-    }
+    },
   },
 });
 

--- a/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
@@ -36,6 +36,7 @@ describe('server/routes/admin/email-campaigns/targeted-emails', () => {
       expect(response.totalEmails).to.deep.equal(1500);
     });
   });
+
   describe('getTargetedEmailTemplates()', () => {
     it('should return 200', async () => {
       const req = httpMocks.createRequest({
@@ -71,6 +72,38 @@ describe('server/routes/admin/email-campaigns/targeted-emails', () => {
       const response = res._getData();
 
       expect(response.templates).to.deep.equal(templates);
+    });
+  });
+
+  describe('createTargetedEmailsCampaign()', () => {
+    it('should return 200', async () => {
+      const req = httpMocks.createRequest({
+        method: 'POST',
+        url: '/api/admin/email-campaigns/targeted-emails',
+      });
+
+      req.role = 'Admin';
+
+      const res = httpMocks.createResponse();
+      await targetedEmailsRoutes.createTargetedEmailsCampaign(req, res);
+
+      expect(res.statusCode).to.deep.equal(200);
+    });
+
+    it('should return a success when complete', async () => {
+      const req = httpMocks.createRequest({
+        method: 'POST',
+        url: '/api/admin/email-campaigns/targeted-emails',
+      });
+
+      req.role = 'Admin';
+
+      const res = httpMocks.createResponse();
+      await targetedEmailsRoutes.createTargetedEmailsCampaign(req, res);
+
+      const response = res._getData();
+
+      expect(response).to.deep.equal({ success: true });
     });
   });
 });

--- a/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
@@ -3,9 +3,30 @@ const httpMocks = require('node-mocks-http');
 const sinon = require('sinon');
 const targetedEmailsRoutes = require('../../../../../../routes/admin/email-campaigns/targeted-emails');
 const sendInBlue = require('../../../../../../utils/email/sendInBlueEmail');
+const models = require('../../../../../../models');
+const { build, fake } = require('@jackfranklin/test-data-bot/build');
+
+const user = build('User', {
+  fields: {
+    FullNameValue: fake((f) => f.name.findName()),
+    email: fake((f) => f.internet.email()),
+    establishment: {
+      NameValue: fake((f) => f.lorem.sentence()),
+      nmdsId: fake((f) => f.helpers.replaceSymbols('?#####'))
+    }
+  },
+});
 
 describe('server/routes/admin/email-campaigns/targeted-emails', () => {
   describe('getTargetedTotalEmails()', () => {
+    beforeEach(() => {
+      sinon.stub(models.user, 'allPrimaryUsers').returns([user, user, user]);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it('should return 200', async () => {
       const req = httpMocks.createRequest({
         method: 'GET',
@@ -35,7 +56,7 @@ describe('server/routes/admin/email-campaigns/targeted-emails', () => {
 
       const response = res._getData();
 
-      expect(response.totalEmails).to.deep.equal(1500);
+      expect(response.totalEmails).to.deep.equal(3);
     });
   });
 

--- a/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
@@ -3,7 +3,7 @@ const httpMocks = require('node-mocks-http');
 const targetedEmailsRoutes = require('../../../../../../routes/admin/email-campaigns/targeted-emails')
 
 describe('server/routes/admin/email-campaigns/targeted-emails', () => {
-    describe('getTargetedUsers()', () => {
+    describe('getTargetedTotalEmails()', () => {
       it('should return 200', async () => {
         const req = httpMocks.createRequest({
           method: 'GET',
@@ -14,7 +14,7 @@ describe('server/routes/admin/email-campaigns/targeted-emails', () => {
         req.query.groupType = 'primaryUsers';
 
         const res = httpMocks.createResponse();
-        await targetedEmailsRoutes.getTargetedUsers(req, res);
+        await targetedEmailsRoutes.getTargetedTotalEmails(req, res);
 
         expect(res.statusCode).to.deep.equal(200);
       });
@@ -29,11 +29,11 @@ describe('server/routes/admin/email-campaigns/targeted-emails', () => {
         req.query.groupType = 'primaryUsers';
 
         const res = httpMocks.createResponse();
-        await targetedEmailsRoutes.getTargetedUsers(req, res);
+        await targetedEmailsRoutes.getTargetedTotalEmails(req, res);
 
         const response = res._getData();
 
-        expect(response.totalUsers).to.deep.equal(1500);
+        expect(response.totalEmails).to.deep.equal(1500);
       })
     });
 });

--- a/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
@@ -1,0 +1,39 @@
+const expect = require('chai').expect;
+const httpMocks = require('node-mocks-http');
+const targetedEmailsRoutes = require('../../../../../../routes/admin/email-campaigns/targeted-emails')
+
+describe('server/routes/admin/email-campaigns/targeted-emails', () => {
+    describe('getTargetedUsers()', () => {
+      it('should return 200', async () => {
+        const req = httpMocks.createRequest({
+          method: 'GET',
+          url: '/api/admin/email-campaigns/targeted-emails',
+        });
+
+        req.role = 'Admin';
+        req.query.groupType = 'primaryUsers';
+
+        const res = httpMocks.createResponse();
+        await targetedEmailsRoutes.getTargetedUsers(req, res);
+
+        expect(res.statusCode).to.deep.equal(200);
+      });
+
+      it('should return the total number of users', async () => {
+        const req = httpMocks.createRequest({
+          method: 'GET',
+          url: '/api/admin/email-campaigns/targeted-emails',
+        });
+
+        req.role = 'Admin';
+        req.query.groupType = 'primaryUsers';
+
+        const res = httpMocks.createResponse();
+        await targetedEmailsRoutes.getTargetedUsers(req, res);
+
+        const response = res._getData();
+
+        expect(response.totalUsers).to.deep.equal(1500);
+      })
+    });
+});

--- a/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
@@ -1,39 +1,76 @@
 const expect = require('chai').expect;
 const httpMocks = require('node-mocks-http');
-const targetedEmailsRoutes = require('../../../../../../routes/admin/email-campaigns/targeted-emails')
+const targetedEmailsRoutes = require('../../../../../../routes/admin/email-campaigns/targeted-emails');
 
 describe('server/routes/admin/email-campaigns/targeted-emails', () => {
-    describe('getTargetedTotalEmails()', () => {
-      it('should return 200', async () => {
-        const req = httpMocks.createRequest({
-          method: 'GET',
-          url: '/api/admin/email-campaigns/targeted-emails',
-        });
-
-        req.role = 'Admin';
-        req.query.groupType = 'primaryUsers';
-
-        const res = httpMocks.createResponse();
-        await targetedEmailsRoutes.getTargetedTotalEmails(req, res);
-
-        expect(res.statusCode).to.deep.equal(200);
+  describe('getTargetedTotalEmails()', () => {
+    it('should return 200', async () => {
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: '/api/admin/email-campaigns/targeted-emails/total',
       });
 
-      it('should return the total number of users', async () => {
-        const req = httpMocks.createRequest({
-          method: 'GET',
-          url: '/api/admin/email-campaigns/targeted-emails',
-        });
+      req.role = 'Admin';
+      req.query.groupType = 'primaryUsers';
 
-        req.role = 'Admin';
-        req.query.groupType = 'primaryUsers';
+      const res = httpMocks.createResponse();
+      await targetedEmailsRoutes.getTargetedTotalEmails(req, res);
 
-        const res = httpMocks.createResponse();
-        await targetedEmailsRoutes.getTargetedTotalEmails(req, res);
-
-        const response = res._getData();
-
-        expect(response.totalEmails).to.deep.equal(1500);
-      })
+      expect(res.statusCode).to.deep.equal(200);
     });
+
+    it('should return the total number of users', async () => {
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: '/api/admin/email-campaigns/targeted-emails/total',
+      });
+
+      req.role = 'Admin';
+      req.query.groupType = 'primaryUsers';
+
+      const res = httpMocks.createResponse();
+      await targetedEmailsRoutes.getTargetedTotalEmails(req, res);
+
+      const response = res._getData();
+
+      expect(response.totalEmails).to.deep.equal(1500);
+    });
+  });
+  describe('getTargetedEmailTemplates()', () => {
+    it('should return 200', async () => {
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: '/api/admin/email-campaigns/targeted-emails/templates',
+      });
+
+      req.role = 'Admin';
+
+      const res = httpMocks.createResponse();
+      await targetedEmailsRoutes.getTargetedEmailTemplates(req, res);
+
+      expect(res.statusCode).to.deep.equal(200);
+    });
+
+    it('should return the templates from send in blue', async () => {
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: '/api/admin/email-campaigns/targeted-emails/templates',
+      });
+
+      req.role = 'Admin';
+
+      const templates = [
+        {
+          id: 3,
+          name: 'Email about something important',
+        },
+      ];
+      const res = httpMocks.createResponse();
+      await targetedEmailsRoutes.getTargetedEmailTemplates(req, res);
+
+      const response = res._getData();
+
+      expect(response.templates).to.deep.equal(templates);
+    });
+  });
 });

--- a/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
+++ b/server/test/unit/routes/admin/email-campaigns/targeted-emails/index.spec.js
@@ -1,6 +1,8 @@
 const expect = require('chai').expect;
 const httpMocks = require('node-mocks-http');
+const sinon = require('sinon');
 const targetedEmailsRoutes = require('../../../../../../routes/admin/email-campaigns/targeted-emails');
+const sendInBlue = require('../../../../../../utils/email/sendInBlueEmail');
 
 describe('server/routes/admin/email-campaigns/targeted-emails', () => {
   describe('getTargetedTotalEmails()', () => {
@@ -38,6 +40,30 @@ describe('server/routes/admin/email-campaigns/targeted-emails', () => {
   });
 
   describe('getTargetedEmailTemplates()', () => {
+    beforeEach(() => {
+      sinon.stub(sendInBlue, 'getTemplates').returns({
+        count: 1,
+        templates: [
+          {
+            id: 3,
+            name: 'Email about something important',
+            subject: 'Merry Christmas',
+            isActive: false,
+            testSent: false,
+            sender: { name: 'John', email: 'john.smith@example.com', id: 23 },
+            replyTo: 'replyto@domain.com',
+            toField: '',
+            tag: 'Festival',
+            htmlContent: 'HTML CONTENT 1',
+            createdAt: '2016-02-24T14:44:24.000Z',
+            modifiedAt: '2016-02-24T15:37:11.000Z',
+          },
+        ],
+      });
+    });
+    afterEach(() => {
+      sinon.restore();
+    });
     it('should return 200', async () => {
       const req = httpMocks.createRequest({
         method: 'GET',
@@ -60,18 +86,43 @@ describe('server/routes/admin/email-campaigns/targeted-emails', () => {
 
       req.role = 'Admin';
 
-      const templates = [
-        {
-          id: 3,
-          name: 'Email about something important',
-        },
-      ];
+      const templates = {
+        templates: [
+          {
+            id: 3,
+            name: 'Email about something important',
+          },
+        ],
+      };
       const res = httpMocks.createResponse();
       await targetedEmailsRoutes.getTargetedEmailTemplates(req, res);
 
       const response = res._getData();
 
-      expect(response.templates).to.deep.equal(templates);
+      expect(response).to.deep.equal(templates);
+    });
+
+    it('should return an empty array if error thrown', async () => {
+      sinon.restore();
+      sinon.stub(sendInBlue, 'getTemplates').throws();
+
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        url: '/api/admin/email-campaigns/targeted-emails/templates',
+      });
+
+      req.role = 'Admin';
+
+      const templates = {
+        templates: [],
+      };
+      const res = httpMocks.createResponse();
+      await targetedEmailsRoutes.getTargetedEmailTemplates(req, res);
+
+      const response = res._getData();
+
+      expect(res.statusCode).to.deep.equal(200);
+      expect(response).to.deep.equal(templates);
     });
   });
 

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -2,7 +2,6 @@ const expect = require('chai').expect;
 const moment = require('moment');
 const sinon = require('sinon');
 
-const config = require('../../../../../config/config');
 const sendEmail = require('../../../../../services/email-campaigns/inactive-workplaces/sendEmail');
 const sendInBlueEmail = require('../../../../../utils/email/sendInBlueEmail');
 
@@ -214,32 +213,6 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
           },
         ],
       });
-    });
-  });
-
-  describe('isWhitelisted', () => {
-    it('should return true if there is no whitelist', () => {
-      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('');
-
-      const whitelisted = sendEmail.isWhitelisted('test@test.com');
-
-      expect(whitelisted).to.equal(true);
-    });
-
-    it('should return true if the email is whitelisted', () => {
-      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
-
-      const whitelisted = sendEmail.isWhitelisted('test@test.com');
-
-      expect(whitelisted).to.equal(true);
-    });
-
-    it('should return false if the email is not whitelisted', () => {
-      sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
-
-      const whitelisted = sendEmail.isWhitelisted('example@example.com');
-
-      expect(whitelisted).to.equal(false);
     });
   });
 });

--- a/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/inactive-workplaces/sendEmail.spec.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 
 const sendEmail = require('../../../../../services/email-campaigns/inactive-workplaces/sendEmail');
 const sendInBlueEmail = require('../../../../../utils/email/sendInBlueEmail');
+const isWhitelisted = require('../../../../../services/email-campaigns/isWhitelisted');
 
 describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', () => {
   afterEach(() => {
@@ -30,8 +31,14 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
       };
 
       const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
+      const isWhitelistedStub = sinon.stub(isWhitelisted, 'isWhitelisted').returns(true);
 
       await sendEmail.sendEmail(inactiveWorkplace);
+
+      sinon.assert.calledWith(
+        isWhitelistedStub,
+        'test@example.com'
+      );
 
       sinon.assert.calledWith(
         sendEmailStub,
@@ -74,8 +81,14 @@ describe('server/routes/admin/email-campaigns/inactive-workplaces/sendEmail', ()
       };
 
       const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
+      const isWhitelistedStub = sinon.stub(isWhitelisted, 'isWhitelisted').returns(true);
 
       await sendEmail.sendEmail(parentWorkplace);
+
+      sinon.assert.calledWith(
+        isWhitelistedStub,
+        'test@example.com'
+      );
 
       sinon.assert.calledWith(
         sendEmailStub,

--- a/server/test/unit/services/email-campaigns/isWhitelisted.spec.js
+++ b/server/test/unit/services/email-campaigns/isWhitelisted.spec.js
@@ -1,0 +1,35 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const { isWhitelisted } = require('../../../../services/email-campaigns/isWhitelisted');
+const config = require('../../../../config/config');
+
+describe('isWhitelisted', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return true if there is no whitelist', () => {
+    sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('');
+
+    const whitelisted = isWhitelisted('test@test.com');
+
+    expect(whitelisted).to.equal(true);
+  });
+
+  it('should return true if the email is whitelisted', () => {
+    sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+    const whitelisted = isWhitelisted('test@test.com');
+
+    expect(whitelisted).to.equal(true);
+  });
+
+  it('should return false if the email is not whitelisted', () => {
+    sinon.stub(config, 'get').withArgs('sendInBlue.whitelist').returns('test@test.com,name@name.com');
+
+    const whitelisted = isWhitelisted('example@example.com');
+
+    expect(whitelisted).to.equal(false);
+  });
+});

--- a/server/test/unit/services/email-campaigns/targeted-emails/sendEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/targeted-emails/sendEmail.spec.js
@@ -1,0 +1,65 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const sendEmail = require('../../../../../services/email-campaigns/targeted-emails/sendEmail');
+const sendInBlueEmail = require('../../../../../utils/email/sendInBlueEmail');
+
+describe('server/routes/admin/email-campaigns/targeted-emails/sendEmail', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('sendEmail', () => {
+    it('should call sendEmails for primary users', async () => {
+      const user = {
+        email: 'test@test.com',
+        FullNameValue: 'Test Name',
+        establishment: {
+          nmdsId: 'J1234567',
+          NameValue: 'Haven Care'
+        },
+        get: () => {
+          return 'test@test.com';
+        }
+      };
+      const templateId = 1;
+
+      const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
+
+      await sendEmail.sendEmail(user, templateId);
+
+      sinon.assert.calledWith(
+        sendEmailStub,
+        {
+          email: 'test@test.com',
+          name: 'Test Name',
+        },
+        1,
+        {
+          FULL_NAME: 'Test Name',
+          WORKPLACE_ID: 'J1234567',
+        },
+      );
+    });
+  });
+
+  describe('getParams', () => {
+    it('returns the right params for primary users', () => {
+      const user = {
+        FullNameValue: 'Test Name',
+        dataValues: {
+          email: 'test@example.com',
+        },
+        establishment: {
+          nmdsId: 'J1234567',
+        },
+      };
+
+      const params = sendEmail.getParams(user);
+      expect(params).to.deep.equal({
+        FULL_NAME: 'Test Name',
+        WORKPLACE_ID: 'J1234567',
+      });
+    });
+  });
+});

--- a/server/test/unit/services/email-campaigns/targeted-emails/sendEmail.spec.js
+++ b/server/test/unit/services/email-campaigns/targeted-emails/sendEmail.spec.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 
 const sendEmail = require('../../../../../services/email-campaigns/targeted-emails/sendEmail');
 const sendInBlueEmail = require('../../../../../utils/email/sendInBlueEmail');
+const isWhitelisted = require('../../../../../services/email-campaigns/isWhitelisted');
 
 describe('server/routes/admin/email-campaigns/targeted-emails/sendEmail', () => {
   afterEach(() => {
@@ -24,10 +25,16 @@ describe('server/routes/admin/email-campaigns/targeted-emails/sendEmail', () => 
       };
       const templateId = 1;
 
+      const isWhitelistedStub = sinon.stub(isWhitelisted, 'isWhitelisted').returns(true);
+
       const sendEmailStub = sinon.stub(sendInBlueEmail, 'sendEmail').returns();
 
       await sendEmail.sendEmail(user, templateId);
 
+      sinon.assert.calledWith(
+        isWhitelistedStub,
+        'test@test.com'
+      )
       sinon.assert.calledWith(
         sendEmailStub,
         {

--- a/server/test/unit/utils/email/sendInBlueEmail.spec.js
+++ b/server/test/unit/utils/email/sendInBlueEmail.spec.js
@@ -1,6 +1,7 @@
 const SibApiV3Sdk = require('sib-api-v3-sdk');
 const sinon = require('sinon');
-const { sendEmail } = require('../../../../utils/email/sendInBlueEmail')
+const { templateOptions } = require('../../../../routes/admin/email-campaigns/targeted-emails');
+const { sendEmail, getTemplates } = require('../../../../utils/email/sendInBlueEmail');
 
 describe('sendInBlueEmail', async () => {
   afterEach(() => {
@@ -14,8 +15,8 @@ describe('sendInBlueEmail', async () => {
     });
 
     const to = {
-      name: "test",
-      email: 'test@test.com'
+      name: 'test',
+      email: 'test@test.com',
     };
     const templateId = 2;
     const params = {
@@ -25,15 +26,28 @@ describe('sendInBlueEmail', async () => {
     await sendEmail(to, templateId, params);
 
     const sendSmtpEmail = new SibApiV3Sdk.SendSmtpEmail();
-    sendSmtpEmail.to = [{
-      name: "test",
-      email: "test@test.com",
-    }];
+    sendSmtpEmail.to = [
+      {
+        name: 'test',
+        email: 'test@test.com',
+      },
+    ];
     sendSmtpEmail.templateId = 2;
     sendSmtpEmail.params = {
       firstName: 'Test',
     };
 
     sinon.assert.calledWith(sendTransacEmail, sendSmtpEmail);
-  })
+  });
+
+  it('should get the email templates', async () => {
+    const getSmtpTemplates = sinon.stub();
+    sinon.stub(SibApiV3Sdk, 'TransactionalEmailsApi').returns({
+      getSmtpTemplates,
+    });
+
+    await getTemplates(templateOptions);
+
+    sinon.assert.calledWith(getSmtpTemplates, templateOptions);
+  });
 });

--- a/server/utils/email/sendInBlueEmail.js
+++ b/server/utils/email/sendInBlueEmail.js
@@ -29,4 +29,16 @@ const sendEmail = async (to, templateId, params) => {
   }
 };
 
+const getTemplates = async (options) => {
+  try {
+    const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();
+
+    return await apiInstance.getSmtpTemplates(options);
+  } catch (error) {
+    console.error(error);
+    throw new Error(error);
+  }
+};
+
 exports.sendEmail = sendEmail;
+exports.getTemplates = getTemplates;

--- a/src/app/core/model/emails.model.ts
+++ b/src/app/core/model/emails.model.ts
@@ -1,0 +1,12 @@
+export interface TotalEmailsResponse {
+  totalEmails: number;
+}
+
+export interface Template {
+  id: number;
+  name: string;
+}
+
+export interface TemplatesResponse {
+  templates: Template[];
+}

--- a/src/app/core/model/emails.model.ts
+++ b/src/app/core/model/emails.model.ts
@@ -1,3 +1,8 @@
+export enum EmailType {
+  'InactiveWorkplaces',
+  'TargetedEmails',
+}
+
 export interface TotalEmailsResponse {
   totalEmails: number;
 }

--- a/src/app/core/resolvers/admin/email-campaign-history.resolver.spec.ts
+++ b/src/app/core/resolvers/admin/email-campaign-history.resolver.spec.ts
@@ -24,10 +24,10 @@ describe('EmailCampaignHistoryResolver', () => {
 
   it('should resolve', () => {
     const emailCampaignService = TestBed.inject(EmailCampaignService);
-    spyOn(emailCampaignService, 'getHistory').and.callThrough();
+    spyOn(emailCampaignService, 'getInactiveWorkplacesHistory').and.callThrough();
 
     resolver.resolve({} as ActivatedRouteSnapshot);
 
-    expect(emailCampaignService.getHistory).toHaveBeenCalled();
+    expect(emailCampaignService.getInactiveWorkplacesHistory).toHaveBeenCalled();
   });
 });

--- a/src/app/core/resolvers/admin/email-campaign-history.resolver.ts
+++ b/src/app/core/resolvers/admin/email-campaign-history.resolver.ts
@@ -9,7 +9,7 @@ export class EmailCampaignHistoryResolver implements Resolve<any> {
   constructor(private router: Router, private emailCampaignService: EmailCampaignService) {}
 
   resolve(route: ActivatedRouteSnapshot) {
-    return this.emailCampaignService.getHistory().pipe(
+    return this.emailCampaignService.getInactiveWorkplacesHistory().pipe(
       catchError(() => {
         this.router.navigate(['/emails']);
         return EMPTY;

--- a/src/app/core/resolvers/admin/email-template.resolver.spec.ts
+++ b/src/app/core/resolvers/admin/email-template.resolver.spec.ts
@@ -1,0 +1,33 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { EmailCampaignService } from '@core/services/admin/email-campaign.service';
+import { SearchModule } from '@features/search/search.module';
+
+import { EmailTemplateResolver } from './email-template.resolver';
+
+describe('EmailTemplateResolver', () => {
+  let resolver: EmailTemplateResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [SearchModule, HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [EmailTemplateResolver],
+    });
+    resolver = TestBed.inject(EmailTemplateResolver);
+  });
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy();
+  });
+
+  it('should resolve', () => {
+    const emailCampaignService = TestBed.inject(EmailCampaignService);
+    spyOn(emailCampaignService, 'getTargetedTemplates').and.callThrough();
+
+    resolver.resolve({} as ActivatedRouteSnapshot);
+
+    expect(emailCampaignService.getTargetedTemplates).toHaveBeenCalled();
+  });
+});

--- a/src/app/core/resolvers/admin/email-template.resolver.ts
+++ b/src/app/core/resolvers/admin/email-template.resolver.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
+import { EmailCampaignService } from '@core/services/admin/email-campaign.service';
+import { EMPTY } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable()
+export class EmailTemplateResolver implements Resolve<any> {
+  constructor(private router: Router, private emailCampaignService: EmailCampaignService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.emailCampaignService.getTargetedTemplates().pipe(
+      catchError(() => {
+        return EMPTY;
+      }),
+    );
+  }
+}

--- a/src/app/core/resolvers/admin/email-template.resolver.ts
+++ b/src/app/core/resolvers/admin/email-template.resolver.ts
@@ -11,6 +11,7 @@ export class EmailTemplateResolver implements Resolve<any> {
   resolve(route: ActivatedRouteSnapshot) {
     return this.emailCampaignService.getTargetedTemplates().pipe(
       catchError(() => {
+        this.router.navigate(['/emails']);
         return EMPTY;
       }),
     );

--- a/src/app/core/services/admin/email-campaign.service.spec.ts
+++ b/src/app/core/services/admin/email-campaign.service.spec.ts
@@ -57,4 +57,22 @@ describe('EmailCampaignService', () => {
 
     expect(req.request.method).toBe('GET');
   });
+
+  it('should get a total number of emails been sent to targeted users', () => {
+    service.getTargetedTotalEmails('primaryUsers').subscribe();
+
+    const http = TestBed.inject(HttpTestingController);
+    const req = http.expectOne('/api/admin/email-campaigns/targeted-emails/total?groupType=primaryUsers');
+
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should get a list of templates that can be sent to targeted users', () => {
+    service.getTargetedTemplates().subscribe();
+
+    const http = TestBed.inject(HttpTestingController);
+    const req = http.expectOne('/api/admin/email-campaigns/targeted-emails/templates');
+
+    expect(req.request.method).toBe('GET');
+  });
 });

--- a/src/app/core/services/admin/email-campaign.service.spec.ts
+++ b/src/app/core/services/admin/email-campaign.service.spec.ts
@@ -32,7 +32,7 @@ describe('EmailCampaignService', () => {
   });
 
   it('should create a campaign', () => {
-    service.createCampaign().subscribe();
+    service.createInactiveWorkplacesCampaign().subscribe();
 
     const http = TestBed.inject(HttpTestingController);
     const req = http.expectOne('/api/admin/email-campaigns/inactive-workplaces');
@@ -41,7 +41,7 @@ describe('EmailCampaignService', () => {
   });
 
   it('should get the history', () => {
-    service.getHistory().subscribe();
+    service.getInactiveWorkplacesHistory().subscribe();
 
     const http = TestBed.inject(HttpTestingController);
     const req = http.expectOne('/api/admin/email-campaigns/inactive-workplaces/history');
@@ -50,7 +50,7 @@ describe('EmailCampaignService', () => {
   });
 
   it('should get a report of inactive workplaces', () => {
-    service.getReport().subscribe();
+    service.getInactiveWorkplacesReport().subscribe();
 
     const http = TestBed.inject(HttpTestingController);
     const req = http.expectOne('/api/admin/email-campaigns/inactive-workplaces/report');

--- a/src/app/core/services/admin/email-campaign.service.spec.ts
+++ b/src/app/core/services/admin/email-campaign.service.spec.ts
@@ -31,7 +31,7 @@ describe('EmailCampaignService', () => {
     expect(req.request.method).toBe('GET');
   });
 
-  it('should create a campaign', () => {
+  it('should create a campaign for inactive workplaces', () => {
     service.createInactiveWorkplacesCampaign().subscribe();
 
     const http = TestBed.inject(HttpTestingController);
@@ -74,5 +74,16 @@ describe('EmailCampaignService', () => {
     const req = http.expectOne('/api/admin/email-campaigns/targeted-emails/templates');
 
     expect(req.request.method).toBe('GET');
+  });
+
+  it('should create a campaign for targeted users', () => {
+    service.createTargetedEmailsCampaign('primaryUsers', '1').subscribe();
+
+    const http = TestBed.inject(HttpTestingController);
+    const req = http.expectOne('/api/admin/email-campaigns/targeted-emails');
+
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.groupType).toEqual('primaryUsers');
+    expect(req.request.body.templateId).toEqual('1');
   });
 });

--- a/src/app/core/services/admin/email-campaign.service.ts
+++ b/src/app/core/services/admin/email-campaign.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 @Injectable()
 export class EmailCampaignService {
@@ -23,5 +23,9 @@ export class EmailCampaignService {
       observe: 'response',
       responseType: 'blob' as 'json',
     });
+  }
+
+  getTargetedUsers(groupType: string): Observable<number> {
+    return of(1500);
   }
 }

--- a/src/app/core/services/admin/email-campaign.service.ts
+++ b/src/app/core/services/admin/email-campaign.service.ts
@@ -1,6 +1,7 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { TemplatesResponse, TotalEmailsResponse } from '@core/model/emails.model';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class EmailCampaignService {
@@ -25,7 +26,16 @@ export class EmailCampaignService {
     });
   }
 
-  getTargetedUsers(groupType: string): Observable<number> {
-    return of(1500);
+  getTargetedTotalEmails(groupType: string): Observable<TotalEmailsResponse> {
+    let params = new HttpParams();
+    params = params.set('groupType', groupType);
+
+    return this.http.get<TotalEmailsResponse>('/api/admin/email-campaigns/targeted-emails/total', {
+      params,
+    });
+  }
+
+  getTargetedTemplates(): Observable<TemplatesResponse> {
+    return this.http.get<TemplatesResponse>('/api/admin/email-campaigns/targeted-emails/templates');
   }
 }

--- a/src/app/core/services/admin/email-campaign.service.ts
+++ b/src/app/core/services/admin/email-campaign.service.ts
@@ -10,15 +10,15 @@ export class EmailCampaignService {
     return this.http.get<any>('/api/admin/email-campaigns/inactive-workplaces');
   }
 
-  createCampaign(): Observable<any> {
+  createInactiveWorkplacesCampaign(): Observable<any> {
     return this.http.post<any>('/api/admin/email-campaigns/inactive-workplaces', {});
   }
 
-  getHistory(): Observable<any> {
+  getInactiveWorkplacesHistory(): Observable<any> {
     return this.http.get<any>('/api/admin/email-campaigns/inactive-workplaces/history');
   }
 
-  getReport(): Observable<any> {
+  getInactiveWorkplacesReport(): Observable<any> {
     return this.http.get<any>('/api/admin/email-campaigns/inactive-workplaces/report', {
       observe: 'response',
       responseType: 'blob' as 'json',

--- a/src/app/core/services/admin/email-campaign.service.ts
+++ b/src/app/core/services/admin/email-campaign.service.ts
@@ -38,4 +38,11 @@ export class EmailCampaignService {
   getTargetedTemplates(): Observable<TemplatesResponse> {
     return this.http.get<TemplatesResponse>('/api/admin/email-campaigns/targeted-emails/templates');
   }
+
+  createTargetedEmailsCampaign(groupType: string, templateId: string): Observable<any> {
+    return this.http.post<any>('/api/admin/email-campaigns/targeted-emails', {
+      groupType,
+      templateId,
+    });
+  }
 }

--- a/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.html
+++ b/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.html
@@ -1,10 +1,10 @@
 <h1 id="dialogHeading" data-testid="send-emails-confirmation-header">Are you sure you want to send these emails?</h1>
 
 <p>
-  This will send an email to <strong>{{ data.inactiveWorkplaces | number }} </strong>
-  <ng-container *ngIf="data.inactiveWorkplaces" [ngPlural]="data.inactiveWorkplaces">
-    <ng-template ngPluralCase="=1">workplace.</ng-template>
-    <ng-template ngPluralCase="other">workplaces.</ng-template>
+  This will send an email to <strong>{{ data.emailCount | number }} </strong>
+  <ng-container *ngIf="data.emailCount" [ngPlural]="data.emailCount">
+    <ng-template ngPluralCase="=1">user.</ng-template>
+    <ng-template ngPluralCase="other">users.</ng-template>
   </ng-container>
 </p>
 

--- a/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.spec.ts
+++ b/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.spec.ts
@@ -17,17 +17,17 @@ describe('SendEmailsConfirmationDialogComponent', () => {
 
   it('should display confirmation dialog', async () => {
     const component = await setup();
-    component.fixture.componentInstance.data.inactiveWorkplaces = 10;
+    component.fixture.componentInstance.data.emailCount = 10;
     component.fixture.detectChanges(true);
     const p = component.fixture.nativeElement.querySelector('p');
-    expect(p.innerText).toContain('This will send an email to 10 workplaces.');
+    expect(p.innerText).toContain('This will send an email to 10 users.');
   });
 
   it('should pluralise the confirmation dialog', async () => {
     const component = await setup();
-    component.fixture.componentInstance.data.inactiveWorkplaces = 1;
+    component.fixture.componentInstance.data.emailCount = 1;
     component.fixture.detectChanges(true);
     const p = component.fixture.nativeElement.querySelector('p');
-    expect(p.innerText).toContain('This will send an email to 1 workplace.');
+    expect(p.innerText).toContain('This will send an email to 1 user.');
   });
 });

--- a/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.ts
+++ b/src/app/features/search/emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component.ts
@@ -8,7 +8,7 @@ import { Dialog, DIALOG_DATA } from '@core/services/dialog.service';
 })
 export class SendEmailsConfirmationDialogComponent extends DialogComponent {
   constructor(
-    @Inject(DIALOG_DATA) public data: { inactiveWorkplaces: number },
+    @Inject(DIALOG_DATA) public data: { emailCount: number },
     public dialog: Dialog<SendEmailsConfirmationDialogComponent>,
   ) {
     super(data, dialog);

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -140,7 +140,7 @@
             data-testid="selectedTemplateId"
           >
             <option value="">Select a template</option>
-            <option value="1">Template 1</option>
+            <option *ngFor="let template of templates" [value]="template.id">{{ template.name }}</option>
           </select>
         </div>
       </div>

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -14,7 +14,7 @@
         <button
           class="govuk-button govuk-!-margin-right-9"
           [disabled]="!inactiveWorkplaces"
-          (click)="confirmSendEmails($event)"
+          (click)="confirmSendEmails($event, inactiveWorkplaces, emailType.InactiveWorkplaces)"
           type="submit"
         >
           Send emails
@@ -146,7 +146,12 @@
       </div>
     </div>
 
-    <button class="govuk-button" [disabled]="emailGroup === '' || selectedTemplateId === ''" type="submit">
+    <button
+      class="govuk-button"
+      [disabled]="emailGroup === '' || selectedTemplateId === ''"
+      (click)="confirmSendEmails($event, totalEmails, emailType.TargetedEmails)"
+      type="submit"
+    >
       Send emails to selected group
     </button>
   </div>

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -104,3 +104,50 @@
     </ul>
   </div>
 </div>
+
+<h1 class="govuk-heading-xl govuk-!-margin-top-5">Targeted Emails</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <dl class="govuk-list--definition">
+      <dt>Total number of users to be emailed</dt>
+      <dd data-testid="totalEmails">
+        {{ totalEmails | number }}
+      </dd>
+    </dl>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-form-group govuk-!-margin-top-3">
+        <div class="govuk-grid-column-one-half">
+          <label class="govuk-label" for="emailGroup"> Email group </label>
+          <select
+            [(ngModel)]="emailGroup"
+            class="govuk-select govuk-!-width-full"
+            id="emailGroup"
+            data-testid="emailGroup"
+            (change)="updateTotalEmails($event.target.value)"
+          >
+            <option value=""></option>
+            <option value="primaryUsers">Primary users</option>
+          </select>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <label class="govuk-label" for="templateId"> Template ID </label>
+          <select
+            [(ngModel)]="templateId"
+            class="govuk-select govuk-!-width-full"
+            id="templateId"
+            data-testid="templateId"
+          >
+            <option value=""></option>
+            <option value="1">Template 1</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <button class="govuk-button" [disabled]="emailGroup === '' || templateId === ''" type="submit">
+      Send emails to selected group
+    </button>
+  </div>
+</div>

--- a/src/app/features/search/emails/emails.component.html
+++ b/src/app/features/search/emails/emails.component.html
@@ -127,26 +127,26 @@
             data-testid="emailGroup"
             (change)="updateTotalEmails($event.target.value)"
           >
-            <option value=""></option>
+            <option value="">Select a user group</option>
             <option value="primaryUsers">Primary users</option>
           </select>
         </div>
         <div class="govuk-grid-column-one-half">
-          <label class="govuk-label" for="templateId"> Template ID </label>
+          <label class="govuk-label" for="selectedTemplateId"> Template ID </label>
           <select
-            [(ngModel)]="templateId"
+            [(ngModel)]="selectedTemplateId"
             class="govuk-select govuk-!-width-full"
-            id="templateId"
-            data-testid="templateId"
+            id="selectedTemplateId"
+            data-testid="selectedTemplateId"
           >
-            <option value=""></option>
+            <option value="">Select a template</option>
             <option value="1">Template 1</option>
           </select>
         </div>
       </div>
     </div>
 
-    <button class="govuk-button" [disabled]="emailGroup === '' || templateId === ''" type="submit">
+    <button class="govuk-button" [disabled]="emailGroup === '' || selectedTemplateId === ''" type="submit">
       Send emails to selected group
     </button>
   </div>

--- a/src/app/features/search/emails/emails.component.spec.ts
+++ b/src/app/features/search/emails/emails.component.spec.ts
@@ -36,201 +36,248 @@ describe('EmailsComponent', () => {
     });
   }
 
-  it('should create', async () => {
-    const component = await setup();
-    expect(component).toBeTruthy();
-  });
+  describe('Inactive workplaces', () => {
+    it('should create', async () => {
+      const component = await setup();
+      expect(component).toBeTruthy();
+    });
 
-  it('should display the total number of inactive workplaces', async () => {
-    const component = await setup();
-
-    component.fixture.componentInstance.inactiveWorkplaces = 1250;
-    component.fixture.detectChanges();
-
-    const numInactiveWorkplaces = component.getByTestId('inactiveWorkplaces');
-    const sendEmailsButton = component.fixture.nativeElement.querySelector('button');
-    expect(numInactiveWorkplaces.innerHTML).toContain('1,250');
-    expect(sendEmailsButton.disabled).toBeFalsy();
-  });
-
-  it('should disable the "Send emails" button when there are no inactive workplaces', async () => {
-    const component = await setup();
-
-    component.fixture.componentInstance.inactiveWorkplaces = 0;
-    component.fixture.detectChanges();
-
-    const sendEmailsButton = component.fixture.nativeElement.querySelector('button');
-    expect(sendEmailsButton.disabled).toBeTruthy();
-  });
-
-  it('should display all existing history', async () => {
-    const component = await setup();
-
-    component.fixture.componentInstance.history = [
-      {
-        date: '2021-01-05',
-        emails: 351,
-      },
-      {
-        date: '2020-12-05',
-        emails: 772,
-      },
-    ];
-
-    component.fixture.detectChanges();
-
-    const numInactiveWorkplaces = component.getByTestId('emailCampaignHistory');
-    expect(numInactiveWorkplaces.innerHTML).toContain('05/01/2021');
-    expect(numInactiveWorkplaces.innerHTML).toContain('772');
-    expect(numInactiveWorkplaces.innerHTML).toContain('05/12/2020');
-    expect(numInactiveWorkplaces.innerHTML).toContain('351');
-  });
-
-  it('should display a message when no emails have been sent', async () => {
-    const component = await setup();
-
-    const numInactiveWorkplaces = component.getByTestId('emailCampaignHistory');
-    expect(numInactiveWorkplaces.innerHTML).toContain('No emails have been sent yet.');
-  });
-
-  it('should call confirmSendEmails when the "Send emails" button is clicked', async () => {
-    const component = await setup();
-
-    component.fixture.componentInstance.inactiveWorkplaces = 25;
-    component.fixture.detectChanges();
-
-    fireEvent.click(component.getByText('Send emails', { exact: false }));
-
-    const dialog = await within(document.body).findByRole('dialog');
-    const dialogHeader = within(dialog).getByTestId('send-emails-confirmation-header');
-
-    expect(dialogHeader).toBeTruthy();
-  });
-
-  [
-    {
-      emails: 2500,
-      expectedMessage: '2,500 emails have been scheduled to be sent.',
-    },
-    {
-      emails: 1,
-      expectedMessage: '1 email has been scheduled to be sent.',
-    },
-  ].forEach(({ emails, expectedMessage }) => {
-    it('should display an alert when the "Send emails" button is clicked', async () => {
+    it('should display the total number of inactive workplaces', async () => {
       const component = await setup();
 
-      component.fixture.componentInstance.inactiveWorkplaces = 2500;
+      component.fixture.componentInstance.inactiveWorkplaces = 1250;
+      component.fixture.detectChanges();
+
+      const numInactiveWorkplaces = component.getByTestId('inactiveWorkplaces');
+      const sendEmailsButton = component.fixture.nativeElement.querySelectorAll('button');
+      expect(numInactiveWorkplaces.innerHTML).toContain('1,250');
+      expect(sendEmailsButton[0].disabled).toBeFalsy();
+    });
+
+    it('should disable the "Send emails" button when there are no inactive workplaces', async () => {
+      const component = await setup();
+
+      component.fixture.componentInstance.inactiveWorkplaces = 0;
+      component.fixture.detectChanges();
+
+      const sendEmailsButton = component.fixture.nativeElement.querySelectorAll('button');
+      expect(sendEmailsButton[0].disabled).toBeTruthy();
+    });
+
+    it('should display all existing history', async () => {
+      const component = await setup();
+
+      component.fixture.componentInstance.history = [
+        {
+          date: '2021-01-05',
+          emails: 351,
+        },
+        {
+          date: '2020-12-05',
+          emails: 772,
+        },
+      ];
+
+      component.fixture.detectChanges();
+
+      const numInactiveWorkplaces = component.getByTestId('emailCampaignHistory');
+      expect(numInactiveWorkplaces.innerHTML).toContain('05/01/2021');
+      expect(numInactiveWorkplaces.innerHTML).toContain('772');
+      expect(numInactiveWorkplaces.innerHTML).toContain('05/12/2020');
+      expect(numInactiveWorkplaces.innerHTML).toContain('351');
+    });
+
+    it('should display a message when no emails have been sent', async () => {
+      const component = await setup();
+
+      const numInactiveWorkplaces = component.getByTestId('emailCampaignHistory');
+      expect(numInactiveWorkplaces.innerHTML).toContain('No emails have been sent yet.');
+    });
+
+    it('should call confirmSendEmails when the "Send emails" button is clicked', async () => {
+      const component = await setup();
+
+      component.fixture.componentInstance.inactiveWorkplaces = 25;
       component.fixture.detectChanges();
 
       fireEvent.click(component.getByText('Send emails', { exact: false }));
 
-      const emailCampaignService = TestBed.inject(EmailCampaignService);
-      spyOn(emailCampaignService, 'createCampaign').and.returnValue(
-        of({
-          emails,
-        }),
-      );
-
-      spyOn(emailCampaignService, 'getInactiveWorkplaces').and.returnValue(
-        of({
-          inactiveWorkplaces: 0,
-        }),
-      );
-
-      const addAlert = spyOn(component.fixture.componentInstance.alertService, 'addAlert').and.callThrough();
-
       const dialog = await within(document.body).findByRole('dialog');
-      within(dialog).getByText('Send emails').click();
+      const dialogHeader = within(dialog).getByTestId('send-emails-confirmation-header');
 
-      expect(addAlert).toHaveBeenCalledWith({
-        type: 'success',
-        message: expectedMessage,
+      expect(dialogHeader).toBeTruthy();
+    });
+
+    [
+      {
+        emails: 2500,
+        expectedMessage: '2,500 emails have been scheduled to be sent.',
+      },
+      {
+        emails: 1,
+        expectedMessage: '1 email has been scheduled to be sent.',
+      },
+    ].forEach(({ emails, expectedMessage }) => {
+      it('should display an alert when the "Send emails" button is clicked', async () => {
+        const component = await setup();
+
+        component.fixture.componentInstance.inactiveWorkplaces = 2500;
+        component.fixture.detectChanges();
+
+        fireEvent.click(component.getByText('Send emails', { exact: false }));
+
+        const emailCampaignService = TestBed.inject(EmailCampaignService);
+        spyOn(emailCampaignService, 'createInactiveWorkplacesCampaign').and.returnValue(
+          of({
+            emails,
+          }),
+        );
+
+        spyOn(emailCampaignService, 'getInactiveWorkplaces').and.returnValue(
+          of({
+            inactiveWorkplaces: 0,
+          }),
+        );
+
+        const addAlert = spyOn(component.fixture.componentInstance.alertService, 'addAlert').and.callThrough();
+
+        const dialog = await within(document.body).findByRole('dialog');
+        within(dialog).getByText('Send emails').click();
+
+        expect(addAlert).toHaveBeenCalledWith({
+          type: 'success',
+          message: expectedMessage,
+        });
+
+        const numInactiveWorkplaces = component.getByTestId('inactiveWorkplaces');
+        expect(numInactiveWorkplaces.innerHTML).toContain('0');
       });
+    });
 
-      const numInactiveWorkplaces = component.getByTestId('inactiveWorkplaces');
-      expect(numInactiveWorkplaces.innerHTML).toContain('0');
+    it('should download a report when the "Download report" button is clicked', async () => {
+      const component = await setup();
+
+      const emailCampaignService = TestBed.inject(EmailCampaignService);
+      const getReport = spyOn(emailCampaignService, 'getInactiveWorkplacesReport').and.callFake(() => of(null));
+      const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+
+      component.fixture.componentInstance.inactiveWorkplaces = 25;
+      component.fixture.detectChanges();
+
+      fireEvent.click(component.getByText('Download report', { exact: false }));
+
+      expect(getReport).toHaveBeenCalled();
+      expect(saveAs).toHaveBeenCalled();
     });
   });
 
-  it('should download a report when the "Download report" button is clicked', async () => {
-    const component = await setup();
+  describe('Targeted emails', () => {
+    it('should display the total number of emails to be sent', async () => {
+      const component = await setup();
 
-    const emailCampaignService = TestBed.inject(EmailCampaignService);
-    const getReport = spyOn(emailCampaignService, 'getReport').and.callFake(() => of(null));
-    const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+      component.fixture.componentInstance.totalEmails = 1500;
+      component.fixture.detectChanges();
 
-    component.fixture.componentInstance.inactiveWorkplaces = 25;
-    component.fixture.detectChanges();
+      const numInactiveWorkplaces = component.getByTestId('totalEmails');
+      expect(numInactiveWorkplaces.innerHTML).toContain('1,500');
+    });
 
-    fireEvent.click(component.getByText('Download report', { exact: false }));
+    it("should display 0 emails to be sent when the group and template haven't been selected", async () => {
+      const component = await setup();
 
-    expect(getReport).toHaveBeenCalled();
-    expect(saveAs).toHaveBeenCalled();
+      component.fixture.componentInstance.emailGroup = null;
+      component.fixture.componentInstance.templateId = null;
+      component.fixture.detectChanges();
+
+      const numInactiveWorkplaces = component.getByTestId('totalEmails');
+      expect(numInactiveWorkplaces.innerHTML).toContain('0');
+    });
+
+    it("should disable the Send emails button when the group and template haven't been selected", async () => {
+      const component = await setup();
+
+      component.fixture.componentInstance.emailGroup = '';
+      component.fixture.componentInstance.templateId = '';
+      component.fixture.detectChanges();
+
+      const sendEmailsButton = component.fixture.nativeElement.querySelectorAll('button');
+      expect(sendEmailsButton[1].disabled).toBeTruthy();
+    });
+
+    it('should update the total emails when updateTotalEmails() is called', async () => {
+      const component = await setup();
+
+      component.fixture.componentInstance.updateTotalEmails('primaryUsers');
+      component.fixture.detectChanges();
+
+      expect(component.fixture.componentInstance.totalEmails).toEqual(1500);
+    });
   });
 
-  it('should download a registration survey report when the "Registration survey" button is clicked', async () => {
-    const component = await setup();
+  describe('Reports', () => {
+    it('should download a registration survey report when the "Registration survey" button is clicked', async () => {
+      const component = await setup();
 
-    const reportService = TestBed.inject(ReportService);
-    const getReport = spyOn(reportService, 'getRegistrationSurveyReport').and.callFake(() => of(null));
-    const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+      const reportService = TestBed.inject(ReportService);
+      const getReport = spyOn(reportService, 'getRegistrationSurveyReport').and.callFake(() => of(null));
+      const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
 
-    fireEvent.click(component.getByText('Registration survey', { exact: false }));
+      fireEvent.click(component.getByText('Registration survey', { exact: false }));
 
-    expect(getReport).toHaveBeenCalled();
-    expect(saveAs).toHaveBeenCalled();
-  });
+      expect(getReport).toHaveBeenCalled();
+      expect(saveAs).toHaveBeenCalled();
+    });
 
-  it('should download a satisfaction survey report when the "Satisfaction survey" button is clicked', async () => {
-    const component = await setup();
+    it('should download a satisfaction survey report when the "Satisfaction survey" button is clicked', async () => {
+      const component = await setup();
 
-    const reportService = TestBed.inject(ReportService);
-    const getReport = spyOn(reportService, 'getSatisfactionSurveyReport').and.callFake(() => of(null));
-    const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+      const reportService = TestBed.inject(ReportService);
+      const getReport = spyOn(reportService, 'getSatisfactionSurveyReport').and.callFake(() => of(null));
+      const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
 
-    fireEvent.click(component.getByText('Satisfaction survey', { exact: false }));
+      fireEvent.click(component.getByText('Satisfaction survey', { exact: false }));
 
-    expect(getReport).toHaveBeenCalled();
-    expect(saveAs).toHaveBeenCalled();
-  });
+      expect(getReport).toHaveBeenCalled();
+      expect(saveAs).toHaveBeenCalled();
+    });
 
-  it('should download a delete report when the "Delete report" button is clicked', async () => {
-    const component = await setup();
+    it('should download a delete report when the "Delete report" button is clicked', async () => {
+      const component = await setup();
 
-    const reportService = TestBed.inject(ReportService);
-    const getReport = spyOn(reportService, 'getDeleteReport').and.callFake(() => of(null));
-    const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+      const reportService = TestBed.inject(ReportService);
+      const getReport = spyOn(reportService, 'getDeleteReport').and.callFake(() => of(null));
+      const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
 
-    fireEvent.click(component.getByText('Delete report', { exact: false }));
+      fireEvent.click(component.getByText('Delete report', { exact: false }));
 
-    expect(getReport).toHaveBeenCalled();
-    expect(saveAs).toHaveBeenCalled();
-  });
+      expect(getReport).toHaveBeenCalled();
+      expect(saveAs).toHaveBeenCalled();
+    });
 
-  it('should download a local authority progress report when the "Local admin authority progress" button is clicked', async () => {
-    const component = await setup();
+    it('should download a local authority progress report when the "Local admin authority progress" button is clicked', async () => {
+      const component = await setup();
 
-    const reportService = TestBed.inject(ReportService);
-    const getReport = spyOn(reportService, 'getLocalAuthorityAdminReport').and.callFake(() => of(null));
-    const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+      const reportService = TestBed.inject(ReportService);
+      const getReport = spyOn(reportService, 'getLocalAuthorityAdminReport').and.callFake(() => of(null));
+      const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
 
-    fireEvent.click(component.getByText('Local admin authority progress', { exact: false }));
+      fireEvent.click(component.getByText('Local admin authority progress', { exact: false }));
 
-    expect(getReport).toHaveBeenCalled();
-    expect(saveAs).toHaveBeenCalled();
-  });
+      expect(getReport).toHaveBeenCalled();
+      expect(saveAs).toHaveBeenCalled();
+    });
 
-  it('should download a WDF Summary report when the "WDF Summary Report" button is clicked', async () => {
-    const component = await setup();
+    it('should download a WDF Summary report when the "WDF Summary Report" button is clicked', async () => {
+      const component = await setup();
 
-    const reportService = TestBed.inject(ReportService);
-    const getReport = spyOn(reportService, 'getWdfSummaryReport').and.callFake(() => of(null));
-    const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+      const reportService = TestBed.inject(ReportService);
+      const getReport = spyOn(reportService, 'getWdfSummaryReport').and.callFake(() => of(null));
+      const saveAs = spyOn(component.fixture.componentInstance, 'saveFile').and.callFake(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
 
-    fireEvent.click(component.getByText('WDF summary report', { exact: false }));
+      fireEvent.click(component.getByText('WDF summary report', { exact: false }));
 
-    expect(getReport).toHaveBeenCalled();
-    expect(saveAs).toHaveBeenCalled();
+      expect(getReport).toHaveBeenCalled();
+      expect(saveAs).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/features/search/emails/emails.component.spec.ts
+++ b/src/app/features/search/emails/emails.component.spec.ts
@@ -12,7 +12,7 @@ import { of } from 'rxjs';
 import { SearchModule } from '../search.module';
 import { EmailsComponent } from './emails.component';
 
-describe('EmailsComponent', () => {
+fdescribe('EmailsComponent', () => {
   async function setup() {
     return render(EmailsComponent, {
       imports: [SharedModule, SearchModule, HttpClientTestingModule, RouterTestingModule],
@@ -241,6 +241,22 @@ describe('EmailsComponent', () => {
 
       expect(templateDropdown.childNodes[1].textContent).toEqual('Template 1');
       expect(templateDropdown.childNodes[2].textContent).toEqual('Template 2');
+    });
+
+    it('should call confirmSendEmails when the "Send emails to selected group" button is clicked', async () => {
+      const component = await setup();
+
+      component.fixture.componentInstance.totalEmails = 45;
+      component.fixture.componentInstance.emailGroup = 'primaryUsers';
+      component.fixture.componentInstance.selectedTemplateId = '1';
+      component.fixture.detectChanges();
+
+      fireEvent.click(component.getByText('Send emails to selected group', { exact: true }));
+
+      const dialog = await within(document.body).findByRole('dialog');
+      const dialogHeader = within(dialog).getByTestId('send-emails-confirmation-header');
+
+      expect(dialogHeader).toBeTruthy();
     });
   });
 

--- a/src/app/features/search/emails/emails.component.spec.ts
+++ b/src/app/features/search/emails/emails.component.spec.ts
@@ -100,7 +100,7 @@ describe('EmailsComponent', () => {
       component.fixture.componentInstance.inactiveWorkplaces = 25;
       component.fixture.detectChanges();
 
-      fireEvent.click(component.getByText('Send emails', { exact: false }));
+      fireEvent.click(component.getByText('Send emails', { exact: true }));
 
       const dialog = await within(document.body).findByRole('dialog');
       const dialogHeader = within(dialog).getByTestId('send-emails-confirmation-header');
@@ -124,7 +124,7 @@ describe('EmailsComponent', () => {
         component.fixture.componentInstance.inactiveWorkplaces = 2500;
         component.fixture.detectChanges();
 
-        fireEvent.click(component.getByText('Send emails', { exact: false }));
+        fireEvent.click(component.getByText('Send emails', { exact: true }));
 
         const emailCampaignService = TestBed.inject(EmailCampaignService);
         spyOn(emailCampaignService, 'createInactiveWorkplacesCampaign').and.returnValue(

--- a/src/app/features/search/emails/emails.component.spec.ts
+++ b/src/app/features/search/emails/emails.component.spec.ts
@@ -28,6 +28,9 @@ describe('EmailsComponent', () => {
               data: {
                 emailCampaignHistory: [],
                 inactiveWorkplaces: { inactiveWorkplaces: 0 },
+                emailTemplates: {
+                  templates: [],
+                },
               },
             },
           },
@@ -186,7 +189,7 @@ describe('EmailsComponent', () => {
       const component = await setup();
 
       component.fixture.componentInstance.emailGroup = null;
-      component.fixture.componentInstance.templateId = null;
+      component.fixture.componentInstance.selectedTemplateId = null;
       component.fixture.detectChanges();
 
       const numInactiveWorkplaces = component.getByTestId('totalEmails');
@@ -197,7 +200,7 @@ describe('EmailsComponent', () => {
       const component = await setup();
 
       component.fixture.componentInstance.emailGroup = '';
-      component.fixture.componentInstance.templateId = '';
+      component.fixture.componentInstance.selectedTemplateId = '';
       component.fixture.detectChanges();
 
       const sendEmailsButton = component.fixture.nativeElement.querySelectorAll('button');
@@ -206,12 +209,27 @@ describe('EmailsComponent', () => {
 
     it('should update the total emails when updateTotalEmails() is called', async () => {
       const component = await setup();
+      const emailCampaignService = TestBed.inject(EmailCampaignService);
+      const getTargetedTotalEmailsSpy = spyOn(emailCampaignService, 'getTargetedTotalEmails').and.callFake(() =>
+        of({ totalEmails: 1500 }),
+      );
 
       component.fixture.componentInstance.updateTotalEmails('primaryUsers');
       component.fixture.detectChanges();
 
       expect(component.fixture.componentInstance.totalEmails).toEqual(1500);
+      expect(getTargetedTotalEmailsSpy).toHaveBeenCalled();
     });
+
+    // it('should get a list of template IDs when the getTemplateIds() function is called', async () => {
+    //   const component = await setup();
+    //   const expectedTemplate = { name: 'Template 1', id: 1 };
+
+    //   component.fixture.componentInstance.getTemplateIds();
+    //   component.fixture.detectChanges();
+
+    //   expect(component.fixture.componentInstance.templates).toEqual([expectedTemplate]);
+    // });
   });
 
   describe('Reports', () => {

--- a/src/app/features/search/emails/emails.component.spec.ts
+++ b/src/app/features/search/emails/emails.component.spec.ts
@@ -221,15 +221,27 @@ describe('EmailsComponent', () => {
       expect(getTargetedTotalEmailsSpy).toHaveBeenCalled();
     });
 
-    // it('should get a list of template IDs when the getTemplateIds() function is called', async () => {
-    //   const component = await setup();
-    //   const expectedTemplate = { name: 'Template 1', id: 1 };
+    it('should display the template names as options', async () => {
+      const component = await setup();
+      const templates = [
+        {
+          id: 1,
+          name: 'Template 1',
+        },
+        {
+          id: 2,
+          name: 'Template 2',
+        },
+      ];
 
-    //   component.fixture.componentInstance.getTemplateIds();
-    //   component.fixture.detectChanges();
+      component.fixture.componentInstance.templates = templates;
+      component.fixture.detectChanges();
 
-    //   expect(component.fixture.componentInstance.templates).toEqual([expectedTemplate]);
-    // });
+      const templateDropdown = component.getByTestId('selectedTemplateId');
+
+      expect(templateDropdown.childNodes[1].textContent).toEqual('Template 1');
+      expect(templateDropdown.childNodes[2].textContent).toEqual('Template 2');
+    });
   });
 
   describe('Reports', () => {

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -10,7 +10,9 @@ import { saveAs } from 'file-saver';
 import { Subscription } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
-import { SendEmailsConfirmationDialogComponent } from './dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component';
+import {
+  SendEmailsConfirmationDialogComponent,
+} from './dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component';
 
 @Component({
   selector: 'app-emails',
@@ -18,6 +20,9 @@ import { SendEmailsConfirmationDialogComponent } from './dialogs/send-emails-con
 })
 export class EmailsComponent implements OnDestroy {
   public inactiveWorkplaces = this.route.snapshot.data.inactiveWorkplaces.inactiveWorkplaces;
+  public totalEmails = 0;
+  public emailGroup = '';
+  public templateId = '';
   public history = this.route.snapshot.data.emailCampaignHistory;
   public isAdmin: boolean;
   public now: Date = new Date();
@@ -34,6 +39,14 @@ export class EmailsComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
+  }
+
+  public updateTotalEmails(groupType: string) {
+    if (groupType === 'primaryUsers') {
+      this.totalEmails = 1500;
+    } else {
+      this.totalEmails = 0;
+    }
   }
 
   public confirmSendEmails(event: Event): void {
@@ -53,7 +66,7 @@ export class EmailsComponent implements OnDestroy {
   private sendEmails(): void {
     this.subscriptions.add(
       this.emailCampaignService
-        .createCampaign()
+        .createInactiveWorkplacesCampaign()
         .pipe(
           switchMap((latestCampaign) => {
             return this.emailCampaignService.getInactiveWorkplaces().pipe(
@@ -83,7 +96,7 @@ export class EmailsComponent implements OnDestroy {
     event.preventDefault();
 
     this.subscriptions.add(
-      this.emailCampaignService.getReport().subscribe((response) => {
+      this.emailCampaignService.getInactiveWorkplacesReport().subscribe((response) => {
         this.saveFile(response);
       }),
     );

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -2,7 +2,7 @@ import { DecimalPipe } from '@angular/common';
 import { HttpResponse } from '@angular/common/http';
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { TotalEmailsResponse } from '@core/model/emails.model';
+import { EmailType, TotalEmailsResponse } from '@core/model/emails.model';
 import { EmailCampaignService } from '@core/services/admin/email-campaign.service';
 import { AlertService } from '@core/services/alert.service';
 import { DialogService } from '@core/services/dialog.service';
@@ -29,6 +29,7 @@ export class EmailsComponent implements OnDestroy {
   public isAdmin: boolean;
   public now: Date = new Date();
   private subscriptions: Subscription = new Subscription();
+  public emailType = EmailType;
 
   constructor(
     public alertService: AlertService,
@@ -55,21 +56,33 @@ export class EmailsComponent implements OnDestroy {
     }
   }
 
-  public confirmSendEmails(event: Event): void {
+  public confirmSendEmails(event: Event, emailCount: number, type: EmailType): void {
     event.preventDefault();
 
     this.subscriptions.add(
       this.dialogService
-        .open(SendEmailsConfirmationDialogComponent, { inactiveWorkplaces: this.inactiveWorkplaces })
+        .open(SendEmailsConfirmationDialogComponent, { emailCount })
         .afterClosed.subscribe((hasConfirmed) => {
           if (hasConfirmed) {
-            this.sendEmails();
+            this.sendEmails(type);
           }
         }),
     );
   }
 
-  private sendEmails(): void {
+  private sendEmails(type: EmailType): void {
+    switch (type) {
+      case EmailType.InactiveWorkplaces:
+        this.sendInactiveEmails();
+        break;
+
+      case EmailType.TargetedEmails:
+        this.sendTargetedEmails();
+        break;
+    }
+  }
+
+  private sendInactiveEmails(): void {
     this.subscriptions.add(
       this.emailCampaignService
         .createInactiveWorkplacesCampaign()
@@ -96,6 +109,11 @@ export class EmailsComponent implements OnDestroy {
           this.inactiveWorkplaces = inactiveWorkplaces;
         }),
     );
+  }
+
+  private sendTargetedEmails(): void {
+    console.log('hello');
+    return;
   }
 
   public downloadReport(event: Event): void {

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -42,8 +42,12 @@ export class EmailsComponent implements OnDestroy {
   }
 
   public updateTotalEmails(groupType: string) {
-    if (groupType === 'primaryUsers') {
-      this.totalEmails = 1500;
+    if (groupType) {
+      this.subscriptions.add(
+        this.emailCampaignService
+          .getTargetedUsers(groupType)
+          .subscribe((totalEmails: number) => (this.totalEmails = totalEmails)),
+      );
     } else {
       this.totalEmails = 0;
     }

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -112,8 +112,18 @@ export class EmailsComponent implements OnDestroy {
   }
 
   private sendTargetedEmails(): void {
-    console.log('hello');
-    return;
+    this.subscriptions.add(
+      this.emailCampaignService.createTargetedEmailsCampaign(this.emailGroup, this.selectedTemplateId).subscribe(() => {
+        this.alertService.addAlert({
+          type: 'success',
+          message: `${this.decimalPipe.transform(this.totalEmails)} ${
+            this.totalEmails > 1 ? 'emails have' : 'email has'
+          } been scheduled to be sent.`,
+        });
+        this.emailGroup = '';
+        this.selectedTemplateId = '';
+      }),
+    );
   }
 
   public downloadReport(event: Event): void {

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -2,6 +2,7 @@ import { DecimalPipe } from '@angular/common';
 import { HttpResponse } from '@angular/common/http';
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { TotalEmailsResponse } from '@core/model/emails.model';
 import { EmailCampaignService } from '@core/services/admin/email-campaign.service';
 import { AlertService } from '@core/services/alert.service';
 import { DialogService } from '@core/services/dialog.service';
@@ -22,7 +23,8 @@ export class EmailsComponent implements OnDestroy {
   public inactiveWorkplaces = this.route.snapshot.data.inactiveWorkplaces.inactiveWorkplaces;
   public totalEmails = 0;
   public emailGroup = '';
-  public templateId = '';
+  public selectedTemplateId = '';
+  public templates = this.route.snapshot.data.emailTemplates.templates;
   public history = this.route.snapshot.data.emailCampaignHistory;
   public isAdmin: boolean;
   public now: Date = new Date();
@@ -41,12 +43,12 @@ export class EmailsComponent implements OnDestroy {
     this.subscriptions.unsubscribe();
   }
 
-  public updateTotalEmails(groupType: string) {
+  public updateTotalEmails(groupType: string): void {
     if (groupType) {
       this.subscriptions.add(
         this.emailCampaignService
-          .getTargetedUsers(groupType)
-          .subscribe((totalEmails: number) => (this.totalEmails = totalEmails)),
+          .getTargetedTotalEmails(groupType)
+          .subscribe((totalEmails: TotalEmailsResponse) => (this.totalEmails = totalEmails.totalEmails)),
       );
     } else {
       this.totalEmails = 0;

--- a/src/app/features/search/emails/emails.component.ts
+++ b/src/app/features/search/emails/emails.component.ts
@@ -122,6 +122,7 @@ export class EmailsComponent implements OnDestroy {
         });
         this.emailGroup = '';
         this.selectedTemplateId = '';
+        this.totalEmails = 0;
       }),
     );
   }

--- a/src/app/features/search/search-routing.module.ts
+++ b/src/app/features/search/search-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { EmailCampaignHistoryResolver } from '@core/resolvers/admin/email-campaign-history.resolver';
+import { EmailTemplateResolver } from '@core/resolvers/admin/email-template.resolver';
 import { InactiveWorkplacesResolver } from '@core/resolvers/admin/inactive-workplaces.resolver';
 
 import { SearchComponent } from './search.component';
@@ -13,6 +14,7 @@ const routes: Routes = [
     resolve: {
       emailCampaignHistory: EmailCampaignHistoryResolver,
       inactiveWorkplaces: InactiveWorkplacesResolver,
+      emailTemplates: EmailTemplateResolver,
     },
   },
 ];

--- a/src/app/features/search/search.module.ts
+++ b/src/app/features/search/search.module.ts
@@ -3,6 +3,7 @@ import { CommonModule, DecimalPipe } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { EmailCampaignHistoryResolver } from '@core/resolvers/admin/email-campaign-history.resolver';
+import { EmailTemplateResolver } from '@core/resolvers/admin/email-template.resolver';
 import { InactiveWorkplacesResolver } from '@core/resolvers/admin/inactive-workplaces.resolver';
 import { EmailCampaignService } from '@core/services/admin/email-campaign.service';
 import { DialogService } from '@core/services/dialog.service';
@@ -14,6 +15,9 @@ import { SharedModule } from '@shared/shared.module';
 
 import { CqcStatusChangeComponent } from './cqc-status-change/cqc-status-change.component';
 import { CqcStatusChangesComponent } from './cqc-status-changes/cqc-status-changes.component';
+import {
+  SendEmailsConfirmationDialogComponent,
+} from './emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component';
 import { EmailsComponent } from './emails/emails.component';
 import { ParentRequestComponent } from './parent-request/parent-request.component';
 import { ParentRequestsComponent } from './parent-requests/parent-requests.component';
@@ -21,7 +25,6 @@ import { RegistrationComponent } from './registration/registration.component';
 import { RegistrationsComponent } from './registrations/registrations.component';
 import { SearchRoutingModule } from './search-routing.module';
 import { SearchComponent } from './search.component';
-import { SendEmailsConfirmationDialogComponent } from './emails/dialogs/send-emails-confirmation-dialog/send-emails-confirmation-dialog.component';
 
 @NgModule({
   imports: [CommonModule, OverlayModule, ReactiveFormsModule, SharedModule, SearchRoutingModule, FormsModule],
@@ -31,6 +34,7 @@ import { SendEmailsConfirmationDialogComponent } from './emails/dialogs/send-ema
     InactiveWorkplacesResolver,
     EmailCampaignService,
     DecimalPipe,
+    EmailTemplateResolver,
   ],
   declarations: [
     SearchComponent,


### PR DESCRIPTION
#### Work done
- Add functionality for admins to send emails to targeted users by selecting a user group and template
- Create `allPrimaryUsers` function in user model to get all primary users
- Add `getTemplates` function to get templates using Send In Blue API

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
