### PR TITLE
Fix: Find workplace address back link

### DIFF
--- a/src/app/features/add-workplace/find-workplace-address/find-workplace-address.component.spec.ts
+++ b/src/app/features/add-workplace/find-workplace-address/find-workplace-address.component.spec.ts
@@ -194,5 +194,20 @@ describe('FindWorkplaceComponent', () => {
         url: ['add-workplace', 'new-regulated-by-cqc'],
       });
     });
+
+    it('should set the back link to `confirm-workplace-details` when returnToConfirmDetails is not null', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.createAccountNewDesign = true;
+      component.fixture.componentInstance.returnToConfirmDetails = {
+        url: ['add-workplace', 'confirm-workplace-details'],
+      };
+      component.fixture.componentInstance.setBackLink();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['add-workplace', 'confirm-workplace-details'],
+      });
+    });
   });
 });

--- a/src/app/features/add-workplace/find-workplace-address/find-workplace-address.component.ts
+++ b/src/app/features/add-workplace/find-workplace-address/find-workplace-address.component.ts
@@ -28,6 +28,7 @@ export class FindWorkplaceAddressComponent extends FindWorkplaceAddress {
 
   protected init(): void {
     this.flow = 'add-workplace';
+    this.returnToConfirmDetails = this.workplaceService.returnTo$.value;
   }
 
   protected setupFormErrorsMap(): void {
@@ -58,5 +59,9 @@ export class FindWorkplaceAddressComponent extends FindWorkplaceAddress {
 
   protected onSuccess(data: LocationSearchResponse): void {
     this.workplaceService.locationAddresses$.next(data.postcodedata);
+  }
+
+  protected setBackLinkToConfirmDetailsPage(): void {
+    this.backService.setBackLink({ url: [this.flow, 'confirm-workplace-details'] });
   }
 }

--- a/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.spec.ts
@@ -185,5 +185,20 @@ describe('FindWorkplaceAddressComponent', () => {
         url: ['registration', 'new-regulated-by-cqc'],
       });
     });
+
+    it('should set the back link to `confirm-details` when returnToConfirmDetails is not null', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.createAccountNewDesign = true;
+      component.fixture.componentInstance.returnToConfirmDetails = {
+        url: ['registration', 'confirm-details'],
+      };
+      component.fixture.componentInstance.setBackLink();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'confirm-details'],
+      });
+    });
   });
 });

--- a/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.ts
+++ b/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.ts
@@ -61,7 +61,7 @@ export class FindWorkplaceAddressComponent extends FindWorkplaceAddress {
     this.registrationService.locationAddresses$.next(data.postcodedata);
   }
 
-  public setBackLinkToConfirmDetailsPage(): void {
+  protected setBackLinkToConfirmDetailsPage(): void {
     this.backService.setBackLink({ url: [this.flow, 'confirm-details'] });
   }
 }

--- a/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.ts
+++ b/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.ts
@@ -28,6 +28,7 @@ export class FindWorkplaceAddressComponent extends FindWorkplaceAddress {
 
   protected init(): void {
     this.flow = 'registration';
+    this.returnToConfirmDetails = this.registrationService.returnTo$.value;
   }
 
   protected setupFormErrorsMap(): void {
@@ -58,5 +59,9 @@ export class FindWorkplaceAddressComponent extends FindWorkplaceAddress {
 
   protected onSuccess(data: LocationSearchResponse): void {
     this.registrationService.locationAddresses$.next(data.postcodedata);
+  }
+
+  public setBackLinkToConfirmDetailsPage(): void {
+    this.backService.setBackLink({ url: [this.flow, 'confirm-details'] });
   }
 }

--- a/src/app/shared/directives/create-workplace/find-workplace-address/find-workplace-address.ts
+++ b/src/app/shared/directives/create-workplace/find-workplace-address/find-workplace-address.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { Router } from '@angular/router';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { LocationSearchResponse } from '@core/model/location.model';
+import { URLStructure } from '@core/model/url.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { LocationService } from '@core/services/location.service';
@@ -22,6 +23,7 @@ export class FindWorkplaceAddress implements OnInit, OnDestroy, AfterViewInit {
   public serverError: string;
   public submitted = false;
   public createAccountNewDesign: boolean;
+  public returnToConfirmDetails: URLStructure;
 
   constructor(
     public backService: BackService,
@@ -133,9 +135,16 @@ export class FindWorkplaceAddress implements OnInit, OnDestroy, AfterViewInit {
   }
 
   public setBackLink(): void {
+    if (this.returnToConfirmDetails) {
+      this.setBackLinkToConfirmDetailsPage();
+      return;
+    }
     const url = this.createAccountNewDesign ? 'new-regulated-by-cqc' : 'select-workplace-address';
     this.backService.setBackLink({ url: [this.flow, url] });
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  protected setBackLinkToConfirmDetailsPage(): void {}
 
   public getFirstErrorMessage(item: string): string {
     const errorType = Object.keys(this.form.get(item).errors)[0];


### PR DESCRIPTION
#### Work done
- Set back link on `find-workplace-address` component to confirm details url if you come from that page 

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
