### PR TITLE
Removed full stops from error messages

### DIFF
--- a/src/app/shared/directives/user/security-question.directive.ts
+++ b/src/app/shared/directives/user/security-question.directive.ts
@@ -95,7 +95,7 @@ export abstract class SecurityQuestionDirective implements OnInit, OnDestroy, Af
           },
           {
             name: 'maxlength',
-            message: `Security question must be ${this.securityDetailsMaxLength} characters or fewer.`,
+            message: `Security question must be ${this.securityDetailsMaxLength} characters or fewer`,
           },
         ],
       },
@@ -108,7 +108,7 @@ export abstract class SecurityQuestionDirective implements OnInit, OnDestroy, Af
           },
           {
             name: 'maxlength',
-            message: `Answer must be ${this.securityDetailsMaxLength} characters or fewer.`,
+            message: `Answer must be ${this.securityDetailsMaxLength} characters or fewer`,
           },
         ],
       },


### PR DESCRIPTION
#### Work done
- Removed the erroneous full stops at the end of 1 of the error messages due to a complaint by the content designer of the service.
- Removed the erroneous full stops at the end of another of the error messages due to a complaint by the content designer of the service.

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
