### PR TITLE
Added open/close functionality to monitor page

### DIFF
--- a/src/app/core/model/admin/local-authorities-return.model.ts
+++ b/src/app/core/model/admin/local-authorities-return.model.ts
@@ -6,4 +6,5 @@ export interface SetDates {
 export interface Area {
   letter: string;
   name: string;
+  open: boolean;
 }

--- a/src/app/features/admin/local-authorities-return/monitor/monitor.component.html
+++ b/src/app/features/admin/local-authorities-return/monitor/monitor.component.html
@@ -4,13 +4,22 @@
   </div>
   <div class="govuk-grid-column-one-third govuk-util__align-right">
     <p>
-      <a role="button" draggable="false" href="openAll" (click)="toggleAll($event)"> Open all </a>
+      <a role="button" draggable="false" href="openAll" (click)="toggleAll($event)">
+        <ng-container *ngIf="!allOpen; else close">Open</ng-container>
+        <ng-template #close>Close</ng-template>
+        all
+      </a>
     </p>
   </div>
 </div>
 <div class="govuk-accordion" data-module="govuk-accordion">
-  <div class="govuk-accordion__section" *ngFor="let area of areas; let i = index">
-    <div class="govuk-accordion__section-header">
+  <div
+    class="govuk-accordion__section"
+    *ngFor="let area of areas; let i = index"
+    [class]="{ 'govuk-accordion__section--expanded': area.open }"
+    [attr.data-testid]="'accordian-' + i"
+  >
+    <div class="govuk-accordion__section-header" (click)="area.open = !area.open">
       <h2 class="govuk-accordion__section-heading">
         <span class="govuk-accordion__section-button" [id]="'accordion-default-heading-' + i">
           {{ area.letter }} - {{ area.name }}
@@ -23,7 +32,29 @@
       [id]="'accordion-default-content-' + i"
       class="govuk-accordion__section-content"
       [aria-labelledby]="'accordion-default-heading-' + i"
-    ></div>
+      [attr.data-testid]="'accordian-drop-' + i"
+    >
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Local authority</th>
+            <th scope="col" class="govuk-table__header">Workers</th>
+            <th scope="col" class="govuk-table__header">Status</th>
+            <th scope="col" class="govuk-table__header">Notes</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <a href="#">Darlington {{ i }}</a>
+            </td>
+            <td class="govuk-table__cell">None added</td>
+            <td class="govuk-table__cell">Not updated</td>
+            <td class="govuk-table__cell">Notes</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 

--- a/src/app/features/admin/local-authorities-return/monitor/monitor.component.spec.ts
+++ b/src/app/features/admin/local-authorities-return/monitor/monitor.component.spec.ts
@@ -8,7 +8,7 @@ import { fireEvent, render } from '@testing-library/angular';
 
 import { MonitorComponent } from './monitor.component';
 
-fdescribe('MonitorComponent', () => {
+describe('MonitorComponent', () => {
   async function setup() {
     const component = await render(MonitorComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],

--- a/src/app/features/admin/local-authorities-return/monitor/monitor.component.spec.ts
+++ b/src/app/features/admin/local-authorities-return/monitor/monitor.component.spec.ts
@@ -4,11 +4,11 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
 
 import { MonitorComponent } from './monitor.component';
 
-describe('MonitorComponent', () => {
+fdescribe('MonitorComponent', () => {
   async function setup() {
     const component = await render(MonitorComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
@@ -39,15 +39,153 @@ describe('MonitorComponent', () => {
     expect(component.getByText('J - Yorkshire and Humber')).toBeTruthy();
   });
 
-  it('should show an open all button', async () => {
-    const { component } = await setup();
-
-    expect(component.getByText('Open all')).toBeTruthy();
-  });
-
   it('should show a reset returns data button', async () => {
     const { component } = await setup();
 
     expect(component.getByText('Reset returns data')).toBeTruthy();
+  });
+
+  describe('Open all/Close all', () => {
+    it('should show an open all button', async () => {
+      const { component } = await setup();
+
+      expect(component.getByText('Open all')).toBeTruthy();
+    });
+
+    it('should change to close all button when clicked', async () => {
+      const { component } = await setup();
+
+      const openAllButton = component.getByText('Open all');
+      fireEvent.click(openAllButton);
+
+      component.fixture.detectChanges();
+
+      expect(component.getByText('Close all')).toBeTruthy();
+    });
+
+    it('should change back to open all button when clicked twice', async () => {
+      const { component } = await setup();
+
+      const openAllButton = component.getByText('Open all');
+      fireEvent.click(openAllButton);
+
+      component.fixture.detectChanges();
+
+      const closeAllButton = component.getByText('Close all');
+      fireEvent.click(closeAllButton);
+
+      component.fixture.detectChanges();
+
+      expect(component.getByText('Open all')).toBeTruthy();
+    });
+  });
+
+  describe('Accordians', () => {
+    it('should drop all when clicking on the open all link', async () => {
+      const { component } = await setup();
+
+      const openAllButton = component.getByText('Open all');
+      fireEvent.click(openAllButton);
+
+      component.fixture.componentInstance.areas.map((_area, index) => {
+        const droppedDiv = component.getByTestId('accordian-drop-' + index);
+
+        expect(component.getByTestId('accordian-' + index).getAttribute('class')).toContain(
+          'govuk-accordion__section--expanded',
+        );
+        expect(droppedDiv.innerText).toContain('Local authority');
+        expect(droppedDiv.innerText).toContain('Workers');
+        expect(droppedDiv.innerText).toContain('Status');
+        expect(droppedDiv.innerText).toContain('Notes');
+      });
+    });
+
+    it('should close all when clicking on the close all link', async () => {
+      const { component } = await setup();
+
+      const openAllButton = component.getByText('Open all');
+      fireEvent.click(openAllButton);
+
+      component.fixture.detectChanges();
+
+      component.fixture.componentInstance.areas.map((_area, index) => {
+        const droppedDiv = component.getByTestId('accordian-drop-' + index);
+
+        expect(component.getByTestId('accordian-' + index).getAttribute('class')).toContain(
+          'govuk-accordion__section--expanded',
+        );
+        expect(droppedDiv.innerText).toContain('Local authority');
+        expect(droppedDiv.innerText).toContain('Workers');
+        expect(droppedDiv.innerText).toContain('Status');
+        expect(droppedDiv.innerText).toContain('Notes');
+      });
+
+      const closeAllButton = component.getByText('Close all');
+      fireEvent.click(closeAllButton);
+
+      component.fixture.componentInstance.areas.map((_area, index) => {
+        expect(component.getByTestId('accordian-' + index).getAttribute('class')).not.toContain(
+          'govuk-accordion__section--expanded',
+        );
+      });
+    });
+
+    it('should drop down when clicking on the heading', async () => {
+      const { component } = await setup();
+
+      const nEastDrop = component.getByText('B - North East');
+      fireEvent.click(nEastDrop);
+
+      const droppedDiv = component.getByTestId('accordian-drop-0');
+
+      expect(component.getByTestId('accordian-0').getAttribute('class')).toContain(
+        'govuk-accordion__section--expanded',
+      );
+      expect(droppedDiv.innerText).toContain('Local authority');
+      expect(droppedDiv.innerText).toContain('Workers');
+      expect(droppedDiv.innerText).toContain('Status');
+      expect(droppedDiv.innerText).toContain('Notes');
+    });
+  });
+
+  describe('toggleAll', () => {
+    it('should set allOpen to true', async () => {
+      const { component } = await setup();
+
+      const event = new Event('click');
+      component.fixture.componentInstance.toggleAll(event);
+
+      component.fixture.detectChanges();
+
+      expect(component.fixture.componentInstance.allOpen).toEqual(true);
+    });
+
+    it('should set allOpen to false', async () => {
+      const { component } = await setup();
+
+      const event = new Event('click');
+      component.fixture.componentInstance.toggleAll(event);
+
+      component.fixture.detectChanges();
+
+      component.fixture.componentInstance.toggleAll(event);
+
+      component.fixture.detectChanges();
+
+      expect(component.fixture.componentInstance.allOpen).toEqual(false);
+    });
+
+    it('should set all areas open to true', async () => {
+      const { component } = await setup();
+
+      const event = new Event('click');
+      component.fixture.componentInstance.toggleAll(event);
+
+      component.fixture.detectChanges();
+
+      component.fixture.componentInstance.areas.map((area) => {
+        expect(area.open).toEqual(true);
+      });
+    });
   });
 });

--- a/src/app/features/admin/local-authorities-return/monitor/monitor.component.ts
+++ b/src/app/features/admin/local-authorities-return/monitor/monitor.component.ts
@@ -8,42 +8,52 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
   templateUrl: './monitor.component.html',
 })
 export class MonitorComponent implements OnInit {
+  public allOpen = false;
   public areas: Area[] = [
     {
       letter: 'B',
       name: 'North East',
+      open: false,
     },
     {
       letter: 'C',
       name: 'East Midlands',
+      open: false,
     },
     {
       letter: 'D',
       name: 'South West',
+      open: false,
     },
     {
       letter: 'E',
       name: 'West Midlands',
+      open: false,
     },
     {
       letter: 'F',
       name: 'North West',
+      open: false,
     },
     {
       letter: 'G',
       name: 'London',
+      open: false,
     },
     {
       letter: 'H',
       name: 'South East',
+      open: false,
     },
     {
       letter: 'I',
       name: 'Eastern',
+      open: false,
     },
     {
       letter: 'J',
       name: 'Yorkshire and Humber',
+      open: false,
     },
   ];
   constructor(private breadcrumbService: BreadcrumbService) {}
@@ -54,5 +64,7 @@ export class MonitorComponent implements OnInit {
 
   toggleAll(event: Event): void {
     event.preventDefault();
+    this.allOpen = !this.allOpen;
+    this.areas.forEach((area: Area) => (area.open = this.allOpen));
   }
 }


### PR DESCRIPTION
#### Work done
- created a `toggleAll` function
- Added open to all areas to know whether it's dropped or not
- Added default data to the table
- Added drops to each heading

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
