### PR TITLE
fix(wdfMeetingRequirementsAlignment): Fix icon alignment for add information message

### DIFF
--- a/src/app/shared/components/eligibility-icon/eligibility-icon.component.html
+++ b/src/app/shared/components/eligibility-icon/eligibility-icon.component.html
@@ -1,6 +1,7 @@
-<span class="govuk-!-margin-bottom-0 govuk-!-margin-top-1 govuk__flex govuk__nowrap">
+<span class="govuk-!-margin-bottom-0 govuk__nowrap">
   <ng-container *ngIf="num !== null">
     <strong class="govuk-line-height__normal govuk-!-margin-right-1">{{ num }}</strong>
   </ng-container>
-  <img class="govuk-!-margin-right-1" src="/assets/images/{{ icon }}.svg" alt="" /> {{ label }}
+  <img src="/assets/images/{{ icon }}.svg" class="asc-icon-align" alt="" />
+  <span class="govuk-!-margin-left-1">{{ label }}</span>
 </span>

--- a/src/app/shared/components/wdf-field-confirmation/wdf-field-confirmation.component.scss
+++ b/src/app/shared/components/wdf-field-confirmation/wdf-field-confirmation.component.scss
@@ -1,4 +1,0 @@
-.asc-icon-align {
-  position: relative;
-  top: 4px;
-}

--- a/src/app/shared/components/wdf-field-confirmation/wdf-field-confirmation.component.ts
+++ b/src/app/shared/components/wdf-field-confirmation/wdf-field-confirmation.component.ts
@@ -3,7 +3,6 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 @Component({
   selector: 'app-wdf-field-confirmation',
   templateUrl: './wdf-field-confirmation.component.html',
-  styleUrls: ['./wdf-field-confirmation.component.scss'],
 })
 export class WdfFieldConfirmationComponent {
   @Input() changeLink: any[];

--- a/src/assets/scss/modules/_utils.scss
+++ b/src/assets/scss/modules/_utils.scss
@@ -97,3 +97,8 @@
 .asc-font-19 {
   @include govuk-font($size: 19);
 }
+
+.asc-icon-align {
+  position: relative;
+  top: 4px;
+}


### PR DESCRIPTION
Work done
- Moved asc-icon-align class into utils scss file
- Added asc-icon-align class to img in eligibility-icon and removed govuk__flex class

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
