### PR TITLE
Fixed links in admin menu

### DIFF
--- a/src/app/features/admin/admin-menu/admin-menu.component.html
+++ b/src/app/features/admin/admin-menu/admin-menu.component.html
@@ -1,29 +1,29 @@
 <ul class="govuk-list">
   <li routerLinkActive="active">
-    <a routerLink="/admin/search" class="govuk-link">Search</a>
+    <a routerLink="/sfcadmin/search" class="govuk-link">Search</a>
   </li>
   <li routerLinkActive="active">
-    <a routerLink="/admin/registrations" class="govuk-link">Registration requests</a>
+    <a routerLink="/sfcadmin/registrations" class="govuk-link">Registration requests</a>
   </li>
   <li routerLinkActive="active">
-    <a routerLink="/admin/parent-requests" class="govuk-link">Parent requests</a>
+    <a routerLink="/sfcadmin/parent-requests" class="govuk-link">Parent requests</a>
   </li>
   <li routerLinkActive="active">
-    <a routerLink="/admin/cqc-status-changes" class="govuk-link">CQC status changes</a>
+    <a routerLink="/sfcadmin/cqc-status-changes" class="govuk-link">CQC status changes</a>
   </li>
   <li routerLinkActive="active">
-    <a routerLink="/admin/emails" class="govuk-link">Emails</a>
+    <a routerLink="/sfcadmin/emails" class="govuk-link">Emails</a>
   </li>
   <li routerLinkActive="active">
-    <a routerLink="/admin/admin-reports" class="govuk-link">Admin reports</a>
+    <a routerLink="/sfcadmin/admin-reports" class="govuk-link">Admin reports</a>
   </li>
   <li routerLinkActive="active">
-    <a routerLink="/admin/local-authorities-return" class="govuk-link">Local authority returns</a>
+    <a routerLink="/sfcadmin/local-authorities-return" class="govuk-link">Local authority returns</a>
   </li>
   <li routerLinkActive="active">
-    <a routerLink="/admin/users" class="govuk-link">Admin users</a>
+    <a routerLink="/sfcadmin/users" class="govuk-link">Admin users</a>
   </li>
   <li routerLinkActive="active">
-    <a routerLink="/admin/external-links" class="govuk-link">External links</a>
+    <a routerLink="/sfcadmin/external-links" class="govuk-link">External links</a>
   </li>
 </ul>

--- a/src/app/features/admin/admin-menu/admin-menu.component.spec.ts
+++ b/src/app/features/admin/admin-menu/admin-menu.component.spec.ts
@@ -26,6 +26,6 @@ describe('AdminMenuComponent', () => {
     const { component } = await setup();
 
     const laCompletionsLink = component.getByText('Local authority returns');
-    expect(laCompletionsLink.getAttribute('href')).toBe('/admin/local-authorities-return');
+    expect(laCompletionsLink.getAttribute('href')).toBe('/sfcadmin/local-authorities-return');
   });
 });


### PR DESCRIPTION
#### Work done
- Fixed admin links from `/admin` to `/sfcadmin`

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
