### PR TITLE
fix(selectWorkplacePostcodeErrorMessage): Override setupFormErrorsMap…

### DIFF
--- a/src/app/features/add-workplace/select-workplace/select-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/select-workplace/select-workplace.component.spec.ts
@@ -93,7 +93,7 @@ describe('SelectWorkplaceComponent', () => {
 
   it('should display none selected error message(twice) when no radio box selected on clicking Continue', async () => {
     const { component, fixture, getAllByText, queryByText, getByText } = await setup();
-    const errorMessage = `Select your workplace if it's displayed`;
+    const errorMessage = `Select the workplace if it's displayed`;
     const form = component.form;
     const continueButton = getByText('Continue');
 

--- a/src/app/features/add-workplace/select-workplace/select-workplace.component.ts
+++ b/src/app/features/add-workplace/select-workplace/select-workplace.component.ts
@@ -31,6 +31,20 @@ export class SelectWorkplaceComponent extends SelectWorkplaceDirective {
     this.setupSubscription();
   }
 
+  protected setupFormErrorsMap(): void {
+    this.formErrorsMap = [
+      {
+        item: 'workplace',
+        type: [
+          {
+            name: 'required',
+            message: `Select the workplace if it's displayed`,
+          },
+        ],
+      },
+    ];
+  }
+
   protected setupSubscription(): void {
     this.subscriptions.add(
       this.registrationService.locationAddresses$.subscribe(

--- a/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
+++ b/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
@@ -68,7 +68,7 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
     });
   }
 
-  public setupFormErrorsMap(): void {
+  protected setupFormErrorsMap(): void {
     this.formErrorsMap = [
       {
         item: 'workplace',


### PR DESCRIPTION
#### Work done
- Override setupFormErrorsMap in add-workplace version of select-workplace component to have different error message

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
