### PR TITLE
Fix/is this your workplace errors

### DIFF
--- a/src/app/core/test-utils/MockConfigCatClient.ts
+++ b/src/app/core/test-utils/MockConfigCatClient.ts
@@ -49,7 +49,7 @@ export const mockConfigCatClient = {
     }
     if (flagName === 'createAccountNewDesign') {
       return new Promise((resolve) => {
-        return resolve(false);
+        return resolve(true);
       });
     }
     return new Promise((resolve) => {

--- a/src/app/core/test-utils/MockConfigCatClient.ts
+++ b/src/app/core/test-utils/MockConfigCatClient.ts
@@ -49,7 +49,7 @@ export const mockConfigCatClient = {
     }
     if (flagName === 'createAccountNewDesign') {
       return new Promise((resolve) => {
-        return resolve(true);
+        return resolve(false);
       });
     }
     return new Promise((resolve) => {

--- a/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive.ts
@@ -67,7 +67,10 @@ export class IsThisYourWorkplaceDirective implements OnInit, AfterViewInit {
   }
 
   protected prefillForm(): void {
-    if (this.workplaceInterfaceService.selectedLocationAddress$.value.locationId === this.locationData.locationId) {
+    if (
+      this.workplaceInterfaceService.selectedLocationAddress$.value &&
+      this.workplaceInterfaceService.selectedLocationAddress$.value.locationId === this.locationData.locationId
+    ) {
       this.form.patchValue({
         yourWorkplace: 'yes',
       });

--- a/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/is-this-your-workplace/is-this-your-workplace.directive.ts
@@ -67,10 +67,7 @@ export class IsThisYourWorkplaceDirective implements OnInit, AfterViewInit {
   }
 
   protected prefillForm(): void {
-    if (
-      this.workplaceInterfaceService.selectedLocationAddress$.value &&
-      this.workplaceInterfaceService.selectedLocationAddress$.value.locationId === this.locationData.locationId
-    ) {
+    if (this.workplaceInterfaceService.selectedLocationAddress$.value?.locationId === this.locationData.locationId) {
       this.form.patchValue({
         yourWorkplace: 'yes',
       });


### PR DESCRIPTION
#### Work done
- add check in the prefill form function to check if the workplaceInterfaceService has a selected location
- if there was no location an error would occur in the console due to trying to access a property of null, and this caused the bug in the error messages

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [ x] No, they are not required for this change
