### PR TITLE
Auto confirm fix

### DIFF
--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
@@ -100,6 +100,50 @@ describe('StaffRecordSummaryComponent', () => {
     component.confirmField('daysSick');
     expect(workerService.updateWorker).not.toHaveBeenCalledWith(component.workplace.uid,component.worker.uid,{dateOfBirth:component.worker.dateOfBirth});
   });
+  it('should run auto run confirmField for careCertificate if its Yes, completed and not updated ', async () => {
+    const { component, fixture, workerService } = await setup();
+    spyOn(workerService, 'updateWorker').and.returnValue(of({uid:"123"} as WorkerEditResponse));
+    component.wdfNewDesign = true;
+    component.worker.wdf.careCertificate = eligibleButNotUpdatedObject;
+    component.worker.careCertificate = "Yes, completed";
+    fixture.detectChanges();
+    component.updateFieldsWhichDontRequireConfirmation();
+    component.confirmField('daysSick');
+    expect(workerService.updateWorker).toHaveBeenCalledWith(component.workplace.uid,component.worker.uid,{careCertificate: component.worker.careCertificate});
+  });
+  it('should NOT run auto run confirmField for careCertificate if its No and not updated ', async () => {
+    const { component, fixture, workerService } = await setup();
+    spyOn(workerService, 'updateWorker').and.returnValue(of({uid:"123"} as WorkerEditResponse));
+    component.wdfNewDesign = true;
+    component.worker.wdf.careCertificate = eligibleButNotUpdatedObject;
+    component.worker.careCertificate = "No";
+    fixture.detectChanges();
+    component.updateFieldsWhichDontRequireConfirmation();
+    component.confirmField('daysSick');
+    expect(workerService.updateWorker).not.toHaveBeenCalledWith(component.workplace.uid,component.worker.uid,{careCertificate: component.worker.careCertificate});
+  });
+  it('should run auto run confirmField for qualificationInSocialCare if its Yes and not updated ', async () => {
+    const { component, fixture, workerService } = await setup();
+    spyOn(workerService, 'updateWorker').and.returnValue(of({uid:"123"} as WorkerEditResponse));
+    component.wdfNewDesign = true;
+    component.worker.wdf.qualificationInSocialCare = eligibleButNotUpdatedObject;
+    component.worker.qualificationInSocialCare = "Yes";
+    fixture.detectChanges();
+    component.updateFieldsWhichDontRequireConfirmation();
+    component.confirmField('daysSick');
+    expect(workerService.updateWorker).toHaveBeenCalledWith(component.workplace.uid,component.worker.uid,{qualificationInSocialCare: component.worker.qualificationInSocialCare});
+  });
+  it('should NOT run auto run confirmField for qualificationInSocialCare if its NO and not updated ', async () => {
+    const { component, fixture, workerService } = await setup();
+    spyOn(workerService, 'updateWorker').and.returnValue(of({uid:"123"} as WorkerEditResponse));
+    component.wdfNewDesign = true;
+    component.worker.wdf.qualificationInSocialCare = eligibleButNotUpdatedObject;
+    component.worker.qualificationInSocialCare = "NO";
+    fixture.detectChanges();
+    component.updateFieldsWhichDontRequireConfirmation();
+    component.confirmField('daysSick');
+    expect(workerService.updateWorker).not.toHaveBeenCalledWith(component.workplace.uid,component.worker.uid,{qualificationInSocialCare: component.worker.qualificationInSocialCare});
+  });
   it('should NOT auto run confirmField if NOT all other fields confirmed', async () => {
     const { component, fixture, workerService } = await setup();
 

--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common';
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';

--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
@@ -134,9 +134,8 @@ export class StaffRecordSummaryComponent implements OnInit {
         continue;
       }
       if (this.worker.wdf?.[fieldCheck].isEligible === 'Yes' && !this.worker.wdf?.[fieldCheck].updatedSinceEffectiveDate) {
-        if ((fieldCheck === 'careCertificate' && this.worker.careCertificate === 'Yes, completed') ||
-        (fieldCheck === 'qualificationInSocialCare' && this.worker.careCertificate === 'Yes') ){
-          this.confirmField(fieldCheck);
+        if ((fieldCheck === 'careCertificate' && this.worker.careCertificate !== 'Yes, completed') ||
+        (fieldCheck === 'qualificationInSocialCare' && this.worker.careCertificate !== 'Yes') ){
           continue;
         }
         this.confirmField(fieldCheck);

--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
@@ -135,7 +135,7 @@ export class StaffRecordSummaryComponent implements OnInit {
       }
       if (this.worker.wdf?.[fieldCheck].isEligible === 'Yes' && !this.worker.wdf?.[fieldCheck].updatedSinceEffectiveDate) {
         if ((fieldCheck === 'careCertificate' && this.worker.careCertificate !== 'Yes, completed') ||
-        (fieldCheck === 'qualificationInSocialCare' && this.worker.careCertificate !== 'Yes') ){
+        (fieldCheck === 'qualificationInSocialCare' && this.worker.qualificationInSocialCare !== 'Yes') ){
           continue;
         }
         this.confirmField(fieldCheck);


### PR DESCRIPTION
Fixing a bug where anytime you go onto a wdf staff page it would auto update the fields that dont need confirmation ( e.g date of birth), which in turn would change the Last Updated date for the staff without any user input.
Its now been checked so that this only happens once all other fields are up-to-date. 
There was also one field missing which has been added in.


Adding missing auto confirm field,
Moving auto confirm to only happen once every other field is confirmed.
adding tests

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
