### PR TITLE
New User not shown staff mismatch banner until 8w after first login

### DIFF
--- a/migrations/20210621154154-eightWeeksFromFirstLogin.js
+++ b/migrations/20210621154154-eightWeeksFromFirstLogin.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const moment = require('moment');
+
+const table = {
+  tableName: 'Establishment',
+  schema: 'cqc',
+};
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(table, 'eightWeeksFromFirstLogin', {
+      type: Sequelize.DataTypes.DATE,
+      allowNull: true,
+      defaultValue: moment().subtract(8, 'w').toDate(),
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn(table, 'eightWeeksFromFirstLogin');
+  },
+};

--- a/migrations/20210621154154-eightWeeksFromFirstLogin.js
+++ b/migrations/20210621154154-eightWeeksFromFirstLogin.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const moment = require('moment');
-
 const table = {
   tableName: 'Establishment',
   schema: 'cqc',

--- a/migrations/20210621154154-eightWeeksFromFirstLogin.js
+++ b/migrations/20210621154154-eightWeeksFromFirstLogin.js
@@ -12,8 +12,10 @@ module.exports = {
     await queryInterface.addColumn(table, 'eightWeeksFromFirstLogin', {
       type: Sequelize.DataTypes.DATE,
       allowNull: true,
-      defaultValue: moment().subtract(8, 'w').toDate(),
+      defaultValue: null,
     });
+
+    queryInterface.sequelize.query(`UPDATE cqc."Establishment" SET "eightWeeksFromFirstLogin" = NOW();`);
   },
 
   down: (queryInterface, Sequelize) => {

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -85,6 +85,7 @@ class Establishment extends EntityValidator {
     this._dataOwnershipRequested = null;
     this._linkToParentRequested = null;
     this._lastBulkUploaded = null;
+    this._eightWeeksFromFirstLogin = null;
 
     // interim reasons for leaving - https://trello.com/c/vNHbfdms
     this._reasonsForLeaving = null;
@@ -330,6 +331,10 @@ class Establishment extends EntityValidator {
 
   get linkToParentRequested() {
     return this._linkToParentRequested;
+  }
+
+  get eightWeeksFromFirstLogin() {
+    return this._eightWeeksFromFirstLogin;
   }
 
   // used by save to initialise a new Establishment; returns true if having initialised this Establishment
@@ -1241,6 +1246,7 @@ class Establishment extends EntityValidator {
         this._dataOwnershipRequested = fetchResults.dataOwnershipRequested;
         this._linkToParentRequested = fetchResults.linkToParentRequested;
         this._lastBulkUploaded = fetchResults.lastBulkUploaded;
+        this._eightWeeksFromFirstLogin = fetchResults.eightWeeksFromFirstLogin;
         // if history of the User is also required; attach the association
         //  and order in reverse chronological - note, order on id (not when)
         //  because ID is primay key and hence indexed
@@ -1716,6 +1722,7 @@ class Establishment extends EntityValidator {
         myDefaultJSON.dataPermissions = this.isParent ? undefined : this.dataPermissions;
         myDefaultJSON.reasonsForLeaving = this.reasonsForLeaving;
         myDefaultJSON.lastBulkUploaded = this.lastBulkUploaded;
+        myDefaultJSON.eightWeeksFromFirstLogin = this.eightWeeksFromFirstLogin;
       }
 
       if (this._ustatus) {

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -1330,5 +1330,13 @@ module.exports = function (sequelize, DataTypes) {
     });
   };
 
+  Establishment.updateEstablishment = async function (establishmentId, updatedEstablishment) {
+    return await this.update(updatedEstablishment, {
+      where: {
+        id: establishmentId,
+      },
+    });
+  };
+
   return Establishment;
 };

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -698,6 +698,11 @@ module.exports = function (sequelize, DataTypes) {
         defaultValue: false,
         field: 'LaReportLockHeld',
       },
+      eightWeeksFromFirstLogin: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        field: 'eightWeeksFromFirstLogin',
+      },
     },
     {
       defaultScope: {

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -1330,6 +1330,7 @@ module.exports = function (sequelize, DataTypes) {
     });
   };
 
+  // DO NOT USE if property is tracked (updatedBy, audit logs etc.)
   Establishment.updateEstablishment = async function (establishmentId, updatedEstablishment) {
     return await this.update(updatedEstablishment, {
       where: {

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -314,7 +314,10 @@ router.post('/', async (req, res) => {
               loginUpdate.firstLogin = new Date();
             }
 
-            if (!establishmentUser.user.establishment.eightWeeksFromFirstLogin) {
+            if (
+              !get(establishmentUser, 'user.establishment.eightWeeksFromFirstLogin') &&
+              get(establishmentUser, 'user.establishment.id')
+            ) {
               await models.establishment.updateEstablishment(establishmentUser.user.establishment.id, {
                 eightWeeksFromFirstLogin: moment().add(8, 'w').toDate(),
               });

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -5,6 +5,8 @@ var router = express.Router();
 require('../utils/security/passport')(passport);
 const crypto = require('crypto');
 const bcrypt = require('bcrypt-nodejs');
+const get = require('lodash/get');
+const moment = require('moment');
 
 const generateJWT = require('../utils/security/generateJWT');
 const isAuthorised = require('../utils/security/isAuthenticated').isAuthorised;
@@ -14,8 +16,6 @@ const config = require('..//config/config');
 const formatSuccessulLoginResponse = require('../utils/login/response');
 
 const sendMail = require('../utils/email/notify-email').sendPasswordReset;
-
-const get = require('lodash/get');
 
 const tribalHashCompare = (password, salt, expectedHash) => {
   const hash = crypto.createHash('sha256');
@@ -90,6 +90,7 @@ router.post('/', async (req, res) => {
                       'parentUid',
                       'parentId',
                       'lastBulkUploaded',
+                      'eightWeeksFromFirstLogin',
                     ],
                     include: [
                       {
@@ -312,6 +313,13 @@ router.post('/', async (req, res) => {
             if (!establishmentUser.firstLogin) {
               loginUpdate.firstLogin = new Date();
             }
+
+            if (!establishmentUser.user.establishment.eightWeeksFromFirstLogin) {
+              await models.establishment.updateEstablishment(establishmentUser.user.establishment.id, {
+                eightWeeksFromFirstLogin: moment().add(8, 'w').toDate(),
+              });
+            }
+
             establishmentUser.update(loginUpdate, { transaction: t });
 
             // add an audit record

--- a/src/app/core/model/establishment.model.ts
+++ b/src/app/core/model/establishment.model.ts
@@ -134,6 +134,7 @@ export interface Establishment {
   county?: string;
   locationId?: string;
   lastBulkUploaded?: string;
+  eightWeeksFromFirstLogin?: string;
 }
 
 export interface UpdateJobsRequest {

--- a/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -22,7 +22,15 @@
         </div>
       </app-inset-text>
     </ng-container>
-    <ng-container *ngIf="workplace && canAddWorker && workerCount !== workplace.numberOfStaff && workerCount > 0">
+    <ng-container
+      *ngIf="
+        workplace &&
+        canAddWorker &&
+        workerCount !== workplace.numberOfStaff &&
+        workerCount > 0 &&
+        convertToDate(workplace.eightWeeksFromFirstLogin) < now
+      "
+    >
       <app-staff-mismatch-banner
         (selectStaffTab)="selectStaffTab($event)"
         (selectTotalStaff)="selectTotalStaff($event)"

--- a/src/app/features/dashboard/home-tab/home-tab.component.spec.ts
+++ b/src/app/features/dashboard/home-tab/home-tab.component.spec.ts
@@ -121,6 +121,7 @@ describe('HomeTabComponent', () => {
     component.fixture.componentInstance.workerCount = 10;
     component.fixture.componentInstance.workplace.numberOfStaff = 10;
     component.fixture.componentInstance.canViewListOfWorkers = true;
+    component.fixture.componentInstance.workplace.eightWeeksFromFirstLogin = new Date('1970-01-01').toString();
 
     component.fixture.detectChanges();
 
@@ -134,6 +135,7 @@ describe('HomeTabComponent', () => {
     // Act
     component.fixture.componentInstance.workerCount = 11;
     component.fixture.componentInstance.workplace.numberOfStaff = 10;
+    component.fixture.componentInstance.workplace.eightWeeksFromFirstLogin = new Date('1970-01-01').toString();
 
     component.fixture.componentInstance.canViewListOfWorkers = true;
 
@@ -149,6 +151,7 @@ describe('HomeTabComponent', () => {
     // Act
     component.fixture.componentInstance.workerCount = 11;
     component.fixture.componentInstance.workplace.numberOfStaff = 10;
+    component.fixture.componentInstance.workplace.eightWeeksFromFirstLogin = new Date('1970-01-01').toString();
 
     component.fixture.componentInstance.canViewListOfWorkers = true;
     component.fixture.componentInstance.canAddWorker = false;
@@ -165,6 +168,40 @@ describe('HomeTabComponent', () => {
     // Act
     component.fixture.componentInstance.workerCount = 0;
     component.fixture.componentInstance.workplace.numberOfStaff = 10;
+    component.fixture.componentInstance.workplace.eightWeeksFromFirstLogin = new Date('1970-01-01').toString();
+
+    component.fixture.componentInstance.canViewListOfWorkers = true;
+    component.fixture.componentInstance.canAddWorker = true;
+
+    component.fixture.detectChanges();
+    const childDebugElement = component.fixture.debugElement.query(By.directive(StaffMismatchBannerComponent));
+    // Assert
+    expect(childDebugElement).toBeFalsy();
+  });
+
+  it('should show the staff mismatch banner if the eight weeks date is in the past', async () => {
+    // Arrange
+    const { component } = await setup();
+    // Act
+    component.fixture.componentInstance.workerCount = 12;
+    component.fixture.componentInstance.workplace.numberOfStaff = 10;
+    component.fixture.componentInstance.workplace.eightWeeksFromFirstLogin = new Date('1970-01-01').toString();
+
+    component.fixture.componentInstance.canViewListOfWorkers = true;
+    component.fixture.componentInstance.canAddWorker = true;
+
+    component.fixture.detectChanges();
+    const childDebugElement = component.fixture.debugElement.query(By.directive(StaffMismatchBannerComponent));
+    // Assert
+    expect(childDebugElement).toBeTruthy();
+  });
+  it('should not show the staff mismatch banner if the eight weeks date is in the future', async () => {
+    // Arrange
+    const { component } = await setup();
+    // Act
+    component.fixture.componentInstance.workerCount = 12;
+    component.fixture.componentInstance.workplace.numberOfStaff = 10;
+    component.fixture.componentInstance.workplace.eightWeeksFromFirstLogin = new Date('2999-01-01').toString();
 
     component.fixture.componentInstance.canViewListOfWorkers = true;
     component.fixture.componentInstance.canAddWorker = true;

--- a/src/app/features/dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/dashboard/home-tab/home-tab.component.ts
@@ -16,13 +16,25 @@ import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { WorkerService } from '@core/services/worker.service';
 import { BecomeAParentDialogComponent } from '@shared/components/become-a-parent/become-a-parent-dialog.component';
-import { CancelDataOwnerDialogComponent } from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
-import { ChangeDataOwnerDialogComponent } from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
-import { LinkToParentCancelDialogComponent } from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
-import { LinkToParentRemoveDialogComponent } from '@shared/components/link-to-parent-remove/link-to-parent-remove-dialog.component';
+import {
+  CancelDataOwnerDialogComponent,
+} from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
+import {
+  ChangeDataOwnerDialogComponent,
+} from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
+import {
+  LinkToParentCancelDialogComponent,
+} from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
+import {
+  LinkToParentRemoveDialogComponent,
+} from '@shared/components/link-to-parent-remove/link-to-parent-remove-dialog.component';
 import { LinkToParentDialogComponent } from '@shared/components/link-to-parent/link-to-parent-dialog.component';
-import { OwnershipChangeMessageDialogComponent } from '@shared/components/ownership-change-message/ownership-change-message-dialog.component';
-import { SetDataPermissionDialogComponent } from '@shared/components/set-data-permission/set-data-permission-dialog.component';
+import {
+  OwnershipChangeMessageDialogComponent,
+} from '@shared/components/ownership-change-message/ownership-change-message-dialog.component';
+import {
+  SetDataPermissionDialogComponent,
+} from '@shared/components/set-data-permission/set-data-permission-dialog.component';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -367,6 +379,10 @@ export class HomeTabComponent implements OnInit, OnDestroy {
     const filename = filenameMatches && filenameMatches.length > 1 ? filenameMatches[1] : null;
     const blob = new Blob([response.body], { type: 'text/plain;charset=utf-8' });
     saveAs(blob, filename);
+  }
+
+  public convertToDate(dateString: string): Date {
+    return new Date(dateString);
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
# Work done
- Added new column called `eightWeeksFromFirstLogin`
- Only show banner if it's after the `eightWeeksFromFirstLogin` date
- Added `eightWeeksFromFirstLogin` on first login
- Some of this I couldn't test due to the large nature of the whole function and how small my function was

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [x] No, I found it difficult to test
- [ ] No, they are not required for this change
