### PR TITLE
Fix: Select workplace navigation

### DIFF
--- a/src/app/features/add-workplace/select-workplace/select-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/select-workplace/select-workplace.component.spec.ts
@@ -106,15 +106,19 @@ describe('SelectWorkplaceComponent', () => {
   });
 
   describe('Navigation', () => {
-    it('should navigate to the select-main-service url in add-workplace flow when workplace selected', async () => {
-      const { getByText, fixture, spy } = await setup();
+    it('should navigate to the new-select-main-service url in add-workplace flow when workplace selected', async () => {
+      const { component, getByText, fixture, spy } = await setup();
+
+      component.createAccountNewDesign = true;
+      fixture.detectChanges();
+
       const firstWorkplaceRadioButton = fixture.nativeElement.querySelector(`input[ng-reflect-value="123"]`);
       fireEvent.click(firstWorkplaceRadioButton);
 
       const continueButton = getByText('Continue');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'select-main-service']);
+      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'new-select-main-service']);
     });
 
     it('should navigate back to the find-workplace url in add-workplace flow when Change clicked', async () => {

--- a/src/app/features/add-workplace/select-workplace/select-workplace.component.ts
+++ b/src/app/features/add-workplace/select-workplace/select-workplace.component.ts
@@ -55,6 +55,6 @@ export class SelectWorkplaceComponent extends SelectWorkplaceDirective {
 
   protected save(): void {
     this.workplaceService.selectedLocationAddress$.next(this.getSelectedLocation());
-    this.router.navigate([this.flow, 'select-main-service']);
+    this.router.navigate([this.flow, this.nextRoute]);
   }
 }

--- a/src/app/features/registration/select-workplace/select-workplace.component.spec.ts
+++ b/src/app/features/registration/select-workplace/select-workplace.component.spec.ts
@@ -105,15 +105,19 @@ describe('SelectWorkplaceComponent', () => {
   });
 
   describe('Navigation', () => {
-    it('should navigate to the select-main-service url in registration flow when workplace selected', async () => {
-      const { getByText, fixture, spy } = await setup();
+    it('should navigate to the new-select-main-service url in registration flow when workplace selected and feature flag is on', async () => {
+      const { component, getByText, fixture, spy } = await setup();
+
+      component.createAccountNewDesign = true;
+      fixture.detectChanges();
+
       const yesRadioButton = fixture.nativeElement.querySelector(`input[ng-reflect-value="123"]`);
       fireEvent.click(yesRadioButton);
 
       const continueButton = getByText('Continue');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(['/registration', 'select-main-service']);
+      expect(spy).toHaveBeenCalledWith(['/registration', 'new-select-main-service']);
     });
 
     it('should navigate back to the find-workplace url in registration flow when Change clicked', async () => {

--- a/src/app/features/registration/select-workplace/select-workplace.component.ts
+++ b/src/app/features/registration/select-workplace/select-workplace.component.ts
@@ -39,6 +39,6 @@ export class SelectWorkplaceComponent extends SelectWorkplaceDirective {
 
   protected save(): void {
     this.registrationService.selectedLocationAddress$.next(this.getSelectedLocation());
-    this.router.navigate([this.flow, 'select-main-service']);
+    this.router.navigate([this.flow, this.nextRoute]);
   }
 }

--- a/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
+++ b/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
@@ -19,10 +19,11 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
   public formErrorsMap: Array<ErrorDetails>;
   public submitted = false;
   public isCQCLocationUpdate: boolean;
-  protected subscriptions: Subscription = new Subscription();
   public createAccountNewDesign: boolean;
   public enteredPostcode: string;
   public workplaceNotDisplayedLink: string;
+  protected subscriptions: Subscription = new Subscription();
+  protected nextRoute: string;
 
   constructor(
     protected backService: BackService,
@@ -42,6 +43,7 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
       this.createAccountNewDesign = value;
       this.setBackLink();
       this.setWorkplaceNotDisplayedLink();
+      this.setNextRoute();
     });
   }
 
@@ -60,6 +62,10 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
 
   protected setWorkplaceNotDisplayedLink(): void {
     this.workplaceNotDisplayedLink = this.createAccountNewDesign ? 'workplace-name-address' : 'enter-workplace-address';
+  }
+
+  protected setNextRoute(): void {
+    this.nextRoute = this.createAccountNewDesign ? 'new-select-main-service' : 'select-main-service';
   }
 
   protected setupForm(): void {


### PR DESCRIPTION
#### Work done
- Fix url on continue button for `select-workplace` page on registration and parent flow to be `new-select-main-service` if feature flag is on

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
