### PR TITLE
fix(removeContentFromAdminHome)

### DIFF
--- a/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -84,7 +84,7 @@
       </ng-template>
     </div>
   </div>
-  <div class="govuk-grid-column-one-third">
+  <div *ngIf="workplace" class="govuk-grid-column-one-third">
     <app-article-list></app-article-list>
     <ng-container
       *ngIf="


### PR DESCRIPTION
#### Work done
- Add check for workplace for related content and news in the home tab to keep admin home tab empty on login

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
