### PR TITLE
create migration to add new laUID column to LA table, update model an…

### DIFF
--- a/migrations/20210804082337-addLocalAuthorityUID.js
+++ b/migrations/20210804082337-addLocalAuthorityUID.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const table = {
+  tableName: 'LocalAuthorities',
+  schema: 'cqc',
+};
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";').then(() => {
+      return queryInterface.addColumn(table, 'LocalAuthorityUID', {
+        type: Sequelize.DataTypes.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        allowNull: false,
+        unique: true,
+      });
+    });
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.removeColumn(table, 'LocalAuthorityUID');
+  },
+};

--- a/server/models/localAuthorities.js
+++ b/server/models/localAuthorities.js
@@ -35,6 +35,12 @@ module.exports = (sequelize, DataTypes) => {
         ],
       },
       Notes: DataTypes.TEXT,
+      LocalAuthorityUID: {
+        type: DataTypes.UUID,
+        unique: true,
+        allowNull: false,
+        defaultValue: DataTypes.UUIDV4,
+      },
     },
     {
       tableName: 'LocalAuthorities',
@@ -52,7 +58,7 @@ module.exports = (sequelize, DataTypes) => {
 
   LocalAuthorities.getAll = async function () {
     return await this.findAll({
-      attributes: ['LocalAuthorityName', 'ThisYear', 'Status', 'Notes'],
+      attributes: ['LocalAuthorityName', 'ThisYear', 'Status', 'Notes', 'LocalAuthorityUID'],
       include: [
         {
           model: sequelize.models.establishment,

--- a/server/services/local-authorities/local-authorities.js
+++ b/server/services/local-authorities/local-authorities.js
@@ -9,10 +9,11 @@ const formatLaResponse = (localAuthorities) => {
       workers: la.ThisYear,
       status: la.Status,
       notes: la.Notes ? true : false,
+      localAuthorityUID: la.LocalAuthorityUID,
     };
+
     replyObj[letter] ? replyObj[letter].push(formattedData) : (replyObj[letter] = [formattedData]);
   });
-
   return replyObj;
 };
 

--- a/server/test/unit/routes/admin/local-authority-returns/local-authorities/index.spec.js
+++ b/server/test/unit/routes/admin/local-authority-returns/local-authorities/index.spec.js
@@ -5,7 +5,7 @@ const models = require('../../../../../../models');
 
 const { getLocalAuthorities } = require('../../../../../../routes/admin/local-authority-return/monitor');
 
-describe.only('server/routes/admin/local-authority-returns/local-authorities', async () => {
+describe('server/routes/admin/local-authority-returns/local-authorities', async () => {
   afterEach(async () => {
     sinon.restore();
   });
@@ -19,6 +19,7 @@ describe.only('server/routes/admin/local-authority-returns/local-authorities', a
             ThisYear: 10,
             Status: 'Not Updated',
             Notes: null,
+            LocalAuthorityUID: 'SomeUID1',
             establishment: {
               nmdsId: 'B123456',
             },
@@ -28,6 +29,7 @@ describe.only('server/routes/admin/local-authority-returns/local-authorities', a
             ThisYear: 50,
             Status: 'Update, Not Complete',
             Notes: 'This is a comment',
+            LocalAuthorityUID: 'SomeUID2',
             establishment: {
               nmdsId: 'B112583',
             },
@@ -37,6 +39,7 @@ describe.only('server/routes/admin/local-authority-returns/local-authorities', a
             ThisYear: 54,
             Status: 'Update, Complete',
             Notes: 'Hello',
+            LocalAuthorityUID: 'SomeUID3',
             establishment: {
               nmdsId: 'C223485',
             },
@@ -46,6 +49,7 @@ describe.only('server/routes/admin/local-authority-returns/local-authorities', a
             ThisYear: 155,
             Status: 'Update, Confirmed',
             Notes: null,
+            LocalAuthorityUID: 'SomeUID4',
             establishment: {
               nmdsId: 'C223485',
             },
@@ -76,12 +80,36 @@ describe.only('server/routes/admin/local-authority-returns/local-authorities', a
 
       const expectedResponse = {
         B: [
-          { name: 'Example B Authority 1', status: 'Not Updated', workers: 10, notes: false },
-          { name: 'Example B Authority 2', status: 'Update, Not Complete', workers: 50, notes: true },
+          {
+            name: 'Example B Authority 1',
+            status: 'Not Updated',
+            workers: 10,
+            notes: false,
+            localAuthorityUID: 'SomeUID1',
+          },
+          {
+            name: 'Example B Authority 2',
+            status: 'Update, Not Complete',
+            workers: 50,
+            notes: true,
+            localAuthorityUID: 'SomeUID2',
+          },
         ],
         C: [
-          { name: 'Example C Authority 1', status: 'Update, Complete', workers: 54, notes: true },
-          { name: 'Example C Authority 2', status: 'Update, Confirmed', workers: 155, notes: false },
+          {
+            name: 'Example C Authority 1',
+            status: 'Update, Complete',
+            workers: 54,
+            notes: true,
+            localAuthorityUID: 'SomeUID3',
+          },
+          {
+            name: 'Example C Authority 2',
+            status: 'Update, Confirmed',
+            workers: 155,
+            notes: false,
+            localAuthorityUID: 'SomeUID4',
+          },
         ],
       };
 

--- a/server/test/unit/services/local-authorities/local-authorities.spec.js
+++ b/server/test/unit/services/local-authorities/local-authorities.spec.js
@@ -10,6 +10,7 @@ describe('/server/services/local-authorities/local-authorities', () => {
           ThisYear: 0,
           Status: 'Not Updated',
           Notes: 'This is a comment',
+          LocalAuthorityUID: 'SomeUID1',
           establishment: {
             nmdsId: 'J103894',
           },
@@ -19,6 +20,7 @@ describe('/server/services/local-authorities/local-authorities', () => {
           ThisYear: 10,
           Status: 'Updated, Complete',
           Notes: 'This is a comment',
+          LocalAuthorityUID: 'SomeUID2',
           establishment: {
             nmdsId: 'J112583',
           },
@@ -28,6 +30,7 @@ describe('/server/services/local-authorities/local-authorities', () => {
           ThisYear: 104,
           Status: 'Not Updated',
           Notes: null,
+          LocalAuthorityUID: 'SomeUID3',
           establishment: {
             nmdsId: 'G223485',
           },
@@ -36,10 +39,10 @@ describe('/server/services/local-authorities/local-authorities', () => {
 
       const expectedResponse = {
         J: [
-          { name: 'Example 1', status: 'Not Updated', workers: 0, notes: true },
-          { name: 'Example 2', status: 'Updated, Complete', workers: 10, notes: true },
+          { name: 'Example 1', status: 'Not Updated', workers: 0, notes: true, localAuthorityUID: 'SomeUID1' },
+          { name: 'Example 2', status: 'Updated, Complete', workers: 10, notes: true, localAuthorityUID: 'SomeUID2' },
         ],
-        G: [{ name: 'Example 3', status: 'Not Updated', workers: 104, notes: false }],
+        G: [{ name: 'Example 3', status: 'Not Updated', workers: 104, notes: false, localAuthorityUID: 'SomeUID3' }],
       };
 
       const reply = formatLaResponse(las);


### PR DESCRIPTION
…d tests to return UID in get request

#### Work done
- create migration to add a LocalAuthoritiesUID column to the LocalAuthorities table which automatically generates the UID
- update the local authorities model
- update the formatLaResponse function in services/local-authorities
- update the tests for formatLaResponse
- update the tests for getLocalAuthorities in the local-authority-return/monitor/index.js

#### Tests
Does this PR include tests for the changes introduced?
- [ X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
