### PR TITLE
Fix: Prefill workplace not found

### DIFF
--- a/src/app/core/services/workplace-interface.service.ts
+++ b/src/app/core/services/workplace-interface.service.ts
@@ -22,6 +22,7 @@ export abstract class WorkplaceInterfaceService {
   public returnTo$: BehaviorSubject<URLStructure> = new BehaviorSubject<URLStructure>(null);
   public invalidPostcodeEntered$: BehaviorSubject<string> = new BehaviorSubject(null);
   public manuallyEnteredWorkplaceName$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public useDifferentLocationIdOrPostcode$: BehaviorSubject<boolean> = new BehaviorSubject(null);
 
   public isRegulated(): boolean {
     return this.isRegulated$.value;
@@ -46,5 +47,6 @@ export abstract class WorkplaceInterfaceService {
     this.returnTo$.next(null);
     this.invalidPostcodeEntered$.next(null);
     this.manuallyEnteredWorkplaceName$.next(false);
+    this.useDifferentLocationIdOrPostcode$.next(null);
   }
 }

--- a/src/app/features/add-workplace/could-not-find-workplace-address/could-not-find-workplace-address.component.spec.ts
+++ b/src/app/features/add-workplace/could-not-find-workplace-address/could-not-find-workplace-address.component.spec.ts
@@ -7,9 +7,12 @@ import { BackService } from '@core/services/back.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkplaceService } from '@core/services/workplace.service';
 import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
-import { CouldNotFindWorkplaceAddressDirective } from '@shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive';
+import {
+  CouldNotFindWorkplaceAddressDirective,
+} from '@shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
+import { BehaviorSubject } from 'rxjs';
 
 import { AddWorkplaceModule } from '../add-workplace.module';
 import { CouldNotFindWorkplaceAddressComponent } from './could-not-find-workplace-address.component';
@@ -108,6 +111,42 @@ describe('CouldNotFindWorkplaceAddressComponent', () => {
       const expectedNoAnswer = "No, I'll enter the workplace details myself";
 
       expect(getByText(expectedNoAnswer)).toBeTruthy();
+    });
+  });
+
+  describe('prefillForm()', () => {
+    it('should preselect the "Yes" radio button if useDifferentLocationIdOrPostcode has been set to true in the service', async () => {
+      const { component } = await setup();
+
+      component.workplaceService.useDifferentLocationIdOrPostcode$ = new BehaviorSubject(true);
+      component.ngOnInit();
+
+      const form = component.form;
+      expect(form.valid).toBeTruthy();
+      expect(form.value.useDifferentPostcode).toBe('yes');
+    });
+
+    it('should preselect the "No" radio button if useDifferentLocationIdOrPostcode has been set to false in the service', async () => {
+      const { component } = await setup();
+
+      component.workplaceService.useDifferentLocationIdOrPostcode$ = new BehaviorSubject(false);
+      component.ngOnInit();
+
+      const form = component.form;
+      expect(form.valid).toBeTruthy();
+      expect(form.value.useDifferentPostcode).toBe('no');
+    });
+
+    it('should not preselect any radio buttons if useDifferentLocationIdOrPostcode has not been set in the service', async () => {
+      const { component } = await setup();
+
+      component.workplaceService.useDifferentLocationIdOrPostcode$ = new BehaviorSubject(null);
+      component.ngOnInit();
+
+      const form = component.form;
+      expect(form.invalid).toBeTruthy();
+      expect(form.value.useDifferentPostcode).not.toBe('yes');
+      expect(form.value.useDifferentPostcode).not.toBe('no');
     });
   });
 

--- a/src/app/features/add-workplace/could-not-find-workplace-address/could-not-find-workplace-address.component.ts
+++ b/src/app/features/add-workplace/could-not-find-workplace-address/could-not-find-workplace-address.component.ts
@@ -5,7 +5,9 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkplaceService } from '@core/services/workplace.service';
-import { CouldNotFindWorkplaceAddressDirective } from '@shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive';
+import {
+  CouldNotFindWorkplaceAddressDirective,
+} from '@shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive';
 
 @Component({
   selector: 'app-could-not-find-workplace-address',
@@ -14,7 +16,7 @@ import { CouldNotFindWorkplaceAddressDirective } from '@shared/directives/create
 })
 export class CouldNotFindWorkplaceAddressComponent extends CouldNotFindWorkplaceAddressDirective {
   constructor(
-    protected workplaceService: WorkplaceService,
+    public workplaceService: WorkplaceService,
     public backService: BackService,
     protected establishmentService: EstablishmentService,
     protected formBuilder: FormBuilder,

--- a/src/app/features/add-workplace/find-workplace-address/find-workplace-address.component.spec.ts
+++ b/src/app/features/add-workplace/find-workplace-address/find-workplace-address.component.spec.ts
@@ -214,15 +214,33 @@ describe('FindWorkplaceComponent', () => {
   });
 
   describe('setBackLink()', () => {
-    it('should set the correct back link when in the registration flow', async () => {
+    it('should set the back link to `new-regulated-by-cqc` if returnToWorkplaceNotFound is false', async () => {
       const { component } = await setup();
       const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.workplaceService.workplaceNotFound$ = new BehaviorSubject(false);
+      component.fixture.componentInstance.ngOnInit();
 
       component.fixture.componentInstance.setBackLink();
       component.fixture.detectChanges();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
         url: ['add-workplace', 'new-regulated-by-cqc'],
+      });
+    });
+
+    it('should set the back link to `workplace-address-not-found` if returnToWorkplaceNotFound is true', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.workplaceService.workplaceNotFound$ = new BehaviorSubject(true);
+      component.fixture.componentInstance.ngOnInit();
+
+      component.fixture.componentInstance.setBackLink();
+      component.fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['add-workplace', 'workplace-address-not-found'],
       });
     });
   });

--- a/src/app/features/add-workplace/new-workplace-not-found/new-workplace-not-found.component.spec.ts
+++ b/src/app/features/add-workplace/new-workplace-not-found/new-workplace-not-found.component.spec.ts
@@ -14,7 +14,12 @@ import { AddWorkplaceModule } from '../add-workplace.module';
 import { NewWorkplaceNotFoundComponent } from './new-workplace-not-found.component';
 
 describe('NewWorkplaceNotFoundComponent', () => {
-  async function setup(postcodeOrLocationId = '', searchMethod = '', workplaceNotFound = false) {
+  async function setup(
+    postcodeOrLocationId = '',
+    searchMethod = '',
+    workplaceNotFound = false,
+    useDifferentLocationIdOrPostcode = null,
+  ) {
     const component = await render(NewWorkplaceNotFoundComponent, {
       imports: [SharedModule, AddWorkplaceModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
@@ -30,6 +35,12 @@ describe('NewWorkplaceNotFoundComponent', () => {
             },
             workplaceNotFound$: {
               value: workplaceNotFound,
+              next: () => {
+                return true;
+              },
+            },
+            useDifferentLocationIdOrPostcode$: {
+              value: useDifferentLocationIdOrPostcode,
               next: () => {
                 return true;
               },
@@ -139,6 +150,33 @@ describe('NewWorkplaceNotFoundComponent', () => {
       component.fixture.detectChanges();
 
       expect(component.getByText(expectedHeading)).toBeTruthy();
+    });
+  });
+
+  describe('prefillForm()', () => {
+    it('should preselect the "Yes" radio button if useDifferentLocationIdOrPostcode has been set to true in the service', async () => {
+      const { component } = await setup('', '', false, true);
+
+      const form = component.fixture.componentInstance.form;
+      expect(form.valid).toBeTruthy();
+      expect(form.value.useDifferentLocationIdOrPostcode).toBe('yes');
+    });
+
+    it('should preselect the "No" radio button if useDifferentLocationIdOrPostcode has been set to false in the service', async () => {
+      const { component } = await setup('', '', false, false);
+
+      const form = component.fixture.componentInstance.form;
+      expect(form.valid).toBeTruthy();
+      expect(form.value.useDifferentLocationIdOrPostcode).toBe('no');
+    });
+
+    it('should not preselect any radio buttons if useDifferentLocationIdOrPostcode has not been set in the service', async () => {
+      const { component } = await setup('', '', false, null);
+
+      const form = component.fixture.componentInstance.form;
+      expect(form.invalid).toBeTruthy();
+      expect(form.value.useDifferentLocationIdOrPostcode).not.toBe('yes');
+      expect(form.value.useDifferentLocationIdOrPostcode).not.toBe('no');
     });
   });
 

--- a/src/app/features/add-workplace/workplace-added-thank-you/workplace-added-thank-you.component.spec.ts
+++ b/src/app/features/add-workplace/workplace-added-thank-you/workplace-added-thank-you.component.spec.ts
@@ -67,5 +67,6 @@ describe('WorkplaceAddedThankYouComponent', () => {
     expect(workplaceService.returnTo$.value).toBeNull();
     expect(workplaceService.invalidPostcodeEntered$.value).toBeNull();
     expect(workplaceService.manuallyEnteredWorkplaceName$.value).toBeFalse();
+    expect(workplaceService.useDifferentLocationIdOrPostcode$.value).toBeNull();
   });
 });

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
@@ -74,10 +74,12 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     if (this.createAccountNewDesign) {
       if (this.isCqcRegulatedAndWorkplaceNotFound()) {
         this.backService.setBackLink({ url: [this.flow, 'new-workplace-not-found'] });
+        this.workplaceService.workplaceNotFound$.next(false);
         return;
       }
       if (this.isNotCqcRegulatedAndWorkplaceNotFound()) {
         this.backService.setBackLink({ url: [this.flow, 'workplace-address-not-found'] });
+        this.workplaceService.workplaceNotFound$.next(false);
         return;
       }
     }

--- a/src/app/features/create-account/workplace/could-not-find-workplace-address/could-not-find-workplace-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/could-not-find-workplace-address/could-not-find-workplace-address.component.spec.ts
@@ -7,9 +7,12 @@ import { BackService } from '@core/services/back.service';
 import { RegistrationService } from '@core/services/registration.service';
 import { MockRegistrationService } from '@core/test-utils/MockRegistrationService';
 import { RegistrationModule } from '@features/registration/registration.module';
-import { CouldNotFindWorkplaceAddressDirective } from '@shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive';
+import {
+  CouldNotFindWorkplaceAddressDirective,
+} from '@shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
+import { BehaviorSubject } from 'rxjs';
 
 import { CouldNotFindWorkplaceAddressComponent } from './could-not-find-workplace-address.component';
 
@@ -99,6 +102,42 @@ describe('CouldNotFindWorkplaceAddressComponent', () => {
       const expectedNoAnswer = "No, I'll enter our workplace details myself";
 
       expect(getByText(expectedNoAnswer)).toBeTruthy();
+    });
+  });
+
+  describe('prefillForm()', () => {
+    it('should preselect the "Yes" radio button if useDifferentLocationIdOrPostcode has been set to true in the service', async () => {
+      const { component } = await setup();
+
+      component.registrationService.useDifferentLocationIdOrPostcode$ = new BehaviorSubject(true);
+      component.ngOnInit();
+
+      const form = component.form;
+      expect(form.valid).toBeTruthy();
+      expect(form.value.useDifferentPostcode).toBe('yes');
+    });
+
+    it('should preselect the "No" radio button if useDifferentLocationIdOrPostcode has been set to false in the service', async () => {
+      const { component } = await setup();
+
+      component.registrationService.useDifferentLocationIdOrPostcode$ = new BehaviorSubject(false);
+      component.ngOnInit();
+
+      const form = component.form;
+      expect(form.valid).toBeTruthy();
+      expect(form.value.useDifferentPostcode).toBe('no');
+    });
+
+    it('should not preselect any radio buttons if useDifferentLocationIdOrPostcode has not been set in the service', async () => {
+      const { component } = await setup();
+
+      component.registrationService.useDifferentLocationIdOrPostcode$ = new BehaviorSubject(null);
+      component.ngOnInit();
+
+      const form = component.form;
+      expect(form.invalid).toBeTruthy();
+      expect(form.value.useDifferentPostcode).not.toBe('yes');
+      expect(form.value.useDifferentPostcode).not.toBe('no');
     });
   });
 

--- a/src/app/features/create-account/workplace/could-not-find-workplace-address/could-not-find-workplace-address.component.ts
+++ b/src/app/features/create-account/workplace/could-not-find-workplace-address/could-not-find-workplace-address.component.ts
@@ -5,7 +5,9 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { RegistrationService } from '@core/services/registration.service';
-import { CouldNotFindWorkplaceAddressDirective } from '@shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive';
+import {
+  CouldNotFindWorkplaceAddressDirective,
+} from '@shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive';
 
 @Component({
   selector: 'app-could-not-find-workplace-address',
@@ -14,7 +16,7 @@ import { CouldNotFindWorkplaceAddressDirective } from '@shared/directives/create
 })
 export class CouldNotFindWorkplaceAddressComponent extends CouldNotFindWorkplaceAddressDirective {
   constructor(
-    protected registrationService: RegistrationService,
+    public registrationService: RegistrationService,
     public backService: BackService,
     protected establishmentService: EstablishmentService,
     protected formBuilder: FormBuilder,

--- a/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/find-workplace-address/find-workplace-address.component.spec.ts
@@ -205,15 +205,33 @@ describe('FindWorkplaceAddressComponent', () => {
   });
 
   describe('setBackLink()', () => {
-    it('should set the correct back link when in the registration flow', async () => {
+    it('should set the back link to `new-regulated-by-cqc` if returnToWorkplaceNotFound is false', async () => {
       const { component } = await setup();
       const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.registrationService.workplaceNotFound$ = new BehaviorSubject(false);
+      component.fixture.componentInstance.ngOnInit();
 
       component.fixture.componentInstance.setBackLink();
       component.fixture.detectChanges();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
         url: ['registration', 'new-regulated-by-cqc'],
+      });
+    });
+
+    it('should set the back link to `workplace-address-not-found` if returnToWorkplaceNotFound is true', async () => {
+      const { component } = await setup();
+      const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
+
+      component.fixture.componentInstance.registrationService.workplaceNotFound$ = new BehaviorSubject(true);
+      component.fixture.componentInstance.ngOnInit();
+
+      component.fixture.componentInstance.setBackLink();
+      component.fixture.detectChanges();
+
+      expect(backLinkSpy).toHaveBeenCalledWith({
+        url: ['registration', 'workplace-address-not-found'],
       });
     });
   });

--- a/src/app/features/create-account/workplace/new-workplace-not-found/new-workplace-not-found.component.spec.ts
+++ b/src/app/features/create-account/workplace/new-workplace-not-found/new-workplace-not-found.component.spec.ts
@@ -14,7 +14,12 @@ import { RegistrationModule } from '../../../registration/registration.module';
 import { NewWorkplaceNotFoundComponent } from './new-workplace-not-found.component';
 
 describe('NewWorkplaceNotFoundComponent', () => {
-  async function setup(postcodeOrLocationId = '', searchMethod = '', workplaceNotFound = false) {
+  async function setup(
+    postcodeOrLocationId = '',
+    searchMethod = '',
+    workplaceNotFound = false,
+    useDifferentLocationIdOrPostcode = null,
+  ) {
     const component = await render(NewWorkplaceNotFoundComponent, {
       imports: [SharedModule, RegistrationModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
@@ -30,6 +35,12 @@ describe('NewWorkplaceNotFoundComponent', () => {
             },
             workplaceNotFound$: {
               value: workplaceNotFound,
+              next: () => {
+                return true;
+              },
+            },
+            useDifferentLocationIdOrPostcode$: {
+              value: useDifferentLocationIdOrPostcode,
               next: () => {
                 return true;
               },
@@ -147,6 +158,33 @@ describe('NewWorkplaceNotFoundComponent', () => {
       const expectedHeading = 'We could not find your workplace';
 
       expect(component.getByText(expectedHeading)).toBeTruthy();
+    });
+  });
+
+  describe('prefillForm()', () => {
+    it('should preselect the "Yes" radio button if useDifferentLocationIdOrPostcode has been set to true in the service', async () => {
+      const { component } = await setup('', '', false, true);
+
+      const form = component.fixture.componentInstance.form;
+      expect(form.valid).toBeTruthy();
+      expect(form.value.useDifferentLocationIdOrPostcode).toBe('yes');
+    });
+
+    it('should preselect the "No" radio button if useDifferentLocationIdOrPostcode has been set to false in the service', async () => {
+      const { component } = await setup('', '', false, false);
+
+      const form = component.fixture.componentInstance.form;
+      expect(form.valid).toBeTruthy();
+      expect(form.value.useDifferentLocationIdOrPostcode).toBe('no');
+    });
+
+    it('should not preselect any radio buttons if useDifferentLocationIdOrPostcode has not been set in the service', async () => {
+      const { component } = await setup('', '', false, null);
+
+      const form = component.fixture.componentInstance.form;
+      expect(form.invalid).toBeTruthy();
+      expect(form.value.useDifferentLocationIdOrPostcode).not.toBe('yes');
+      expect(form.value.useDifferentLocationIdOrPostcode).not.toBe('no');
     });
   });
 

--- a/src/app/features/create-account/workplace/thank-you/thank-you.component.spec.ts
+++ b/src/app/features/create-account/workplace/thank-you/thank-you.component.spec.ts
@@ -93,5 +93,6 @@ describe('ThankYouComponent', () => {
     expect(registrationService.returnTo$.value).toBeNull();
     expect(registrationService.invalidPostcodeEntered$.value).toBeNull();
     expect(registrationService.manuallyEnteredWorkplaceName$.value).toBeFalse();
+    expect(registrationService.useDifferentLocationIdOrPostcode$.value).toBeNull();
   });
 });

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
@@ -74,10 +74,12 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     if (this.createAccountNewDesign) {
       if (this.isCqcRegulatedAndWorkplaceNotFound()) {
         this.backService.setBackLink({ url: [this.flow, 'new-workplace-not-found'] });
+        this.registrationService.workplaceNotFound$.next(false);
         return;
       }
       if (this.isNotCqcRegulatedAndWorkplaceNotFound()) {
         this.backService.setBackLink({ url: [this.flow, 'workplace-address-not-found'] });
+        this.registrationService.workplaceNotFound$.next(false);
         return;
       }
     }

--- a/src/app/shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive.ts
+++ b/src/app/shared/directives/create-workplace/could-not-find-workplace-address/could-not-find-workplace-address.directive.ts
@@ -37,7 +37,9 @@ export class CouldNotFindWorkplaceAddressDirective implements OnInit {
     this.setBackLink();
     this.setupForm();
     this.setupFormErrorsMap();
+    this.prefillForm();
     this.invalidPostcodeEntered = this.workplaceInterfaceService.invalidPostcodeEntered$.value;
+    this.workplaceInterfaceService.useDifferentLocationIdOrPostcode$.next(null);
   }
 
   ngAfterViewInit(): void {
@@ -68,6 +70,16 @@ export class CouldNotFindWorkplaceAddressDirective implements OnInit {
     ];
   }
 
+  protected prefillForm(): void {
+    const useDifferentPostcode = this.workplaceInterfaceService.useDifferentLocationIdOrPostcode$.value;
+    if (useDifferentPostcode !== null) {
+      const radioButton = useDifferentPostcode ? 'yes' : 'no';
+      this.form.patchValue({
+        useDifferentPostcode: radioButton,
+      });
+    }
+  }
+
   public getErrorMessage(item: string): string {
     const errorType = Object.keys(this.form.get(item).errors)[0];
     return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
@@ -77,12 +89,14 @@ export class CouldNotFindWorkplaceAddressDirective implements OnInit {
     this.submitted = true;
 
     if (this.form.valid) {
-      const useDifferentPostcode = this.form.get('useDifferentPostcode');
+      const radioButton = this.form.get('useDifferentPostcode');
       this.workplaceInterfaceService.workplaceNotFound$.next(true);
-      if (useDifferentPostcode.value === 'yes') {
+      if (radioButton.value === 'yes') {
         this.router.navigate([this.flow, 'find-workplace-address']);
+        this.workplaceInterfaceService.useDifferentLocationIdOrPostcode$.next(true);
       } else {
         this.router.navigate([this.flow, 'workplace-name-address']);
+        this.workplaceInterfaceService.useDifferentLocationIdOrPostcode$.next(false);
       }
     } else {
       this.errorSummaryService.scrollToErrorSummary();

--- a/src/app/shared/directives/create-workplace/find-workplace-address/find-workplace-address.ts
+++ b/src/app/shared/directives/create-workplace/find-workplace-address/find-workplace-address.ts
@@ -148,8 +148,16 @@ export class FindWorkplaceAddress implements OnInit, OnDestroy, AfterViewInit {
   }
 
   public setBackLink(): void {
-    const url = this.createAccountNewDesign ? 'new-regulated-by-cqc' : 'select-workplace-address';
-    this.backService.setBackLink({ url: [this.flow, url] });
+    const returnToWorkplaceNotFound = this.workplaceInterfaceService.workplaceNotFound$.value;
+
+    let backLink: string;
+    if (this.createAccountNewDesign) {
+      backLink = returnToWorkplaceNotFound ? 'workplace-address-not-found' : 'new-regulated-by-cqc';
+    } else {
+      backLink = 'select-workplace-address';
+    }
+    this.backService.setBackLink({ url: [this.flow, backLink] });
+    this.workplaceInterfaceService.workplaceNotFound$.next(false);
   }
 
   public getFirstErrorMessage(item: string): string {

--- a/src/app/shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.directive.ts
+++ b/src/app/shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.directive.ts
@@ -40,6 +40,8 @@ export class NewWorkplaceNotFoundDirective implements OnInit, AfterViewInit {
     this.setBackLink();
     this.setupForm();
     this.setupFormErrorsMap();
+    this.prefillForm();
+    this.workplaceInterfaceService.useDifferentLocationIdOrPostcode$.next(null);
   }
 
   ngAfterViewInit(): void {
@@ -75,6 +77,16 @@ export class NewWorkplaceNotFoundDirective implements OnInit, AfterViewInit {
     ];
   }
 
+  protected prefillForm(): void {
+    const useDifferentLocationIdOrPostcode = this.workplaceInterfaceService.useDifferentLocationIdOrPostcode$.value;
+    if (useDifferentLocationIdOrPostcode !== null) {
+      const radioButton = useDifferentLocationIdOrPostcode ? 'yes' : 'no';
+      this.form.patchValue({
+        useDifferentLocationIdOrPostcode: radioButton,
+      });
+    }
+  }
+
   public setBackLink(): void {
     this.backService.setBackLink({ url: [this.flow, 'find-workplace'] });
   }
@@ -88,12 +100,14 @@ export class NewWorkplaceNotFoundDirective implements OnInit, AfterViewInit {
     this.submitted = true;
 
     if (this.form.valid) {
-      const useDifferentLocationIdOrPostcode = this.form.get('useDifferentLocationIdOrPostcode');
+      const radioButton = this.form.get('useDifferentLocationIdOrPostcode');
       this.workplaceInterfaceService.workplaceNotFound$.next(true);
-      if (useDifferentLocationIdOrPostcode.value === 'yes') {
+      if (radioButton.value === 'yes') {
         this.router.navigate([`/${this.flow}`, 'find-workplace']);
+        this.workplaceInterfaceService.useDifferentLocationIdOrPostcode$.next(true);
       } else {
         this.router.navigate([`/${this.flow}`, 'workplace-name-address']);
+        this.workplaceInterfaceService.useDifferentLocationIdOrPostcode$.next(false);
       }
     } else {
       this.errorSummaryService.scrollToErrorSummary();


### PR DESCRIPTION
#### Work done
- Added a new behaviour subject in `workplaceInterfaceService` which is used to decide which radio buttons to pre fill on the `workplace-not-found` pages
- Added `prefillForm()` functions to `workplace-not-found` and `workplace-address-not-found`
- Update back link on `find-workplace-address` page so that it takes you back to the `workplace-address-not-found` page if that's where you came from
- Set `workplaceNotFound$` to false after setting back button in `workplace-name-address` to prevent back button loop

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
