### PR TITLE
Fix: select workplace continue button

### DIFF
--- a/src/app/features/add-workplace/select-workplace/select-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/select-workplace/select-workplace.component.spec.ts
@@ -151,11 +151,11 @@ describe('SelectWorkplaceComponent', () => {
       expect(spy).toHaveBeenCalledWith(['/add-workplace', 'new-select-main-service']);
     });
 
-    it('should navigate to the confirm-details page in registration flow when returnToConfirmDetails is not null', async () => {
+    it('should navigate to the confirm-workplace-details page when returnToConfirmDetails is not null', async () => {
       const { component, getByText, fixture, spy } = await setup();
 
       component.createAccountNewDesign = true;
-      component.returnToConfirmDetails = { url: ['add-workplace', 'confirm-details'] };
+      component.returnToConfirmDetails = { url: ['add-workplace', 'confirm-workplace-details'] };
       component.setNextRoute();
       fixture.detectChanges();
 
@@ -165,7 +165,7 @@ describe('SelectWorkplaceComponent', () => {
       const continueButton = getByText('Continue');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'confirm-details']);
+      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'confirm-workplace-details']);
     });
 
     it('should navigate back to the find-workplace url in add-workplace flow when Change clicked', async () => {

--- a/src/app/features/add-workplace/select-workplace/select-workplace.component.ts
+++ b/src/app/features/add-workplace/select-workplace/select-workplace.component.ts
@@ -36,4 +36,12 @@ export class SelectWorkplaceComponent extends SelectWorkplaceDirective {
   protected setTitle(): void {
     this.title = 'Select the workplace you want to add';
   }
+
+  public setNextRoute(): void {
+    if (this.createAccountNewDesign) {
+      this.nextRoute = this.returnToConfirmDetails ? 'confirm-workplace-details' : 'new-select-main-service';
+    } else {
+      this.nextRoute = this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
+    }
+  }
 }

--- a/src/app/features/create-account/workplace/select-workplace/select-workplace.component.ts
+++ b/src/app/features/create-account/workplace/select-workplace/select-workplace.component.ts
@@ -28,4 +28,12 @@ export class SelectWorkplaceComponent extends SelectWorkplaceDirective {
     this.returnToConfirmDetails = this.registrationService.returnTo$.value;
     this.prefillForm();
   }
+
+  public setNextRoute(): void {
+    if (this.createAccountNewDesign) {
+      this.nextRoute = this.returnToConfirmDetails ? 'confirm-details' : 'new-select-main-service';
+    } else {
+      this.nextRoute = this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
+    }
+  }
 }

--- a/src/app/shared/directives/create-workplace/select-workplace/select-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/select-workplace/select-workplace.directive.ts
@@ -77,13 +77,7 @@ export class SelectWorkplaceDirective implements OnInit, OnDestroy, AfterViewIni
     this.title = 'Select your workplace';
   }
 
-  public setNextRoute(): void {
-    if (this.createAccountNewDesign) {
-      this.nextRoute = this.returnToConfirmDetails ? 'confirm-details' : 'new-select-main-service';
-    } else {
-      this.nextRoute = this.returnToConfirmDetails ? 'confirm-workplace-details' : 'select-main-service';
-    }
-  }
+  public setNextRoute(): void {} // eslint-disable-line @typescript-eslint/no-empty-function
 
   protected setupForm(): void {
     this.form = this.formBuilder.group({


### PR DESCRIPTION
#### Work done
- Fix the url for the continue button on `select-workplace` page in `add-workplace` flow

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
