### PR TITLE
Feat/move workplace name page

### DIFF
--- a/src/app/core/services/workplace-interface.service.ts
+++ b/src/app/core/services/workplace-interface.service.ts
@@ -17,6 +17,7 @@ export abstract class WorkplaceInterfaceService {
   public searchMethod$: BehaviorSubject<string> = new BehaviorSubject(null);
   public postcodeOrLocationId$: BehaviorSubject<string> = new BehaviorSubject(null);
   public workplaceNotFound$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public manuallyEnteredWorkplaceName$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   public isRegulated(): boolean {
     return this.isRegulated$.value;

--- a/src/app/features/add-workplace/find-workplace-address/find-workplace-address.component.spec.ts
+++ b/src/app/features/add-workplace/find-workplace-address/find-workplace-address.component.spec.ts
@@ -191,7 +191,7 @@ describe('FindWorkplaceComponent', () => {
       component.fixture.detectChanges();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
-        url: ['add-workplace', 'workplace-name'],
+        url: ['add-workplace', 'new-regulated-by-cqc'],
       });
     });
   });

--- a/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.spec.ts
@@ -5,6 +5,8 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BackService } from '@core/services/back.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceService } from '@core/services/workplace.service';
+import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
 import { RegistrationModule } from '@features/registration/registration.module';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
@@ -28,6 +30,10 @@ describe('NameOfWorkplaceComponent', () => {
         {
           provide: EstablishmentService,
           useValue: { primaryWorkplace },
+        },
+        {
+          provide: WorkplaceService,
+          useClass: MockWorkplaceService,
         },
         {
           provide: ActivatedRoute,
@@ -94,6 +100,19 @@ describe('NameOfWorkplaceComponent', () => {
 
       expect(form.valid).toBeTruthy();
       expect(spy).toHaveBeenCalledWith(['add-workplace', 'new-select-main-service']);
+    });
+
+    it('should set locationName in workplace service when continue button is clicked and a workplace name is given', async () => {
+      const { component } = await setup();
+      const form = component.fixture.componentInstance.form;
+      const continueButton = component.getByText('Continue');
+      const registrationService = component.fixture.componentInstance.workplaceService;
+
+      form.controls['workplaceName'].setValue('Place Name');
+      fireEvent.click(continueButton);
+
+      expect(form.valid).toBeTruthy();
+      expect(registrationService.selectedLocationAddress$.value.locationName).toBe('Place Name');
     });
   });
 

--- a/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.spec.ts
@@ -106,13 +106,13 @@ describe('NameOfWorkplaceComponent', () => {
       const { component } = await setup();
       const form = component.fixture.componentInstance.form;
       const continueButton = component.getByText('Continue');
-      const registrationService = component.fixture.componentInstance.workplaceService;
+      const workplaceService = component.fixture.componentInstance.workplaceService;
 
       form.controls['workplaceName'].setValue('Place Name');
       fireEvent.click(continueButton);
 
       expect(form.valid).toBeTruthy();
-      expect(registrationService.selectedLocationAddress$.value.locationName).toBe('Place Name');
+      expect(workplaceService.selectedLocationAddress$.value.locationName).toBe('Place Name');
     });
   });
 

--- a/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.spec.ts
@@ -84,7 +84,7 @@ describe('NameOfWorkplaceComponent', () => {
       expect(component.getAllByText(errorMessage).length).toBe(2);
     });
 
-    it('should navigate to find-workplace-address url when continue button is clicked and a workplace name is given', async () => {
+    it('should navigate to new-select-main-service url when continue button is clicked and a workplace name is given', async () => {
       const { component, spy } = await setup();
       const form = component.fixture.componentInstance.form;
       const continueButton = component.getByText('Continue');
@@ -93,7 +93,7 @@ describe('NameOfWorkplaceComponent', () => {
       fireEvent.click(continueButton);
 
       expect(form.valid).toBeTruthy();
-      expect(spy).toHaveBeenCalledWith(['add-workplace', 'find-workplace-address']);
+      expect(spy).toHaveBeenCalledWith(['add-workplace', 'new-select-main-service']);
     });
   });
 

--- a/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.spec.ts
@@ -125,7 +125,7 @@ describe('NameOfWorkplaceComponent', () => {
       component.fixture.detectChanges();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
-        url: ['/add-workplace', 'new-regulated-by-cqc'],
+        url: ['/add-workplace', 'select-workplace-address'],
       });
     });
   });

--- a/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.ts
+++ b/src/app/features/add-workplace/name-of-workplace/name-of-workplace.component.ts
@@ -18,7 +18,7 @@ export class NameOfWorkplaceComponent extends NameOfWorkplaceDirective {
     protected router: Router,
     protected route: ActivatedRoute,
     protected errorSummaryService: ErrorSummaryService,
-    protected workplaceService: WorkplaceService,
+    public workplaceService: WorkplaceService,
     protected establishmentService: EstablishmentService,
   ) {
     super(formBuilder, backService, router, route, errorSummaryService, workplaceService, establishmentService);

--- a/src/app/features/add-workplace/new-regulated-by-cqc/new-regulated-by-cqc.component.spec.ts
+++ b/src/app/features/add-workplace/new-regulated-by-cqc/new-regulated-by-cqc.component.spec.ts
@@ -66,7 +66,7 @@ describe('NewRegulatedByCqcComponent', () => {
       expect(spy).toHaveBeenCalledWith(['/add-workplace', 'find-workplace']);
     });
 
-    it('should navigate to the workplace name page when selecting no', async () => {
+    it('should navigate to the find-workplace-address page when selecting no', async () => {
       const { component, spy } = await setup();
       const noRadioButton = component.fixture.nativeElement.querySelector(`input[ng-reflect-value="no"]`);
       fireEvent.click(noRadioButton);
@@ -74,7 +74,7 @@ describe('NewRegulatedByCqcComponent', () => {
       const continueButton = component.getByText('Continue');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'workplace-name']);
+      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'find-workplace-address']);
     });
 
     it('should display an error message when not selecting anything', async () => {

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -283,18 +283,35 @@ describe('NewSelectMainServiceComponent', () => {
       });
     });
 
-    it('should set back link to select-workplace-address when is not regulated and address was not entered manually', async () => {
+    it('should set back link to select-workplace-address when is not regulated, address was not entered manually and nameEnteredManually set to false', async () => {
       const { component, fixture } = await setup();
 
       const backLinkSpy = spyOn(component.backService, 'setBackLink');
       component.isRegulated = false;
       component.workplaceService.manuallyEnteredWorkplace$.next(false);
+      component.workplaceService.manuallyEnteredWorkplaceName$.next(false);
 
       component.setBackLink();
       fixture.detectChanges();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
         url: ['add-workplace', 'select-workplace-address'],
+      });
+    });
+
+    it('should set back link to workplace-name when is not regulated, address was not entered manually and nameEnteredManually set to true', async () => {
+      const { component, fixture } = await setup();
+
+      const backLinkSpy = spyOn(component.backService, 'setBackLink');
+      component.isRegulated = false;
+      component.workplaceService.manuallyEnteredWorkplace$.next(false);
+      component.workplaceService.manuallyEnteredWorkplaceName$.next(true);
+
+      component.setBackLink();
+      fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['add-workplace', 'workplace-name'],
       });
     });
   });

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
@@ -90,11 +90,13 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
     if (this.workplaceService.manuallyEnteredWorkplace$.value) {
       if (this.workplaceService.locationAddresses$.value.length > 0) {
         return 'workplace-name-address';
-      } else {
-        return 'workplace-address-not-found';
       }
-    } else {
-      return 'select-workplace-address';
+      return 'workplace-address-not-found';
     }
+
+    if (this.workplaceService.manuallyEnteredWorkplaceName$.value) {
+      return 'workplace-name';
+    }
+    return 'select-workplace-address';
   }
 }

--- a/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.spec.ts
+++ b/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.spec.ts
@@ -104,6 +104,26 @@ describe('SelectWorkplaceAddressComponent', () => {
     });
   });
 
+  describe('onLocationChange()', () => {
+    it('should update selectedLocationAddress$ in workplace service to have currently selected address', async () => {
+      const { component } = await setup();
+
+      // address in first index of locationAddresses with location name changed to current name in selectedLocationAddress (from MockWorkplace service)
+      const expectedSelectedLocationAddress = {
+        postalCode: 'ABC 123',
+        addressLine1: '2 Street',
+        county: 'Greater Manchester',
+        locationName: 'Test Care Home',
+        townCity: 'Manchester',
+        locationId: '12345',
+      };
+
+      component.onLocationChange(1);
+
+      expect(component.workplaceService.selectedLocationAddress$.value).toEqual(expectedSelectedLocationAddress);
+    });
+  });
+
   describe('Navigation', () => {
     it('should navigate back to the find-workplace-address url in add-workplace flow when Change clicked', async () => {
       const { component, fixture, getByText } = await setup();

--- a/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.spec.ts
+++ b/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.spec.ts
@@ -108,7 +108,6 @@ describe('SelectWorkplaceAddressComponent', () => {
     it('should update selectedLocationAddress$ in workplace service to have currently selected address', async () => {
       const { component } = await setup();
 
-      // address in first index of locationAddresses with location name changed to current name in selectedLocationAddress (from MockWorkplace service)
       const expectedSelectedLocationAddress = {
         postalCode: 'ABC 123',
         addressLine1: '2 Street',

--- a/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.spec.ts
+++ b/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.spec.ts
@@ -126,10 +126,11 @@ describe('SelectWorkplaceAddressComponent', () => {
       expect(notDisplayedButton.getAttribute('href')).toBe('/add-workplace/workplace-address');
     });
 
-    it('should navigate to select-main-service url in add-workplace flow when workplace selected and Continue clicked', async () => {
-      const { component, spy, fixture, getByText } = await setup();
+    it('should navigate to select-main-service url in add-workplace flow when workplace with name selected and Continue clicked', async () => {
+      const { component, spy, getByText, fixture } = await setup();
       const form = component.form;
       const continueButton = getByText('Continue');
+      component.selectedLocationAddress.locationName = 'Name';
 
       form.controls['address'].setValue('1');
       form.controls['address'].markAsDirty();
@@ -139,6 +140,22 @@ describe('SelectWorkplaceAddressComponent', () => {
       expect(form.valid).toBeTruthy();
 
       expect(spy).toHaveBeenCalledWith(['/add-workplace/new-select-main-service']);
+    });
+
+    it('should navigate to workplace-name url in add-workplace flow when workplace without name selected and Continue clicked', async () => {
+      const { component, spy, getByText, fixture } = await setup();
+      const form = component.form;
+      const continueButton = getByText('Continue');
+      component.selectedLocationAddress.locationName = null;
+
+      form.controls['address'].setValue('1');
+      form.controls['address'].markAsDirty();
+      fixture.detectChanges();
+      fireEvent.click(continueButton);
+
+      expect(form.valid).toBeTruthy();
+
+      expect(spy).toHaveBeenCalledWith(['/add-workplace/workplace-name']);
     });
   });
 });

--- a/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.ts
@@ -27,6 +27,7 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
   protected init(): void {
     this.flow = '/add-workplace';
     this.workplaceService.manuallyEnteredWorkplace$.next(false);
+    this.workplaceService.manuallyEnteredWorkplaceName$.next(false);
     this.setupSubscriptions();
   }
 

--- a/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.ts
@@ -14,7 +14,7 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 })
 export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirective {
   constructor(
-    private workplaceService: WorkplaceService,
+    public workplaceService: WorkplaceService,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
@@ -61,6 +61,10 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
   }
 
   public onLocationChange(index): void {
-    this.workplaceService.selectedLocationAddress$.next(this.locationAddresses[index]);
+    const selectedAddress = this.locationAddresses[index];
+    // make copy of selectedAddress to avoid name getting added to address in locationAddresses array when name added on workplace-name page
+    const selectedAddressCopy = Object.assign({}, selectedAddress);
+
+    this.workplaceService.selectedLocationAddress$.next(selectedAddressCopy);
   }
 }

--- a/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.spec.ts
@@ -182,7 +182,7 @@ describe('FindWorkplaceAddressComponent', () => {
       component.fixture.detectChanges();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
-        url: ['registration', 'workplace-name'],
+        url: ['registration', 'new-regulated-by-cqc'],
       });
     });
   });

--- a/src/app/features/create-account/workplace/name-of-workplace/name-of-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/name-of-workplace/name-of-workplace.component.spec.ts
@@ -75,7 +75,7 @@ describe('NameOfWorkplaceComponent', () => {
       expect(component.getAllByText(errorMessage).length).toBe(2);
     });
 
-    it('should navigate to find-workplace-address url when continue button is clicked and a workplace name is given', async () => {
+    it('should navigate to new-select-main-service url when continue button is clicked and a workplace name is given', async () => {
       const { component, spy } = await setup();
       const form = component.fixture.componentInstance.form;
       const continueButton = component.getByText('Continue');
@@ -84,7 +84,7 @@ describe('NameOfWorkplaceComponent', () => {
       fireEvent.click(continueButton);
 
       expect(form.valid).toBeTruthy();
-      expect(spy).toHaveBeenCalledWith(['registration', 'find-workplace-address']);
+      expect(spy).toHaveBeenCalledWith(['registration', 'new-select-main-service']);
     });
   });
 

--- a/src/app/features/create-account/workplace/name-of-workplace/name-of-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/name-of-workplace/name-of-workplace.component.spec.ts
@@ -4,6 +4,8 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BackService } from '@core/services/back.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { RegistrationService } from '@core/services/registration.service';
+import { MockRegistrationService } from '@core/test-utils/MockRegistrationService';
 import { RegistrationModule } from '@features/registration/registration.module';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
@@ -19,6 +21,10 @@ describe('NameOfWorkplaceComponent', () => {
         {
           provide: EstablishmentService,
           useValue: {},
+        },
+        {
+          provide: RegistrationService,
+          useClass: MockRegistrationService,
         },
         {
           provide: ActivatedRoute,
@@ -85,6 +91,19 @@ describe('NameOfWorkplaceComponent', () => {
 
       expect(form.valid).toBeTruthy();
       expect(spy).toHaveBeenCalledWith(['registration', 'new-select-main-service']);
+    });
+
+    it('should set locationName in registration service when continue button is clicked and a workplace name is given', async () => {
+      const { component } = await setup();
+      const form = component.fixture.componentInstance.form;
+      const continueButton = component.getByText('Continue');
+      const registrationService = component.fixture.componentInstance.registrationService;
+
+      form.controls['workplaceName'].setValue('Place Name');
+      fireEvent.click(continueButton);
+
+      expect(form.valid).toBeTruthy();
+      expect(registrationService.selectedLocationAddress$.value.locationName).toBe('Place Name');
     });
   });
 

--- a/src/app/features/create-account/workplace/name-of-workplace/name-of-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/name-of-workplace/name-of-workplace.component.spec.ts
@@ -116,7 +116,7 @@ describe('NameOfWorkplaceComponent', () => {
       component.fixture.detectChanges();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
-        url: ['/registration', 'new-regulated-by-cqc'],
+        url: ['/registration', 'select-workplace-address'],
       });
     });
   });

--- a/src/app/features/create-account/workplace/name-of-workplace/name-of-workplace.component.ts
+++ b/src/app/features/create-account/workplace/name-of-workplace/name-of-workplace.component.ts
@@ -18,7 +18,7 @@ export class NameOfWorkplaceComponent extends NameOfWorkplaceDirective {
     protected router: Router,
     protected route: ActivatedRoute,
     protected errorSummaryService: ErrorSummaryService,
-    protected registrationService: RegistrationService,
+    public registrationService: RegistrationService,
     protected establishmentService: EstablishmentService,
   ) {
     super(formBuilder, backService, router, route, errorSummaryService, registrationService, establishmentService);

--- a/src/app/features/create-account/workplace/new-regulated-by-cqc/new-regulated-by-cqc.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-regulated-by-cqc/new-regulated-by-cqc.component.spec.ts
@@ -66,7 +66,7 @@ describe('NewRegulatedByCqcComponent', () => {
       expect(spy).toHaveBeenCalledWith(['/registration', 'find-workplace']);
     });
 
-    it('should navigate to the workplace name page when selecting no', async () => {
+    it('should navigate to the find-workplace-address page when selecting no', async () => {
       const { component, spy } = await setup();
       const noRadioButton = component.fixture.nativeElement.querySelector(`input[ng-reflect-value="no"]`);
       fireEvent.click(noRadioButton);
@@ -74,7 +74,7 @@ describe('NewRegulatedByCqcComponent', () => {
       const continueButton = component.getByText('Continue');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(['/registration', 'workplace-name']);
+      expect(spy).toHaveBeenCalledWith(['/registration', 'find-workplace-address']);
     });
 
     it('should display an error message when not selecting anything', async () => {

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -291,18 +291,35 @@ describe('NewSelectMainServiceComponent', () => {
       });
     });
 
-    it('should set back link to select-workplace-address when is not regulated and address was not entered manually', async () => {
+    it('should set back link to select-workplace-address when is not regulated, address was not entered manually and nameEnteredManually set to false', async () => {
       const { component, fixture } = await setup();
 
       const backLinkSpy = spyOn(component.backService, 'setBackLink');
       component.isRegulated = false;
       component.registrationService.manuallyEnteredWorkplace$.next(false);
+      component.registrationService.manuallyEnteredWorkplaceName$.next(false);
 
       component.setBackLink();
       fixture.detectChanges();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
         url: ['registration', 'select-workplace-address'],
+      });
+    });
+
+    it('should set back link to workplace-name when is not regulated, address was not entered manually and nameEnteredManually set to true', async () => {
+      const { component, fixture } = await setup();
+
+      const backLinkSpy = spyOn(component.backService, 'setBackLink');
+      component.isRegulated = false;
+      component.registrationService.manuallyEnteredWorkplace$.next(false);
+      component.registrationService.manuallyEnteredWorkplaceName$.next(true);
+
+      component.setBackLink();
+      fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'workplace-name'],
       });
     });
   });

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
@@ -92,11 +92,13 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
     if (this.registrationService.manuallyEnteredWorkplace$.value) {
       if (this.registrationService.locationAddresses$.value.length > 0) {
         return 'workplace-name-address';
-      } else {
-        return 'workplace-address-not-found';
       }
-    } else {
-      return 'select-workplace-address';
+      return 'workplace-address-not-found';
     }
+
+    if (this.registrationService.manuallyEnteredWorkplaceName$.value) {
+      return 'workplace-name';
+    }
+    return 'select-workplace-address';
   }
 }

--- a/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.spec.ts
@@ -104,6 +104,26 @@ describe('SelectWorkplaceAddressComponent', () => {
     });
   });
 
+  describe('onLocationChange()', () => {
+    it('should update selectedLocationAddress$ in workplace service to have currently selected address', async () => {
+      const { component } = await setup();
+
+      // address in first index of locationAddresses with location name changed to current name in selectedLocationAddress (from MockWorkplace service)
+      const expectedSelectedLocationAddress = {
+        postalCode: 'ABC 123',
+        addressLine1: '2 Street',
+        county: 'Greater Manchester',
+        locationName: 'Test Care Home',
+        townCity: 'Manchester',
+        locationId: '12345',
+      };
+
+      component.onLocationChange(1);
+
+      expect(component.registrationService.selectedLocationAddress$.value).toEqual(expectedSelectedLocationAddress);
+    });
+  });
+
   describe('Navigation', () => {
     it('should navigate back to the find-workplace-address url in registration flow when Change clicked', async () => {
       const { component, fixture, getByText } = await setup();

--- a/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.spec.ts
@@ -126,10 +126,11 @@ describe('SelectWorkplaceAddressComponent', () => {
       expect(notDisplayedButton.getAttribute('href')).toBe('/registration/workplace-address');
     });
 
-    it('should navigate to select-main-service url in registration flow when workplace selected and Continue clicked', async () => {
+    it('should navigate to select-main-service url in registration flow when workplace with name selected and Continue clicked', async () => {
       const { component, spy, getByText, fixture } = await setup();
       const form = component.form;
       const continueButton = getByText('Continue');
+      component.selectedLocationAddress.locationName = 'Name';
 
       form.controls['address'].setValue('1');
       form.controls['address'].markAsDirty();
@@ -139,6 +140,22 @@ describe('SelectWorkplaceAddressComponent', () => {
       expect(form.valid).toBeTruthy();
 
       expect(spy).toHaveBeenCalledWith(['/registration/new-select-main-service']);
+    });
+
+    it('should navigate to workplace-name url in registration flow when workplace without name selected and Continue clicked', async () => {
+      const { component, spy, getByText, fixture } = await setup();
+      const form = component.form;
+      const continueButton = getByText('Continue');
+      component.selectedLocationAddress.locationName = null;
+
+      form.controls['address'].setValue('1');
+      form.controls['address'].markAsDirty();
+      fixture.detectChanges();
+      fireEvent.click(continueButton);
+
+      expect(form.valid).toBeTruthy();
+
+      expect(spy).toHaveBeenCalledWith(['/registration/workplace-name']);
     });
   });
 });

--- a/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.spec.ts
@@ -108,7 +108,6 @@ describe('SelectWorkplaceAddressComponent', () => {
     it('should update selectedLocationAddress$ in workplace service to have currently selected address', async () => {
       const { component } = await setup();
 
-      // address in first index of locationAddresses with location name changed to current name in selectedLocationAddress (from MockWorkplace service)
       const expectedSelectedLocationAddress = {
         postalCode: 'ABC 123',
         addressLine1: '2 Street',

--- a/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.ts
@@ -14,7 +14,7 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 })
 export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirective {
   constructor(
-    private registrationService: RegistrationService,
+    public registrationService: RegistrationService,
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
@@ -61,6 +61,10 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
   }
 
   public onLocationChange(index): void {
-    this.registrationService.selectedLocationAddress$.next(this.locationAddresses[index]);
+    const selectedAddress = this.locationAddresses[index];
+    // make copy of selectedAddress to avoid name getting added to address in locationAddresses array when name added on workplace-name page
+    const selectedAddressCopy = Object.assign({}, selectedAddress);
+
+    this.registrationService.selectedLocationAddress$.next(selectedAddressCopy);
   }
 }

--- a/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.ts
@@ -27,6 +27,7 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
   protected init(): void {
     this.flow = '/registration';
     this.registrationService.manuallyEnteredWorkplace$.next(false);
+    this.registrationService.manuallyEnteredWorkplaceName$.next(false);
     this.setupSubscriptions();
   }
 

--- a/src/app/shared/directives/create-workplace/find-workplace-address/find-workplace-address.ts
+++ b/src/app/shared/directives/create-workplace/find-workplace-address/find-workplace-address.ts
@@ -130,8 +130,7 @@ export class FindWorkplaceAddress implements OnInit, OnDestroy, AfterViewInit {
   }
 
   public setBackLink(): void {
-    let url;
-    this.createAccountNewDesign ? (url = 'workplace-name') : (url = 'select-workplace-address');
+    const url = this.createAccountNewDesign ? 'new-regulated-by-cqc' : 'select-workplace-address';
     this.backService.setBackLink({ url: [this.flow, url] });
   }
 

--- a/src/app/shared/directives/create-workplace/name-of-workplace/name-of-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/name-of-workplace/name-of-workplace.directive.ts
@@ -63,6 +63,7 @@ export class NameOfWorkplaceDirective implements OnInit, AfterViewInit {
 
   public onSubmit(): void {
     this.submitted = true;
+    this.workplaceInterfaceService.manuallyEnteredWorkplaceName$.next(true);
 
     if (this.form.valid) {
       this.setEnteredNameIntoFlowService();

--- a/src/app/shared/directives/create-workplace/name-of-workplace/name-of-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/name-of-workplace/name-of-workplace.directive.ts
@@ -67,7 +67,7 @@ export class NameOfWorkplaceDirective implements OnInit, AfterViewInit {
 
     if (this.form.valid) {
       this.workplaceInterfaceService.selectedLocationAddress$.next(this.getLocationAddress());
-      this.router.navigate([this.flow, 'find-workplace-address']);
+      this.router.navigate([this.flow, 'new-select-main-service']);
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }

--- a/src/app/shared/directives/create-workplace/name-of-workplace/name-of-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/name-of-workplace/name-of-workplace.directive.ts
@@ -3,7 +3,6 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ErrorDetails } from '@core/model/errorSummary.model';
 import { Establishment } from '@core/model/establishment.model';
-import { LocationAddress } from '@core/model/location.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -27,7 +26,7 @@ export class NameOfWorkplaceDirective implements OnInit, AfterViewInit {
     protected router: Router,
     protected route: ActivatedRoute,
     protected errorSummaryService: ErrorSummaryService,
-    protected workplaceInterfaceService: WorkplaceInterfaceService,
+    public workplaceInterfaceService: WorkplaceInterfaceService,
     protected establishmentService: EstablishmentService,
   ) {}
 
@@ -66,22 +65,15 @@ export class NameOfWorkplaceDirective implements OnInit, AfterViewInit {
     this.submitted = true;
 
     if (this.form.valid) {
-      this.workplaceInterfaceService.selectedLocationAddress$.next(this.getLocationAddress());
+      this.setEnteredNameIntoFlowService();
       this.router.navigate([this.flow, 'new-select-main-service']);
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }
   }
 
-  private getLocationAddress(): LocationAddress {
-    return {
-      addressLine1: null,
-      addressLine2: null,
-      addressLine3: null,
-      county: null,
-      locationName: this.form.get('workplaceName').value,
-      postalCode: null,
-      townCity: null,
-    };
+  private setEnteredNameIntoFlowService(): void {
+    const enteredWorkplaceName = this.form.get('workplaceName').value;
+    this.workplaceInterfaceService.selectedLocationAddress$.value.locationName = enteredWorkplaceName;
   }
 }

--- a/src/app/shared/directives/create-workplace/name-of-workplace/name-of-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/name-of-workplace/name-of-workplace.directive.ts
@@ -58,7 +58,7 @@ export class NameOfWorkplaceDirective implements OnInit, AfterViewInit {
   }
 
   public setBackLink(): void {
-    this.backService.setBackLink({ url: [`/${this.flow}`, 'new-regulated-by-cqc'] });
+    this.backService.setBackLink({ url: [`/${this.flow}`, 'select-workplace-address'] });
   }
 
   public onSubmit(): void {

--- a/src/app/shared/directives/create-workplace/new-regulated-by-cqc/new-regulated-by-cqc.directive.ts
+++ b/src/app/shared/directives/create-workplace/new-regulated-by-cqc/new-regulated-by-cqc.directive.ts
@@ -71,7 +71,7 @@ export class NewRegulatedByCqcDirective implements OnInit, AfterViewInit {
       if (regulatedByCQC.value === 'yes') {
         this.router.navigate([`/${this.flow}`, 'find-workplace']);
       } else {
-        this.router.navigate([`/${this.flow}`, 'workplace-name']);
+        this.router.navigate([`/${this.flow}`, 'find-workplace-address']);
       }
     } else {
       this.errorSummaryService.scrollToErrorSummary();

--- a/src/app/shared/directives/create-workplace/select-workplace-address.directive.ts
+++ b/src/app/shared/directives/create-workplace/select-workplace-address.directive.ts
@@ -20,7 +20,7 @@ export class SelectWorkplaceAddressDirective implements OnInit, OnDestroy, After
   public submitted = false;
   public createAccountNewDesign: boolean;
   public workplaceNotListedLink: string;
-  protected selectedLocationAddress: LocationAddress;
+  public selectedLocationAddress: LocationAddress;
   protected subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -50,6 +50,7 @@ export class SelectWorkplaceAddressDirective implements OnInit, OnDestroy, After
     this.errorSummaryService.formEl$.next(this.formEl);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected init(): void {}
 
   protected setBackLink(): void {
@@ -69,8 +70,10 @@ export class SelectWorkplaceAddressDirective implements OnInit, OnDestroy, After
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected setupFormErrorsMap(): void {}
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   public onLocationChange(addressLine1: string): void {}
 
   public onSubmit(): void {
@@ -86,9 +89,13 @@ export class SelectWorkplaceAddressDirective implements OnInit, OnDestroy, After
 
   protected navigateToNextRoute(locationName: string): void {
     if (this.createAccountNewDesign) {
-      this.router.navigate([`${this.flow}/new-select-main-service`]);
+      if (locationName?.length) {
+        this.router.navigate([`${this.flow}/new-select-main-service`]);
+      } else {
+        this.router.navigate([`${this.flow}/workplace-name`]);
+      }
     } else {
-      if (locationName.length) {
+      if (locationName?.length) {
         this.router.navigate([`${this.flow}/select-main-service`]);
       } else {
         this.router.navigate([`${this.flow}/enter-workplace-address`]);


### PR DESCRIPTION
#### Work done
- Moved workplace name page in create account and add-workplace flows to come after selecting an address
- Changed name-of-workplace component to only set name in selectedAddress
- Added manuallyEnteredWorkplaceName$ to workplace-interface service
- Changed setting of back buttons in pages affected by moving workplace name(workplace-name, new-select-main-service, find-your-workplace)
- Added conditional routing to workplace name or new-select-main-service based on whether selected location has name in select-workplace-address
- Changed onLocationChange in select-workplace-address to make copy of workplace address when set into service to stop name getting added to addresses in locationAddresses array

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
