### PR TITLE
Fix: pre filling workplace name address

### DIFF
--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -91,6 +91,7 @@ describe('WorkplaceNameAddressComponent', () => {
 
       component.workplaceService.manuallyEnteredWorkplace$ = new BehaviorSubject(true);
       component.ngOnInit();
+      component.setupPreFillForm();
 
       const continueButton = getByText('Continue');
       fireEvent.click(continueButton);
@@ -114,6 +115,7 @@ describe('WorkplaceNameAddressComponent', () => {
 
       component.workplaceService.returnTo$ = new BehaviorSubject({ url: ['add-workplace', 'confirm-details'] });
       component.ngOnInit();
+      component.setupPreFillForm();
 
       const continueButton = getByText('Continue');
       fireEvent.click(continueButton);

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.ts
@@ -39,8 +39,8 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     this.manuallyEnteredWorkplace = this.workplaceService.manuallyEnteredWorkplace$.value;
     this.isCqcRegulated = this.workplaceService.isCqcRegulated$.value;
 
-    this.setupPreFillForm();
     await this.setFeatureFlag();
+    this.setupPreFillForm();
     this.setBackLink();
   }
 
@@ -51,9 +51,14 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     );
   }
 
-  private setupPreFillForm(): void {
+  public setupPreFillForm(): void {
     const selectedLocation = this.workplaceService.selectedLocationAddress$.value;
-    if (this.manuallyEnteredWorkplace || this.returnToConfirmDetails) {
+    if (this.createAccountNewDesign) {
+      if (this.manuallyEnteredWorkplace || this.returnToConfirmDetails) {
+        this.preFillForm(selectedLocation);
+      }
+    }
+    if (!this.createAccountNewDesign && selectedLocation) {
       this.preFillForm(selectedLocation);
     }
   }

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -91,6 +91,7 @@ describe('WorkplaceNameAddressComponent', () => {
 
       component.registrationService.manuallyEnteredWorkplace$ = new BehaviorSubject(true);
       component.ngOnInit();
+      component.setupPreFillForm();
 
       const continueButton = getByText('Continue');
       fireEvent.click(continueButton);
@@ -114,6 +115,7 @@ describe('WorkplaceNameAddressComponent', () => {
 
       component.registrationService.returnTo$ = new BehaviorSubject({ url: ['registration', 'confirm-details'] });
       component.ngOnInit();
+      component.setupPreFillForm();
 
       const continueButton = getByText('Continue');
       fireEvent.click(continueButton);

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.ts
@@ -39,8 +39,8 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     this.manuallyEnteredWorkplace = this.registrationService.manuallyEnteredWorkplace$.value;
     this.isCqcRegulated = this.registrationService.isCqcRegulated$.value;
 
-    this.setupPreFillForm();
     await this.setFeatureFlag();
+    this.setupPreFillForm();
     this.setBackLink();
   }
 
@@ -51,9 +51,14 @@ export class WorkplaceNameAddressComponent extends WorkplaceNameAddressDirective
     );
   }
 
-  private setupPreFillForm(): void {
+  public setupPreFillForm(): void {
     const selectedLocation = this.registrationService.selectedLocationAddress$.value;
-    if (this.manuallyEnteredWorkplace || this.returnToConfirmDetails) {
+    if (this.createAccountNewDesign) {
+      if (this.manuallyEnteredWorkplace || this.returnToConfirmDetails) {
+        this.preFillForm(selectedLocation);
+      }
+    }
+    if (!this.createAccountNewDesign && selectedLocation) {
       this.preFillForm(selectedLocation);
     }
   }

--- a/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
+++ b/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
@@ -150,8 +150,8 @@ export class WorkplaceNameAddressDirective implements OnInit, OnDestroy, AfterVi
   public preFillForm(selectedLocation: LocationAddress): void {
     this.form.setValue({
       address1: selectedLocation.addressLine1,
-      address2: selectedLocation.addressLine2,
-      address3: selectedLocation.addressLine3,
+      address2: selectedLocation.addressLine2 ? selectedLocation.addressLine2 : null,
+      address3: selectedLocation.addressLine3 ? selectedLocation.addressLine3 : null,
       county: selectedLocation.county,
       postcode: selectedLocation.postalCode,
       townOrCity: selectedLocation.townCity,


### PR DESCRIPTION
#### Work done
- Fixed an issue with `workplace-name-address` not pre filling the form at all for old flow
- Fixed an issue where the back button for the `workplace-name-address` page was disappearing because address line 2 and 3 didn't exist, so `prefillForm()` was erroring

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
