### PR TITLE
Fix/average weekly hours and contracted weekly hours change links

### DIFF
--- a/src/app/shared/components/staff-record-summary/employment/employment.component.html
+++ b/src/app/shared/components/staff-record-summary/employment/employment.component.html
@@ -305,7 +305,12 @@
         "
         [explanationText]="' average weekly working hours'"
         [link]="getRoutePath('average-weekly-hours')"
-        [hasData]="!!worker.weeklyHoursAverage"
+        [hasData]="
+          !(
+            worker.weeklyHoursAverage === null ||
+            (worker.weeklyHoursAverage?.value == null && worker.weeklyHoursAverage?.hours == null)
+          )
+        "
         (setReturnClicked)="this.setReturn()"
       ></app-summary-record-change>
     </dd>

--- a/src/app/shared/components/staff-record-summary/employment/employment.component.html
+++ b/src/app/shared/components/staff-record-summary/employment/employment.component.html
@@ -10,7 +10,7 @@
         [explanationText]="' year arrived in UK'"
         [link]="getRoutePath('year-arrived-uk')"
         [hasData]="
-          !(worker.yearArrived === null || (worker.yearArrived?.value == null && worker.yearArrived?.year == null))
+          !(worker.yearArrived === null || (worker.yearArrived?.value === null && worker.yearArrived?.year === null))
         "
         (setReturnClicked)="this.setReturn()"
       ></app-summary-record-change>
@@ -308,7 +308,7 @@
         [hasData]="
           !(
             worker.weeklyHoursAverage === null ||
-            (worker.weeklyHoursAverage?.value == null && worker.weeklyHoursAverage?.hours == null)
+            (worker.weeklyHoursAverage?.value === null && worker.weeklyHoursAverage?.hours === null)
           )
         "
         (setReturnClicked)="this.setReturn()"
@@ -355,7 +355,12 @@
         "
         [explanationText]="' contracted weekly hours'"
         [link]="getRoutePath('weekly-contracted-hours')"
-        [hasData]="!!worker.weeklyHoursContracted"
+        [hasData]="
+          !(
+            worker.weeklyHoursContracted === null ||
+            (worker.weeklyHoursContracted?.value === null && worker.weeklyHoursContracted?.hours === null)
+          )
+        "
         (setReturnClicked)="this.setReturn()"
       ></app-summary-record-change>
     </dd>


### PR DESCRIPTION
#### Work done
- Added check for reset contracted weekly hours(object with value and hours set to null) to display add information instead of change
- Same for average weekly hours

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [X] No, I found it difficult to test
- [ ] No, they are not required for this change
