### PR TITLE
Fix/year of entry bug

### DIFF
--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -366,9 +366,9 @@ class Worker extends EntityValidator {
         document.britishCitizenship = null;
       }
 
-      // Remove year arriced if born in the UK
+      // Remove year arrived if born in the UK
       if (document.countryOfBirth) {
-        if (document.countryOfBirth.value === 'United Kingdom') {
+        if (document.countryOfBirth.value === 'United Kingdom' || document.countryOfBirth.value === "Don't know") {
           document.yearArrived = { value: null, year: null };
         }
       }

--- a/server/models/classes/worker.js
+++ b/server/models/classes/worker.js
@@ -366,7 +366,7 @@ class Worker extends EntityValidator {
         document.britishCitizenship = null;
       }
 
-      // Remove year arrived if born in the UK
+      // Remove year arrived if born in the UK or setting to Don't know
       if (document.countryOfBirth) {
         if (document.countryOfBirth.value === 'United Kingdom' || document.countryOfBirth.value === "Don't know") {
           document.yearArrived = { value: null, year: null };

--- a/server/test/unit/models/classes/worker.spec.js
+++ b/server/test/unit/models/classes/worker.spec.js
@@ -244,6 +244,45 @@ describe('Worker Class', () => {
       expect(qual.highestQualification.title).to.deep.equal('Level 7');
       expect(qualWorker).to.deep.equal(true);
     });
+
+    describe('Resetting yearArrived', () => {
+      it('should remove year of entry when country of birth is set to Don\'t know', async () => {
+        const countryOfBirth = {
+          countryOfBirth: { value: `Don't know` },
+        };
+
+        const countryOfBirthWorker = await worker.load(countryOfBirth);
+
+        expect(countryOfBirth.countryOfBirth.value).to.deep.equal(`Don't know`);
+        expect(countryOfBirth.yearArrived).to.deep.equal({ value: null, year: null });
+        expect(countryOfBirthWorker).to.deep.equal(true);
+      });
+
+      it('should remove year of entry when country of birth is set to United Kingdom', async () => {
+        const countryOfBirth = {
+          countryOfBirth: { value: 'United Kingdom' },
+        };
+
+        const countryOfBirthWorker = await worker.load(countryOfBirth);
+
+        expect(countryOfBirth.countryOfBirth.value).to.deep.equal('United Kingdom');
+        expect(countryOfBirth.yearArrived).to.deep.equal({ value: null, year: null });
+        expect(countryOfBirthWorker).to.deep.equal(true);
+      });
+
+      it('should not change the year of entry when country of birth is set to Other', async () => {
+        const countryOfBirth = {
+          countryOfBirth: { value: 'Other', other: { country: 'Uganda' }}
+        };
+
+        const countryOfBirthWorker = await worker.load(countryOfBirth);
+
+        expect(countryOfBirth.countryOfBirth.value).to.deep.equal('Other');
+        expect(countryOfBirth.countryOfBirth.other).to.deep.equal({ country: 'Uganda' });
+        expect(countryOfBirth.yearArrived).to.deep.equal(undefined);
+        expect(countryOfBirthWorker).to.deep.equal(true);
+      });
+    });
   });
 
   describe('setWdfProperties()', async () => {

--- a/src/app/shared/components/staff-record-summary/employment/employment.component.html
+++ b/src/app/shared/components/staff-record-summary/employment/employment.component.html
@@ -9,7 +9,9 @@
       <app-summary-record-change
         [explanationText]="' year arrived in UK'"
         [link]="getRoutePath('year-arrived-uk')"
-        [hasData]="worker.yearArrived"
+        [hasData]="
+          !(worker.yearArrived === null || (worker.yearArrived?.value == null && worker.yearArrived?.year == null))
+        "
         (setReturnClicked)="this.setReturn()"
       ></app-summary-record-change>
     </dd>


### PR DESCRIPTION
#### Work done
- Changed worker class in backend to remove year arrived when the _Country of birth_ is set to _Don't know_.
- Added check for year arrived being set to `{ value: null, year: null }` to display add information link instead of change link in case when year arrived has been reset

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
