### PR TITLE
Fix: workplace name address back buttons

### DIFF
--- a/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/add-workplace/select-workplace-address/select-workplace-address.component.ts
@@ -27,6 +27,7 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
   protected init(): void {
     this.flow = '/add-workplace';
     this.returnToConfirmDetails = this.workplaceService.returnTo$.value;
+    this.workplaceService.workplaceNotFound$.next(false);
     this.workplaceService.manuallyEnteredWorkplace$.next(false);
     this.workplaceService.manuallyEnteredWorkplaceName$.next(false);
     this.setupSubscriptions();

--- a/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.ts
+++ b/src/app/features/create-account/workplace/select-workplace-address/select-workplace-address.component.ts
@@ -27,6 +27,7 @@ export class SelectWorkplaceAddressComponent extends SelectWorkplaceAddressDirec
   protected init(): void {
     this.flow = '/registration';
     this.returnToConfirmDetails = this.registrationService.returnTo$.value;
+    this.registrationService.workplaceNotFound$.next(false);
     this.registrationService.manuallyEnteredWorkplace$.next(false);
     this.registrationService.manuallyEnteredWorkplaceName$.next(false);
     this.setupSubscriptions();


### PR DESCRIPTION
#### Work done
- Set `workplaceNotFound$` to false on `select-workplace-address` page so that the back button on `workplace-name-address` takes you back to `select-workplace-address`

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
