### PR TITLE
Added formatting for `UL` and `OL` in CMS content

### DIFF
--- a/src/app/features/articles/article/article.component.html
+++ b/src/app/features/articles/article/article.component.html
@@ -4,7 +4,7 @@
       <span class="govuk-caption-xl">ASC-WDS news</span>
       <span [innerHTML]="article.title"></span>
     </h1>
-    <div [innerHTML]="article.content"></div>
+    <div class="asc-cms-content" [innerHTML]="article.content"></div>
     <a role="button" draggable="false" class="govuk-button govuk-!-margin-top-3" [routerLink]="['/']">
       Return to home
     </a>

--- a/src/app/shared/components/page/page.component.html
+++ b/src/app/shared/components/page/page.component.html
@@ -1,4 +1,4 @@
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">
   {{ page.title }}
 </h1>
-<div [innerHTML]="page.content"></div>
+<div class="asc-cms-content" [innerHTML]="page.content"></div>

--- a/src/assets/scss/partials/_lists.scss
+++ b/src/assets/scss/partials/_lists.scss
@@ -200,12 +200,14 @@
   }
 }
 
-ul {
-  @extend .govuk-list;
-  @extend .govuk-list--bullet;
-}
+.asc-cms-content {
+  ul {
+    @extend .govuk-list;
+    @extend .govuk-list--bullet;
+  }
 
-ol {
-  @extend .govuk-list;
-  @extend .govuk-list--number;
+  ol {
+    @extend .govuk-list;
+    @extend .govuk-list--number;
+  }
 }

--- a/src/assets/scss/partials/_lists.scss
+++ b/src/assets/scss/partials/_lists.scss
@@ -199,3 +199,13 @@
     float: left;
   }
 }
+
+ul {
+  @extend .govuk-list;
+  @extend .govuk-list--bullet;
+}
+
+ol {
+  @extend .govuk-list;
+  @extend .govuk-list--number;
+}


### PR DESCRIPTION
# Work done
- Added class around CMS content
- Added SCSS to copy the govuk styles for `ul` and `ol` bulleted and numbers lists.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
