### PR TITLE
Fix: Workplace name address form

### DIFF
--- a/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
+++ b/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
@@ -99,8 +99,8 @@ export class WorkplaceNameAddressDirective implements OnInit, OnDestroy, AfterVi
   }
 
   ngOnInit() {
-    this.init();
     this.setupForm();
+    this.init();
     this.setupFormErrorsMap();
   }
 


### PR DESCRIPTION
#### Work done
- Fixed an issue where the workplace name and address form wasn't prefilling workplace information on workplace tab
- Swapped `setupForm()` function with `init()` so that the form is set up before `prefillForm()` is run in `init`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
