### PR TITLE
Fix/create account snagging list

### DIFF
--- a/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -76,6 +76,12 @@ describe('FindYourWorkplaceComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should show add-workplace flow title', async () => {
+    const { component } = await setup();
+    const title = 'Find the workplace';
+    expect(component.getByText(title)).toBeTruthy();
+  });
+
   it('should not lookup workplaces the form if the input is empty', async () => {
     const { component, locationService } = await setup();
     const findWorkplaceButton = component.getByText('Find workplace');

--- a/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -103,7 +103,7 @@ describe('FindYourWorkplaceComponent', () => {
     expect(getLocationByPostcodeOrLocationID).not.toHaveBeenCalled();
   });
 
-  it('should show error the form if the input is empty', async () => {
+  it('should show add-workplace version of error message if the input is empty on submit', async () => {
     const { component } = await setup();
     const form = component.fixture.componentInstance.form;
     const findWorkplaceButton = component.getByText('Find workplace');
@@ -113,9 +113,9 @@ describe('FindYourWorkplaceComponent', () => {
     component.fixture.detectChanges();
 
     expect(form.invalid).toBeTruthy();
-    expect(
-      component.getAllByText('Enter your CQC location ID or your workplace postcode', { exact: false }).length,
-    ).toBe(2);
+    expect(component.getAllByText('Enter its CQC location ID or its workplace postcode', { exact: false }).length).toBe(
+      2,
+    );
   });
 
   it('should submit the value if value is inputted', async () => {

--- a/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -82,6 +82,12 @@ describe('FindYourWorkplaceComponent', () => {
     expect(component.getByText(title)).toBeTruthy();
   });
 
+  it('should show add-workplace flow hint message', async () => {
+    const { component } = await setup();
+    const hint = `We'll use its CQC location ID or workplace postcode to find the workplace in the Care Quality Commision database.`;
+    expect(component.getByText(hint)).toBeTruthy();
+  });
+
   it('should not lookup workplaces the form if the input is empty', async () => {
     const { component, locationService } = await setup();
     const findWorkplaceButton = component.getByText('Find workplace');

--- a/src/app/features/add-workplace/is-this-your-workplace/is-this-your-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/is-this-your-workplace/is-this-your-workplace.component.spec.ts
@@ -107,6 +107,14 @@ describe('IsThisYourWorkplaceComponent', () => {
     expect(registrationHeading).toBeFalsy();
   });
 
+  it('should render the correct reveal title when in the parent journey', async () => {
+    const { component } = await setup();
+
+    const revealTitle = 'Spotted a mistake in the workplace details?';
+
+    expect(component.queryByText(revealTitle)).toBeTruthy();
+  });
+
   it('should show the id and address when given the locationId', async () => {
     const { component } = await setup();
 

--- a/src/app/features/add-workplace/new-regulated-by-cqc/new-regulated-by-cqc.component.html
+++ b/src/app/features/add-workplace/new-regulated-by-cqc/new-regulated-by-cqc.component.html
@@ -6,10 +6,10 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
-            Is the main service you provide regulated by the Care Quality Commission?
+            Is the main service it provides regulated by the Care Quality Commission?
           </h1>
         </legend>
-        <app-details [title]="'Not sure if your main service is regulated?'">
+        <app-details [title]="'Not sure if its main service is regulated?'">
           <p>
             Call the ASC-WDS Support Team on <strong>0113 241 0969</strong> or email
             <strong>ascwds-support@skillsforcare.org.uk</strong> for help.

--- a/src/app/features/add-workplace/new-regulated-by-cqc/new-regulated-by-cqc.component.spec.ts
+++ b/src/app/features/add-workplace/new-regulated-by-cqc/new-regulated-by-cqc.component.spec.ts
@@ -85,7 +85,7 @@ describe('NewRegulatedByCqcComponent', () => {
 
       const errorMessage = component.getByTestId('errorMessage');
       expect(errorMessage.innerText).toContain(
-        'Select yes if the main service you provide is regulated by the Care Quality Commission',
+        'Select yes if the main service it provides is regulated by the Care Quality Commission',
       );
     });
   });

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -86,7 +86,6 @@ describe('NewSelectMainServiceComponent', () => {
     const { component, fixture, getByText } = await setup();
 
     component.isRegulated = true;
-    component.renderForm = true;
 
     fixture.detectChanges();
     const cqcText = getByText(
@@ -100,7 +99,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.createAccountNewDesign = false;
     component.isRegulated = false;
-    component.renderForm = true;
 
     fixture.detectChanges();
     const cqcText = getByText(
@@ -115,7 +113,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.createAccountNewDesign = true;
     component.isRegulated = false;
-    component.renderForm = true;
 
     fixture.detectChanges();
     const cqcText = queryByText(
@@ -130,7 +127,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.isParent = true;
     component.isRegulated = false;
-    component.renderForm = true;
     fixture.detectChanges();
 
     expect(queryByText('Select its main service')).toBeTruthy();
@@ -139,7 +135,6 @@ describe('NewSelectMainServiceComponent', () => {
   it('should error when nothing has been selected', async () => {
     const { component, fixture, getByText, getAllByText } = await setup();
     component.isRegulated = true;
-    component.renderForm = true;
     const form = component.form;
 
     fixture.detectChanges();
@@ -158,7 +153,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.isParent = true;
     component.isRegulated = true;
-    component.renderForm = true;
     fixture.detectChanges();
 
     const radioButton = getByLabelText('Name');

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -132,20 +132,20 @@ describe('NewSelectMainServiceComponent', () => {
     expect(queryByText('Select its main service')).toBeTruthy();
   });
 
-  it('should error when nothing has been selected', async () => {
+  it('should show add-workplace error message when nothing has been selected', async () => {
     const { component, fixture, getByText, getAllByText } = await setup();
     component.isRegulated = true;
     const form = component.form;
 
     fixture.detectChanges();
 
-    const errorMessage = 'Select your main service';
+    const errorMessage = 'Select the main service it provides';
 
     const continueButton = getByText('Continue');
     fireEvent.click(continueButton);
 
     expect(form.invalid).toBeTruthy();
-    expect(getAllByText(errorMessage).length).toBe(3);
+    expect(getAllByText(errorMessage).length).toBe(2);
   });
 
   it('should submit and go to the add-workplace/confirm-workplace-details url when option selected', async () => {

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
@@ -7,9 +7,7 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkplaceService } from '@core/services/workplace.service';
-import {
-  SelectMainServiceDirective,
-} from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
+import { SelectMainServiceDirective } from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
@@ -18,7 +16,6 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 })
 export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   public isRegulated: boolean;
-  public isParent: boolean;
   public workplace: Establishment;
   public createAccountNewDesign: boolean;
 
@@ -39,7 +36,7 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
     this.flow = 'add-workplace';
     this.isRegulated = this.workplaceService.isRegulated();
     this.workplace = this.establishmentService.primaryWorkplace;
-    this.workplace?.isParent ? (this.isParent = true) : (this.isParent = false);
+    this.isParent = this.workplace?.isParent;
     this.returnToConfirmDetails = this.workplaceService.returnTo$.value;
     this.setBackLink();
     this.createAccountNewDesign = await this.featureFlagsService.configCatClient.getValueAsync(

--- a/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/add-workplace/new-select-main-service/new-select-main-service.component.ts
@@ -59,6 +59,20 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
     );
   }
 
+  protected setupFormErrorsMap(): void {
+    this.formErrorsMap = [
+      {
+        item: 'workplaceService',
+        type: [
+          {
+            name: 'required',
+            message: 'Select the main service it provides',
+          },
+        ],
+      },
+    ];
+  }
+
   protected onSuccess(): void {
     this.workplaceService.selectedWorkplaceService$.next(this.getSelectedWorkPlaceService());
     this.navigateToNextPage();

--- a/src/app/features/add-workplace/new-workplace-not-found/new-workplace-not-found.component.spec.ts
+++ b/src/app/features/add-workplace/new-workplace-not-found/new-workplace-not-found.component.spec.ts
@@ -4,6 +4,7 @@ import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkplaceService } from '@core/services/workplace.service';
 import { SanitizePostcodeUtil } from '@core/utils/sanitize-postcode-util';
 import { SharedModule } from '@shared/shared.module';
@@ -35,6 +36,14 @@ describe('NewWorkplaceNotFoundComponent', () => {
             },
           },
           deps: [HttpClient],
+        },
+        {
+          provide: EstablishmentService,
+          useValue: {
+            primaryWorkplace: {
+              isParent: true,
+            },
+          },
         },
         {
           provide: ActivatedRoute,
@@ -75,6 +84,29 @@ describe('NewWorkplaceNotFoundComponent', () => {
     const { component } = await setup(inputtedPostcode);
 
     expect(component.getByText(inputtedPostcode)).toBeTruthy();
+  });
+
+  describe('Parent messages', () => {
+    it('should display add workplace version of heading', async () => {
+      const { component } = await setup();
+      const expectedHeading = 'We could not find the workplace';
+
+      expect(component.getByText(expectedHeading)).toBeTruthy();
+    });
+
+    it('should display add workplace version of question', async () => {
+      const { component } = await setup();
+      const expectedQuestion = 'Do you want to try find the workplace with a different CQC location ID or postcode?';
+
+      expect(component.getByText(expectedQuestion)).toBeTruthy();
+    });
+
+    it('should display add workplace version of No answer', async () => {
+      const { component } = await setup();
+      const expectedNoAnswer = "No, I'll enter the workplace details myself";
+
+      expect(component.getByText(expectedNoAnswer)).toBeTruthy();
+    });
   });
 
   describe('Parent journey', () => {

--- a/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.ts
+++ b/src/app/features/create-account/user/confirm-account-details/confirm-account-details.component.ts
@@ -105,7 +105,7 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetailsDirecti
         route: { url: ['/registration/create-security-question'] },
       },
       {
-        label: 'Security answer',
+        label: 'Answer',
         data: this.securityDetails.securityQuestionAnswer,
       },
     ];

--- a/src/app/features/create-account/workplace/confirm-details/confirm-details.component.html
+++ b/src/app/features/create-account/workplace/confirm-details/confirm-details.component.html
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">Confirm your details before you submit them</h1>
+    <h1 class="govuk-heading-l">Check your details before you submit them</h1>
   </div>
 </div>
 

--- a/src/app/features/create-account/workplace/confirm-details/confirm-details.component.spec.ts
+++ b/src/app/features/create-account/workplace/confirm-details/confirm-details.component.spec.ts
@@ -63,9 +63,9 @@ describe('ConfirmDetailsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have the title Confirm your details before you submit them', async () => {
+  it('should have the title Check your details before you submit them', async () => {
     const { queryByText } = await setup();
-    const expectedTitle = 'Confirm your details before you submit them';
+    const expectedTitle = 'Check your details before you submit them';
 
     expect(queryByText(expectedTitle, { exact: false })).toBeTruthy();
   });

--- a/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -68,6 +68,12 @@ describe('FindYourWorkplaceComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should show registration flow title', async () => {
+    const { component } = await setup();
+    const title = 'Find your workplace';
+    expect(component.getByText(title)).toBeTruthy();
+  });
+
   it('should not lookup workplaces the form if the input is empty', async () => {
     const { component, locationService } = await setup();
     const findWorkplaceButton = component.getByText('Find workplace');

--- a/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -74,6 +74,12 @@ describe('FindYourWorkplaceComponent', () => {
     expect(component.getByText(title)).toBeTruthy();
   });
 
+  it('should show registration flow hint message', async () => {
+    const { component } = await setup();
+    const hint = `We'll use your CQC location ID or workplace postcode to find your workplace in the Care Quality Commision database.`;
+    expect(component.getByText(hint)).toBeTruthy();
+  });
+
   it('should not lookup workplaces the form if the input is empty', async () => {
     const { component, locationService } = await setup();
     const findWorkplaceButton = component.getByText('Find workplace');

--- a/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -95,7 +95,7 @@ describe('FindYourWorkplaceComponent', () => {
     expect(getLocationByPostcodeOrLocationID).not.toHaveBeenCalled();
   });
 
-  it('should show error the form if the input is empty', async () => {
+  it('should show registration version of error message if the input is empty on submit', async () => {
     const { component } = await setup();
     const form = component.fixture.componentInstance.form;
     const findWorkplaceButton = component.getByText('Find workplace');

--- a/src/app/features/create-account/workplace/is-this-your-workplace/is-this-your-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/is-this-your-workplace/is-this-your-workplace.component.spec.ts
@@ -92,10 +92,18 @@ describe('IsThisYourWorkplaceComponent', () => {
     const { component } = await setup();
 
     const registrationHeading = component.queryByText('Is this your workplace?');
-    const parentHeading = component.queryByText('Is this your workplace you want to add?');
+    const parentHeading = component.queryByText('Is this the workplace you want to add?');
 
     expect(registrationHeading).toBeTruthy();
     expect(parentHeading).toBeFalsy();
+  });
+
+  it('should render the correct reveal title when in the registration journey', async () => {
+    const { component } = await setup();
+
+    const revealTitle = 'Spotted a mistake in your workplace details?';
+
+    expect(component.queryByText(revealTitle)).toBeTruthy();
   });
 
   it('should show the id and address when given the locationId', async () => {

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -140,7 +140,7 @@ describe('NewSelectMainServiceComponent', () => {
     expect(queryByText('Select your main service')).toBeTruthy();
   });
 
-  it('should error when nothing has been selected', async () => {
+  it('should show registration error message when nothing has been selected(plus title with same wording)', async () => {
     const { component, fixture, getByText, getAllByText } = await setup();
     component.isRegulated = true;
     const form = component.form;

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -94,7 +94,6 @@ describe('NewSelectMainServiceComponent', () => {
     const { component, fixture, getByText } = await setup();
 
     component.isRegulated = true;
-    component.renderForm = true;
 
     fixture.detectChanges();
     const cqcText = getByText(
@@ -108,7 +107,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.createAccountNewDesign = false;
     component.isRegulated = false;
-    component.renderForm = true;
 
     fixture.detectChanges();
     const cqcText = getByText(
@@ -123,7 +121,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.createAccountNewDesign = true;
     component.isRegulated = false;
-    component.renderForm = true;
 
     fixture.detectChanges();
     const cqcText = queryByText(
@@ -138,7 +135,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.isParent = false;
     component.isRegulated = false;
-    component.renderForm = true;
     fixture.detectChanges();
 
     expect(queryByText('Select your main service')).toBeTruthy();
@@ -147,7 +143,6 @@ describe('NewSelectMainServiceComponent', () => {
   it('should error when nothing has been selected', async () => {
     const { component, fixture, getByText, getAllByText } = await setup();
     component.isRegulated = true;
-    component.renderForm = true;
     const form = component.form;
 
     fixture.detectChanges();
@@ -166,7 +161,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.isParent = false;
     component.isRegulated = true;
-    component.renderForm = true;
     fixture.detectChanges();
 
     const radioButton = getByLabelText('Name');
@@ -183,7 +177,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.isParent = false;
     component.isRegulated = true;
-    component.renderForm = true;
     component.returnToConfirmDetails = { url: ['registration', 'confirm-details'] };
     fixture.detectChanges();
 

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
@@ -1,11 +1,9 @@
 import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Establishment } from '@core/model/establishment.model';
 import { Service } from '@core/model/services.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { EstablishmentService } from '@core/services/establishment.service';
 import { RegistrationService } from '@core/services/registration.service';
 import { WorkplaceService } from '@core/services/workplace.service';
 import { SelectMainServiceDirective } from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
@@ -17,7 +15,6 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 })
 export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   public isRegulated: boolean;
-  public workplace: Establishment;
   public createAccountNewDesign: boolean;
 
   constructor(
@@ -27,7 +24,6 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
     protected formBuilder: FormBuilder,
     protected router: Router,
     protected workplaceService: WorkplaceService,
-    private establishmentService: EstablishmentService,
     private featureFlagsService: FeatureFlagsService,
     private route: ActivatedRoute,
   ) {
@@ -37,8 +33,7 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   protected async init(): Promise<void> {
     this.flow = this.route.snapshot.parent.url[0].path;
     this.isRegulated = this.registrationService.isRegulated();
-    this.workplace = this.establishmentService.primaryWorkplace;
-    this.isParent = this.workplace?.isParent;
+    this.isParent = false;
     this.returnToConfirmDetails = this.registrationService.returnTo$.value;
     this.createAccountNewDesign = await this.featureFlagsService.configCatClient.getValueAsync(
       'createAccountNewDesign',

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.ts
@@ -8,9 +8,7 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { RegistrationService } from '@core/services/registration.service';
 import { WorkplaceService } from '@core/services/workplace.service';
-import {
-  SelectMainServiceDirective,
-} from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
+import { SelectMainServiceDirective } from '@shared/directives/create-workplace/select-main-service/select-main-service.directive';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
@@ -19,7 +17,6 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 })
 export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   public isRegulated: boolean;
-  public isParent: boolean;
   public workplace: Establishment;
   public createAccountNewDesign: boolean;
 
@@ -40,6 +37,8 @@ export class NewSelectMainServiceComponent extends SelectMainServiceDirective {
   protected async init(): Promise<void> {
     this.flow = this.route.snapshot.parent.url[0].path;
     this.isRegulated = this.registrationService.isRegulated();
+    this.workplace = this.establishmentService.primaryWorkplace;
+    this.isParent = this.workplace?.isParent;
     this.returnToConfirmDetails = this.registrationService.returnTo$.value;
     this.createAccountNewDesign = await this.featureFlagsService.configCatClient.getValueAsync(
       'createAccountNewDesign',

--- a/src/app/features/create-account/workplace/new-workplace-not-found/new-workplace-not-found.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-workplace-not-found/new-workplace-not-found.component.spec.ts
@@ -4,6 +4,7 @@ import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { RegistrationService } from '@core/services/registration.service';
 import { SanitizePostcodeUtil } from '@core/utils/sanitize-postcode-util';
 import { SharedModule } from '@shared/shared.module';
@@ -35,6 +36,14 @@ describe('NewWorkplaceNotFoundComponent', () => {
             },
           },
           deps: [HttpClient],
+        },
+        {
+          provide: EstablishmentService,
+          useValue: {
+            primaryWorkplace: {
+              isParent: false,
+            },
+          },
         },
         {
           provide: ActivatedRoute,
@@ -75,6 +84,29 @@ describe('NewWorkplaceNotFoundComponent', () => {
     const { component } = await setup(inputtedPostcode);
 
     expect(component.getByText(inputtedPostcode)).toBeTruthy();
+  });
+
+  describe('Registration messages', () => {
+    it('should display registration version of heading', async () => {
+      const { component } = await setup();
+      const expectedHeading = 'We could not find your workplace';
+
+      expect(component.getByText(expectedHeading)).toBeTruthy();
+    });
+
+    it('should display registration version of question', async () => {
+      const { component } = await setup();
+      const expectedQuestion = 'Do you want to try find your workplace with a different CQC location ID or postcode?';
+
+      expect(component.getByText(expectedQuestion)).toBeTruthy();
+    });
+
+    it('should display registration version of No answer', async () => {
+      const { component } = await setup();
+      const expectedNoAnswer = "No, I'll enter our workplace details myself";
+
+      expect(component.getByText(expectedNoAnswer)).toBeTruthy();
+    });
   });
 
   describe('Registration journey', () => {

--- a/src/app/shared/components/summary-list/summary-list.component.html
+++ b/src/app/shared/components/summary-list/summary-list.component.html
@@ -11,19 +11,15 @@
     </dt>
     <ng-container *ngIf="item.label === 'Password' && displayShowPasswordToggle; else nonPassword">
       <dd class="govuk-summary-list__value">
-        <div class="govuk-!-display-inline-block govuk-!-width-one-third">
-          {{ showPassword ? item.data : '******' }}
-        </div>
-        <div class="govuk-!-display-inline-block govuk-!-width-two-thirds">
-          <a
-            class="govuk-link govuk-link--no-visited-state govuk-!-margin-left-5"
-            href="#"
-            role="button"
-            (click)="togglePassword($event)"
-            ><ng-container *ngIf="showPassword; else showText">Hide</ng-container
-            ><ng-template #showText>Show</ng-template> password</a
-          >
-        </div>
+        <span class="asc-password-wrap">{{ showPassword ? item.data : '******' }}</span>
+        <a
+          class="govuk-link govuk-link--no-visited-state govuk-util__float-right govuk-!-margin-right-6"
+          href="#"
+          role="button"
+          (click)="togglePassword($event)"
+          ><ng-container *ngIf="showPassword; else showText">Hide</ng-container
+          ><ng-template #showText>Show</ng-template> password</a
+        >
       </dd>
     </ng-container>
     <ng-template #nonPassword>

--- a/src/app/shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive.ts
+++ b/src/app/shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive.ts
@@ -33,7 +33,7 @@ export class CouldNotFindWorkplaceAddressDirective implements OnInit {
   ngOnInit(): void {
     this.flow = this.route.snapshot.parent.url[0].path;
     this.workplace = this.establishmentService.primaryWorkplace;
-    this.isParent = this.workplace?.isParent ? true : false;
+    this.isParent = this.workplace?.isParent;
     this.setBackLink();
     this.setupForm();
     this.setupFormErrorsMap();

--- a/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.component.html
+++ b/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.component.html
@@ -17,8 +17,8 @@
         </legend>
 
         <p>
-          We'll use your CQC location ID or workplace postcode to find your workplace in the Care Quality Commision
-          database.
+          We'll use {{ flow === 'registration' ? 'your' : 'its' }} CQC location ID or workplace postcode to find
+          {{ flow === 'registration' ? 'your' : 'the' }} workplace in the Care Quality Commision database.
         </p>
 
         <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && (form.invalid || serverError)">

--- a/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.component.html
+++ b/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.component.html
@@ -11,7 +11,9 @@
     <form #formEl novalidate (ngSubmit)="onSubmit()" [formGroup]="form" id="server-error">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h1 class="govuk-fieldset__heading">Find your workplace</h1>
+          <h1 class="govuk-fieldset__heading">
+            Find {{ flow === 'registration' ? 'your workplace' : 'the workplace' }}
+          </h1>
         </legend>
 
         <p>

--- a/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive.ts
@@ -96,13 +96,14 @@ export class FindYourWorkplaceDirective implements OnInit, AfterViewInit, OnDest
   }
 
   private setupFormErrorsMap(): void {
+    const yourOrIts = this.flow === 'registration' ? 'your' : 'its';
     this.formErrorsMap = [
       {
         item: 'postcodeOrLocationID',
         type: [
           {
             name: 'required',
-            message: `Enter your CQC location ID or your workplace postcode`,
+            message: `Enter ${yourOrIts} CQC location ID or ${yourOrIts} workplace postcode`,
           },
         ],
       },

--- a/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive.ts
@@ -16,7 +16,7 @@ import { Subscription } from 'rxjs';
 export class FindYourWorkplaceDirective implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('formEl') formEl: ElementRef;
 
-  protected flow: string;
+  public flow: string;
   protected serverErrorsMap: Array<ErrorDefinition>;
   protected subscriptions: Subscription = new Subscription();
   public submitted = false;

--- a/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.component.html
+++ b/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.component.html
@@ -63,7 +63,7 @@
           </div>
         </div>
         <div class="govuk-!-margin-top-8">
-          <app-details [title]="'Spotted a mistake in your workplace details?'">
+          <app-details [title]="revealTitle">
             <p>
               Call the ASC-WDS Support Team on <strong>0113 241 0969</strong> or email
               <strong>ascwds-support@skillsforcare.org.uk</strong> for help.

--- a/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive.ts
@@ -23,6 +23,7 @@ export class IsThisYourWorkplaceDirective implements OnInit, AfterViewInit {
   public workplace: Establishment;
   public isParent: boolean;
   public searchMethod: string;
+  public revealTitle: string;
   public returnToConfirmDetails: URLStructure;
 
   constructor(
@@ -43,7 +44,8 @@ export class IsThisYourWorkplaceDirective implements OnInit, AfterViewInit {
     this.locationData = this.workplaceInterfaceService.locationAddresses$.value[0];
     this.searchMethod = this.workplaceInterfaceService.searchMethod$.value;
     this.workplace = this.establishmentService.primaryWorkplace;
-    this.workplace?.isParent ? (this.isParent = true) : (this.isParent = false);
+    this.isParent = this.workplace?.isParent;
+    this.revealTitle = `Spotted a mistake in ${this.isParent ? 'the' : 'your'} workplace details?`;
     this.setupFormErrorsMap();
   }
 

--- a/src/app/shared/directives/create-workplace/new-regulated-by-cqc/new-regulated-by-cqc.directive.ts
+++ b/src/app/shared/directives/create-workplace/new-regulated-by-cqc/new-regulated-by-cqc.directive.ts
@@ -40,14 +40,15 @@ export class NewRegulatedByCqcDirective implements OnInit, AfterViewInit {
     });
   }
 
-  private setupFormErrorsMap(): void {
+  protected setupFormErrorsMap(): void {
+    const flowWording = this.flow === 'registration' ? 'you provide' : 'it provides';
     this.formErrorsMap = [
       {
         item: 'regulatedByCQC',
         type: [
           {
             name: 'required',
-            message: `Select yes if the main service you provide is regulated by the Care Quality Commission`,
+            message: `Select yes if the main service ${flowWording} is regulated by the Care Quality Commission`,
           },
         ],
       },

--- a/src/app/shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.component.html
+++ b/src/app/shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.component.html
@@ -5,14 +5,14 @@
     <form #formEl novalidate [formGroup]="form" (ngSubmit)="onSubmit()">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h1 *ngIf="isParent" class="govuk-fieldset__heading">We could not find the workplace</h1>
-          <h1 *ngIf="!isParent" class="govuk-fieldset__heading">We could not find your workplace</h1>
+          <h1 class="govuk-fieldset__heading">We could not find {{ isParent ? 'the' : 'your' }} workplace</h1>
         </legend>
         <p>
           CQC location ID or postcode entered: <strong>{{ postcodeOrLocationId }}</strong>
         </p>
         <h4 class="govuk-heading-s">
-          Do you want to try find your workplace with a different CQC location ID or postcode?
+          Do you want to try find {{ isParent ? 'the' : 'your' }} workplace with a different CQC location ID or
+          postcode?
         </h4>
         <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.invalid">
           <span
@@ -48,7 +48,7 @@
                 [formControlName]="'useDifferentLocationIdOrPostcode'"
               />
               <label for="useDifferentLocationIdOrPostcode-2" class="govuk-label govuk-radios__label"
-                >No, I'll enter our workplace details myself</label
+                >No, I'll enter {{ isParent ? 'the' : 'our' }} workplace details myself</label
               >
             </div>
           </div>

--- a/src/app/shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.directive.ts
+++ b/src/app/shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.directive.ts
@@ -35,7 +35,7 @@ export class NewWorkplaceNotFoundDirective implements OnInit, AfterViewInit {
   ngOnInit(): void {
     this.flow = this.route.snapshot.parent.url[0].path;
     this.workplace = this.establishmentService.primaryWorkplace;
-    this.isParent = this.workplace?.isParent ? true : false;
+    this.isParent = this.workplace?.isParent;
     this.sanitizePostcode();
     this.setBackLink();
     this.setupForm();

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
@@ -6,7 +6,7 @@
 >
 </app-error-summary>
 
-<form #formEl novalidate (ngSubmit)="onSubmit()" [formGroup]="form" id="server-error" *ngIf="renderForm">
+<form #formEl novalidate (ngSubmit)="onSubmit()" [formGroup]="form" id="server-error">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.invalid">

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
@@ -115,6 +115,6 @@
     </div>
   </div>
   <div class="govuk-grid-row">
-    <app-submit-exit-buttons [cta]="callToActionLabel" [return]="return"></app-submit-exit-buttons>
+    <app-submit-exit-buttons [cta]="callToActionLabel"></app-submit-exit-buttons>
   </div>
 </form>

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
@@ -12,12 +12,7 @@
       <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.invalid">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <ng-container *ngIf="isParent; else notParent">
-              <h1 class="govuk-fieldset__heading">Select its main service</h1>
-            </ng-container>
-            <ng-template #notParent>
-              <h1 class="govuk-fieldset__heading">Select your main service</h1>
-            </ng-template>
+            <h1 class="govuk-fieldset__heading">Select {{ isParent ? 'its' : 'your' }} main service</h1>
           </legend>
           <div *ngIf="displayIntro">
             <ng-container *ngIf="isRegulated; else notRegulated">

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { HttpErrorResponse } from '@angular/common/http';
 import { AfterViewInit, Directive, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
@@ -23,7 +24,6 @@ export class SelectMainServiceDirective implements OnInit, OnDestroy, AfterViewI
   public categories: Array<ServiceGroup>;
   public form: FormGroup;
   public formErrorsMap: Array<ErrorDetails>;
-  public renderForm = false;
   public serverError: string;
   public submitted = false;
   public returnToConfirmDetails: URLStructure;
@@ -146,7 +146,6 @@ export class SelectMainServiceDirective implements OnInit, OnDestroy, AfterViewI
         this.form.get(`otherWorkplaceService${this.selectedMainService.id}`).patchValue(this.selectedMainService.other);
       }
     }
-    this.renderForm = true;
     this.errorSummaryService.formEl$.next(this.formEl);
   }
 

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
@@ -27,6 +27,7 @@ export class SelectMainServiceDirective implements OnInit, OnDestroy, AfterViewI
   public serverError: string;
   public submitted = false;
   public returnToConfirmDetails: URLStructure;
+  public isParent: boolean;
 
   constructor(
     protected backService: BackService,
@@ -43,7 +44,6 @@ export class SelectMainServiceDirective implements OnInit, OnDestroy, AfterViewI
     this.setupServerErrorsMap();
     this.setSelectedWorkplaceService();
     this.getServiceCategories();
-    this.init();
   }
 
   ngAfterViewInit(): void {

--- a/src/assets/scss/components/_summary-list.scss
+++ b/src/assets/scss/components/_summary-list.scss
@@ -63,6 +63,11 @@
   }
 }
 
+.asc-password-wrap {
+  display: inline-block;
+  max-width: 40%;
+}
+
 .govuk-summary-list--contains-warnings {
   .govuk-summary-list__key {
     width: 30%;


### PR DESCRIPTION
#### Work done
- Added css class to password show hide to stop button getting pushed onto second line in confirm details
- Removed renderForm in select main service to stop focus bug on error handling
- Changed wording in several components(_regulated-by-cqc, find-your-workplace, is-this-your-workplace, select-main-service, new-workplace-not-found_) for the parent flow and added tests to them

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
