### PR TITLE
Fix: WDF staff mismatch message

### DIFF
--- a/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.html
+++ b/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.html
@@ -1,8 +1,8 @@
 <span class="govuk-!-margin-bottom-2 govuk-!-margin-top-2 govuk__flex govuk__nowrap">
   <img class="govuk-!-margin-right-1" src="/assets/images/{{ icon }}.svg" alt="" />{{ staffMismatchMessage }}
 </span>
-<span class="govuk__nowrap">
+<span *ngIf="workplace.numberOfStaff !== 0" class="govuk__nowrap">
   Either change the total or
-  <a [routerLink]="staffRecordsUrl.url" [fragment]="staffRecordsUrl.fragment">view staff records</a> to add more
-  records.
+  <a [routerLink]="staffRecordsUrl.url" [fragment]="staffRecordsUrl.fragment">view staff records</a> to
+  {{ addOrDeleteRecordsMessage }}.
 </span>

--- a/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.spec.ts
+++ b/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.spec.ts
@@ -50,7 +50,9 @@ describe('WdfStaffMismatchMessageComponent', () => {
     fixture.detectChanges();
 
     const expectedStaffMismatchMessage = "You've 1 more staff than staff records.";
+    const addRecordsMessage = 'add more records';
     expect(component.staffMismatchMessage).toEqual(expectedStaffMismatchMessage);
+    expect(component.addOrDeleteRecordsMessage).toEqual(addRecordsMessage);
   });
 
   it('should show staff mismatch message if you have more staff records than staff', async () => {
@@ -61,7 +63,9 @@ describe('WdfStaffMismatchMessageComponent', () => {
     fixture.detectChanges();
 
     const expectedStaffMismatchMessage = "You've 1 more staff record than staff.";
+    const deleteRecordsMessage = 'delete some records';
     expect(component.staffMismatchMessage).toEqual(expectedStaffMismatchMessage);
+    expect(component.addOrDeleteRecordsMessage).toEqual(deleteRecordsMessage);
   });
 
   it('should show staff mismatch message pluralized if you have more staff records than staff', async () => {
@@ -72,7 +76,22 @@ describe('WdfStaffMismatchMessageComponent', () => {
     fixture.detectChanges();
 
     const expectedStaffMismatchMessage = "You've 6 more staff records than staff.";
+    const deleteRecordsMessage = 'delete some records';
     expect(component.staffMismatchMessage).toEqual(expectedStaffMismatchMessage);
+    expect(component.addOrDeleteRecordsMessage).toEqual(deleteRecordsMessage);
+  });
+
+  it('should not show a "Either change the total" message when total staff is zero', async () => {
+    const { component, fixture, queryByText } = await setup();
+    component.workerCount = 4;
+    component.workplace.numberOfStaff = 0;
+    component.setMessage();
+    fixture.detectChanges();
+
+    const expectedStaffMismatchMessage = "You've 4 more staff records than staff.";
+    expect(component.staffMismatchMessage).toEqual(expectedStaffMismatchMessage);
+
+    expect(queryByText('Either change the total', { exact: false })).toBeFalsy();
   });
 
   it('should show an orange flag if the user is meeting WDF overall but has made changes', async () => {

--- a/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.ts
+++ b/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.ts
@@ -13,6 +13,7 @@ export class WdfStaffMismatchMessageComponent implements OnInit, OnChanges {
   @Input() public workerCount: number;
   @Input() public overallWdfEligibility: boolean;
   public staffMismatchMessage: string;
+  public addOrDeleteRecordsMessage: string;
   public icon: string;
   public staffRecordsDifference: number;
   public staffRecordsUrl: URLStructure;
@@ -36,12 +37,14 @@ export class WdfStaffMismatchMessageComponent implements OnInit, OnChanges {
     this.calculateStaffRecordsDifference();
     if (this.workplace.numberOfStaff > this.workerCount) {
       this.staffMismatchMessage = `You've ${this.staffRecordsDifference} more staff than staff records.`;
+      this.addOrDeleteRecordsMessage = 'add more records';
       return;
     }
     if (this.workplace.numberOfStaff < this.workerCount) {
       this.staffMismatchMessage = `You've ${
         this.staffRecordsDifference
       } more staff ${this.pluralizeRecords()} than staff.`;
+      this.addOrDeleteRecordsMessage = 'delete some records';
       return;
     }
   }


### PR DESCRIPTION
#### Work done
- Changed the staff mismatch message to say 'delete more records' or 'add more records' depending on how many staff and records you have
- Removed the 'Either change the total or...' message when the total number of staff is set to zero

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
