### PR TITLE
Fix: Create account change links - non CQC regulated

### DIFF
--- a/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
+++ b/src/app/features/add-workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
@@ -225,7 +225,22 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       expect(changeLink.getAttribute('href')).toBe('/add-workplace/find-workplace');
     });
 
-    it('should set the change link for workplace address to `find-workplace` when location ID is null', async () => {
+    it('should set the change link for workplace address to `find-workplace` when location ID is null and workplace is CQC regulated', async () => {
+      const { component, fixture, getByTestId } = await setup();
+
+      component.workplace.isCQC = true;
+      component.locationAddress.locationId = null;
+      component.createAccountNewDesign = true;
+      component.setWorkplaceDetails();
+      fixture.detectChanges();
+
+      const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
+      const changeLink = workplaceNameAddressSummaryList.getByText('Change');
+
+      expect(changeLink.getAttribute('href')).toBe('/add-workplace/find-workplace');
+    });
+
+    it('should set the change link for workplace address to `find-workplace-address` when workplace is not CQC regulated', async () => {
       const { component, fixture, getByTestId } = await setup();
 
       component.workplace.isCQC = false;
@@ -237,7 +252,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
       const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeLink.getAttribute('href')).toBe('/add-workplace/find-workplace');
+      expect(changeLink.getAttribute('href')).toBe('/add-workplace/find-workplace-address');
     });
 
     it('should set the change link for main service to `select-main-service`', async () => {

--- a/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
+++ b/src/app/features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component.spec.ts
@@ -181,7 +181,22 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       expect(changeLink.getAttribute('href')).toBe('/registration/find-workplace');
     });
 
-    it('should set the change link for workplace address to `find-workplace` when location ID is null', async () => {
+    it('should set the change link for workplace address to `find-workplace` when location ID is null and workplace is CQC regulated', async () => {
+      const { component, fixture, getByTestId } = await setup();
+
+      component.workplace.isCQC = true;
+      component.locationAddress.locationId = null;
+      component.createAccountNewDesign = true;
+      component.setWorkplaceDetails();
+      fixture.detectChanges();
+
+      const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
+      const changeLink = workplaceNameAddressSummaryList.getByText('Change');
+
+      expect(changeLink.getAttribute('href')).toBe('/registration/find-workplace');
+    });
+
+    it('should set the change link for workplace address to `find-workplace-address` when workplace is not CQC regulated', async () => {
       const { component, fixture, getByTestId } = await setup();
 
       component.workplace.isCQC = false;
@@ -193,7 +208,7 @@ describe('ConfirmWorkplaceDetailsComponent', () => {
       const workplaceNameAddressSummaryList = within(getByTestId('workplaceNameAddress'));
       const changeLink = workplaceNameAddressSummaryList.getByText('Change');
 
-      expect(changeLink.getAttribute('href')).toBe('/registration/find-workplace');
+      expect(changeLink.getAttribute('href')).toBe('/registration/find-workplace-address');
     });
 
     it('should set the change link for main service to `select-main-service`', async () => {

--- a/src/app/shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive.ts
+++ b/src/app/shared/directives/create-workplace/confirm-workplace-details/confirm-workplace-details.directive.ts
@@ -40,9 +40,13 @@ export class ConfirmWorkplaceDetailsDirective implements OnInit, OnDestroy {
 
   public setWorkplaceDetails(): void {
     if (this.workplace.isCQC && this.locationAddress.locationId) {
-      this.setCqcLocationIdWorkplaceDetails();
-    } else {
-      this.setNonLocationIdWorkplaceDetails();
+      this.setCqcRegulatedWithLocationIdWorkplaceDetails();
+    }
+    if (this.workplace.isCQC && !this.locationAddress.locationId) {
+      this.setCqcRegulatedWithoutLocationIdWorkplaceDetails();
+    }
+    if (!this.workplace.isCQC) {
+      this.setNonCqcRegulatedWorkplaceDetails();
     }
 
     this.mainService = [
@@ -54,7 +58,7 @@ export class ConfirmWorkplaceDetailsDirective implements OnInit, OnDestroy {
     ];
   }
 
-  protected setCqcLocationIdWorkplaceDetails(): void {
+  protected setCqcRegulatedWithLocationIdWorkplaceDetails(): void {
     this.workplaceNameAndAddress = [
       {
         label: 'CQC location ID',
@@ -68,12 +72,26 @@ export class ConfirmWorkplaceDetailsDirective implements OnInit, OnDestroy {
     ];
   }
 
-  protected setNonLocationIdWorkplaceDetails(): void {
+  protected setCqcRegulatedWithoutLocationIdWorkplaceDetails(): void {
     this.workplaceNameAndAddress = [
       {
         label: 'Name',
         data: this.locationAddress.locationName,
         route: { url: [this.flow, 'find-workplace'] },
+      },
+      {
+        label: 'Address',
+        data: this.nameAndAddress,
+      },
+    ];
+  }
+
+  protected setNonCqcRegulatedWorkplaceDetails(): void {
+    this.workplaceNameAndAddress = [
+      {
+        label: 'Name',
+        data: this.locationAddress.locationName,
+        route: { url: [this.flow, 'find-workplace-address'] },
       },
       {
         label: 'Address',


### PR DESCRIPTION
#### Work done
- Fix change link for non CQC regulated flow to go to `find-workplace-address` instead of `find-workplace`

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
