### PR TITLE
Tech debt/mock feature flag endpoint

### DIFF
--- a/src/app/core/test-utils/MockConfigCatClient.ts
+++ b/src/app/core/test-utils/MockConfigCatClient.ts
@@ -49,7 +49,7 @@ export const mockConfigCatClient = {
     }
     if (flagName === 'createAccountNewDesign') {
       return new Promise((resolve) => {
-        return resolve(true);
+        return resolve(false);
       });
     }
     return new Promise((resolve) => {

--- a/src/app/core/test-utils/MockConfigCatClient.ts
+++ b/src/app/core/test-utils/MockConfigCatClient.ts
@@ -40,9 +40,20 @@ export const mockConfigCatClient = {
       return new SettingKeyValue();
     });
   },
-  getValueAsync: () => {
+
+  getValueAsync: (flagName, defaultSetting) => {
+    if (flagName === 'wdfNewDesign') {
+      return new Promise((resolve) => {
+        return resolve(true);
+      });
+    }
+    if (flagName === 'createAccountNewDesign') {
+      return new Promise((resolve) => {
+        return resolve(true);
+      });
+    }
     return new Promise((resolve) => {
-      resolve(true);
+      return resolve(defaultSetting);
     });
   },
 } as IConfigCatClient;

--- a/src/app/core/test-utils/MockConfigCatClient.ts
+++ b/src/app/core/test-utils/MockConfigCatClient.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { IConfigCatClient, SettingKeyValue } from 'configcat-common/lib/ConfigCatClient';
+
+export const mockConfigCatClient = {
+  dispose: () => {},
+  getValue: () => {},
+  forceRefresh: () => {},
+  forceRefreshAsync: () => {
+    return new Promise((resolve) => {
+      resolve('');
+    });
+  },
+  getAllKeys: () => {},
+  getAllKeysAsync: () => {
+    return new Promise((resolve) => {
+      return [];
+    });
+  },
+  getVariationId: () => {},
+  getVariationIdAsync: () => {
+    return new Promise((resolve) => {
+      return '';
+    });
+  },
+  getAllVariationIds: () => {},
+  getAllVariationIdsAsync: () => {
+    return new Promise((resolve) => {
+      return '';
+    });
+  },
+  getKeyAndValue: () => {},
+  getKeyAndValueAsync: () => {
+    return new Promise((resolve) => {
+      return new SettingKeyValue();
+    });
+  },
+  getAllValues: () => {},
+  getAllValuesAsync: () => {
+    return new Promise((resolve) => {
+      return new SettingKeyValue();
+    });
+  },
+  getValueAsync: () => {
+    return new Promise((resolve) => {
+      resolve(true);
+    });
+  },
+} as IConfigCatClient;

--- a/src/app/core/test-utils/MockFeatureFlagService.ts
+++ b/src/app/core/test-utils/MockFeatureFlagService.ts
@@ -1,52 +1,11 @@
 import { Injectable } from '@angular/core';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
-import { IConfigCatClient, SettingKeyValue } from 'configcat-common/lib/ConfigCatClient';
+
+import { mockConfigCatClient } from './MockConfigCatClient';
 
 @Injectable()
 export class MockFeatureFlagsService extends FeatureFlagsService {
-  public configCatClient = {
-    dispose: () => {},
-    getValue: () => {},
-    forceRefresh: () => {},
-    forceRefreshAsync: () => {
-      return new Promise((resolve) => {
-        resolve('');
-      });
-    },
-    getAllKeys: () => {},
-    getAllKeysAsync: () => {
-      return new Promise((resolve) => {
-        return [];
-      });
-    },
-    getVariationId: () => {},
-    getVariationIdAsync: () => {
-      return new Promise((resolve) => {
-        return '';
-      });
-    },
-    getAllVariationIds: () => {},
-    getAllVariationIdsAsync: () => {
-      return new Promise((resolve) => {
-        return '';
-      });
-    },
-    getKeyAndValue: () => {},
-    getKeyAndValueAsync: () => {
-      return new Promise((resolve) => {
-        return new SettingKeyValue();
-      });
-    },
-    getAllValues: () => {},
-    getAllValuesAsync: () => {
-      return new Promise((resolve) => {
-        return new SettingKeyValue();
-      });
-    },
-    getValueAsync: () => {
-      return new Promise((resolve) => {
-        resolve(true);
-      });
-    },
-  } as IConfigCatClient;
+  public configCatClient = mockConfigCatClient;
+
+  public start(): void {}
 }

--- a/src/app/core/test-utils/MockFeatureFlagService.ts
+++ b/src/app/core/test-utils/MockFeatureFlagService.ts
@@ -7,5 +7,25 @@ import { mockConfigCatClient } from './MockConfigCatClient';
 export class MockFeatureFlagsService extends FeatureFlagsService {
   public configCatClient = mockConfigCatClient;
 
+  constructor() {
+    super();
+    this.configCatClient.getValueAsync = (flagName, defaultSetting) => {
+      if (flagName === 'wdfNewDesign') {
+        return new Promise((resolve) => {
+          return resolve(true);
+        });
+      }
+      if (flagName === 'createAccountNewDesign') {
+        return new Promise((resolve) => {
+          return resolve(true);
+        });
+      }
+      return new Promise((resolve) => {
+        return resolve(defaultSetting);
+      });
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   public start(): void {}
 }

--- a/src/app/shared/services/feature-flags.service.ts
+++ b/src/app/shared/services/feature-flags.service.ts
@@ -1,14 +1,18 @@
+import { mockConfigCatClient } from '@core/test-utils/MockConfigCatClient';
 import { IConfigCatClient } from 'configcat-common/lib/ConfigCatClient';
 import * as configcat from 'configcat-js';
-import { environment } from '../../../environments/environment';
+import { environment } from 'src/environments/environment';
 
 export class FeatureFlagsService {
   public configCatClient: IConfigCatClient;
 
   constructor() {}
 
-  start(){
-    this.configCatClient = configcat.createClientWithManualPoll(environment.configCatKey,{}
-      );
+  start(): void {
+    if (environment.environmentName === 'other') {
+      this.configCatClient = mockConfigCatClient;
+    } else {
+      this.configCatClient = configcat.createClientWithManualPoll(environment.configCatKey, {});
+    }
   }
 }


### PR DESCRIPTION
#### Work done
- Moved mockConfigCatClient from mockFeatureFlagsService into separate file
- Changed getValueAsync in mockConfigCatClient to return based on flag name
- Added environment check in featureFlagsService to pass in mockConfigCatClient when in other(localhost) environment
- Override getValueAsync in mockFeatureFlagsService to set flags to true for tests  

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [X] No, I found it difficult to test
- [ ] No, they are not required for this change
