### PR TITLE
create migration for changing the possible values in the la table sta…

### DIFF
--- a/migrations/20210802105345-localAuthoritiesTable.js
+++ b/migrations/20210802105345-localAuthoritiesTable.js
@@ -37,13 +37,7 @@ module.exports = {
           Status: {
             type: Sequelize.DataTypes.ENUM,
             defaultValue: 'Not Updated',
-            values: [
-              'Not Updated',
-              'Update, Not Complete',
-              'Update, Complete',
-              'Confirmed, Not Complete',
-              'Confirmed, Complete',
-            ],
+            values: ['Not Updated', 'Updated'],
           },
           Notes: {
             type: Sequelize.TEXT,

--- a/migrations/20210804155741-alterLAStatusEnum.js
+++ b/migrations/20210804155741-alterLAStatusEnum.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const table = {
+  tableName: 'LocalAuthorities',
+  schema: 'cqc',
+};
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface
+      .removeColumn(table, 'Status')
+      .then(() => {
+        return queryInterface.sequelize.query('DROP TYPE IF EXISTS cqc."enum_LocalAuthorities_Status";');
+      })
+      .then(() => {
+        return queryInterface.addColumn(table, 'Status', {
+          type: Sequelize.DataTypes.ENUM,
+          defaultValue: 'Not updated',
+          values: [
+            'Not updated',
+            'Update, complete',
+            'Update, not complete',
+            'Confirmed, not complete',
+            'Confirmed, complete',
+          ],
+        });
+      });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface
+      .removeColumn(table, 'Status')
+      .then(() => {
+        return queryInterface.sequelize.query('DROP TYPE IF EXISTS cqc."enum_LocalAuthorities_Status";');
+      })
+      .then(() => {
+        return queryInterface.addColumn(table, 'Status', {
+          type: Sequelize.DataTypes.ENUM,
+          defaultValue: 'Not Updated',
+          values: ['Not Updated', 'Updated'],
+        });
+      });
+  },
+};

--- a/server/test/unit/routes/admin/local-authority-returns/local-authorities/index.spec.js
+++ b/server/test/unit/routes/admin/local-authority-returns/local-authorities/index.spec.js
@@ -17,7 +17,7 @@ describe('server/routes/admin/local-authority-returns/local-authorities', async 
           {
             LocalAuthorityName: 'Example B Authority 1',
             ThisYear: 10,
-            Status: 'Not Updated',
+            Status: 'Not updated',
             Notes: null,
             LocalAuthorityUID: 'SomeUID1',
             establishment: {
@@ -27,7 +27,7 @@ describe('server/routes/admin/local-authority-returns/local-authorities', async 
           {
             LocalAuthorityName: 'Example B Authority 2',
             ThisYear: 50,
-            Status: 'Update, Not Complete',
+            Status: 'Update, not complete',
             Notes: 'This is a comment',
             LocalAuthorityUID: 'SomeUID2',
             establishment: {
@@ -37,7 +37,7 @@ describe('server/routes/admin/local-authority-returns/local-authorities', async 
           {
             LocalAuthorityName: 'Example C Authority 1',
             ThisYear: 54,
-            Status: 'Update, Complete',
+            Status: 'Update, complete',
             Notes: 'Hello',
             LocalAuthorityUID: 'SomeUID3',
             establishment: {
@@ -47,7 +47,7 @@ describe('server/routes/admin/local-authority-returns/local-authorities', async 
           {
             LocalAuthorityName: 'Example C Authority 2',
             ThisYear: 155,
-            Status: 'Update, Confirmed',
+            Status: 'Confirmed, complete',
             Notes: null,
             LocalAuthorityUID: 'SomeUID4',
             establishment: {
@@ -82,14 +82,14 @@ describe('server/routes/admin/local-authority-returns/local-authorities', async 
         B: [
           {
             name: 'Example B Authority 1',
-            status: 'Not Updated',
+            status: 'Not updated',
             workers: 10,
             notes: false,
             localAuthorityUID: 'SomeUID1',
           },
           {
             name: 'Example B Authority 2',
-            status: 'Update, Not Complete',
+            status: 'Update, not complete',
             workers: 50,
             notes: true,
             localAuthorityUID: 'SomeUID2',
@@ -98,14 +98,14 @@ describe('server/routes/admin/local-authority-returns/local-authorities', async 
         C: [
           {
             name: 'Example C Authority 1',
-            status: 'Update, Complete',
+            status: 'Update, complete',
             workers: 54,
             notes: true,
             localAuthorityUID: 'SomeUID3',
           },
           {
             name: 'Example C Authority 2',
-            status: 'Update, Confirmed',
+            status: 'Confirmed, complete',
             workers: 155,
             notes: false,
             localAuthorityUID: 'SomeUID4',

--- a/server/test/unit/services/local-authorities/local-authorities.spec.js
+++ b/server/test/unit/services/local-authorities/local-authorities.spec.js
@@ -8,7 +8,7 @@ describe('/server/services/local-authorities/local-authorities', () => {
         {
           LocalAuthorityName: 'Example 1',
           ThisYear: 0,
-          Status: 'Not Updated',
+          Status: 'Not updated',
           Notes: 'This is a comment',
           LocalAuthorityUID: 'SomeUID1',
           establishment: {
@@ -18,7 +18,7 @@ describe('/server/services/local-authorities/local-authorities', () => {
         {
           LocalAuthorityName: 'Example 2',
           ThisYear: 10,
-          Status: 'Updated, Complete',
+          Status: 'Update, complete',
           Notes: 'This is a comment',
           LocalAuthorityUID: 'SomeUID2',
           establishment: {
@@ -28,7 +28,7 @@ describe('/server/services/local-authorities/local-authorities', () => {
         {
           LocalAuthorityName: 'Example 3',
           ThisYear: 104,
-          Status: 'Not Updated',
+          Status: 'Not updated',
           Notes: null,
           LocalAuthorityUID: 'SomeUID3',
           establishment: {
@@ -39,10 +39,10 @@ describe('/server/services/local-authorities/local-authorities', () => {
 
       const expectedResponse = {
         J: [
-          { name: 'Example 1', status: 'Not Updated', workers: 0, notes: true, localAuthorityUID: 'SomeUID1' },
-          { name: 'Example 2', status: 'Updated, Complete', workers: 10, notes: true, localAuthorityUID: 'SomeUID2' },
+          { name: 'Example 1', status: 'Not updated', workers: 0, notes: true, localAuthorityUID: 'SomeUID1' },
+          { name: 'Example 2', status: 'Update, complete', workers: 10, notes: true, localAuthorityUID: 'SomeUID2' },
         ],
-        G: [{ name: 'Example 3', status: 'Not Updated', workers: 104, notes: false, localAuthorityUID: 'SomeUID3' }],
+        G: [{ name: 'Example 3', status: 'Not updated', workers: 104, notes: false, localAuthorityUID: 'SomeUID3' }],
       };
 
       const reply = formatLaResponse(las);


### PR DESCRIPTION
…tus column

#### Work done
- added new migration to change the enum values for the status column in local authorities
- reverted the original migration back to original enum values
- updated tests to have the correct values for status

#### Tests
Does this PR include tests for the changes introduced?
- [x ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
