### PR TITLE
Fix: Delete user migration

### DIFF
--- a/migrations/20210819131429-addDeleteToUserAuditChangeType.js
+++ b/migrations/20210819131429-addDeleteToUserAuditChangeType.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.query(`ALTER TYPE cqc."UserAuditChangeType" ADD VALUE 'delete';`)
+    return queryInterface.sequelize.query(`ALTER TYPE cqc."UserAuditChangeType" ADD VALUE IF NOT EXISTS 'delete';`)
   },
 
   down: (queryInterface, Sequelize) => {


### PR DESCRIPTION
#### Work done
- Fixed an issue where migrations were failing on staging because the enum label `delete` already exists
- Added a check to the migration to only add `delete` to the enum if it doesn't already exist 

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
