### PR TITLE
Hotfix/wdf automatic update and field confirmation bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "exceljs": "^4.2.0",
         "express": "^4.17.1",
         "express-http-proxy": "^1.6.2",
-        "express-sanitizer": "^1.0.5",
+        "express-sanitizer": "^1.0.6",
         "file-saver": "^2.0.5",
         "govuk-frontend": "^3.10.2",
         "helmet": "^4.3.1",
@@ -71,7 +71,7 @@
         "rate-limiter-flexible": "^1.3.2",
         "request": "^2.88.2",
         "rxjs": "^6.6.7",
-        "rxjs-compat": "^6.6.3",
+        "rxjs-compat": "^6.6.7",
         "sequelize": "^5.3.0",
         "sequelize-cli": "^5.5.1",
         "sequelize-replace-enum-postgres": "^1.6.0",
@@ -82,7 +82,7 @@
         "text-encoding-utf-8": "^1.0.2",
         "tslib": "^2.1.0",
         "typescript": "^4.0.5",
-        "ua-parser-js": "^0.7.24",
+        "ua-parser-js": "^0.7.28",
         "url-parse": "^1.4.7",
         "uuid": "^3.4.0",
         "walk": "^2.3.14",
@@ -103,10 +103,10 @@
         "@testing-library/angular": "^10.3.2",
         "@testing-library/dom": "^7.31.0",
         "@testing-library/user-event": "^12.7.3",
-        "@types/faker": "^5.5.3",
+        "@types/faker": "^5.5.6",
         "@types/file-saver": "^2.0.2",
         "@types/jasmine": "^3.6.9",
-        "@types/jasminewd2": "~2.0.8",
+        "@types/jasminewd2": "~2.0.9",
         "@types/node": "^14.14.37",
         "@typescript-eslint/eslint-plugin": "4.0.0",
         "@typescript-eslint/parser": "3.10.1",
@@ -115,7 +115,7 @@
         "codelyzer": "^6.0.2",
         "eslint": "^7.23.0",
         "eslint-config-prettier": "^7.2.0",
-        "faker": "^5.4.0",
+        "faker": "^5.5.3",
         "husky": "^4.3.8",
         "jasmine-core": "^3.7.1",
         "jasmine-spec-reporter": "^6.0.0",
@@ -140,7 +140,7 @@
         "rimraf": "^3.0.2",
         "sandboxed-module": "^2.0.4",
         "sinon": "^9.2.4",
-        "sinon-chai": "^3.6.0",
+        "sinon-chai": "^3.7.0",
         "supertest": "^6.1.3",
         "ts-node": "~9.1.1",
         "tslint": "~6.1.3"
@@ -3839,9 +3839,9 @@
       "dev": true
     },
     "node_modules/@types/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-InxkM6sCFQTI6YQl29M/XGlO19ecv/EHH5X5zLEFdge2/qya8oIT0XkJUKTqheVYWJtGi+FBAfP7hbbunDiOmg==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.7.tgz",
+      "integrity": "sha512-ejzb61Q5zQTtS0ZIafgQ7ahO5ACzmGhG5PfX2hxWyth3k0/aysb4ZOxKQB8DbzwSPppA5jmFBwqnBxjv5hqI5Q==",
       "dev": true
     },
     "node_modules/@types/file-saver": {
@@ -3891,9 +3891,9 @@
       "dev": true
     },
     "node_modules/@types/jasminewd2": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/jasminewd2/-/jasminewd2-2.0.8.tgz",
-      "integrity": "sha512-d9p31r7Nxk0ZH0U39PTH0hiDlJ+qNVGjlt1ucOoTUptxb2v+Y5VMnsxfwN+i3hK4yQnqBi3FMmoMFcd1JHDxdg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jasminewd2/-/jasminewd2-2.0.10.tgz",
+      "integrity": "sha512-J7mDz7ovjwjc+Y9rR9rY53hFWKATcIkrr9DwQWmOas4/pnIPJTXawnzjwpHm3RSxz/e3ZVUvQ7cRbd5UQLo10g==",
       "dev": true,
       "dependencies": {
         "@types/jasmine": "*"
@@ -9773,12 +9773,11 @@
       }
     },
     "node_modules/express-sanitizer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/express-sanitizer/-/express-sanitizer-1.0.5.tgz",
-      "integrity": "sha512-48/Tf1DZ7JklRVTcXQLHAxhq4GNJTuHq2jjIYhyTmu0Bw+X06YPDD/e/tdn1QLYk706xw4N8JFxtjslRrDGb8g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/express-sanitizer/-/express-sanitizer-1.0.6.tgz",
+      "integrity": "sha512-77Ruhr/NTVGE2Ecc8pH3XedpreQiHRtwA+ONON0/nJam8Re/AvkGngd8EqKb2YKCqaL4Iw+W33IJXgHgMe7xaQ==",
       "dependencies": {
-        "sanitizer": "0.1.3",
-        "underscore": "1.8.3"
+        "sanitizer": "0.1.3"
       },
       "engines": {
         "node": "*"
@@ -9949,9 +9948,9 @@
       }
     },
     "node_modules/faker": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.4.0.tgz",
-      "integrity": "sha512-Y9n/Ky/xZx/Bj8DePvXspUYRtHl/rGQytoIT5LaxmNwSe3wWyOeOXb3lT6Dpipq240PVpeFaGKzScz/5fvff2g==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
       "dev": true
     },
     "node_modules/fast-csv": {
@@ -16509,7 +16508,10 @@
         "wide-align",
         "wrappy",
         "write-file-atomic",
-        "yallist"
+        "yallist",
+        "hosted-git-info",
+        "puka",
+        "ssri"
       ],
       "dev": true,
       "dependencies": {
@@ -23451,9 +23453,9 @@
       }
     },
     "node_modules/rxjs-compat": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.6.tgz",
-      "integrity": "sha512-P6JOpjCYUBdXLMktko0a6JHltGaktFJA2W3DWDIjc+I9x9IwRQprOrHQf/fIykY3wAaSbbZIt6GASGMVC1mGfQ=="
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.7.tgz",
+      "integrity": "sha512-szN4fK+TqBPOFBcBcsR0g2cmTTUF/vaFEOZNuSdfU8/pGFnNmmn2u8SystYXG1QMrjOPBc6XTKHMVfENDf6hHw=="
     },
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.14.1",
@@ -24359,10 +24361,14 @@
       }
     },
     "node_modules/sinon-chai": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.6.0.tgz",
-      "integrity": "sha512-bk2h+0xyKnmvazAnc7HE5esttqmCerSMcBtuB2PS2T4tG6x8woXAxZeJaOJWD+8reXHngnXn0RtIbfEW9OTHFg==",
-      "dev": true
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
     },
     "node_modules/sinon/node_modules/diff": {
       "version": "4.0.2",
@@ -27077,9 +27083,19 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.24",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
-      "integrity": "sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==",
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
       "engines": {
         "node": "*"
       }
@@ -33396,9 +33412,9 @@
       "dev": true
     },
     "@types/faker": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.6.tgz",
-      "integrity": "sha512-UCRj0kLg4sXs2XFVm48OU/wIjyJZkpRkwxhRGVQb5l5GmemkeW22WTz9iiDhYPBUqTzDsIWzhFRuF/4DD5+q2Q==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.7.tgz",
+      "integrity": "sha512-ejzb61Q5zQTtS0ZIafgQ7ahO5ACzmGhG5PfX2hxWyth3k0/aysb4ZOxKQB8DbzwSPppA5jmFBwqnBxjv5hqI5Q==",
       "dev": true
     },
     "@types/file-saver": {
@@ -33448,9 +33464,9 @@
       "dev": true
     },
     "@types/jasminewd2": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@types/jasminewd2/-/jasminewd2-2.0.9.tgz",
-      "integrity": "sha512-Oz+Faunpe2SimFvkMYMXxpK89WXl7rZHG8abTOKcGndu4xOoSbUZ+jUdZ0LQpmDqPEGLBWXF/yZP1tlsplGhzw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jasminewd2/-/jasminewd2-2.0.10.tgz",
+      "integrity": "sha512-J7mDz7ovjwjc+Y9rR9rY53hFWKATcIkrr9DwQWmOas4/pnIPJTXawnzjwpHm3RSxz/e3ZVUvQ7cRbd5UQLo10g==",
       "dev": true,
       "requires": {
         "@types/jasmine": "*"
@@ -50228,7 +50244,8 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "slash": {
       "version": "3.0.0",

--- a/src/app/core/test-utils/MockFeatureFlagService.ts
+++ b/src/app/core/test-utils/MockFeatureFlagService.ts
@@ -45,7 +45,7 @@ export class MockFeatureFlagsService extends FeatureFlagsService {
     },
     getValueAsync: () => {
       return new Promise((resolve) => {
-        return false;
+        return resolve(true);
       });
     },
   } as IConfigCatClient;

--- a/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
+++ b/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
@@ -39,6 +39,7 @@
         "
         [changeLink]="getRoutePath('staff-details')"
         (fieldConfirmation)="this.confirmField('mainJob')"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -75,6 +76,7 @@
         "
         [changeLink]="getRoutePath('staff-details')"
         (fieldConfirmation)="this.confirmField('contract')"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">

--- a/src/app/shared/components/staff-record-summary/employment/employment.component.html
+++ b/src/app/shared/components/staff-record-summary/employment/employment.component.html
@@ -36,6 +36,7 @@
         [changeLink]="getRoutePath('main-job-start-date')"
         (fieldConfirmation)="this.confirmField('mainJobStartDate')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -203,6 +204,7 @@
         [changeLink]="getRoutePath('days-of-sickness')"
         (fieldConfirmation)="this.confirmField('daysSick')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -244,6 +246,7 @@
         [changeLink]="getRoutePath('contract-with-zero-hours')"
         (fieldConfirmation)="this.confirmField('zeroHoursContract')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -289,6 +292,7 @@
         [changeLink]="getRoutePath('average-weekly-hours')"
         (fieldConfirmation)="this.confirmField('weeklyHoursAverage')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -334,6 +338,7 @@
         [changeLink]="getRoutePath('weekly-contracted-hours')"
         (fieldConfirmation)="this.confirmField('weeklyHoursContracted')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -376,6 +381,7 @@
         [changeLink]="getRoutePath('salary')"
         (fieldConfirmation)="this.confirmField('annualHourlyPay')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">

--- a/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
+++ b/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
@@ -22,6 +22,7 @@
         [changeLink]="getRoutePath('care-certificate')"
         (fieldConfirmation)="this.confirmField('careCertificate')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -65,6 +66,7 @@
         [changeLink]="getRoutePath('social-care-qualification')"
         (fieldConfirmation)="this.confirmField('qualificationInSocialCare')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -109,6 +111,7 @@
           this.confirmField('socialCareQualification'); this.confirmField('qualificationInSocialCare')
         "
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -151,6 +154,7 @@
         [changeLink]="getRoutePath('other-qualifications')"
         (fieldConfirmation)="this.confirmField('otherQualification')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
@@ -184,6 +188,7 @@
         [changeLink]="getRoutePath('other-qualifications-level')"
         (fieldConfirmation)="this.confirmField('highestQualification'); this.confirmField('otherQualification')"
         (setReturnClicked)="this.setReturn()"
+        [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">

--- a/src/app/shared/components/wdf-field-confirmation/wdf-field-confirmation.component.spec.ts
+++ b/src/app/shared/components/wdf-field-confirmation/wdf-field-confirmation.component.spec.ts
@@ -1,24 +1,70 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+import { WdfModule } from '@features/wdf/wdf.module';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
 
 import { WdfFieldConfirmationComponent } from './wdf-field-confirmation.component';
 
-describe('WdfFieldConfirmationComponent', () => {
-  let component: WdfFieldConfirmationComponent;
-  let fixture: ComponentFixture<WdfFieldConfirmationComponent>;
+describe('WdfFieldConfirmationComponent', async () => {
+  const setup = async () => {
+    const { fixture, getByText, queryByText } = await render(WdfFieldConfirmationComponent, {
+      imports: [SharedModule, RouterTestingModule, HttpClientTestingModule, BrowserModule, WdfModule],
+      providers: [],
+      declarations: [],
+      componentProperties: {
+        changeLink: ['123', 'nationality'],
+        workerUid: 'abc123',
+      },
+    });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [WdfFieldConfirmationComponent],
-    }).compileComponents();
-  });
+    const component = fixture.componentInstance;
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(WdfFieldConfirmationComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    return { component, fixture, getByText, queryByText };
+  };
 
-  it('should create', () => {
+  it('should render a WdfFieldConfirmationComponent', async () => {
+    const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should show meeting requirements message when Yes it is is clicked', async () => {
+    const { fixture, getByText } = await setup();
+
+    const yesItIsButton = getByText('Yes, it is', { exact: false });
+    yesItIsButton.click();
+
+    fixture.detectChanges();
+
+    expect(getByText('Meeting requirements')).toBeTruthy();
+  });
+
+  it('should call workerUid setter when worker uid is changed', async () => {
+    const { component } = await setup();
+
+    const setterSpy = spyOnProperty(component, 'workerUid', 'set').and.callThrough();
+
+    component.workerUid = 'def456';
+
+    expect(component.workerUid).toEqual('def456');
+    expect(setterSpy).toHaveBeenCalledWith('def456');
+  });
+
+  it('should remove meeting requirements message and show confirmation button when resetConfirmButtonClicked is run', async () => {
+    const { component, fixture, getByText, queryByText } = await setup();
+
+    const yesItIsButton = getByText('Yes, it is', { exact: false });
+    yesItIsButton.click();
+
+    fixture.detectChanges();
+
+    expect(getByText('Meeting requirements')).toBeTruthy();
+
+    component.resetConfirmButtonClicked();
+    fixture.detectChanges();
+
+    expect(queryByText('Meeting requirements')).toBeFalsy();
+    expect(getByText('Yes, it is', { exact: false })).toBeTruthy();
   });
 });

--- a/src/app/shared/components/wdf-field-confirmation/wdf-field-confirmation.component.ts
+++ b/src/app/shared/components/wdf-field-confirmation/wdf-field-confirmation.component.ts
@@ -5,18 +5,32 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   templateUrl: './wdf-field-confirmation.component.html',
 })
 export class WdfFieldConfirmationComponent {
-  @Input() changeLink: any[];
+  public confirmButtonClicked = false;
+  private _workerUid: string = null;
+
   @Output() fieldConfirmation: EventEmitter<Event> = new EventEmitter();
   @Output() setReturnClicked: EventEmitter<Event> = new EventEmitter();
+  @Input() changeLink: any[];
 
-  public confirmButtonClicked = false;
+  @Input() set workerUid(uid: string) {
+    this._workerUid = uid;
+    this.resetConfirmButtonClicked();
+  }
 
-  confirmField() {
+  get workerUid(): string {
+    return this._workerUid;
+  }
+
+  public confirmField(): void {
     this.fieldConfirmation.emit();
     this.confirmButtonClicked = true;
   }
 
-  setReturn() {
+  public resetConfirmButtonClicked(): void {
+    this.confirmButtonClicked = false;
+  }
+
+  public setReturn(): void {
     this.setReturnClicked.emit();
   }
 }

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -557,4 +557,31 @@ describe('WDF Field Confirmation for WorkplaceSummaryComponent', async () => {
       expect(component.allRequiredFieldsUpdated()).toBeTrue();
     });
   });
+
+  describe('Updating employer type automatically', async () => {
+    it('should call updateEmployerType function in ngOnInit when can edit establishment and on WDF page', async () => {
+      const { component } = await setup();
+
+      const updateFunction = spyOn(component, 'updateEmployerTypeIfNotUpdatedSinceEffectiveDate');
+
+      component.wdfNewDesign = true;
+
+      await component.ngOnInit();
+
+      expect(updateFunction).toHaveBeenCalled();
+    });
+
+    it('should call confirmField from updateEmployerType function when employer type is eligible but not updated since effective date', async () => {
+      const { component } = await setup();
+
+      const confirmField = spyOn(component, 'confirmField');
+
+      component.workplace.wdf.employerType.isEligible = true;
+      component.workplace.wdf.employerType.updatedSinceEffectiveDate = false;
+
+      component.updateEmployerTypeIfNotUpdatedSinceEffectiveDate();
+
+      expect(confirmField).toHaveBeenCalledWith('employerType');
+    });
+  });
 });

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -562,13 +562,16 @@ describe('WDF Field Confirmation for WorkplaceSummaryComponent', async () => {
     it('should call updateEmployerType function in ngOnInit when can edit establishment and on WDF page', async () => {
       const { component } = await setup();
 
-      const updateFunction = spyOn(component, 'updateEmployerTypeIfNotUpdatedSinceEffectiveDate');
+      const updateEmployerTypeIfNotUpdatedSinceEffectiveDate = spyOn(
+        component,
+        'updateEmployerTypeIfNotUpdatedSinceEffectiveDate',
+      );
 
       component.wdfNewDesign = true;
 
       await component.ngOnInit();
 
-      expect(updateFunction).toHaveBeenCalled();
+      expect(updateEmployerTypeIfNotUpdatedSinceEffectiveDate).toHaveBeenCalled();
     });
 
     it('should call confirmField from updateEmployerType function when employer type is eligible but not updated since effective date', async () => {

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.ts
@@ -206,11 +206,6 @@ export class WorkplaceSummaryComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   public updateEmployerTypeIfNotUpdatedSinceEffectiveDate(): void {
-    console.log(
-      this.workplace.wdf?.employerType.isEligible,
-      !this.workplace.wdf?.employerType.updatedSinceEffectiveDate,
-    );
-
     if (this.workplace.wdf?.employerType.isEligible && !this.workplace.wdf?.employerType.updatedSinceEffectiveDate) {
       this.confirmField('employerType');
     }

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.ts
@@ -110,21 +110,16 @@ export class WorkplaceSummaryComponent implements OnInit, OnDestroy, OnChanges {
     };
   }
 
-  ngOnInit(): void {
-    this.subscriptions.add(
-      this.permissionsService.getPermissions(this.workplace.uid).subscribe((permission) => {
-        this.canViewListOfWorkers = permission.permissions.canViewListOfWorkers;
-        this.canEditEstablishment = permission.permissions.canEditEstablishment;
-      }),
-    );
+  async ngOnInit(): Promise<void> {
+    this.canEditEstablishment = this.permissionsService.can(this.workplace.uid, 'canEditEstablishment');
+    this.canViewListOfWorkers = this.permissionsService.can(this.workplace.uid, 'canViewListOfWorkers');
 
-    this.featureFlagsService.configCatClient.getValueAsync('wdfNewDesign', false).then((value) => {
-      this.wdfNewDesign = value;
-      this.setTotalStaffWarning();
-      if (this.canEditEstablishment && this.wdfView && this.wdfNewDesign) {
-        this.updateEmployerTypeIfNotUpdatedSinceEffectiveDate();
-      }
-    });
+    this.wdfNewDesign = await this.featureFlagsService.configCatClient.getValueAsync('wdfNewDesign', false);
+
+    this.setTotalStaffWarning();
+    if (this.canEditEstablishment && this.wdfView && this.wdfNewDesign) {
+      this.updateEmployerTypeIfNotUpdatedSinceEffectiveDate();
+    }
 
     this.subscriptions.add(
       this.establishmentService.getCapacity(this.workplace.uid, true).subscribe((response) => {
@@ -210,7 +205,12 @@ export class WorkplaceSummaryComponent implements OnInit, OnDestroy, OnChanges {
     );
   }
 
-  private updateEmployerTypeIfNotUpdatedSinceEffectiveDate(): void {
+  public updateEmployerTypeIfNotUpdatedSinceEffectiveDate(): void {
+    console.log(
+      this.workplace.wdf?.employerType.isEligible,
+      !this.workplace.wdf?.employerType.updatedSinceEffectiveDate,
+    );
+
     if (this.workplace.wdf?.employerType.isEligible && !this.workplace.wdf?.employerType.updatedSinceEffectiveDate) {
       this.confirmField('employerType');
     }


### PR DESCRIPTION
#### Work done
- Changed ngOnInit to async and use can in permissions service instead of making call to backend in workplace summary component
- Changed mock feature flag service to return true for getValueAsync
- Added worker uid to wdf-field-confirmation component and reset confirmButtonClicked when uid is changed(user has gone on to different staff record)

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
