### PR TITLE
Fix: Workplace name address - back button

### DIFF
--- a/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
+++ b/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
@@ -339,12 +339,10 @@ export class WorkplaceNameAddressDirective implements OnInit, OnDestroy, AfterVi
     if (this.createAccountNewDesign) {
       if (this.isCqcRegulatedAndWorkplaceNotFound()) {
         this.backService.setBackLink({ url: [this.flow, 'new-workplace-not-found'] });
-        this.workplaceInterfaceService.workplaceNotFound$.next(false);
         return;
       }
       if (this.isNotCqcRegulatedAndWorkplaceNotFound()) {
         this.backService.setBackLink({ url: [this.flow, 'workplace-address-not-found'] });
-        this.workplaceInterfaceService.workplaceNotFound$.next(false);
         return;
       }
     }


### PR DESCRIPTION
#### Issue
- After entering workplace details manually and continuing to the select main service page, if you pressed the back button twice it would take you to the `select-workplace` / `select-workplace-address` page where the information was empty, instead of to the `workplace-not-found` page

#### Work done
- Removed lines where `workplaceNotFound` was being set to false in the service as it gets set to false already when navigating to the `select-workplace` or `select-workplace-address` page


#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
