### PR TITLE
Feat/add workplace new select main service

### DIFF
--- a/src/app/features/add-workplace/add-workplace-routing.module.ts
+++ b/src/app/features/add-workplace/add-workplace-routing.module.ts
@@ -10,13 +10,13 @@ import { FindWorkplaceAddressComponent } from '@features/add-workplace/find-work
 import { FindYourWorkplaceComponent } from '@features/add-workplace/find-your-workplace/find-your-workplace.component';
 import { IsThisYourWorkplaceComponent } from '@features/add-workplace/is-this-your-workplace/is-this-your-workplace.component';
 import { NewRegulatedByCqcComponent } from '@features/add-workplace/new-regulated-by-cqc/new-regulated-by-cqc.component';
+import { NewSelectMainServiceComponent } from '@features/add-workplace/new-select-main-service/new-select-main-service.component';
 import { RegulatedByCqcComponent } from '@features/add-workplace/regulated-by-cqc/regulated-by-cqc.component';
 import { SelectMainServiceComponent } from '@features/add-workplace/select-main-service/select-main-service.component';
 import { SelectWorkplaceAddressComponent } from '@features/add-workplace/select-workplace-address/select-workplace-address.component';
 import { SelectWorkplaceComponent } from '@features/add-workplace/select-workplace/select-workplace.component';
 import { WorkplaceNameAddressComponent } from '@features/add-workplace/workplace-name-address/workplace-name-address.component';
 import { WorkplaceNotFoundComponent } from '@features/add-workplace/workplace-not-found/workplace-not-found.component';
-import { NewSelectMainServiceComponent } from '@features/create-account/workplace/new-select-main-service/new-select-main-service.component';
 
 import { NameOfWorkplaceComponent } from './name-of-workplace/name-of-workplace.component';
 import { NewWorkplaceNotFoundComponent } from './new-workplace-not-found/new-workplace-not-found.component';

--- a/src/app/features/add-workplace/add-workplace.module.ts
+++ b/src/app/features/add-workplace/add-workplace.module.ts
@@ -16,6 +16,7 @@ import { FindYourWorkplaceComponent } from './find-your-workplace/find-your-work
 import { IsThisYourWorkplaceComponent } from './is-this-your-workplace/is-this-your-workplace.component';
 import { NameOfWorkplaceComponent } from './name-of-workplace/name-of-workplace.component';
 import { NewRegulatedByCqcComponent } from './new-regulated-by-cqc/new-regulated-by-cqc.component';
+import { NewSelectMainServiceComponent } from './new-select-main-service/new-select-main-service.component';
 import { NewWorkplaceNotFoundComponent } from './new-workplace-not-found/new-workplace-not-found.component';
 import { SelectMainServiceComponent } from './select-main-service/select-main-service.component';
 import { SelectWorkplaceAddressComponent } from './select-workplace-address/select-workplace-address.component';
@@ -44,6 +45,7 @@ import { WorkplaceNotFoundComponent } from './workplace-not-found/workplace-not-
     NewWorkplaceNotFoundComponent,
     IsThisYourWorkplaceComponent,
     FindYourWorkplaceComponent,
+    NewSelectMainServiceComponent,
   ],
 })
 export class AddWorkplaceModule {}

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -1,0 +1,187 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { RegistrationService } from '@core/services/registration.service';
+import { WorkplaceService } from '@core/services/workplace.service';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
+import { RegistrationModule } from '@features/registration/registration.module';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render } from '@testing-library/angular';
+
+import { NewSelectMainServiceComponent } from './new-select-main-service.component';
+
+describe('NewSelectMainServiceComponent', () => {
+  async function setup() {
+    const { fixture, getByText, getAllByText, queryByText, getByLabelText } = await render(
+      NewSelectMainServiceComponent,
+      {
+        imports: [
+          SharedModule,
+          RegistrationModule,
+          RouterTestingModule,
+          HttpClientTestingModule,
+          FormsModule,
+          ReactiveFormsModule,
+        ],
+        providers: [
+          {
+            provide: WorkplaceService,
+            useClass: MockWorkplaceService,
+          },
+          {
+            provide: EstablishmentService,
+            useClass: MockEstablishmentService,
+          },
+          { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                parent: {
+                  url: [
+                    {
+                      path: 'add-workplace',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          FormBuilder,
+        ],
+      },
+    );
+
+    const injector = getTestBed();
+    const router = injector.inject(Router) as Router;
+    const registrationService = injector.inject(RegistrationService) as RegistrationService;
+
+    const spy = spyOn(router, 'navigate');
+    spy.and.returnValue(Promise.resolve(true));
+
+    const component = fixture.componentInstance;
+
+    return {
+      fixture,
+      component,
+      spy,
+      registrationService,
+      getAllByText,
+      queryByText,
+      getByText,
+      getByLabelText,
+    };
+  }
+
+  it('should show NewSelectMainServiceComponent component', async () => {
+    const { component } = await setup();
+
+    expect(component).toBeTruthy();
+  });
+
+  it('should show CQC text when following the CQC regulated flow', async () => {
+    const { component, fixture, getByText } = await setup();
+
+    component.isRegulated = true;
+    component.renderForm = true;
+
+    fixture.detectChanges();
+    const cqcText = getByText(
+      'Because you said the main service you provide is regulated by the Care Quality Commission (CQC), Skills for Care will need to check your selection matches the CQC database.',
+    );
+    expect(cqcText).toBeTruthy();
+  });
+
+  it('should show standard text when following the not CQC regulated flow and feature flag is off', async () => {
+    const { component, fixture, getByText } = await setup();
+
+    component.createAccountNewDesign = false;
+    component.isRegulated = false;
+    component.renderForm = true;
+
+    fixture.detectChanges();
+    const cqcText = getByText(
+      'We need some details about where you work. You need to answer these questions before we can create your account.',
+    );
+
+    expect(cqcText).toBeTruthy();
+  });
+
+  it('should show no description text when following the not CQC regulated flow and feature flag is on', async () => {
+    const { component, fixture, queryByText } = await setup();
+
+    component.createAccountNewDesign = true;
+    component.isRegulated = false;
+    component.renderForm = true;
+
+    fixture.detectChanges();
+    const cqcText = queryByText(
+      'We need some details about where you work. You need to answer these questions before we can create your account.',
+    );
+
+    expect(cqcText).toBeNull();
+  });
+
+  it('should set the correct back link to the is this your workplace page in add-workplace flow', async () => {
+    const { component, fixture } = await setup();
+    const backLinkSpy = spyOn(fixture.componentInstance.backService, 'setBackLink');
+
+    component.setBackLink();
+    fixture.detectChanges();
+
+    expect(backLinkSpy).toHaveBeenCalledWith({
+      url: ['add-workplace/your-workplace'],
+    });
+  });
+
+  it("should see 'Select its main service' when is a parent", async () => {
+    const { component, fixture, queryByText } = await setup();
+
+    component.isParent = true;
+    component.isRegulated = false;
+    component.renderForm = true;
+    fixture.detectChanges();
+
+    expect(queryByText('Select its main service')).toBeTruthy();
+  });
+
+  it('should error when nothing has been selected', async () => {
+    const { component, fixture, getByText, getAllByText } = await setup();
+    component.isRegulated = true;
+    component.renderForm = true;
+    const form = component.form;
+
+    fixture.detectChanges();
+
+    const errorMessage = 'Select your main service';
+
+    const continueButton = getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.invalid).toBeTruthy();
+    expect(getAllByText(errorMessage).length).toBe(3);
+  });
+
+  it('should submit and go to the add-workplace/add-user-details url when option selected and is a parent', async () => {
+    const { component, fixture, getByText, getByLabelText, spy } = await setup();
+
+    component.isParent = true;
+    component.isRegulated = true;
+    component.renderForm = true;
+    fixture.detectChanges();
+
+    const radioButton = getByLabelText('Name');
+    fireEvent.click(radioButton);
+
+    const continueButton = getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(spy).toHaveBeenCalledWith(['add-workplace', 'confirm-workplace-details']);
+  });
+});

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
@@ -1,0 +1,75 @@
+import { Component } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Establishment } from '@core/model/establishment.model';
+import { Service } from '@core/model/services.model';
+import { BackService } from '@core/services/back.service';
+import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceService } from '@core/services/workplace.service';
+import { SelectMainServiceDirective } from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+
+@Component({
+  selector: 'app-new-select-main-service',
+  templateUrl: '../../../shared/directives/create-workplace/select-main-service/select-main-service.component.html',
+})
+export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
+  public isRegulated: boolean;
+  public isParent: boolean;
+  public workplace: Establishment;
+  public createAccountNewDesign: boolean;
+
+  constructor(
+    public backService: BackService,
+    protected errorSummaryService: ErrorSummaryService,
+    protected formBuilder: FormBuilder,
+    protected router: Router,
+    protected workplaceService: WorkplaceService,
+    private establishmentService: EstablishmentService,
+    private featureFlagsService: FeatureFlagsService,
+    private route: ActivatedRoute,
+  ) {
+    super(backService, errorSummaryService, formBuilder, router, workplaceService);
+  }
+
+  protected async init(): Promise<void> {
+    this.flow = 'add-workplace';
+    this.setBackLink();
+    this.isRegulated = this.workplaceService.isRegulated();
+    this.workplace = this.establishmentService.primaryWorkplace;
+    this.workplace?.isParent ? (this.isParent = true) : (this.isParent = false);
+    this.createAccountNewDesign = await this.featureFlagsService.configCatClient.getValueAsync(
+      'createAccountNewDesign',
+      false,
+    );
+  }
+
+  protected getServiceCategories(): void {
+    this.subscriptions.add(this.getServicesByCategory(this.isRegulated));
+  }
+
+  protected setSelectedWorkplaceService(): void {
+    this.subscriptions.add(
+      this.workplaceService.selectedWorkplaceService$.subscribe((service: Service) => {
+        if (service) {
+          this.selectedMainService = service;
+        }
+      }),
+    );
+  }
+
+  protected onSuccess(): void {
+    this.workplaceService.selectedWorkplaceService$.next(this.getSelectedWorkPlaceService());
+    this.navigateToNextPage();
+  }
+
+  protected navigateToNextPage(): void {
+    const url = this.isParent ? 'confirm-workplace-details' : 'add-user-details';
+    this.router.navigate([this.flow, url]);
+  }
+
+  public setBackLink(): void {
+    this.backService.setBackLink({ url: [`${this.flow}/your-workplace`] });
+  }
+}

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -18,7 +18,7 @@ import { fireEvent, render } from '@testing-library/angular';
 import { NewSelectMainServiceComponent } from './new-select-main-service.component';
 
 describe('NewSelectMainServiceComponent', () => {
-  async function setup(flow) {
+  async function setup() {
     const { fixture, getByText, getAllByText, queryByText, getByLabelText } = await render(
       NewSelectMainServiceComponent,
       {
@@ -51,7 +51,7 @@ describe('NewSelectMainServiceComponent', () => {
                 parent: {
                   url: [
                     {
-                      path: flow,
+                      path: 'registration',
                     },
                   ],
                 },
@@ -85,13 +85,13 @@ describe('NewSelectMainServiceComponent', () => {
   }
 
   it('should show NewSelectMainServiceComponent component', async () => {
-    const { component } = await setup('registration');
+    const { component } = await setup();
 
     expect(component).toBeTruthy();
   });
 
   it('should show CQC text when following the CQC regulated flow', async () => {
-    const { component, fixture, getByText } = await setup('registration');
+    const { component, fixture, getByText } = await setup();
 
     component.isRegulated = true;
     component.renderForm = true;
@@ -104,7 +104,7 @@ describe('NewSelectMainServiceComponent', () => {
   });
 
   it('should show standard text when following the not CQC regulated flow and feature flag is off', async () => {
-    const { component, fixture, getByText } = await setup('registration');
+    const { component, fixture, getByText } = await setup();
 
     component.createAccountNewDesign = false;
     component.isRegulated = false;
@@ -119,7 +119,7 @@ describe('NewSelectMainServiceComponent', () => {
   });
 
   it('should show no description text when following the not CQC regulated flow and feature flag is on', async () => {
-    const { component, fixture, queryByText } = await setup('registration');
+    const { component, fixture, queryByText } = await setup();
 
     component.createAccountNewDesign = true;
     component.isRegulated = false;
@@ -134,7 +134,7 @@ describe('NewSelectMainServiceComponent', () => {
   });
 
   it('should set the correct back link to the is this your workplace page in regstration flow', async () => {
-    const { component, fixture } = await setup('registration');
+    const { component, fixture } = await setup();
     const backLinkSpy = spyOn(fixture.componentInstance.backService, 'setBackLink');
 
     component.setBackLink();
@@ -145,31 +145,8 @@ describe('NewSelectMainServiceComponent', () => {
     });
   });
 
-  it('should set the correct back link to the is this your workplace page in add-workplace flow', async () => {
-    const { component, fixture } = await setup('add-workplace');
-    const backLinkSpy = spyOn(fixture.componentInstance.backService, 'setBackLink');
-
-    component.setBackLink();
-    fixture.detectChanges();
-
-    expect(backLinkSpy).toHaveBeenCalledWith({
-      url: ['add-workplace/your-workplace'],
-    });
-  });
-
-  it("should see 'Select its main service' when is a parent", async () => {
-    const { component, fixture, queryByText } = await setup('add-workplace');
-
-    component.isParent = true;
-    component.isRegulated = false;
-    component.renderForm = true;
-    fixture.detectChanges();
-
-    expect(queryByText('Select its main service')).toBeTruthy();
-  });
-
   it("should see 'Select your main service' when is not a parent", async () => {
-    const { component, fixture, queryByText } = await setup('registration');
+    const { component, fixture, queryByText } = await setup();
 
     component.isParent = false;
     component.isRegulated = false;
@@ -180,7 +157,7 @@ describe('NewSelectMainServiceComponent', () => {
   });
 
   it('should error when nothing has been selected', async () => {
-    const { component, fixture, getByText, getAllByText } = await setup('registration');
+    const { component, fixture, getByText, getAllByText } = await setup();
     component.isRegulated = true;
     component.renderForm = true;
     const form = component.form;
@@ -197,7 +174,7 @@ describe('NewSelectMainServiceComponent', () => {
   });
 
   it('should submit and go to the registration/add-user-details url when option selected and is not parent', async () => {
-    const { component, fixture, getByText, getByLabelText, spy } = await setup('registration');
+    const { component, fixture, getByText, getByLabelText, spy } = await setup();
 
     component.isParent = false;
     component.isRegulated = true;
@@ -211,22 +188,5 @@ describe('NewSelectMainServiceComponent', () => {
     fireEvent.click(continueButton);
 
     expect(spy).toHaveBeenCalledWith(['registration', 'add-user-details']);
-  });
-
-  it('should submit and go to the add-workplace/add-user-details url when option selected and is a parent', async () => {
-    const { component, fixture, getByText, getByLabelText, spy } = await setup('add-workplace');
-
-    component.isParent = true;
-    component.isRegulated = true;
-    component.renderForm = true;
-    fixture.detectChanges();
-
-    const radioButton = getByLabelText('Name');
-    fireEvent.click(radioButton);
-
-    const continueButton = getByText('Continue');
-    fireEvent.click(continueButton);
-
-    expect(spy).toHaveBeenCalledWith(['add-workplace', 'confirm-workplace-details']);
   });
 });


### PR DESCRIPTION
#### Work done
- Created new-select-main-service component in add-workplace which extends old select-main-service directive and uses the workplace service
- Changed routing in add-workplace to use this component

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
