### PR TITLE
Feat: Create Account - Confirm details change links

### DIFF
--- a/src/app/core/services/registration.service.ts
+++ b/src/app/core/services/registration.service.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@angular/core';
 import { LoginCredentials } from '@core/model/login-credentials.model';
 import { RegistrationPayload } from '@core/model/registration.model';
 import { SecurityDetails } from '@core/model/security-details.model';
-import { URLStructure } from '@core/model/url.model';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 import { WorkplaceInterfaceService } from './workplace-interface.service';
@@ -15,7 +14,6 @@ export class RegistrationService extends WorkplaceInterfaceService {
   public registrationInProgress$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public loginCredentials$: BehaviorSubject<LoginCredentials> = new BehaviorSubject(null);
   public securityDetails$: BehaviorSubject<SecurityDetails> = new BehaviorSubject(null);
-  public returnTo$ = new BehaviorSubject<URLStructure>(null);
 
   constructor(private http: HttpClient) {
     super();
@@ -28,9 +26,5 @@ export class RegistrationService extends WorkplaceInterfaceService {
   /* TODO: Give proper return */
   public getUsernameDuplicate(id: string): Observable<any> {
     return this.http.get(`/api/registration/username/${id}`);
-  }
-
-  public setReturnTo(returnTo: URLStructure): void {
-    this.returnTo$.next(returnTo);
   }
 }

--- a/src/app/core/services/workplace-interface.service.ts
+++ b/src/app/core/services/workplace-interface.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { LocationAddress } from '@core/model/location.model';
 import { Service } from '@core/model/services.model';
+import { URLStructure } from '@core/model/url.model';
 import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
@@ -17,8 +18,13 @@ export abstract class WorkplaceInterfaceService {
   public searchMethod$: BehaviorSubject<string> = new BehaviorSubject(null);
   public postcodeOrLocationId$: BehaviorSubject<string> = new BehaviorSubject(null);
   public workplaceNotFound$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public returnTo$: BehaviorSubject<URLStructure> = new BehaviorSubject<URLStructure>(null);
 
   public isRegulated(): boolean {
     return this.isRegulated$.value;
+  }
+
+  public setReturnTo(returnTo: URLStructure): void {
+    this.returnTo$.next(returnTo);
   }
 }

--- a/src/app/core/services/workplace.service.ts
+++ b/src/app/core/services/workplace.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { ErrorDefinition } from '@core/model/errorSummary.model';
 import { LocationAddress } from '@core/model/location.model';
 import { Service, ServiceGroup } from '@core/model/services.model';
+import { URLStructure } from '@core/model/url.model';
 import { AddWorkplaceRequest, AddWorkplaceResponse } from '@core/model/workplace.model';
 import { BehaviorSubject, Observable } from 'rxjs';
 
@@ -16,6 +17,7 @@ export class WorkplaceService extends WorkplaceInterfaceService {
     super();
   }
 
+  public returnTo$ = new BehaviorSubject<URLStructure>(null);
   public addWorkplaceFlow$: BehaviorSubject<string> = new BehaviorSubject(null);
   public addWorkplaceInProgress$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public serverErrorsMap: ErrorDefinition[] = [
@@ -50,5 +52,9 @@ export class WorkplaceService extends WorkplaceInterfaceService {
       postalCode: locationAddress.postalCode,
       townCity: locationAddress.townCity,
     };
+  }
+
+  public setReturnTo(returnTo: URLStructure): void {
+    this.returnTo$.next(returnTo);
   }
 }

--- a/src/app/core/services/workplace.service.ts
+++ b/src/app/core/services/workplace.service.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@angular/core';
 import { ErrorDefinition } from '@core/model/errorSummary.model';
 import { LocationAddress } from '@core/model/location.model';
 import { Service, ServiceGroup } from '@core/model/services.model';
-import { URLStructure } from '@core/model/url.model';
 import { AddWorkplaceRequest, AddWorkplaceResponse } from '@core/model/workplace.model';
 import { BehaviorSubject, Observable } from 'rxjs';
 
@@ -17,7 +16,6 @@ export class WorkplaceService extends WorkplaceInterfaceService {
     super();
   }
 
-  public returnTo$ = new BehaviorSubject<URLStructure>(null);
   public addWorkplaceFlow$: BehaviorSubject<string> = new BehaviorSubject(null);
   public addWorkplaceInProgress$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public serverErrorsMap: ErrorDefinition[] = [

--- a/src/app/core/services/workplace.service.ts
+++ b/src/app/core/services/workplace.service.ts
@@ -53,8 +53,4 @@ export class WorkplaceService extends WorkplaceInterfaceService {
       townCity: locationAddress.townCity,
     };
   }
-
-  public setReturnTo(returnTo: URLStructure): void {
-    this.returnTo$.next(returnTo);
-  }
 }

--- a/src/app/core/test-utils/MockUserService.ts
+++ b/src/app/core/test-utils/MockUserService.ts
@@ -131,3 +131,13 @@ export class MockUserService extends UserService {
     return userDetails;
   }
 }
+
+export class MockUserServiceWithNoUserDetails extends MockUserService {
+  public userDetails$ = of({
+    uid: '',
+    email: '',
+    fullname: '',
+    jobTitle: '',
+    phone: '',
+  });
+}

--- a/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.html
+++ b/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.html
@@ -12,11 +12,13 @@
           [topBorder]="true"
           [summaryList]="workplaceNameAndAddress"
           (setReturn)="onSetReturn()"
+          data-testid="workplaceNameAddress"
         ></app-summary-list>
         <app-summary-list
           [wrapBorder]="true"
           [summaryList]="mainService"
           (setReturn)="onSetReturn()"
+          data-testid="mainService"
         ></app-summary-list>
       </div>
 

--- a/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
+++ b/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
@@ -10,38 +10,41 @@ import { MockUserService } from '@core/test-utils/MockUserService';
 import { MockWorkplaceServiceWithMainService } from '@core/test-utils/MockWorkplaceService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { fireEvent, render } from '@testing-library/angular';
+import { render, within } from '@testing-library/angular';
 
 import { AddWorkplaceModule } from '../add-workplace.module';
 import { ConfirmWorkplaceDetailsComponent } from './confirm-workplace-details.component';
 
 describe('ConfirmWorkplaceDetailsComponent', () => {
   async function setup() {
-    const { fixture, getByText, getAllByText, queryByText } = await render(ConfirmWorkplaceDetailsComponent, {
-      imports: [
-        SharedModule,
-        AddWorkplaceModule,
-        RouterTestingModule,
-        HttpClientTestingModule,
-        FormsModule,
-        ReactiveFormsModule,
-      ],
-      providers: [
-        {
-          provide: WorkplaceService,
-          useClass: MockWorkplaceServiceWithMainService,
-        },
-        {
-          provide: EstablishmentService,
-          useClass: MockEstablishmentService,
-        },
-        {
-          provide: UserService,
-          useClass: MockUserService,
-        },
-        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
-      ],
-    });
+    const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(
+      ConfirmWorkplaceDetailsComponent,
+      {
+        imports: [
+          SharedModule,
+          AddWorkplaceModule,
+          RouterTestingModule,
+          HttpClientTestingModule,
+          FormsModule,
+          ReactiveFormsModule,
+        ],
+        providers: [
+          {
+            provide: WorkplaceService,
+            useClass: MockWorkplaceServiceWithMainService,
+          },
+          {
+            provide: EstablishmentService,
+            useClass: MockEstablishmentService,
+          },
+          {
+            provide: UserService,
+            useClass: MockUserService,
+          },
+          { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+        ],
+      },
+    );
 
     const component = fixture.componentInstance;
 
@@ -51,6 +54,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       getAllByText,
       queryByText,
       getByText,
+      getByTestId,
     };
   }
 
@@ -207,7 +211,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
     });
 
     it('should set the change link for location ID to `find-workplace` when CQC regulated with location ID', async () => {
-      const { component, fixture, getAllByText } = await setup();
+      const { component, fixture, getByTestId } = await setup();
 
       component.workplace.isCQC = true;
       component.locationAddress.locationId = '123';
@@ -215,15 +219,14 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       component.setWorkplaceDetails();
       fixture.detectChanges();
 
-      const changeWorkplaceAddressLink = getAllByText('Change')[0];
-      console.log(changeWorkplaceAddressLink);
-      fireEvent.click(changeWorkplaceAddressLink);
+      const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
+      const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeWorkplaceAddressLink.getAttribute('href')).toBe('/add-workplace/find-workplace');
+      expect(changeLink.getAttribute('href')).toBe('/add-workplace/find-workplace');
     });
 
     it('should set the change link for workplace address to `workplace-name-address` when location ID is null', async () => {
-      const { component, fixture, getAllByText } = await setup();
+      const { component, fixture, getByTestId } = await setup();
 
       component.workplace.isCQC = false;
       component.locationAddress.locationId = null;
@@ -231,25 +234,23 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       component.setWorkplaceDetails();
       fixture.detectChanges();
 
-      const changeWorkplaceAddressLink = getAllByText('Change')[0];
-      console.log(changeWorkplaceAddressLink);
-      fireEvent.click(changeWorkplaceAddressLink);
+      const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
+      const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeWorkplaceAddressLink.getAttribute('href')).toBe('/add-workplace/workplace-name-address');
+      expect(changeLink.getAttribute('href')).toBe('/add-workplace/workplace-name-address');
     });
 
     it('should set the change link for main service to `select-main-service`', async () => {
-      const { component, fixture, getAllByText } = await setup();
+      const { component, fixture, getByTestId } = await setup();
 
       component.createAccountNewDesign = true;
       component.setWorkplaceDetails();
       fixture.detectChanges();
 
-      const changeMainServiceLink = getAllByText('Change')[1];
-      console.log(changeMainServiceLink);
-      fireEvent.click(changeMainServiceLink);
+      const workplaceNameAddressSummaryList = within(getByTestId('mainService'));
+      const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeMainServiceLink.getAttribute('href')).toEqual('/add-workplace/new-select-main-service');
+      expect(changeLink.getAttribute('href')).toEqual('/add-workplace/new-select-main-service');
     });
   });
 });

--- a/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
+++ b/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
@@ -10,7 +10,7 @@ import { MockUserService } from '@core/test-utils/MockUserService';
 import { MockWorkplaceServiceWithMainService } from '@core/test-utils/MockWorkplaceService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
 
 import { AddWorkplaceModule } from '../add-workplace.module';
 import { ConfirmWorkplaceDetailsComponent } from './confirm-workplace-details.component';
@@ -194,6 +194,62 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
 
     expect(backLinkSpy).toHaveBeenCalledWith({
       url: ['/add-workplace', 'select-main-service'],
+    });
+  });
+
+  describe('Change links', () => {
+    it('should always display two change links', async () => {
+      const { getAllByText } = await setup();
+
+      const changeLinks = getAllByText('Change');
+
+      expect(changeLinks.length).toEqual(2);
+    });
+
+    it('should set the change link for location ID to `find-workplace` when CQC regulated with location ID', async () => {
+      const { component, fixture, getAllByText } = await setup();
+
+      component.workplace.isCQC = true;
+      component.locationAddress.locationId = '123';
+      component.createAccountNewDesign = true;
+      component.setWorkplaceDetails();
+      fixture.detectChanges();
+
+      const changeWorkplaceAddressLink = getAllByText('Change')[0];
+      console.log(changeWorkplaceAddressLink);
+      fireEvent.click(changeWorkplaceAddressLink);
+
+      expect(changeWorkplaceAddressLink.getAttribute('href')).toBe('/add-workplace/find-workplace');
+    });
+
+    it('should set the change link for workplace address to `workplace-name-address` when location ID is null', async () => {
+      const { component, fixture, getAllByText } = await setup();
+
+      component.workplace.isCQC = false;
+      component.locationAddress.locationId = null;
+      component.createAccountNewDesign = true;
+      component.setWorkplaceDetails();
+      fixture.detectChanges();
+
+      const changeWorkplaceAddressLink = getAllByText('Change')[0];
+      console.log(changeWorkplaceAddressLink);
+      fireEvent.click(changeWorkplaceAddressLink);
+
+      expect(changeWorkplaceAddressLink.getAttribute('href')).toBe('/add-workplace/workplace-name-address');
+    });
+
+    it('should set the change link for main service to `select-main-service`', async () => {
+      const { component, fixture, getAllByText } = await setup();
+
+      component.createAccountNewDesign = true;
+      component.setWorkplaceDetails();
+      fixture.detectChanges();
+
+      const changeMainServiceLink = getAllByText('Change')[1];
+      console.log(changeMainServiceLink);
+      fireEvent.click(changeMainServiceLink);
+
+      expect(changeMainServiceLink.getAttribute('href')).toEqual('/add-workplace/new-select-main-service');
     });
   });
 });

--- a/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
+++ b/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
@@ -225,7 +225,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       expect(changeLink.getAttribute('href')).toBe('/add-workplace/find-workplace');
     });
 
-    it('should set the change link for workplace address to `workplace-name-address` when location ID is null', async () => {
+    it('should set the change link for workplace address to `find-workplace` when location ID is null', async () => {
       const { component, fixture, getByTestId } = await setup();
 
       component.workplace.isCQC = false;
@@ -237,7 +237,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
       const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeLink.getAttribute('href')).toBe('/add-workplace/workplace-name-address');
+      expect(changeLink.getAttribute('href')).toBe('/add-workplace/find-workplace');
     });
 
     it('should set the change link for main service to `select-main-service`', async () => {

--- a/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.ts
+++ b/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.ts
@@ -70,4 +70,10 @@ export class ConfirmWorkplaceDetailsComponent extends ConfirmWorkplaceDetailsDir
         ),
     );
   }
+
+  public onSetReturn(): void {
+    this.workplaceService.setReturnTo({
+      url: [`${this.flow}/confirm-details`],
+    });
+  }
 }

--- a/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.ts
+++ b/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.ts
@@ -7,9 +7,7 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkplaceService } from '@core/services/workplace.service';
-import {
-  ConfirmWorkplaceDetailsDirective,
-} from '@shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive';
+import { ConfirmWorkplaceDetailsDirective } from '@shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
@@ -33,6 +31,7 @@ export class ConfirmWorkplaceDetailsComponent extends ConfirmWorkplaceDetailsDir
 
   protected init(): void {
     this.flow = '/add-workplace';
+    this.resetReturnTo();
     this.getWorkplaceData();
   }
 
@@ -75,5 +74,9 @@ export class ConfirmWorkplaceDetailsComponent extends ConfirmWorkplaceDetailsDir
     this.workplaceService.setReturnTo({
       url: [`${this.flow}/confirm-details`],
     });
+  }
+
+  private resetReturnTo(): void {
+    this.workplaceService.returnTo$.next(null);
   }
 }

--- a/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -6,7 +6,9 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BackService } from '@core/services/back.service';
 import { LocationService } from '@core/services/location.service';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockLocationService } from '@core/test-utils/MockLocationService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { throwError } from 'rxjs';
@@ -30,6 +32,10 @@ describe('FindYourWorkplaceComponent', () => {
         {
           provide: LocationService,
           useClass: MockLocationService,
+        },
+        {
+          provide: FeatureFlagsService,
+          useClass: MockFeatureFlagsService,
         },
         {
           provide: ActivatedRoute,
@@ -215,6 +221,21 @@ describe('FindYourWorkplaceComponent', () => {
 
       expect(backLinkSpy).toHaveBeenCalledWith({
         url: ['add-workplace', 'new-workplace-not-found'],
+      });
+    });
+
+    it('should set the back link to `confirm-workplace-details` when returnToConfirmDetails is not null', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.createAccountNewDesign = true;
+      component.fixture.componentInstance.returnToConfirmDetails = {
+        url: ['add-workplace', 'confirm-workplace-details'],
+      };
+      component.fixture.componentInstance.setBackLink();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['add-workplace', 'confirm-workplace-details'],
       });
     });
   });

--- a/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.ts
+++ b/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.ts
@@ -5,7 +5,10 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { LocationService } from '@core/services/location.service';
 import { WorkplaceService } from '@core/services/workplace.service';
-import { FindYourWorkplaceDirective } from '@shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive';
+import {
+  FindYourWorkplaceDirective,
+} from '@shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
   selector: 'app-find-your-workplace',
@@ -20,7 +23,21 @@ export class FindYourWorkplaceComponent extends FindYourWorkplaceDirective {
     protected formBuilder: FormBuilder,
     protected workplaceService: WorkplaceService,
     protected locationService: LocationService,
+    protected featureFlagsService: FeatureFlagsService,
   ) {
-    super(router, backService, errorSummaryService, route, formBuilder, workplaceService, locationService);
+    super(
+      router,
+      backService,
+      errorSummaryService,
+      route,
+      formBuilder,
+      workplaceService,
+      locationService,
+      featureFlagsService,
+    );
+  }
+
+  protected navigateToConfirmDetails(): void {
+    this.backService.setBackLink({ url: [this.flow, 'confirm-workplace-details'] });
   }
 }

--- a/src/app/features/add-workplace/is-this-your-workplace/is-this-your-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/is-this-your-workplace/is-this-your-workplace.component.spec.ts
@@ -51,6 +51,7 @@ describe('IsThisYourWorkplaceComponent', () => {
             },
             selectedLocationAddress$: new BehaviorSubject(null),
             manuallyEnteredWorkplace$: new BehaviorSubject(null),
+            returnTo$: new BehaviorSubject(null),
           },
         },
         {
@@ -154,6 +155,22 @@ describe('IsThisYourWorkplaceComponent', () => {
     fireEvent.click(continueButton);
 
     expect(spy).toHaveBeenCalledWith(['add-workplace', 'new-select-main-service']);
+  });
+
+  it('should navigate to the confirm-workplace-details page when selecting yes if returnToConfirmDetails is not null', async () => {
+    const { component, spy } = await setup();
+
+    component.fixture.componentInstance.returnToConfirmDetails = {
+      url: ['add-workplace', 'confirm-workplace-details'],
+    };
+
+    const yesRadioButton = component.fixture.nativeElement.querySelector(`input[ng-reflect-value="yes"]`);
+    fireEvent.click(yesRadioButton);
+
+    const continueButton = component.getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(spy).toHaveBeenCalledWith(['add-workplace', 'confirm-workplace-details']);
   });
 
   it('should navigate back to find-workplace url when selecting no', async () => {

--- a/src/app/features/add-workplace/is-this-your-workplace/is-this-your-workplace.component.ts
+++ b/src/app/features/add-workplace/is-this-your-workplace/is-this-your-workplace.component.ts
@@ -5,7 +5,9 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkplaceService } from '@core/services/workplace.service';
-import { IsThisYourWorkplaceDirective } from '@shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive';
+import {
+  IsThisYourWorkplaceDirective,
+} from '@shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive';
 
 @Component({
   selector: 'app-is-this-your-workplace',
@@ -37,5 +39,9 @@ export class IsThisYourWorkplaceComponent extends IsThisYourWorkplaceDirective {
         ],
       },
     ];
+  }
+
+  protected getNextRoute(): string {
+    return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'new-select-main-service';
   }
 }

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -125,7 +125,7 @@ describe('NewSelectMainServiceComponent', () => {
     expect(cqcText).toBeNull();
   });
 
-  it("should see 'Select its main service' when is a parent", async () => {
+  it('should see "Select its main service"', async () => {
     const { component, fixture, queryByText } = await setup();
 
     component.isParent = true;
@@ -153,7 +153,7 @@ describe('NewSelectMainServiceComponent', () => {
     expect(getAllByText(errorMessage).length).toBe(3);
   });
 
-  it('should submit and go to the add-workplace/add-user-details url when option selected and is a parent', async () => {
+  it('should submit and go to the add-workplace/confirm-workplace-details url when option selected', async () => {
     const { component, fixture, getByText, getByLabelText, spy } = await setup();
 
     component.isParent = true;

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -314,5 +314,19 @@ describe('NewSelectMainServiceComponent', () => {
         url: ['add-workplace', 'workplace-name'],
       });
     });
+
+    it('should set back link to confirm-workplace-details when returnToConfirmDetails is not null and feature flag is on', async () => {
+      const { component } = await setup();
+
+      const backLinkSpy = spyOn(component.backService, 'setBackLink');
+
+      component.createAccountNewDesign = true;
+      component.returnToConfirmDetails = { url: ['add-workplace', 'confirm-workplace-details'] };
+      component.setBackLink();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['add-workplace', 'confirm-workplace-details'],
+      });
+    });
   });
 });

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
@@ -38,6 +38,7 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
     this.isRegulated = this.workplaceService.isRegulated();
     this.workplace = this.establishmentService.primaryWorkplace;
     this.workplace?.isParent ? (this.isParent = true) : (this.isParent = false);
+    this.returnToConfirmDetails = this.workplaceService.returnTo$.value;
     this.setBackLink();
     this.createAccountNewDesign = await this.featureFlagsService.configCatClient.getValueAsync(
       'createAccountNewDesign',
@@ -65,8 +66,7 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   }
 
   protected navigateToNextPage(): void {
-    const url = this.isParent ? 'confirm-workplace-details' : 'add-user-details';
-    this.router.navigate([this.flow, url]);
+    this.router.navigate([this.flow, 'confirm-workplace-details']);
   }
 
   public setBackLink(): void {

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
@@ -7,7 +7,9 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkplaceService } from '@core/services/workplace.service';
-import { SelectMainServiceDirective } from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
+import {
+  SelectMainServiceDirective,
+} from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
@@ -70,6 +72,11 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   }
 
   public setBackLink(): void {
+    if (this.returnToConfirmDetails) {
+      this.backService.setBackLink({ url: [this.flow, 'confirm-workplace-details'] });
+      return;
+    }
+
     const route = this.isRegulated ? this.getCQCRegulatedBackLink() : this.getNonCQCRegulatedBackLink();
     this.backService.setBackLink({ url: [this.flow, route] });
   }

--- a/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.spec.ts
+++ b/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.spec.ts
@@ -138,7 +138,24 @@ describe('SelectWorkplaceAddressComponent', () => {
 
       expect(form.valid).toBeTruthy();
 
-      expect(spy).toHaveBeenCalledWith(['/add-workplace/new-select-main-service']);
+      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'new-select-main-service']);
+    });
+
+    it('should navigate to the confirm-workplace-details page in add-workplace flow when workplace selected, Continue clicked and returnToConfirmDetails is not null', async () => {
+      const { component, spy, getByText } = await setup();
+
+      component.createAccountNewDesign = true;
+      component.returnToConfirmDetails = { url: ['add-workplace', 'confirm-workplace-details'] };
+
+      const form = component.form;
+      form.controls['address'].setValue('1');
+      form.controls['address'].markAsDirty();
+
+      const continueButton = getByText('Continue');
+      fireEvent.click(continueButton);
+
+      expect(form.valid).toBeTruthy();
+      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'confirm-workplace-details']);
     });
   });
 });

--- a/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.ts
@@ -27,6 +27,7 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
   protected init(): void {
     this.flow = '/add-workplace';
     this.workplaceService.manuallyEnteredWorkplace$.next(false);
+    this.returnToConfirmDetails = this.workplaceService.returnTo$.value;
     this.setupSubscriptions();
   }
 
@@ -61,5 +62,18 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
 
   public onLocationChange(index): void {
     this.workplaceService.selectedLocationAddress$.next(this.locationAddresses[index]);
+  }
+
+  protected getNextRoute(): string {
+    if (this.returnToConfirmDetails) {
+      return 'confirm-workplace-details';
+    }
+    if (this.createAccountNewDesign) {
+      return 'new-select-main-service';
+    }
+    if (this.selectedLocationAddress.locationName.length) {
+      return 'select-main-service';
+    }
+    return 'workplace-name-address';
   }
 }

--- a/src/app/features/add-workplace/select-workplace/select-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/select-workplace/select-workplace.component.spec.ts
@@ -121,6 +121,23 @@ describe('SelectWorkplaceComponent', () => {
       expect(spy).toHaveBeenCalledWith(['/add-workplace', 'new-select-main-service']);
     });
 
+    it('should navigate to the confirm-details page in registration flow when returnToConfirmDetails is not null', async () => {
+      const { component, getByText, fixture, spy } = await setup();
+
+      component.createAccountNewDesign = true;
+      component.returnToConfirmDetails = { url: ['add-workplace', 'confirm-details'] };
+      component.setNextRoute();
+      fixture.detectChanges();
+
+      const yesRadioButton = fixture.nativeElement.querySelector(`input[ng-reflect-value="123"]`);
+      fireEvent.click(yesRadioButton);
+
+      const continueButton = getByText('Continue');
+      fireEvent.click(continueButton);
+
+      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'confirm-details']);
+    });
+
     it('should navigate back to the find-workplace url in add-workplace flow when Change clicked', async () => {
       const { component, fixture, getByText } = await setup();
       component.createAccountNewDesign = true;

--- a/src/app/features/add-workplace/select-workplace/select-workplace.component.ts
+++ b/src/app/features/add-workplace/select-workplace/select-workplace.component.ts
@@ -28,6 +28,7 @@ export class SelectWorkplaceComponent extends SelectWorkplaceDirective {
 
   protected init(): void {
     this.flow = '/add-workplace';
+    this.returnToConfirmDetails = this.registrationService.returnTo$.value;
     this.setupSubscription();
   }
 

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -200,17 +200,5 @@ describe('WorkplaceNameAddressComponent', () => {
         url: ['/add-workplace', 'select-workplace-address'],
       });
     });
-
-    it('should set the back link to `confirm-workplace-details` when returnToConfirmDetails is not null', async () => {
-      const { component } = await setup();
-      const backLinkSpy = spyOn(component.backService, 'setBackLink');
-
-      component.returnToConfirmDetails = { url: ['add-workplace', 'confirm-workplace-details'] };
-      component.setBackLink();
-
-      expect(backLinkSpy).toHaveBeenCalledWith({
-        url: ['/add-workplace', 'confirm-workplace-details'],
-      });
-    });
   });
 });

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -200,5 +200,17 @@ describe('WorkplaceNameAddressComponent', () => {
         url: ['/add-workplace', 'select-workplace-address'],
       });
     });
+
+    it('should set the back link to `confirm-workplace-details` when returnToConfirmDetails is not null', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.backService, 'setBackLink');
+
+      component.returnToConfirmDetails = { url: ['add-workplace', 'confirm-workplace-details'] };
+      component.setBackLink();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['/add-workplace', 'confirm-workplace-details'],
+      });
+    });
   });
 });

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -118,6 +118,27 @@ describe('WorkplaceNameAddressComponent', () => {
     expect(spy).toHaveBeenCalledWith(['/add-workplace', 'select-main-service']);
   });
 
+  it('should navigate to confirm-workplace-details page on success if returnToConfirmDetails is not null', async () => {
+    const { component, fixture, getByText, spy } = await setup();
+    const form = component.form;
+
+    form.controls['workplaceName'].setValue('Workplace');
+    form.controls['address1'].setValue('1 Main Street');
+    form.controls['townOrCity'].setValue('London');
+    form.controls['county'].setValue('Greater London');
+    form.controls['postcode'].setValue('SE1 1AA');
+
+    component.createAccountNewDesign = true;
+    component.returnToConfirmDetails = { url: ['add-workplace', 'confirm-workplace-details'] };
+    fixture.detectChanges();
+
+    const continueButton = getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.invalid).toBeFalsy();
+    expect(spy).toHaveBeenCalledWith(['/add-workplace', 'confirm-workplace-details']);
+  });
+
   describe('Error messages', () => {
     it(`should display an error message when workplace name isn't filled in`, async () => {
       const { component, getByText, getAllByText } = await setup();

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
@@ -66,6 +66,11 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
   }
 
   public setBackLink(): void {
+    if (this.returnToConfirmDetails) {
+      this.setBackLinkToConfirmDetails();
+      return;
+    }
+
     if (this.returnToWorkplaceNotFound && this.createAccountNewDesign) {
       this.backService.setBackLink({ url: [this.flow, 'new-workplace-not-found'] });
       return;
@@ -84,5 +89,9 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
       return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'new-select-main-service';
     }
     return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
+  }
+
+  protected setBackLinkToConfirmDetails(): void {
+    this.backService.setBackLink({ url: [this.flow, 'confirm-workplace-details'] });
   }
 }

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { LocationAddress } from '@core/model/location.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { RegistrationService } from '@core/services/registration.service';
 import { WorkplaceService } from '@core/services/workplace.service';
 import {
   WorkplaceNameAddressDirective,
@@ -17,14 +16,9 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
     '../../../shared/directives/create-workplace/workplace-name-address/workplace-name-address.component.html',
 })
 export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective {
-  public returnToWorkplaceNotFound: boolean;
-  public isCqcRegulated: boolean;
-  public createAccountNewDesign: boolean;
-
   constructor(
     private featureFlagsService: FeatureFlagsService,
     private workplaceService: WorkplaceService,
-    private registrationService: RegistrationService,
     public backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
@@ -38,8 +32,9 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     this.flow = '/add-workplace';
     this.title = `What's the workplace name and address?`;
     this.workplaceErrorMessage = 'Enter the name of the workplace';
-    this.returnToWorkplaceNotFound = this.registrationService.workplaceNotFound$.value;
-    this.isCqcRegulated = this.registrationService.isCqcRegulated$.value;
+    this.returnToConfirmDetails = this.workplaceService.returnTo$.value;
+    this.returnToWorkplaceNotFound = this.workplaceService.workplaceNotFound$.value;
+    this.isCqcRegulated = this.workplaceService.isCqcRegulated$.value;
 
     await this.setFeatureFlag();
     this.setBackLink();
@@ -66,7 +61,7 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
   protected setSelectedLocationAddress(): void {
     this.workplaceService.selectedLocationAddress$.next(this.getLocationAddress());
     this.workplaceService.manuallyEnteredWorkplace$.next(true);
-    const url = this.createAccountNewDesign ? 'new-select-main-service' : 'select-main-service';
+    const url = this.getNextRoute();
     this.router.navigate([this.flow, url]);
   }
 
@@ -82,5 +77,12 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     }
 
     this.backService.setBackLink({ url: [this.flow, 'select-workplace-address'] });
+  }
+
+  protected getNextRoute(): string {
+    if (this.createAccountNewDesign) {
+      return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'new-select-main-service';
+    }
+    return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
   }
 }

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
@@ -66,11 +66,6 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
   }
 
   public setBackLink(): void {
-    if (this.returnToConfirmDetails) {
-      this.setBackLinkToConfirmDetails();
-      return;
-    }
-
     if (this.returnToWorkplaceNotFound && this.createAccountNewDesign) {
       this.backService.setBackLink({ url: [this.flow, 'new-workplace-not-found'] });
       return;
@@ -89,9 +84,5 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
       return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'new-select-main-service';
     }
     return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
-  }
-
-  protected setBackLinkToConfirmDetails(): void {
-    this.backService.setBackLink({ url: [this.flow, 'confirm-workplace-details'] });
   }
 }

--- a/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.html
+++ b/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.html
@@ -15,14 +15,25 @@
       <span class="govuk-caption-l govuk-!-margin-bottom-2">User account</span>
       <h1 class="govuk-heading-l">Confirm your account details</h1>
     </ng-template>
-    <app-summary-list [topBorder]="true" [summaryList]="userInfo" (setReturn)="onSetReturn()"></app-summary-list>
+    <app-summary-list
+      [topBorder]="true"
+      [summaryList]="userInfo"
+      (setReturn)="onSetReturn()"
+      data-testid="userInfo"
+    ></app-summary-list>
     <app-summary-list
       [topBorder]="true"
       [summaryList]="loginInfo"
       [displayShowPasswordToggle]="true"
       (setReturn)="onSetReturn()"
+      data-testid="loginInfo"
     ></app-summary-list>
-    <app-summary-list [wrapBorder]="true" [summaryList]="securityInfo" (setReturn)="onSetReturn()"></app-summary-list>
+    <app-summary-list
+      [wrapBorder]="true"
+      [summaryList]="securityInfo"
+      (setReturn)="onSetReturn()"
+      data-testid="securityInfo"
+    ></app-summary-list>
 
     <ng-container *ngIf="!createAccountNewDesign">
       <form #formEl (ngSubmit)="onSubmit()" [formGroup]="form" id="form" class="govuk-!-margin-top-6">

--- a/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.spec.ts
+++ b/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.spec.ts
@@ -11,48 +11,51 @@ import { MockUserService } from '@core/test-utils/MockUserService';
 import { RegistrationModule } from '@features/registration/registration.module';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { fireEvent, queryByText, render } from '@testing-library/angular';
+import { fireEvent, queryByText, render, within } from '@testing-library/angular';
 
 import { ConfirmAccountDetailsComponent } from './confirm-account-details.component';
 
 describe('ConfirmAccountDetailsComponent', () => {
   async function setup() {
-    const { fixture, getByText, getAllByText, queryByText } = await render(ConfirmAccountDetailsComponent, {
-      imports: [
-        SharedModule,
-        RegistrationModule,
-        RouterTestingModule,
-        HttpClientTestingModule,
-        FormsModule,
-        ReactiveFormsModule,
-      ],
-      providers: [
-        {
-          provide: RegistrationService,
-          useClass: MockRegistrationServiceWithMainService,
-        },
-        {
-          provide: UserService,
-          useClass: MockUserService,
-        },
-        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            snapshot: {
-              parent: {
-                url: [
-                  {
-                    path: 'registration',
-                  },
-                ],
+    const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(
+      ConfirmAccountDetailsComponent,
+      {
+        imports: [
+          SharedModule,
+          RegistrationModule,
+          RouterTestingModule,
+          HttpClientTestingModule,
+          FormsModule,
+          ReactiveFormsModule,
+        ],
+        providers: [
+          {
+            provide: RegistrationService,
+            useClass: MockRegistrationServiceWithMainService,
+          },
+          {
+            provide: UserService,
+            useClass: MockUserService,
+          },
+          { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                parent: {
+                  url: [
+                    {
+                      path: 'registration',
+                    },
+                  ],
+                },
               },
             },
           },
-        },
-        FormBuilder,
-      ],
-    });
+          FormBuilder,
+        ],
+      },
+    );
 
     const injector = getTestBed();
     const router = injector.inject(Router) as Router;
@@ -69,6 +72,7 @@ describe('ConfirmAccountDetailsComponent', () => {
       getAllByText,
       queryByText,
       getByText,
+      getByTestId,
     };
   }
 
@@ -151,30 +155,30 @@ describe('ConfirmAccountDetailsComponent', () => {
     });
 
     it('should set the change link for user info to `add-user-details`', async () => {
-      const { getAllByText } = await setup();
+      const { getByTestId } = await setup();
 
-      const changeUserDetailsLink = getAllByText('Change')[0];
-      fireEvent.click(changeUserDetailsLink);
+      const userInfoSummaryList = within(getByTestId('userInfo'));
+      const changeLink = userInfoSummaryList.getByText('Change');
 
-      expect(changeUserDetailsLink.getAttribute('href')).toBe('/registration/add-user-details');
+      expect(changeLink.getAttribute('href')).toBe('/registration/add-user-details');
     });
 
     it('should set the change link for login info to `username-password`', async () => {
-      const { getAllByText } = await setup();
+      const { getByTestId } = await setup();
 
-      const changeUserDetailsLink = getAllByText('Change')[1];
-      fireEvent.click(changeUserDetailsLink);
+      const loginInfoSummaryList = within(getByTestId('loginInfo'));
+      const changeLink = loginInfoSummaryList.getByText('Change');
 
-      expect(changeUserDetailsLink.getAttribute('href')).toBe('/registration/username-password');
+      expect(changeLink.getAttribute('href')).toBe('/registration/username-password');
     });
 
     it('should set the change link for security info to `username-password`', async () => {
-      const { getAllByText } = await setup();
+      const { getByTestId } = await setup();
 
-      const changeSecurityQuestionLink = getAllByText('Change')[2];
-      fireEvent.click(changeSecurityQuestionLink);
+      const securityInfoSummaryList = within(getByTestId('securityInfo'));
+      const changeLink = securityInfoSummaryList.getByText('Change');
 
-      expect(changeSecurityQuestionLink.getAttribute('href')).toBe('/registration/create-security-question');
+      expect(changeLink.getAttribute('href')).toBe('/registration/create-security-question');
     });
   });
 });

--- a/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.spec.ts
+++ b/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.spec.ts
@@ -140,4 +140,41 @@ describe('ConfirmAccountDetailsComponent', () => {
       expect(queryByText(expectedShownPassword)).toBeTruthy();
     });
   });
+
+  describe('Change links', () => {
+    it('should always display three change links', async () => {
+      const { getAllByText } = await setup();
+
+      const changeLinks = getAllByText('Change');
+
+      expect(changeLinks.length).toEqual(3);
+    });
+
+    it('should set the change link for user info to `add-user-details`', async () => {
+      const { getAllByText } = await setup();
+
+      const changeUserDetailsLink = getAllByText('Change')[0];
+      fireEvent.click(changeUserDetailsLink);
+
+      expect(changeUserDetailsLink.getAttribute('href')).toBe('/registration/add-user-details');
+    });
+
+    it('should set the change link for login info to `username-password`', async () => {
+      const { getAllByText } = await setup();
+
+      const changeUserDetailsLink = getAllByText('Change')[1];
+      fireEvent.click(changeUserDetailsLink);
+
+      expect(changeUserDetailsLink.getAttribute('href')).toBe('/registration/username-password');
+    });
+
+    it('should set the change link for security info to `username-password`', async () => {
+      const { getAllByText } = await setup();
+
+      const changeSecurityQuestionLink = getAllByText('Change')[2];
+      fireEvent.click(changeSecurityQuestionLink);
+
+      expect(changeSecurityQuestionLink.getAttribute('href')).toBe('/registration/create-security-question');
+    });
+  });
 });

--- a/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.ts
+++ b/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.ts
@@ -64,12 +64,12 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetailsDirecti
     );
   }
 
-  private setAccountDetails(): void {
+  public setAccountDetails(): void {
     this.userInfo = [
       {
         label: 'Full name',
         data: this.userDetails.fullname,
-        route: { url: ['/registration/change-your-details'] },
+        route: { url: ['/registration/add-user-details'] },
       },
       {
         label: 'Job title',
@@ -142,7 +142,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetailsDirecti
 
   public onSetReturn(): void {
     this.registrationService.setReturnTo({
-      url: ['/registration/confirm-account-details'],
+      url: ['/registration/confirm-details'],
     });
   }
 }

--- a/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.ts
+++ b/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.ts
@@ -31,6 +31,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetailsDirecti
   }
 
   protected async init() {
+    this.resetReturnTo();
     this.setupSubscriptions();
     this.setBackLink();
     this.subscriptions.add(
@@ -144,5 +145,9 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetailsDirecti
     this.registrationService.setReturnTo({
       url: ['/registration/confirm-details'],
     });
+  }
+
+  private resetReturnTo(): void {
+    this.registrationService.returnTo$.next(null);
   }
 }

--- a/src/app/features/create-account/user/create-security-question/create-security-question.component.html
+++ b/src/app/features/create-account/user/create-security-question/create-security-question.component.html
@@ -37,7 +37,7 @@
         </ng-container>
       </fieldset>
 
-      <button type="submit" class="govuk-button">{{ callToActionLabel }}</button>
+      <button type="submit" class="govuk-button">Continue</button>
     </form>
   </div>
 </div>

--- a/src/app/features/create-account/user/create-security-question/create-security-question.component.spec.ts
+++ b/src/app/features/create-account/user/create-security-question/create-security-question.component.spec.ts
@@ -148,4 +148,31 @@ describe('SecurityQuestionComponent', () => {
     expect(form.valid).toBeTruthy();
     expect(spy).toHaveBeenCalledWith(['/registration/confirm-details']);
   });
+
+  describe('setBackLink()', () => {
+    it('should set the back link to username-password if feature flag is on and return url is null', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.setBackLink();
+      component.fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'username-password'],
+      });
+    });
+
+    it('should set the back link to confirm-details if the feature flag is on and return url is not null', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.return = { url: ['registration', 'confirm-details'] };
+      component.fixture.componentInstance.setBackLink();
+      component.fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'confirm-details'],
+      });
+    });
+  });
 });

--- a/src/app/features/create-account/user/create-security-question/create-security-question.component.spec.ts
+++ b/src/app/features/create-account/user/create-security-question/create-security-question.component.spec.ts
@@ -129,4 +129,23 @@ describe('SecurityQuestionComponent', () => {
     expect(form.invalid).toBeTruthy();
     expect(component.getAllByText('Answer must be 255 characters or fewer', { exact: false }).length).toBe(2);
   });
+
+  it('should navigate to confirm-details if form is valid', async () => {
+    const { component, spy } = await setup();
+    const form = component.fixture.componentInstance.form;
+
+    component.fixture.componentInstance.return = { url: ['registration', 'confirm-details'] };
+
+    form.controls['securityQuestion'].markAsDirty();
+    form.controls['securityQuestion'].setValue('question');
+
+    form.controls['securityQuestionAnswer'].markAsDirty();
+    form.controls['securityQuestionAnswer'].setValue('answer');
+
+    const continueButton = component.getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.valid).toBeTruthy();
+    expect(spy).toHaveBeenCalledWith(['/registration/confirm-details']);
+  });
 });

--- a/src/app/features/create-account/user/create-security-question/create-security-question.component.ts
+++ b/src/app/features/create-account/user/create-security-question/create-security-question.component.ts
@@ -17,7 +17,7 @@ export class SecurityQuestionComponent extends SecurityQuestionDirective {
 
   constructor(
     private registrationService: RegistrationService,
-    protected backService: BackService,
+    public backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
     protected router: Router,
@@ -29,9 +29,9 @@ export class SecurityQuestionComponent extends SecurityQuestionDirective {
   protected init(): void {
     this.featureFlagsService.configCatClient.getValueAsync('createAccountNewDesign', false).then((value) => {
       this.createAccountNewDesign = value;
+      this.setBackLink();
     });
     this.return = this.registrationService.returnTo$.value;
-    this.setBackLink();
     this.setupSubscription();
   }
 
@@ -45,9 +45,13 @@ export class SecurityQuestionComponent extends SecurityQuestionDirective {
     );
   }
 
-  protected setBackLink(): void {
-    const route: string = this.return ? this.return.url[0] : '/registration/username-password';
-    this.backService.setBackLink({ url: [route] });
+  public setBackLink(): void {
+    if (this.return) {
+      const url = this.createAccountNewDesign ? 'confirm-details' : 'confirm-account-details';
+      this.backService.setBackLink({ url: ['registration', url] });
+      return;
+    }
+    this.backService.setBackLink({ url: ['registration', 'username-password'] });
   }
 
   protected save(): void {

--- a/src/app/features/create-account/user/create-security-question/create-security-question.component.ts
+++ b/src/app/features/create-account/user/create-security-question/create-security-question.component.ts
@@ -67,9 +67,4 @@ export class SecurityQuestionComponent extends SecurityQuestionDirective {
       });
     }
   }
-
-  protected setCallToActionLabel(): void {
-    const label: string = this.return ? 'Save and return' : 'Continue';
-    this.callToActionLabel = label;
-  }
 }

--- a/src/app/features/create-account/user/username-password/username-password.component.html
+++ b/src/app/features/create-account/user/username-password/username-password.component.html
@@ -91,7 +91,7 @@
         </div>
       </fieldset>
 
-      <button type="submit" class="govuk-button">{{ callToActionLabel }}</button>
+      <button type="submit" class="govuk-button">Continue</button>
     </form>
   </div>
 </div>

--- a/src/app/features/create-account/user/username-password/username-password.component.spec.ts
+++ b/src/app/features/create-account/user/username-password/username-password.component.spec.ts
@@ -337,4 +337,31 @@ describe('UsernamePasswordComponent', () => {
     expect(form.valid).toBeTruthy();
     expect(spy).toHaveBeenCalledWith(['/registration/confirm-details']);
   });
+
+  describe('setBackLink()', () => {
+    it('should set the back link to your-details if feature flag is on and return url is null', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.setBackLink();
+      component.fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'your-details'],
+      });
+    });
+
+    it('should set the back link to confirm-details if the feature flag is on and return url is not null', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.return = { url: ['registration', 'confirm-details'] };
+      component.fixture.componentInstance.setBackLink();
+      component.fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'confirm-details'],
+      });
+    });
+  });
 });

--- a/src/app/features/create-account/user/username-password/username-password.component.spec.ts
+++ b/src/app/features/create-account/user/username-password/username-password.component.spec.ts
@@ -310,4 +310,24 @@ describe('UsernamePasswordComponent', () => {
     expect(form.valid).toBeTruthy();
     expect(spy).toHaveBeenCalledWith(['/registration/create-security-question']);
   });
+
+  it('should navigate to confirm-details if return URL is not null', async () => {
+    const { component, spy } = await setup();
+    const form = component.fixture.componentInstance.form;
+
+    component.fixture.componentInstance.return = { url: ['registration', 'confirm-details'] };
+
+    form.controls['username'].markAsDirty();
+    form.controls['username'].setValue('username123');
+    form.get(['passwordGroup', 'createPasswordInput']).markAsDirty();
+    form.get(['passwordGroup', 'createPasswordInput']).setValue('Hello123!');
+    form.get(['passwordGroup', 'confirmPasswordInput']).markAsDirty();
+    form.get(['passwordGroup', 'confirmPasswordInput']).setValue('Hello123!');
+
+    const continueButton = component.getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.valid).toBeTruthy();
+    expect(spy).toHaveBeenCalledWith(['/registration/confirm-details']);
+  });
 });

--- a/src/app/features/create-account/user/username-password/username-password.component.spec.ts
+++ b/src/app/features/create-account/user/username-password/username-password.component.spec.ts
@@ -5,9 +5,11 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BackService } from '@core/services/back.service';
 import { LocationService } from '@core/services/location.service';
 import { RegistrationService } from '@core/services/registration.service';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockLocationService } from '@core/test-utils/MockLocationService';
 import { MockRegistrationService } from '@core/test-utils/MockRegistrationService';
 import { RegistrationModule } from '@features/registration/registration.module';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
@@ -26,6 +28,10 @@ describe('UsernamePasswordComponent', () => {
         {
           provide: RegistrationService,
           useClass: MockRegistrationService,
+        },
+        {
+          provide: FeatureFlagsService,
+          useClass: MockFeatureFlagsService,
         },
         {
           provide: ActivatedRoute,
@@ -315,6 +321,7 @@ describe('UsernamePasswordComponent', () => {
     const { component, spy } = await setup();
     const form = component.fixture.componentInstance.form;
 
+    component.fixture.componentInstance.createAccountNewDesign = true;
     component.fixture.componentInstance.return = { url: ['registration', 'confirm-details'] };
 
     form.controls['username'].markAsDirty();

--- a/src/app/features/create-account/user/username-password/username-password.component.ts
+++ b/src/app/features/create-account/user/username-password/username-password.component.ts
@@ -27,11 +27,6 @@ export class UsernamePasswordComponent extends CreateUsernameDirective {
     this.setBackLink();
   }
 
-  protected setCallToActionLabel(): void {
-    const label: string = this.return ? 'Save and return' : 'Continue';
-    this.callToActionLabel = label;
-  }
-
   protected setBackLink(): void {
     const route: string = this.return ? this.return.url[0] : '/registration/your-details';
     this.backService.setBackLink({ url: [route] });
@@ -48,7 +43,7 @@ export class UsernamePasswordComponent extends CreateUsernameDirective {
   }
 
   protected setFormSubmissionLink(): string {
-    return this.return ? this.return.url[0] : '/registration/create-security-question';
+    return this.return ? '/registration/confirm-details' : '/registration/create-security-question';
   }
 
   protected save(): void {

--- a/src/app/features/create-account/user/username-password/username-password.component.ts
+++ b/src/app/features/create-account/user/username-password/username-password.component.ts
@@ -6,25 +6,32 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { RegistrationService } from '@core/services/registration.service';
 import { CreateUsernameDirective } from '@shared/directives/user/create-username.directive';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
   selector: 'app-username-password',
   templateUrl: './username-password.component.html',
 })
 export class UsernamePasswordComponent extends CreateUsernameDirective {
+  public createAccountNewDesign: boolean;
+
   constructor(
     protected backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
     protected registrationService: RegistrationService,
     protected router: Router,
+    private featureFlagsService: FeatureFlagsService,
   ) {
     super(backService, errorSummaryService, formBuilder, registrationService, router);
   }
 
   protected init(): void {
     this.return = this.registrationService.returnTo$.value;
-    this.setBackLink();
+    this.featureFlagsService.configCatClient.getValueAsync('createAccountNewDesign', false).then((value) => {
+      this.createAccountNewDesign = value;
+      this.setBackLink();
+    });
   }
 
   protected setBackLink(): void {
@@ -43,7 +50,10 @@ export class UsernamePasswordComponent extends CreateUsernameDirective {
   }
 
   protected setFormSubmissionLink(): string {
-    return this.return ? '/registration/confirm-details' : '/registration/create-security-question';
+    if (this.createAccountNewDesign) {
+      return this.return ? '/registration/confirm-details' : '/registration/create-security-question';
+    }
+    return this.return ? '/registration/confirm-account-details' : '/registration/create-security-question';
   }
 
   protected save(): void {

--- a/src/app/features/create-account/user/username-password/username-password.component.ts
+++ b/src/app/features/create-account/user/username-password/username-password.component.ts
@@ -16,7 +16,7 @@ export class UsernamePasswordComponent extends CreateUsernameDirective {
   public createAccountNewDesign: boolean;
 
   constructor(
-    protected backService: BackService,
+    public backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected formBuilder: FormBuilder,
     protected registrationService: RegistrationService,
@@ -34,9 +34,13 @@ export class UsernamePasswordComponent extends CreateUsernameDirective {
     });
   }
 
-  protected setBackLink(): void {
-    const route: string = this.return ? this.return.url[0] : '/registration/your-details';
-    this.backService.setBackLink({ url: [route] });
+  public setBackLink(): void {
+    if (this.return) {
+      const url = this.createAccountNewDesign ? 'confirm-details' : 'confirm-account-details';
+      this.backService.setBackLink({ url: ['registration', url] });
+      return;
+    }
+    this.backService.setBackLink({ url: ['registration', 'your-details'] });
   }
 
   protected setupSubscriptions(): void {

--- a/src/app/features/create-account/user/your-details/your-details.component.spec.ts
+++ b/src/app/features/create-account/user/your-details/your-details.component.spec.ts
@@ -256,7 +256,7 @@ describe('YourDetailsComponent', () => {
     expect(updateState).toHaveBeenCalledWith(formInputs);
   });
 
-  it('should submit and go to create-username-password url when the form is valid', async () => {
+  it('should submit and go to username-password url when the form is valid', async () => {
     const { component, spy } = await setup();
     const form = component.fixture.componentInstance.form;
     const continueButton = component.getByText('Continue');
@@ -276,6 +276,7 @@ describe('YourDetailsComponent', () => {
     const { component, spy } = await setup();
     const form = component.fixture.componentInstance.form;
 
+    component.fixture.componentInstance.createAccountNewDesign = true;
     component.fixture.componentInstance.return = { url: ['registration', 'confirm-details'] };
 
     form.controls['fullname'].setValue('name');

--- a/src/app/features/create-account/user/your-details/your-details.component.spec.ts
+++ b/src/app/features/create-account/user/your-details/your-details.component.spec.ts
@@ -272,6 +272,24 @@ describe('YourDetailsComponent', () => {
     expect(spy).toHaveBeenCalledWith(['registration', 'username-password']);
   });
 
+  it('should submit and go to confirm-details url when the form is valid and return URL is not null', async () => {
+    const { component, spy } = await setup();
+    const form = component.fixture.componentInstance.form;
+
+    component.fixture.componentInstance.return = { url: ['registration', 'confirm-details'] };
+
+    form.controls['fullname'].setValue('name');
+    form.controls['jobTitle'].setValue('job');
+    form.controls['email'].setValue('name@email.com');
+    form.controls['phone'].setValue('01234567890');
+
+    const continueButton = component.getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.valid).toBeTruthy();
+    expect(spy).toHaveBeenCalledWith(['registration', 'confirm-details']);
+  });
+
   describe('setBackLink()', () => {
     it('should set the correct back link', async () => {
       const { component } = await setup();

--- a/src/app/features/create-account/user/your-details/your-details.component.spec.ts
+++ b/src/app/features/create-account/user/your-details/your-details.component.spec.ts
@@ -292,7 +292,7 @@ describe('YourDetailsComponent', () => {
   });
 
   describe('setBackLink()', () => {
-    it('should set the correct back link', async () => {
+    it('should set the back link to new-select-main-service if the feature flag is on and return url is null', async () => {
       const { component } = await setup();
       const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
 
@@ -301,6 +301,19 @@ describe('YourDetailsComponent', () => {
 
       expect(backLinkSpy).toHaveBeenCalledWith({
         url: ['registration', 'new-select-main-service'],
+      });
+    });
+
+    it('should set the back link to new-select-main-service if the feature flag is on and return url is not null', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.return = { url: ['registration', 'confirm-details'] };
+      component.fixture.componentInstance.setBackLink();
+      component.fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'confirm-details'],
       });
     });
   });

--- a/src/app/features/create-account/user/your-details/your-details.component.spec.ts
+++ b/src/app/features/create-account/user/your-details/your-details.component.spec.ts
@@ -5,7 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BackService } from '@core/services/back.service';
 import { UserService } from '@core/services/user.service';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
-import { MockUserService } from '@core/test-utils/MockUserService';
+import { MockUserServiceWithNoUserDetails } from '@core/test-utils/MockUserService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
@@ -25,7 +25,7 @@ describe('YourDetailsComponent', () => {
         },
         {
           provide: UserService,
-          useClass: MockUserService,
+          useClass: MockUserServiceWithNoUserDetails,
         },
       ],
     });

--- a/src/app/features/create-account/user/your-details/your-details.component.ts
+++ b/src/app/features/create-account/user/your-details/your-details.component.ts
@@ -28,7 +28,12 @@ export class YourDetailsComponent extends AccountDetailsDirective {
   }
 
   public setBackLink(): void {
-    const url = this.createAccountNewDesign ? 'new-select-main-service' : 'confirm-workplace-details';
+    let url: string;
+    if (this.createAccountNewDesign) {
+      url = this.return ? 'confirm-details' : 'new-select-main-service';
+    } else {
+      url = this.return ? 'confirm-account-details' : 'confirm-workplace-details';
+    }
     this.backService.setBackLink({ url: ['registration', url] });
   }
 

--- a/src/app/features/create-account/user/your-details/your-details.component.ts
+++ b/src/app/features/create-account/user/your-details/your-details.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
+import { UserDetails } from '@core/model/userDetails.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { RegistrationService } from '@core/services/registration.service';
@@ -44,6 +45,17 @@ export class YourDetailsComponent extends AccountDetailsDirective {
       false,
     );
     this.return = this.registrationService.returnTo$.value;
+    this.prefillFormIfUserDetailsExist();
+  }
+
+  protected prefillFormIfUserDetailsExist(): void {
+    this.subscriptions.add(
+      this.userService.userDetails$.subscribe((userDetails: UserDetails) => {
+        if (userDetails) {
+          this.prefillForm(userDetails);
+        }
+      }),
+    );
   }
 
   protected setFormSubmissionLink(): string {

--- a/src/app/features/create-account/user/your-details/your-details.component.ts
+++ b/src/app/features/create-account/user/your-details/your-details.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { RegistrationService } from '@core/services/registration.service';
 import { UserService } from '@core/services/user.service';
 import { AccountDetailsDirective } from '@shared/directives/user/account-details.directive';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
@@ -12,10 +13,11 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
   templateUrl: './your-details.component.html',
 })
 export class YourDetailsComponent extends AccountDetailsDirective {
-  createAccountNewDesign: boolean;
+  public createAccountNewDesign: boolean;
 
   constructor(
     private userService: UserService,
+    private registrationService: RegistrationService,
     public backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
@@ -36,10 +38,12 @@ export class YourDetailsComponent extends AccountDetailsDirective {
       'createAccountNewDesign',
       false,
     );
+    this.return = this.registrationService.returnTo$.value;
   }
 
   protected save(): void {
     this.userService.updateState(this.setUserDetails());
-    this.router.navigate(['registration', 'username-password']);
+    const url = this.return ? 'confirm-details' : 'username-password';
+    this.router.navigate(['registration', url]);
   }
 }

--- a/src/app/features/create-account/user/your-details/your-details.component.ts
+++ b/src/app/features/create-account/user/your-details/your-details.component.ts
@@ -41,9 +41,16 @@ export class YourDetailsComponent extends AccountDetailsDirective {
     this.return = this.registrationService.returnTo$.value;
   }
 
+  protected setFormSubmissionLink(): string {
+    if (this.createAccountNewDesign) {
+      return this.return ? 'confirm-details' : 'username-password';
+    }
+    return this.return ? 'confirm-account-details' : 'username-password';
+  }
+
   protected save(): void {
     this.userService.updateState(this.setUserDetails());
-    const url = this.return ? 'confirm-details' : 'username-password';
+    const url = this.setFormSubmissionLink();
     this.router.navigate(['registration', url]);
   }
 }

--- a/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.html
+++ b/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.html
@@ -10,11 +10,13 @@
           [topBorder]="true"
           [summaryList]="workplaceNameAndAddress"
           (setReturn)="onSetReturn()"
+          data-testid="workplaceNameAddress"
         ></app-summary-list>
         <app-summary-list
           [wrapBorder]="true"
           [summaryList]="mainService"
           (setReturn)="onSetReturn()"
+          data-testid="mainService"
         ></app-summary-list>
       </div>
     </ng-template>

--- a/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
+++ b/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
@@ -11,37 +11,40 @@ import { MockUserService } from '@core/test-utils/MockUserService';
 import { RegistrationModule } from '@features/registration/registration.module';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { fireEvent, render } from '@testing-library/angular';
+import { getByTestId, render, within } from '@testing-library/angular';
 
 import { ConfirmWorkplaceDetailsComponent } from './confirm-workplace-details.component';
 
 describe('ConfirmWorkplaceDetailsComponent', () => {
   async function setup() {
-    const { fixture, getByText, getAllByText, queryByText } = await render(ConfirmWorkplaceDetailsComponent, {
-      imports: [
-        SharedModule,
-        RegistrationModule,
-        RouterTestingModule,
-        HttpClientTestingModule,
-        FormsModule,
-        ReactiveFormsModule,
-      ],
-      providers: [
-        {
-          provide: RegistrationService,
-          useClass: MockRegistrationServiceWithMainService,
-        },
-        {
-          provide: EstablishmentService,
-          useClass: MockEstablishmentService,
-        },
-        {
-          provide: UserService,
-          useClass: MockUserService,
-        },
-        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
-      ],
-    });
+    const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(
+      ConfirmWorkplaceDetailsComponent,
+      {
+        imports: [
+          SharedModule,
+          RegistrationModule,
+          RouterTestingModule,
+          HttpClientTestingModule,
+          FormsModule,
+          ReactiveFormsModule,
+        ],
+        providers: [
+          {
+            provide: RegistrationService,
+            useClass: MockRegistrationServiceWithMainService,
+          },
+          {
+            provide: EstablishmentService,
+            useClass: MockEstablishmentService,
+          },
+          {
+            provide: UserService,
+            useClass: MockUserService,
+          },
+          { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+        ],
+      },
+    );
 
     const component = fixture.componentInstance;
 
@@ -51,6 +54,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       getAllByText,
       queryByText,
       getByText,
+      getByTestId,
     };
   }
 
@@ -163,7 +167,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
     });
 
     it('should set the change link for location ID to `find-workplace` when CQC regulated with location ID', async () => {
-      const { component, fixture, getAllByText } = await setup();
+      const { component, fixture, getByTestId } = await setup();
 
       component.workplace.isCQC = true;
       component.locationAddress.locationId = '123';
@@ -171,36 +175,38 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       component.setWorkplaceDetails();
       fixture.detectChanges();
 
-      const changeWorkplaceAddressLink = getAllByText('Change')[0];
-      fireEvent.click(changeWorkplaceAddressLink);
+      const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
+      const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeWorkplaceAddressLink.getAttribute('href')).toBe('/registration/find-workplace');
+      expect(changeLink.getAttribute('href')).toBe('/registration/find-workplace');
     });
 
     it('should set the change link for workplace address to `workplace-name-address` when location ID is null', async () => {
-      const { component, fixture, getAllByText } = await setup();
+      const { component, fixture, getByTestId } = await setup();
 
+      component.workplace.isCQC = false;
       component.locationAddress.locationId = null;
       component.createAccountNewDesign = true;
       component.setWorkplaceDetails();
       fixture.detectChanges();
 
-      const changeWorkplaceAddressLink = getAllByText('Change')[0];
-      fireEvent.click(changeWorkplaceAddressLink);
+      const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
+      const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeWorkplaceAddressLink.getAttribute('href')).toBe('/registration/workplace-name-address');
+      expect(changeLink.getAttribute('href')).toBe('/registration/workplace-name-address');
     });
 
     it('should set the change link for main service to `select-main-service`', async () => {
-      const { component, fixture, getAllByText } = await setup();
+      const { component, fixture, getByTestId } = await setup();
 
       component.createAccountNewDesign = true;
+      component.setWorkplaceDetails();
       fixture.detectChanges();
 
-      const changeMainServiceLink = getAllByText('Change')[1];
-      fireEvent.click(changeMainServiceLink);
+      const workplaceNameAddressSummaryList = within(getByTestId('mainService'));
+      const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeMainServiceLink.getAttribute('href')).toBe('/registration/new-select-main-service');
+      expect(changeLink.getAttribute('href')).toBe('/registration/new-select-main-service');
     });
   });
 });

--- a/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
+++ b/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
@@ -181,7 +181,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       expect(changeLink.getAttribute('href')).toBe('/registration/find-workplace');
     });
 
-    it('should set the change link for workplace address to `workplace-name-address` when location ID is null', async () => {
+    it('should set the change link for workplace address to `find-workplace` when location ID is null', async () => {
       const { component, fixture, getByTestId } = await setup();
 
       component.workplace.isCQC = false;
@@ -193,7 +193,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
       const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeLink.getAttribute('href')).toBe('/registration/workplace-name-address');
+      expect(changeLink.getAttribute('href')).toBe('/registration/find-workplace');
     });
 
     it('should set the change link for main service to `select-main-service`', async () => {

--- a/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
+++ b/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
@@ -162,17 +162,45 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       expect(changeLinks.length).toEqual(2);
     });
 
-    it('should set the change link for workplace address to `find-your-workplace` when CQC regulated with location ID', async () => {
+    it('should set the change link for location ID to `find-workplace` when CQC regulated with location ID', async () => {
       const { component, fixture, getAllByText } = await setup();
 
+      component.workplace.isCQC = true;
       component.locationAddress.locationId = '123';
       component.createAccountNewDesign = true;
+      component.setWorkplaceDetails();
       fixture.detectChanges();
 
       const changeWorkplaceAddressLink = getAllByText('Change')[0];
       fireEvent.click(changeWorkplaceAddressLink);
 
       expect(changeWorkplaceAddressLink.getAttribute('href')).toBe('/registration/find-workplace');
+    });
+
+    it('should set the change link for workplace address to `workplace-name-address` when location ID is null', async () => {
+      const { component, fixture, getAllByText } = await setup();
+
+      component.locationAddress.locationId = null;
+      component.createAccountNewDesign = true;
+      component.setWorkplaceDetails();
+      fixture.detectChanges();
+
+      const changeWorkplaceAddressLink = getAllByText('Change')[0];
+      fireEvent.click(changeWorkplaceAddressLink);
+
+      expect(changeWorkplaceAddressLink.getAttribute('href')).toBe('/registration/workplace-name-address');
+    });
+
+    it('should set the change link for main service to `select-main-service`', async () => {
+      const { component, fixture, getAllByText } = await setup();
+
+      component.createAccountNewDesign = true;
+      fixture.detectChanges();
+
+      const changeMainServiceLink = getAllByText('Change')[1];
+      fireEvent.click(changeMainServiceLink);
+
+      expect(changeMainServiceLink.getAttribute('href')).toBe('/registration/new-select-main-service');
     });
   });
 });

--- a/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
+++ b/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
@@ -11,7 +11,7 @@ import { MockUserService } from '@core/test-utils/MockUserService';
 import { RegistrationModule } from '@features/registration/registration.module';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
 
 import { ConfirmWorkplaceDetailsComponent } from './confirm-workplace-details.component';
 
@@ -151,5 +151,28 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
     fixture.detectChanges();
 
     expect(getByText(expectedMainService, { exact: false })).toBeTruthy();
+  });
+
+  describe('Change links', () => {
+    it('should always display two change links', async () => {
+      const { getAllByText } = await setup();
+
+      const changeLinks = getAllByText('Change');
+
+      expect(changeLinks.length).toEqual(2);
+    });
+
+    it('should set the change link for workplace address to `find-your-workplace` when CQC regulated with location ID', async () => {
+      const { component, fixture, getAllByText } = await setup();
+
+      component.locationAddress.locationId = '123';
+      component.createAccountNewDesign = true;
+      fixture.detectChanges();
+
+      const changeWorkplaceAddressLink = getAllByText('Change')[0];
+      fireEvent.click(changeWorkplaceAddressLink);
+
+      expect(changeWorkplaceAddressLink.getAttribute('href')).toBe('/registration/find-workplace');
+    });
   });
 });

--- a/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.ts
+++ b/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.ts
@@ -34,4 +34,10 @@ export class ConfirmWorkplaceDetailsComponent extends ConfirmWorkplaceDetailsDir
       this.backService.setBackLink({ url: [this.flow, 'select-main-service'] });
     }
   }
+
+  public onSetReturn(): void {
+    this.registrationService.setReturnTo({
+      url: [`${this.flow}/confirm-details`],
+    });
+  }
 }

--- a/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.ts
+++ b/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.ts
@@ -1,9 +1,7 @@
 import { Component } from '@angular/core';
 import { BackService } from '@core/services/back.service';
 import { RegistrationService } from '@core/services/registration.service';
-import {
-  ConfirmWorkplaceDetailsDirective,
-} from '@shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive';
+import { ConfirmWorkplaceDetailsDirective } from '@shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
@@ -21,6 +19,7 @@ export class ConfirmWorkplaceDetailsComponent extends ConfirmWorkplaceDetailsDir
 
   protected async init(): Promise<void> {
     this.flow = '/registration';
+    this.resetReturnTo();
     this.getWorkplaceData();
   }
 
@@ -39,5 +38,9 @@ export class ConfirmWorkplaceDetailsComponent extends ConfirmWorkplaceDetailsDir
     this.registrationService.setReturnTo({
       url: [`${this.flow}/confirm-details`],
     });
+  }
+
+  private resetReturnTo(): void {
+    this.registrationService.returnTo$.next(null);
   }
 }

--- a/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -5,8 +5,10 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BackService } from '@core/services/back.service';
 import { LocationService } from '@core/services/location.service';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockLocationService } from '@core/test-utils/MockLocationService';
 import { RegistrationModule } from '@features/registration/registration.module';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { throwError } from 'rxjs';
@@ -22,6 +24,10 @@ describe('FindYourWorkplaceComponent', () => {
         {
           provide: LocationService,
           useClass: MockLocationService,
+        },
+        {
+          provide: FeatureFlagsService,
+          useClass: MockFeatureFlagsService,
         },
         {
           provide: ActivatedRoute,
@@ -207,6 +213,19 @@ describe('FindYourWorkplaceComponent', () => {
 
       expect(backLinkSpy).toHaveBeenCalledWith({
         url: ['registration', 'new-workplace-not-found'],
+      });
+    });
+
+    it('should set the back link to `confirm-details` when returnToConfirmDetails is not null and feature flag is on', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.createAccountNewDesign = true;
+      component.fixture.componentInstance.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
+      component.fixture.componentInstance.setBackLink();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'confirm-details'],
       });
     });
   });

--- a/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.ts
+++ b/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.ts
@@ -5,7 +5,10 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { LocationService } from '@core/services/location.service';
 import { RegistrationService } from '@core/services/registration.service';
-import { FindYourWorkplaceDirective } from '@shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive';
+import {
+  FindYourWorkplaceDirective,
+} from '@shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
   selector: 'app-find-your-workplace',
@@ -20,7 +23,22 @@ export class FindYourWorkplaceComponent extends FindYourWorkplaceDirective {
     protected formBuilder: FormBuilder,
     protected registrationService: RegistrationService,
     protected locationService: LocationService,
+    protected featureFlagsService: FeatureFlagsService,
   ) {
-    super(router, backService, errorSummaryService, route, formBuilder, registrationService, locationService);
+    super(
+      router,
+      backService,
+      errorSummaryService,
+      route,
+      formBuilder,
+      registrationService,
+      locationService,
+      featureFlagsService,
+    );
+  }
+
+  protected navigateToConfirmDetails(): void {
+    const url = this.createAccountNewDesign ? 'confirm-details' : 'confirm-workplace-details';
+    this.backService.setBackLink({ url: [this.flow, url] });
   }
 }

--- a/src/app/features/create-account/workplace/is-this-your-workplace/is-this-your-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/is-this-your-workplace/is-this-your-workplace.component.spec.ts
@@ -42,6 +42,7 @@ describe('IsThisYourWorkplaceComponent', () => {
             },
             selectedLocationAddress$: new BehaviorSubject(null),
             manuallyEnteredWorkplace$: new BehaviorSubject(null),
+            returnTo$: new BehaviorSubject(null),
           },
         },
         {
@@ -145,6 +146,20 @@ describe('IsThisYourWorkplaceComponent', () => {
     fireEvent.click(continueButton);
 
     expect(spy).toHaveBeenCalledWith(['registration', 'new-select-main-service']);
+  });
+
+  it('should navigate to the confirm-details page when selecting yes when returnToConfirmDetails is not null', async () => {
+    const { component, spy } = await setup();
+
+    component.fixture.componentInstance.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
+
+    const yesRadioButton = component.fixture.nativeElement.querySelector(`input[ng-reflect-value="yes"]`);
+    fireEvent.click(yesRadioButton);
+
+    const continueButton = component.getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(spy).toHaveBeenCalledWith(['registration', 'confirm-details']);
   });
 
   it('should navigate back to find-workplace url when selecting no', async () => {

--- a/src/app/features/create-account/workplace/is-this-your-workplace/is-this-your-workplace.component.ts
+++ b/src/app/features/create-account/workplace/is-this-your-workplace/is-this-your-workplace.component.ts
@@ -5,7 +5,9 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { RegistrationService } from '@core/services/registration.service';
-import { IsThisYourWorkplaceDirective } from '@shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive';
+import {
+  IsThisYourWorkplaceDirective,
+} from '@shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive';
 
 @Component({
   selector: 'app-is-this-your-workplace',
@@ -37,5 +39,9 @@ export class IsThisYourWorkplaceComponent extends IsThisYourWorkplaceDirective {
         ],
       },
     ];
+  }
+
+  protected getNextRoute(): string {
+    return this.returnToConfirmDetails ? 'confirm-details' : 'new-select-main-service';
   }
 }

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -178,7 +178,7 @@ describe('NewSelectMainServiceComponent', () => {
     expect(spy).toHaveBeenCalledWith(['registration', 'add-user-details']);
   });
 
-  it('should submit and go to the registration/confirm-details url when option selected and returnToConfirmDetails is set to true', async () => {
+  it('should submit and go to the registration/confirm-details url when option selected and returnToConfirmDetails is not null', async () => {
     const { component, fixture, getByText, getByLabelText, spy } = await setup();
 
     component.isParent = false;

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -178,6 +178,24 @@ describe('NewSelectMainServiceComponent', () => {
     expect(spy).toHaveBeenCalledWith(['registration', 'add-user-details']);
   });
 
+  it('should submit and go to the registration/confirm-details url when option selected and returnToConfirmDetails is set to true', async () => {
+    const { component, fixture, getByText, getByLabelText, spy } = await setup();
+
+    component.isParent = false;
+    component.isRegulated = true;
+    component.renderForm = true;
+    component.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
+    fixture.detectChanges();
+
+    const radioButton = getByLabelText('Name');
+    fireEvent.click(radioButton);
+
+    const continueButton = getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(spy).toHaveBeenCalledWith(['registration', 'confirm-details']);
+  });
+
   describe('setBackLink()', () => {
     it('should set back link to workplace-name-address when is regulated and address entered manually', async () => {
       const { component, fixture } = await setup();

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -340,5 +340,21 @@ describe('NewSelectMainServiceComponent', () => {
         url: ['registration', 'workplace-name'],
       });
     });
+
+    it('should set back link to confirm-details when returnToConfirmDetails is not null and feature flag is on', async () => {
+      const { component, fixture } = await setup();
+
+      const backLinkSpy = spyOn(component.backService, 'setBackLink');
+
+      component.createAccountNewDesign = true;
+      component.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
+
+      component.setBackLink();
+      fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'confirm-details'],
+      });
+    });
   });
 });

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
@@ -8,7 +8,9 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { RegistrationService } from '@core/services/registration.service';
 import { WorkplaceService } from '@core/services/workplace.service';
-import { SelectMainServiceDirective } from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
+import {
+  SelectMainServiceDirective,
+} from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
@@ -39,11 +41,11 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
     this.flow = this.route.snapshot.parent.url[0].path;
     this.isRegulated = this.registrationService.isRegulated();
     this.returnToConfirmDetails = this.registrationService.returnTo$.value;
-    this.setBackLink();
     this.createAccountNewDesign = await this.featureFlagsService.configCatClient.getValueAsync(
       'createAccountNewDesign',
       false,
     );
+    this.setBackLink();
   }
 
   protected getServiceCategories(): void {
@@ -71,7 +73,14 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   }
 
   public setBackLink(): void {
-    const route = this.isRegulated ? this.getCQCRegulatedBackLink() : this.getNonCQCRegulatedBackLink();
+    let route: string;
+    if (this.returnToConfirmDetails) {
+      route = this.createAccountNewDesign ? 'confirm-details' : 'confirm-workplace-details';
+      this.backService.setBackLink({ url: [this.flow, route] });
+      return;
+    }
+
+    route = this.isRegulated ? this.getCQCRegulatedBackLink() : this.getNonCQCRegulatedBackLink();
     this.backService.setBackLink({ url: [this.flow, route] });
   }
 

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
@@ -38,8 +38,7 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   protected async init(): Promise<void> {
     this.flow = this.route.snapshot.parent.url[0].path;
     this.isRegulated = this.registrationService.isRegulated();
-    this.workplace = this.establishmentService.primaryWorkplace;
-    this.workplace?.isParent ? (this.isParent = true) : (this.isParent = false);
+    this.returnToConfirmDetails = this.registrationService.returnTo$.value;
     this.setBackLink();
     this.createAccountNewDesign = await this.featureFlagsService.configCatClient.getValueAsync(
       'createAccountNewDesign',
@@ -67,7 +66,7 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   }
 
   protected navigateToNextPage(): void {
-    const url = this.isParent ? 'confirm-workplace-details' : 'add-user-details';
+    const url = this.returnToConfirmDetails ? 'confirm-details' : 'add-user-details';
     this.router.navigate([this.flow, url]);
   }
 

--- a/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.spec.ts
@@ -138,7 +138,24 @@ describe('SelectWorkplaceAddressComponent', () => {
 
       expect(form.valid).toBeTruthy();
 
-      expect(spy).toHaveBeenCalledWith(['/registration/new-select-main-service']);
+      expect(spy).toHaveBeenCalledWith(['/registration', 'new-select-main-service']);
+    });
+
+    it('should navigate to the confirm-details page in registration flow when workplace selected, Continue clicked and returnToConfirmDetails is not null', async () => {
+      const { component, spy, getByText } = await setup();
+
+      component.createAccountNewDesign = true;
+      component.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
+
+      const form = component.form;
+      form.controls['address'].setValue('1');
+      form.controls['address'].markAsDirty();
+
+      const continueButton = getByText('Continue');
+      fireEvent.click(continueButton);
+
+      expect(form.valid).toBeTruthy();
+      expect(spy).toHaveBeenCalledWith(['/registration', 'confirm-details']);
     });
   });
 });

--- a/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.ts
@@ -27,6 +27,7 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
   protected init(): void {
     this.flow = '/registration';
     this.registrationService.manuallyEnteredWorkplace$.next(false);
+    this.returnToConfirmDetails = this.registrationService.returnTo$.value;
     this.setupSubscriptions();
   }
 
@@ -61,5 +62,12 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
 
   public onLocationChange(index): void {
     this.registrationService.selectedLocationAddress$.next(this.locationAddresses[index]);
+  }
+
+  protected getNextRoute(): string {
+    if (this.createAccountNewDesign) {
+      return this.returnToConfirmDetails ? 'confirm-details' : 'new-select-main-service';
+    }
+    return this.returnToConfirmDetails ? 'confirm-details' : 'select-main-service';
   }
 }

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -328,18 +328,5 @@ describe('WorkplaceNameAddressComponent', () => {
         url: ['/registration', 'select-workplace-address'],
       });
     });
-
-    it('should set the back link to `confirm-details` when returnToConfirmDetails is not null and feature flag is on', async () => {
-      const { component } = await setup();
-      const backLinkSpy = spyOn(component.backService, 'setBackLink');
-
-      component.createAccountNewDesign = true;
-      component.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
-      component.setBackLink();
-
-      expect(backLinkSpy).toHaveBeenCalledWith({
-        url: ['/registration', 'confirm-details'],
-      });
-    });
   });
 });

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -118,6 +118,27 @@ describe('WorkplaceNameAddressComponent', () => {
     expect(spy).toHaveBeenCalledWith(['/registration', 'select-main-service']);
   });
 
+  it('should navigate to confirm-details page on success if returnToConfirmDetails is not null', async () => {
+    const { component, fixture, getByText, spy } = await setup();
+    const form = component.form;
+
+    form.controls['workplaceName'].setValue('Workplace');
+    form.controls['address1'].setValue('1 Main Street');
+    form.controls['townOrCity'].setValue('London');
+    form.controls['county'].setValue('Greater London');
+    form.controls['postcode'].setValue('SE1 1AA');
+
+    component.createAccountNewDesign = true;
+    component.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
+    fixture.detectChanges();
+
+    const continueButton = getByText('Continue');
+    fireEvent.click(continueButton);
+
+    expect(form.invalid).toBeFalsy();
+    expect(spy).toHaveBeenCalledWith(['/registration', 'confirm-details']);
+  });
+
   describe('Error messages', () => {
     it(`should display an error message when workplace name isn't filled in`, async () => {
       const { component, getByText, getAllByText } = await setup();

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -328,5 +328,18 @@ describe('WorkplaceNameAddressComponent', () => {
         url: ['/registration', 'select-workplace-address'],
       });
     });
+
+    it('should set the back link to `confirm-details` when returnToConfirmDetails is not null and feature flag is on', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.backService, 'setBackLink');
+
+      component.createAccountNewDesign = true;
+      component.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
+      component.setBackLink();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['/registration', 'confirm-details'],
+      });
+    });
   });
 });

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
@@ -66,11 +66,6 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
   }
 
   public setBackLink(): void {
-    if (this.returnToConfirmDetails) {
-      this.setBackLinkToConfirmDetails();
-      return;
-    }
-
     if (this.returnToWorkplaceNotFound && this.createAccountNewDesign) {
       this.backService.setBackLink({ url: [this.flow, 'new-workplace-not-found'] });
       return;
@@ -89,10 +84,5 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
       return this.returnToConfirmDetails ? 'confirm-details' : 'new-select-main-service';
     }
     return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
-  }
-
-  protected setBackLinkToConfirmDetails(): void {
-    const url = this.createAccountNewDesign ? 'confirm-details' : 'confirm-workplace-details';
-    this.backService.setBackLink({ url: [this.flow, url] });
   }
 }

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
@@ -16,10 +16,6 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
     '../../../../shared/directives/create-workplace/workplace-name-address/workplace-name-address.component.html',
 })
 export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective {
-  public returnToWorkplaceNotFound: boolean;
-  public isCqcRegulated: boolean;
-  public createAccountNewDesign: boolean;
-
   constructor(
     private registrationService: RegistrationService,
     private featureFlagsService: FeatureFlagsService,
@@ -36,6 +32,7 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     this.flow = '/registration';
     this.title = `What's your workplace name and address?`;
     this.workplaceErrorMessage = 'Enter the name of your workplace';
+    this.returnToConfirmDetails = this.registrationService.returnTo$.value;
     this.returnToWorkplaceNotFound = this.registrationService.workplaceNotFound$.value;
     this.isCqcRegulated = this.registrationService.isCqcRegulated$.value;
 
@@ -64,7 +61,7 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
   protected setSelectedLocationAddress(): void {
     this.registrationService.selectedLocationAddress$.next(this.getLocationAddress());
     this.registrationService.manuallyEnteredWorkplace$.next(true);
-    const url = this.createAccountNewDesign ? 'new-select-main-service' : 'select-main-service';
+    const url = this.getNextRoute();
     this.router.navigate([this.flow, url]);
   }
 
@@ -80,5 +77,12 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     }
 
     this.backService.setBackLink({ url: [this.flow, 'select-workplace-address'] });
+  }
+
+  protected getNextRoute(): string {
+    if (this.createAccountNewDesign) {
+      return this.returnToConfirmDetails ? 'confirm-details' : 'new-select-main-service';
+    }
+    return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
   }
 }

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
@@ -66,6 +66,11 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
   }
 
   public setBackLink(): void {
+    if (this.returnToConfirmDetails) {
+      this.setBackLinkToConfirmDetails();
+      return;
+    }
+
     if (this.returnToWorkplaceNotFound && this.createAccountNewDesign) {
       this.backService.setBackLink({ url: [this.flow, 'new-workplace-not-found'] });
       return;
@@ -84,5 +89,10 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
       return this.returnToConfirmDetails ? 'confirm-details' : 'new-select-main-service';
     }
     return this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
+  }
+
+  protected setBackLinkToConfirmDetails(): void {
+    const url = this.createAccountNewDesign ? 'confirm-details' : 'confirm-workplace-details';
+    this.backService.setBackLink({ url: [this.flow, url] });
   }
 }

--- a/src/app/features/registration/select-workplace/select-workplace.component.spec.ts
+++ b/src/app/features/registration/select-workplace/select-workplace.component.spec.ts
@@ -120,6 +120,23 @@ describe('SelectWorkplaceComponent', () => {
       expect(spy).toHaveBeenCalledWith(['/registration', 'new-select-main-service']);
     });
 
+    it('should navigate to the confirm-details page in registration flow when returnToConfirmDetails is not null', async () => {
+      const { component, getByText, fixture, spy } = await setup();
+
+      component.createAccountNewDesign = true;
+      component.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
+      component.setNextRoute();
+      fixture.detectChanges();
+
+      const yesRadioButton = fixture.nativeElement.querySelector(`input[ng-reflect-value="123"]`);
+      fireEvent.click(yesRadioButton);
+
+      const continueButton = getByText('Continue');
+      fireEvent.click(continueButton);
+
+      expect(spy).toHaveBeenCalledWith(['/registration', 'confirm-details']);
+    });
+
     it('should navigate back to the find-workplace url in registration flow when Change clicked', async () => {
       const { component, fixture, getByText } = await setup();
       component.createAccountNewDesign = true;
@@ -127,6 +144,15 @@ describe('SelectWorkplaceComponent', () => {
 
       const changeButton = getByText('Change');
       expect(changeButton.getAttribute('href')).toBe('/registration/find-workplace');
+    });
+
+    it('should navigate to workplace-name-address url in registration flow when workplace not displayed button clicked', async () => {
+      const { component, fixture, getByText } = await setup();
+      component.createAccountNewDesign = true;
+      fixture.detectChanges();
+
+      const notDisplayedButton = getByText('Workplace is not displayed or is not correct');
+      expect(notDisplayedButton.getAttribute('href')).toBe('/registration/workplace-name-address');
     });
   });
 });

--- a/src/app/features/registration/select-workplace/select-workplace.component.ts
+++ b/src/app/features/registration/select-workplace/select-workplace.component.ts
@@ -26,6 +26,7 @@ export class SelectWorkplaceComponent extends SelectWorkplaceDirective {
 
   protected init(): void {
     this.flow = '/registration';
+    this.returnToConfirmDetails = this.registrationService.returnTo$.value;
     this.setupSubscription();
   }
 

--- a/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
+++ b/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ErrorDetails } from '@core/model/errorSummary.model';
 import { LocationAddress } from '@core/model/location.model';
+import { URLStructure } from '@core/model/url.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { RegistrationService } from '@core/services/registration.service';
@@ -21,6 +22,7 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
   public isCQCLocationUpdate: boolean;
   public createAccountNewDesign: boolean;
   public enteredPostcode: string;
+  public returnToConfirmDetails: URLStructure;
   protected subscriptions: Subscription = new Subscription();
   protected nextRoute: string;
 

--- a/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
+++ b/src/app/features/workplace-find-and-select/select-workplace/select-workplace.directive.ts
@@ -60,8 +60,12 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
     this.backService.setBackLink({ url: [`${this.flow}/${backLink}`] });
   }
 
-  protected setNextRoute(): void {
-    this.nextRoute = this.createAccountNewDesign ? 'new-select-main-service' : 'select-main-service';
+  public setNextRoute(): void {
+    if (this.createAccountNewDesign) {
+      this.nextRoute = this.returnToConfirmDetails ? 'confirm-details' : 'new-select-main-service';
+    } else {
+      this.nextRoute = this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
+    }
   }
 
   protected setupForm(): void {

--- a/src/app/shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive.ts
+++ b/src/app/shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive.ts
@@ -73,7 +73,7 @@ export class ConfirmWorkplaceDetailsDirective implements OnInit, OnDestroy {
       {
         label: 'Name',
         data: this.locationAddress.locationName,
-        route: { url: [this.flow, 'workplace-name-address'] },
+        route: { url: [this.flow, 'find-workplace'] },
       },
       {
         label: 'Address',

--- a/src/app/shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive.ts
+++ b/src/app/shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive.ts
@@ -59,7 +59,7 @@ export class ConfirmWorkplaceDetailsDirective implements OnInit, OnDestroy {
       {
         label: 'CQC location ID',
         data: this.locationAddress.locationId,
-        route: { url: ['/'] },
+        route: { url: [this.flow, 'find-workplace'] },
       },
       {
         label: 'Name and address',

--- a/src/app/shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive.ts
+++ b/src/app/shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive.ts
@@ -49,7 +49,7 @@ export class ConfirmWorkplaceDetailsDirective implements OnInit, OnDestroy {
       {
         label: 'Main service',
         data: this.workplace.name,
-        route: { url: ['/'] },
+        route: { url: [this.flow, 'new-select-main-service'] },
       },
     ];
   }
@@ -73,7 +73,7 @@ export class ConfirmWorkplaceDetailsDirective implements OnInit, OnDestroy {
       {
         label: 'Name',
         data: this.locationAddress.locationName,
-        route: { url: ['/'] },
+        route: { url: [this.flow, 'workplace-name-address'] },
       },
       {
         label: 'Address',

--- a/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { Establishment } from '@core/model/establishment.model';
 import { LocationAddress } from '@core/model/location.model';
+import { URLStructure } from '@core/model/url.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -22,6 +23,7 @@ export class IsThisYourWorkplaceDirective implements OnInit, AfterViewInit {
   public workplace: Establishment;
   public isParent: boolean;
   public searchMethod: string;
+  public returnToConfirmDetails: URLStructure;
 
   constructor(
     protected errorSummaryService: ErrorSummaryService,
@@ -35,6 +37,7 @@ export class IsThisYourWorkplaceDirective implements OnInit, AfterViewInit {
 
   ngOnInit(): void {
     this.flow = this.route.snapshot.parent.url[0].path;
+    this.returnToConfirmDetails = this.workplaceInterfaceService.returnTo$.value;
     this.setupForm();
     this.setBackLink();
     this.locationData = this.workplaceInterfaceService.locationAddresses$.value[0];
@@ -80,7 +83,7 @@ export class IsThisYourWorkplaceDirective implements OnInit, AfterViewInit {
       if (yourWorkplace.value === 'yes') {
         this.workplaceInterfaceService.manuallyEnteredWorkplace$.next(false);
         this.setCurrentLocationToSelectedAddress();
-        this.router.navigate([this.flow, 'new-select-main-service']);
+        this.router.navigate([this.flow, this.getNextRoute()]);
       } else {
         this.router.navigate([this.flow, 'find-workplace']);
       }
@@ -92,4 +95,7 @@ export class IsThisYourWorkplaceDirective implements OnInit, AfterViewInit {
   private setCurrentLocationToSelectedAddress(): void {
     this.workplaceInterfaceService.selectedLocationAddress$.next(this.locationData);
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  protected getNextRoute(): void {}
 }

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { Router } from '@angular/router';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { Service, ServiceGroup } from '@core/model/services.model';
+import { URLStructure } from '@core/model/url.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { WorkplaceService } from '@core/services/workplace.service';
@@ -25,6 +26,7 @@ export class SelectMainServiceDirective implements OnInit, OnDestroy, AfterViewI
   public renderForm = false;
   public serverError: string;
   public submitted = false;
+  public returnToConfirmDetails: URLStructure;
 
   constructor(
     protected backService: BackService,

--- a/src/app/shared/directives/create-workplace/select-workplace-address.directive.ts
+++ b/src/app/shared/directives/create-workplace/select-workplace-address.directive.ts
@@ -3,6 +3,7 @@ import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/fo
 import { Router } from '@angular/router';
 import { ErrorDetails } from '@core/model/errorSummary.model';
 import { LocationAddress } from '@core/model/location.model';
+import { URLStructure } from '@core/model/url.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
@@ -20,6 +21,7 @@ export class SelectWorkplaceAddressDirective implements OnInit, OnDestroy, After
   public submitted = false;
   public createAccountNewDesign: boolean;
   public workplaceNotListedLink: string;
+  public returnToConfirmDetails: URLStructure;
   protected selectedLocationAddress: LocationAddress;
   protected subscriptions: Subscription = new Subscription();
 
@@ -78,22 +80,15 @@ export class SelectWorkplaceAddressDirective implements OnInit, OnDestroy, After
     this.errorSummaryService.syncFormErrorsEvent.next(true);
 
     if (this.form.valid) {
-      this.navigateToNextRoute(this.selectedLocationAddress.locationName);
+      this.navigateToNextRoute();
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }
   }
 
-  protected navigateToNextRoute(locationName: string): void {
-    if (this.createAccountNewDesign) {
-      this.router.navigate([`${this.flow}/new-select-main-service`]);
-    } else {
-      if (locationName.length) {
-        this.router.navigate([`${this.flow}/select-main-service`]);
-      } else {
-        this.router.navigate([`${this.flow}/enter-workplace-address`]);
-      }
-    }
+  protected navigateToNextRoute(): void {
+    const url = this.getNextRoute();
+    this.router.navigate([this.flow, url]);
   }
 
   public getLocationName(location: LocationAddress): string {
@@ -117,6 +112,9 @@ export class SelectWorkplaceAddressDirective implements OnInit, OnDestroy, After
   public getFormErrorMessage(item: string, errorType: string): string {
     return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  protected getNextRoute(): void {}
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();

--- a/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
+++ b/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { ActivatedRoute, Router } from '@angular/router';
 import { ErrorDetails } from '@core/model/errorSummary.model';
 import { LocationAddress } from '@core/model/location.model';
+import { URLStructure } from '@core/model/url.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { SanitizePostcodeUtil } from '@core/utils/sanitize-postcode-util';
@@ -56,6 +57,10 @@ export class WorkplaceNameAddressDirective implements OnInit, OnDestroy, AfterVi
   public submitted = false;
   public title: string;
   public workplaceErrorMessage: string;
+  public returnToConfirmDetails: URLStructure;
+  public returnToWorkplaceNotFound: boolean;
+  public isCqcRegulated: boolean;
+  public createAccountNewDesign: boolean;
   protected flow: string;
   protected workplaceNameMaxLength = 120;
   protected addressMaxLength = 40;

--- a/src/app/shared/directives/user/account-details.directive.ts
+++ b/src/app/shared/directives/user/account-details.directive.ts
@@ -176,14 +176,12 @@ export abstract class AccountDetailsDirective implements OnInit, OnDestroy, Afte
   }
 
   protected prefillForm(userDetails: UserDetails): void {
-    if (userDetails) {
-      this.form.setValue({
-        email: userDetails.email,
-        fullname: userDetails.fullname,
-        jobTitle: userDetails.jobTitle,
-        phone: userDetails.phone,
-      });
-    }
+    this.form.setValue({
+      email: userDetails.email,
+      fullname: userDetails.fullname,
+      jobTitle: userDetails.jobTitle,
+      phone: userDetails.phone,
+    });
   }
 
   protected onError(response: HttpErrorResponse): void {


### PR DESCRIPTION
#### Work done
- Add links to change buttons on confirm details page
- Reset the `returnTo$` variable every time the confirm details pages are rendered to to ensure back buttons still work when going back through the flow
- Back buttons set to return to confirm details page for: `find-workplace`, `select-main-service`, `user-details`, `username-password` and `security-question` components
- Continue buttons set to return to confirm details page for: `is-this-your-workplace`, `select-workplace`, `select-workplace-address`, `workplace-name-address`, `select-main-service`, `user-details`, `username-password` and `security-question` components
- Implement `prefillForm` function for user details page

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
