### PR TITLE
hotfix(onlyAutomaticallyUpdateFieldsInStaffRecordSummaryWhenCanEdit)

### DIFF
--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
@@ -51,7 +51,7 @@ export class StaffRecordSummaryComponent implements OnInit, OnDestroy {
 
     this.featureFlagsService.configCatClient.getValueAsync('wdfNewDesign', false).then((value) => {
       this.wdfNewDesign = value;
-      if (this.wdfNewDesign && this.wdfView) {
+      if (this.canEditWorker && this.wdfNewDesign && this.wdfView) {
         if (this.allRequiredFieldsUpdatedAndEligible()) {
           this.updateFieldsWhichDontRequireConfirmation();
         }


### PR DESCRIPTION
#### Issue
- For parents who only have read access looking at staff records of child workplaces in WDF, the `updateFieldsWhichDontRequireConfirmation` would still run if conditions met and the PUT would be unsuccessful and log out user 

#### Work done
- Add canEditUser check before automatically updating fields in staff record summary

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
