### PR TITLE
Pattern Validation to only allow postcode and location ID's

### DIFF
--- a/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -110,6 +110,26 @@ describe('FindYourWorkplaceComponent', () => {
     expect(getLocationByPostcodeOrLocationID).not.toHaveBeenCalled();
   });
 
+  it('should show an error if it has special characters other than a hyphen', async () => {
+    const { component, locationService } = await setup();
+    const getLocationByPostcodeOrLocationID = spyOn(
+      locationService,
+      'getLocationByPostcodeOrLocationID',
+    ).and.callThrough();
+
+    const form = component.fixture.componentInstance.form;
+    form.controls['postcodeOrLocationID'].setValue('http://localhost');
+
+    const findWorkplaceButton = component.getByText('Find workplace');
+    fireEvent.click(findWorkplaceButton);
+
+    expect(getLocationByPostcodeOrLocationID).not.toHaveBeenCalled();
+    expect(form.invalid).toBeTruthy();
+    expect(component.getAllByText('Enter a valid CQC location ID or workplace postcode', { exact: false }).length).toBe(
+      2,
+    );
+  });
+
   it('should show registration version of error message if the input is empty on submit', async () => {
     const { component } = await setup();
 
@@ -123,7 +143,7 @@ describe('FindYourWorkplaceComponent', () => {
     ).toBe(2);
   });
 
-  it('should submit the value if value is inputted', async () => {
+  it('should submit the value if a postcode is inputted', async () => {
     const { component, locationService } = await setup();
     const form = component.fixture.componentInstance.form;
     const findWorkplaceButton = component.getByText('Find workplace');
@@ -140,6 +160,25 @@ describe('FindYourWorkplaceComponent', () => {
 
     expect(form.valid).toBeTruthy();
     expect(getLocationByPostcodeOrLocationID).toHaveBeenCalledWith('LS1 1AA');
+  });
+
+  it('should submit the value if a locationID is inputted', async () => {
+    const { component, locationService } = await setup();
+    const form = component.fixture.componentInstance.form;
+    const findWorkplaceButton = component.getByText('Find workplace');
+    const getLocationByPostcodeOrLocationID = spyOn(
+      locationService,
+      'getLocationByPostcodeOrLocationID',
+    ).and.callThrough();
+
+    form.controls['postcodeOrLocationID'].setValue('1-123456789');
+
+    fireEvent.click(findWorkplaceButton);
+
+    component.fixture.detectChanges();
+
+    expect(form.valid).toBeTruthy();
+    expect(getLocationByPostcodeOrLocationID).toHaveBeenCalledWith('1-123456789');
   });
 
   it("should submit and go to your-workplace if there's only one address", async () => {

--- a/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive.ts
@@ -77,7 +77,10 @@ export class FindYourWorkplaceDirective implements OnInit, AfterViewInit, OnDest
 
   private setupForm(): void {
     this.form = this.formBuilder.group({
-      postcodeOrLocationID: [null, { validators: Validators.required, updateOn: 'submit' }],
+      postcodeOrLocationID: [
+        null,
+        { validators: [Validators.required, Validators.pattern(`^[a-zA-Z0-9 -]{1,}$`)], updateOn: 'submit' },
+      ],
     });
   }
 
@@ -107,6 +110,10 @@ export class FindYourWorkplaceDirective implements OnInit, AfterViewInit, OnDest
           {
             name: 'required',
             message: `Enter ${yourOrIts} CQC location ID or ${yourOrIts} workplace postcode`,
+          },
+          {
+            name: 'pattern',
+            message: `Enter a valid CQC location ID or workplace postcode`,
           },
         ],
       },


### PR DESCRIPTION
#### Work done
- Added a pattern validation to now allow special characters other than hyphens

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
