### PR TITLE
Bug/parent permissions wdf

### DIFF
--- a/src/app/core/services/permissions/permissions.service.ts
+++ b/src/app/core/services/permissions/permissions.service.ts
@@ -76,12 +76,7 @@ export class PermissionsService {
       )
       .pipe(map(() => true));
   }
-  public canViewWorkplace(workplace){
-    if (workplace.isParent === true){
-      return true;
-    }
-    return !(workplace.dataOwner === WorkplaceDataOwner.Workplace && workplace.dataPermissions === DataPermissions.None);
-  }
+
 
   private hasValidPermissions(requiredPermissions: string[], permissionsList: PermissionsList): boolean {
     if (!permissionsList) {

--- a/src/app/core/services/permissions/permissions.service.ts
+++ b/src/app/core/services/permissions/permissions.service.ts
@@ -6,7 +6,6 @@ import { Roles } from '@core/model/roles.enum';
 import { UserService } from '@core/services/user.service';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
-import { DataPermissions, WorkplaceDataOwner } from '@core/model/my-workplaces.model';
 
 @Injectable({
   providedIn: 'root',
@@ -76,7 +75,6 @@ export class PermissionsService {
       )
       .pipe(map(() => true));
   }
-
 
   private hasValidPermissions(requiredPermissions: string[], permissionsList: PermissionsList): boolean {
     if (!permissionsList) {

--- a/src/app/core/services/permissions/permissions.service.ts
+++ b/src/app/core/services/permissions/permissions.service.ts
@@ -6,6 +6,7 @@ import { Roles } from '@core/model/roles.enum';
 import { UserService } from '@core/services/user.service';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
+import { DataPermissions, WorkplaceDataOwner } from '@core/model/my-workplaces.model';
 
 @Injectable({
   providedIn: 'root',
@@ -74,6 +75,12 @@ export class PermissionsService {
         })
       )
       .pipe(map(() => true));
+  }
+  public canViewWorkplace(workplace){
+    if (workplace.isParent === true){
+      return true;
+    }
+    return !(workplace.dataOwner === WorkplaceDataOwner.Workplace && workplace.dataPermissions === DataPermissions.None);
   }
 
   private hasValidPermissions(requiredPermissions: string[], permissionsList: PermissionsList): boolean {

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.spec.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.spec.ts
@@ -93,7 +93,6 @@ describe('WdfWorkplacesSummaryTableComponent', () => {
     component.workplaces[0].dataOwner = WorkplaceDataOwner.Workplace;
     component.workplaces[0].dataPermissions = DataPermissions.None;
     component.workplaces[0].isParent = true;
-
     component.workplaces[0].name = "Test Workplace";
 
     fixture.detectChanges();
@@ -101,8 +100,10 @@ describe('WdfWorkplacesSummaryTableComponent', () => {
   });
   it('canViewWorkplace should return true if parent', async () => {
     const { component } = await setup();
+
     const workplace = component.workplaces[0];
     workplace.isParent = true;
+
     const canViewWorkplace = component.canViewWorkplace(workplace);
     expect(canViewWorkplace).toBeTruthy(true);
   });

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.spec.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.spec.ts
@@ -7,6 +7,7 @@ import { render } from '@testing-library/angular';
 import { WdfModule } from '../wdf.module.js';
 import { WdfWorkplacesSummaryTableComponent } from './wdf-workplaces-summary-table.component';
 import { DataPermissions, WorkplaceDataOwner } from '@core/model/my-workplaces.model';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
 
 describe('WdfWorkplacesSummaryTableComponent', () => {
   const workplaces = [
@@ -68,7 +69,7 @@ describe('WdfWorkplacesSummaryTableComponent', () => {
   });
   it('should not display a link for workplaces without rights', async () => {
     const { component, fixture, getAllByText } = await setup();
-
+    component.workplaces[0].isParent = false;
     component.workplaces[0].dataOwner = WorkplaceDataOwner.Workplace;
     component.workplaces[0].dataPermissions = DataPermissions.None;
     component.workplaces[0].name = "Test Workplace"
@@ -86,7 +87,25 @@ describe('WdfWorkplacesSummaryTableComponent', () => {
     fixture.detectChanges();
     expect(getAllByText("Test Workplace", { exact: false })[0].outerHTML).toContain('</a>');
   });
+  it('should display a link for workplaces if parent', async () => {
+    const { component, fixture, getAllByText } = await setup();
 
+    component.workplaces[0].dataOwner = WorkplaceDataOwner.Workplace;
+    component.workplaces[0].dataPermissions = DataPermissions.None;
+    component.workplaces[0].isParent = true;
+
+    component.workplaces[0].name = "Test Workplace";
+
+    fixture.detectChanges();
+    expect(getAllByText("Test Workplace", { exact: false })[0].outerHTML).toContain('</a>');
+  });
+  it('canViewWorkplace should return true if parent', async () => {
+    const { component } = await setup();
+    const workplace = component.workplaces[0];
+    workplace.isParent = true;
+    const canViewWorkplace = component.canViewWorkplace(workplace);
+    expect(canViewWorkplace).toBeTruthy(true);
+  });
 
   describe('sortByColumn', async () => {
     it('should put workplaces not meeting WDF at top of table when sorting by WDF requirements (not meeting)', async () => {

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
@@ -49,9 +49,14 @@ export class WdfWorkplacesSummaryTableComponent implements OnInit {
       }
     }
   }
+
   public canViewWorkplace(workplace){
-    return this.permissionsService.canViewWorkplace(workplace);
+    if (workplace.isParent === true){
+      return true;
+    }
+    return !(workplace.dataOwner === WorkplaceDataOwner.Workplace && workplace.dataPermissions === DataPermissions.None);
   }
+
   private orderWorkplaces(order: string): Array<any> {
     return orderBy(
       this.workplaces,

--- a/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
+++ b/src/app/features/wdf/wdf-workplaces-summary-table/wdf-workplaces-summary-table.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { WdfParentSortWorkplacesOptions } from '@core/model/establishment.model';
 import { orderBy } from 'lodash';
 import { DataPermissions, WorkplaceDataOwner } from '@core/model/my-workplaces.model';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
 
 @Component({
   selector: 'app-wdf-workplaces-summary-table',
@@ -11,6 +12,10 @@ export class WdfWorkplacesSummaryTableComponent implements OnInit {
   @Input() public workplaces = [];
   public sortWorkplacesOptions;
   public sortBy: string;
+  constructor(
+    private permissionsService: PermissionsService,
+  ) {
+  }
 
   ngOnInit(): void {
     this.sortWorkplacesOptions = WdfParentSortWorkplacesOptions;
@@ -45,7 +50,7 @@ export class WdfWorkplacesSummaryTableComponent implements OnInit {
     }
   }
   public canViewWorkplace(workplace){
-    return !(workplace.dataOwner === WorkplaceDataOwner.Workplace && workplace.dataPermissions === DataPermissions.None);
+    return this.permissionsService.canViewWorkplace(workplace);
   }
   private orderWorkplaces(order: string): Array<any> {
     return orderBy(


### PR DESCRIPTION
This is a bug where parents might not see the link to their own data. 

I at first moved this function into the permissions service but then took it out again as the function itself relies on the fact the page can only be viewed by parents. It also cant use the permissionsService.can function as that can only store permissions for one workplace atm.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [] No, they are not required for this change
