### PR TITLE
Fix: Workplace name address navigation

### DIFF
--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -78,6 +78,46 @@ describe('WorkplaceNameAddressComponent', () => {
     expect(getByText(expectedTitle, { exact: false })).toBeTruthy();
   });
 
+  it('should navigate to new-select-main-service page on success if feature flag is on', async () => {
+    const { component, fixture, getByText, spy } = await setup();
+    const form = component.form;
+
+    form.controls['workplaceName'].setValue('Workplace');
+    form.controls['address1'].setValue('1 Main Street');
+    form.controls['townOrCity'].setValue('London');
+    form.controls['county'].setValue('Greater London');
+    form.controls['postcode'].setValue('SE1 1AA');
+
+    component.createAccountNewDesign = true;
+    fixture.detectChanges();
+
+    const continueButton = getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.invalid).toBeFalsy();
+    expect(spy).toHaveBeenCalledWith(['/add-workplace', 'new-select-main-service']);
+  });
+
+  it('should navigate to select-main-service page on success if feature flag is off', async () => {
+    const { component, fixture, getByText, spy } = await setup();
+    const form = component.form;
+
+    form.controls['workplaceName'].setValue('Workplace');
+    form.controls['address1'].setValue('1 Main Street');
+    form.controls['townOrCity'].setValue('London');
+    form.controls['county'].setValue('Greater London');
+    form.controls['postcode'].setValue('SE1 1AA');
+
+    component.createAccountNewDesign = false;
+    fixture.detectChanges();
+
+    const continueButton = getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.invalid).toBeFalsy();
+    expect(spy).toHaveBeenCalledWith(['/add-workplace', 'select-main-service']);
+  });
+
   describe('Error messages', () => {
     it(`should display an error message when workplace name isn't filled in`, async () => {
       const { component, getByText, getAllByText } = await setup();

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
@@ -66,7 +66,8 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
   protected setSelectedLocationAddress(): void {
     this.workplaceService.selectedLocationAddress$.next(this.getLocationAddress());
     this.workplaceService.manuallyEnteredWorkplace$.next(true);
-    this.router.navigate([`${this.flow}/select-main-service`]);
+    const url = this.createAccountNewDesign ? 'new-select-main-service' : 'select-main-service';
+    this.router.navigate([this.flow, url]);
   }
 
   public setBackLink(): void {

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -78,6 +78,46 @@ describe('WorkplaceNameAddressComponent', () => {
     expect(getByText(expectedTitle, { exact: false })).toBeTruthy();
   });
 
+  it('should navigate to new-select-main-service page on success if feature flag is on', async () => {
+    const { component, fixture, getByText, spy } = await setup();
+    const form = component.form;
+
+    form.controls['workplaceName'].setValue('Workplace');
+    form.controls['address1'].setValue('1 Main Street');
+    form.controls['townOrCity'].setValue('London');
+    form.controls['county'].setValue('Greater London');
+    form.controls['postcode'].setValue('SE1 1AA');
+
+    component.createAccountNewDesign = true;
+    fixture.detectChanges();
+
+    const continueButton = getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.invalid).toBeFalsy();
+    expect(spy).toHaveBeenCalledWith(['/registration', 'new-select-main-service']);
+  });
+
+  it('should navigate to select-main-service page on success if feature flag is off', async () => {
+    const { component, fixture, getByText, spy } = await setup();
+    const form = component.form;
+
+    form.controls['workplaceName'].setValue('Workplace');
+    form.controls['address1'].setValue('1 Main Street');
+    form.controls['townOrCity'].setValue('London');
+    form.controls['county'].setValue('Greater London');
+    form.controls['postcode'].setValue('SE1 1AA');
+
+    component.createAccountNewDesign = false;
+    fixture.detectChanges();
+
+    const continueButton = getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.invalid).toBeFalsy();
+    expect(spy).toHaveBeenCalledWith(['/registration', 'select-main-service']);
+  });
+
   describe('Error messages', () => {
     it(`should display an error message when workplace name isn't filled in`, async () => {
       const { component, getByText, getAllByText } = await setup();

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
@@ -64,7 +64,8 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
   protected setSelectedLocationAddress(): void {
     this.registrationService.selectedLocationAddress$.next(this.getLocationAddress());
     this.registrationService.manuallyEnteredWorkplace$.next(true);
-    this.router.navigate([`${this.flow}/select-main-service`]);
+    const url = this.createAccountNewDesign ? 'new-select-main-service' : 'select-main-service';
+    this.router.navigate([this.flow, url]);
   }
 
   public setBackLink(): void {

--- a/src/app/features/registration/select-workplace/select-workplace.component.html
+++ b/src/app/features/registration/select-workplace/select-workplace.component.html
@@ -38,7 +38,7 @@
       </fieldset>
 
       <p class="govuk-!-margin-bottom-7">
-        <a [routerLink]="[flow, workplaceNotDisplayedLink]" role="button" draggable="false">
+        <a [routerLink]="[flow, 'workplace-name-address']" role="button" draggable="false">
           Workplace is not displayed or is not correct
         </a>
       </p>

--- a/src/app/features/workplace-find-and-select/select-workplace/select-workplace.component.html
+++ b/src/app/features/workplace-find-and-select/select-workplace/select-workplace.component.html
@@ -60,7 +60,7 @@
       </ng-container>
       <ng-template #CQCLocationAdd>
         <p class="govuk-!-margin-bottom-7">
-          <a [routerLink]="[flow, workplaceNotDisplayedLink]" role="button" draggable="false">
+          <a [routerLink]="[flow, 'workplace-name-address']" role="button" draggable="false">
             Workplace is not displayed or is not correct
           </a>
         </p>

--- a/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
+++ b/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
@@ -21,7 +21,6 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
   public isCQCLocationUpdate: boolean;
   public createAccountNewDesign: boolean;
   public enteredPostcode: string;
-  public workplaceNotDisplayedLink: string;
   protected subscriptions: Subscription = new Subscription();
   protected nextRoute: string;
 
@@ -42,7 +41,6 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
     this.featureFlagsService.configCatClient.getValueAsync('createAccountNewDesign', false).then((value) => {
       this.createAccountNewDesign = value;
       this.setBackLink();
-      this.setWorkplaceNotDisplayedLink();
       this.setNextRoute();
     });
   }
@@ -58,10 +56,6 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
   protected setBackLink(): void {
     const backLink = this.createAccountNewDesign ? 'find-workplace' : 'regulated-by-cqc';
     this.backService.setBackLink({ url: [`${this.flow}/${backLink}`] });
-  }
-
-  protected setWorkplaceNotDisplayedLink(): void {
-    this.workplaceNotDisplayedLink = this.createAccountNewDesign ? 'workplace-name-address' : 'enter-workplace-address';
   }
 
   protected setNextRoute(): void {


### PR DESCRIPTION
#### Work done
- Add feature flag to navigation in `workplace-name-address` component to go to `new-select-main-service` page
- Fix links to workplace not found page

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
