### PR TITLE
Fixed other services input not showing when selecting an other option

### DIFF
--- a/src/app/core/test-utils/MockRegistrationService.ts
+++ b/src/app/core/test-utils/MockRegistrationService.ts
@@ -63,8 +63,10 @@ export class MockRegistrationServiceWithMainService extends MockRegistrationServ
   });
 
   public selectedWorkplaceService$: BehaviorSubject<Service> = new BehaviorSubject({
-    id: 1,
+    id: 123,
     isCQC: true,
     name: 'Name of service',
+    other: true,
+    otherName: 'Hello!',
   });
 }

--- a/src/app/core/test-utils/MockWorkplaceService.ts
+++ b/src/app/core/test-utils/MockWorkplaceService.ts
@@ -48,6 +48,7 @@ export class MockWorkplaceService extends WorkplaceService {
             isCQC: true,
             name: 'Name',
           },
+          { id: 123, name: 'Other Mock Service', other: true },
         ],
       },
     ]);

--- a/src/app/core/test-utils/MockWorkplaceService.ts
+++ b/src/app/core/test-utils/MockWorkplaceService.ts
@@ -61,5 +61,7 @@ export class MockWorkplaceServiceWithMainService extends MockWorkplaceService {
     id: 1,
     name: 'Shared lives',
     isCqc: true,
+    other: true,
+    otherName: 'Hello!',
   });
 }

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -19,7 +19,7 @@ import { NewSelectMainServiceComponent } from './new-select-main-service.compone
 
 describe('NewSelectMainServiceComponent', () => {
   async function setup() {
-    const { fixture, getByText, getAllByText, queryByText, getByLabelText } = await render(
+    const { fixture, getByText, getAllByText, queryByText, getByLabelText, getByTestId } = await render(
       NewSelectMainServiceComponent,
       {
         imports: [
@@ -81,6 +81,7 @@ describe('NewSelectMainServiceComponent', () => {
       queryByText,
       getByText,
       getByLabelText,
+      getByTestId,
     };
   }
 
@@ -194,6 +195,23 @@ describe('NewSelectMainServiceComponent', () => {
     fireEvent.click(continueButton);
 
     expect(spy).toHaveBeenCalledWith(['registration', 'confirm-details']);
+  });
+
+  it('should show the other input box when an other option is selected', async () => {
+    const { component, fixture, getByTestId } = await setup();
+
+    component.isParent = false;
+    component.isRegulated = true;
+    component.renderForm = true;
+    fixture.detectChanges();
+    const otherDrop = getByTestId('workplaceServiceOther-123');
+
+    expect(otherDrop.getAttribute('class')).toContain('govuk-radios__conditional--hidden');
+
+    const otherOption = getByTestId('workplaceService-123');
+    fireEvent.click(otherOption);
+
+    expect(otherDrop.getAttribute('class')).not.toContain('govuk-radios__conditional--hidden');
   });
 
   describe('setBackLink()', () => {

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -8,7 +8,10 @@ import { RegistrationService } from '@core/services/registration.service';
 import { WorkplaceService } from '@core/services/workplace.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
-import { MockRegistrationService } from '@core/test-utils/MockRegistrationService';
+import {
+  MockRegistrationService,
+  MockRegistrationServiceWithMainService,
+} from '@core/test-utils/MockRegistrationService';
 import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
 import { RegistrationModule } from '@features/registration/registration.module';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
@@ -18,7 +21,7 @@ import { fireEvent, getByText, render } from '@testing-library/angular';
 import { NewSelectMainServiceComponent } from './new-select-main-service.component';
 
 describe('NewSelectMainServiceComponent', () => {
-  async function setup() {
+  async function setup(mainServicePrefilled = false) {
     const { fixture, getByText, getAllByText, queryByText, getByLabelText, getByTestId } = await render(
       NewSelectMainServiceComponent,
       {
@@ -33,7 +36,7 @@ describe('NewSelectMainServiceComponent', () => {
         providers: [
           {
             provide: RegistrationService,
-            useClass: MockRegistrationService,
+            useClass: mainServicePrefilled ? MockRegistrationServiceWithMainService : MockRegistrationService,
           },
           {
             provide: WorkplaceService,
@@ -65,7 +68,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     const injector = getTestBed();
     const router = injector.inject(Router) as Router;
-    const registrationService = injector.inject(RegistrationService) as RegistrationService;
 
     const spy = spyOn(router, 'navigate');
     spy.and.returnValue(Promise.resolve(true));
@@ -76,7 +78,6 @@ describe('NewSelectMainServiceComponent', () => {
       fixture,
       component,
       spy,
-      registrationService,
       getAllByText,
       queryByText,
       getByText,
@@ -214,24 +215,17 @@ describe('NewSelectMainServiceComponent', () => {
     expect(otherDrop.getAttribute('class')).not.toContain('govuk-radios__conditional--hidden');
   });
 
-  fit('should prefill the other input box with the correct value', async () => {
-    const { component, fixture, getByTestId } = await setup();
+  it('should prefill the other input box with the correct value', async () => {
+    const { component, fixture } = await setup(true);
 
     component.isParent = false;
     component.isRegulated = true;
     component.renderForm = true;
+
     fixture.detectChanges();
     const form = component.form;
-    const otherOption = getByTestId('workplaceService-123');
-    fireEvent.click(otherOption);
 
-    form.get('otherWorkplaceService123').setValue('A main service you have never heard of');
-
-    component.ngOnInit();
-
-    fixture.detectChanges();
-
-    expect(form.get('otherWorkplaceService123').value).toEqual('A main service you have never heard of');
+    expect(form.get('otherWorkplaceService123').value).toEqual('Hello!');
   });
 
   describe('setBackLink()', () => {

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -196,7 +196,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.isParent = false;
     component.isRegulated = true;
-    component.renderForm = true;
     fixture.detectChanges();
     const otherDrop = getByTestId('workplaceServiceOther-123');
 
@@ -213,7 +212,6 @@ describe('NewSelectMainServiceComponent', () => {
 
     component.isParent = false;
     component.isRegulated = true;
-    component.renderForm = true;
 
     fixture.detectChanges();
     const form = component.form;

--- a/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-select-main-service/new-select-main-service.component.spec.ts
@@ -13,7 +13,7 @@ import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
 import { RegistrationModule } from '@features/registration/registration.module';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { fireEvent, render } from '@testing-library/angular';
+import { fireEvent, getByText, render } from '@testing-library/angular';
 
 import { NewSelectMainServiceComponent } from './new-select-main-service.component';
 
@@ -212,6 +212,26 @@ describe('NewSelectMainServiceComponent', () => {
     fireEvent.click(otherOption);
 
     expect(otherDrop.getAttribute('class')).not.toContain('govuk-radios__conditional--hidden');
+  });
+
+  fit('should prefill the other input box with the correct value', async () => {
+    const { component, fixture, getByTestId } = await setup();
+
+    component.isParent = false;
+    component.isRegulated = true;
+    component.renderForm = true;
+    fixture.detectChanges();
+    const form = component.form;
+    const otherOption = getByTestId('workplaceService-123');
+    fireEvent.click(otherOption);
+
+    form.get('otherWorkplaceService123').setValue('A main service you have never heard of');
+
+    component.ngOnInit();
+
+    fixture.detectChanges();
+
+    expect(form.get('otherWorkplaceService123').value).toEqual('A main service you have never heard of');
   });
 
   describe('setBackLink()', () => {

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
@@ -81,7 +81,7 @@
                 <div
                   *ngIf="service.other"
                   class="govuk-radios__conditional"
-                  [class.govuk-radios__conditional--hidden]="form.get('workplaceService').value !== service.id"
+                  [class.govuk-radios__conditional--hidden]="serviceSelected('workplaceService-' + service.id)"
                   id="workplaceService-conditional-{{ i }}"
                 >
                   <div class="govuk-form-group govuk-!-margin-bottom-2">

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
@@ -82,7 +82,7 @@
                 <div
                   *ngIf="service.other"
                   class="govuk-radios__conditional"
-                  [class.govuk-radios__conditional--hidden]="serviceSelected('workplaceService-' + service.id)"
+                  [class.govuk-radios__conditional--hidden]="serviceNotSelected('workplaceService-' + service.id)"
                   id="workplaceService-conditional-{{ i }}"
                   [attr.data-testid]="'workplaceServiceOther-' + service.id"
                 >

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.component.html
@@ -72,6 +72,7 @@
                     type="radio"
                     [formControlName]="'workplaceService'"
                     [class.govuk-input--error]="submitted && form.get('workplaceService').errors"
+                    [attr.data-testid]="'workplaceService-' + service.id"
                   />
                   <label class="govuk-label govuk-radios__label" for="workplaceService-{{ service.id }}">
                     {{ service.name }}
@@ -83,6 +84,7 @@
                   class="govuk-radios__conditional"
                   [class.govuk-radios__conditional--hidden]="serviceSelected('workplaceService-' + service.id)"
                   id="workplaceService-conditional-{{ i }}"
+                  [attr.data-testid]="'workplaceServiceOther-' + service.id"
                 >
                   <div class="govuk-form-group govuk-!-margin-bottom-2">
                     <label class="govuk-label" for="otherWorkplaceService-{{ service.id }}">

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
@@ -191,4 +191,8 @@ export class SelectMainServiceDirective implements OnInit, OnDestroy, AfterViewI
   ngOnDestroy() {
     this.subscriptions.unsubscribe();
   }
+
+  serviceSelected(id: string): boolean {
+    return !(<HTMLInputElement>document.getElementById(id)).checked;
+  }
 }

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
@@ -143,7 +143,9 @@ export class SelectMainServiceDirective implements OnInit, OnDestroy, AfterViewI
       this.form.get('workplaceService').patchValue(this.selectedMainService.id);
 
       if (this.selectedMainService.other && this.form.get(`otherWorkplaceService${this.selectedMainService.id}`)) {
-        this.form.get(`otherWorkplaceService${this.selectedMainService.id}`).patchValue(this.selectedMainService.other);
+        this.form
+          .get(`otherWorkplaceService${this.selectedMainService.id}`)
+          .patchValue(this.selectedMainService.otherName);
       }
     }
     this.renderForm = true;

--- a/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
+++ b/src/app/shared/directives/create-workplace/select-main-service/select-main-service.directive.ts
@@ -192,7 +192,7 @@ export class SelectMainServiceDirective implements OnInit, OnDestroy, AfterViewI
     this.subscriptions.unsubscribe();
   }
 
-  serviceSelected(id: string): boolean {
+  serviceNotSelected(id: string): boolean {
     return !(<HTMLInputElement>document.getElementById(id)).checked;
   }
 }


### PR DESCRIPTION
#### Work done
- Due to us using `updateOn: 'submit'` the value is not updated until submitted, to combat this we have to get the JS value of the option to know if it's checked or not

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
