### PR TITLE
Feat/registration requests page

### DIFF
--- a/server/routes/admin/registrations/index.js
+++ b/server/routes/admin/registrations/index.js
@@ -13,50 +13,90 @@ router.route('/').get(async (req, res) => {
     const loginResults = await models.login.findAll({
       attributes: ['id', 'username'],
       where: {
-          isActive: false,
-          status: 'PENDING'
+        isActive: false,
+        status: 'PENDING',
       },
-      order: [
-        ['id', 'DESC']
-      ],
+      order: [['id', 'DESC']],
       include: [
         {
           model: models.user,
-          attributes: ['EmailValue', 'PhoneValue', 'FullNameValue', 'SecurityQuestionValue', 'SecurityQuestionAnswerValue', 'created'],
+          attributes: [
+            'EmailValue',
+            'PhoneValue',
+            'FullNameValue',
+            'SecurityQuestionValue',
+            'SecurityQuestionAnswerValue',
+            'created',
+          ],
           include: [
             {
               model: models.establishment,
-              attributes: ['NameValue', 'IsRegulated', 'LocationID', 'ProvID', 'Address1', 'Address2', 'Address3', 'Town', 'County', 'PostCode', 'NmdsID', 'EstablishmentID'],
-              include: [{
-                model: models.services,
-                as: 'mainService',
-                attributes: ['id', 'name']
-              }]
-            }
-          ]
-        }
-      ]
+              attributes: [
+                'NameValue',
+                'IsRegulated',
+                'LocationID',
+                'ProvID',
+                'Address1',
+                'Address2',
+                'Address3',
+                'Town',
+                'County',
+                'PostCode',
+                'NmdsID',
+                'EstablishmentID',
+                'Status',
+                'EstablishmentUID',
+              ],
+              include: [
+                {
+                  model: models.services,
+                  as: 'mainService',
+                  attributes: ['id', 'name'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
     });
     // Get the pending workplace records
     const workplaceResults = await models.establishment.findAll({
-      attributes: ['NameValue', 'IsRegulated', 'LocationID', 'ProvID', 'Address1', 'Address2', 'Address3', 'Town', 'County', 'PostCode', 'NmdsID', 'EstablishmentID', 'ParentID', 'created', 'updatedBy'],
-      where: {
-          ustatus: 'PENDING'
-      },
-      order: [
-        ['id', 'DESC']
+      attributes: [
+        'NameValue',
+        'IsRegulated',
+        'LocationID',
+        'ProvID',
+        'Address1',
+        'Address2',
+        'Address3',
+        'Town',
+        'County',
+        'PostCode',
+        'NmdsID',
+        'EstablishmentID',
+        'ParentID',
+        'created',
+        'updatedBy',
+        'Status',
+        'EstablishmentUID',
       ],
-      include: [{
-        model: models.services,
-        as: 'mainService',
-        attributes: ['id', 'name']
-      }]
+      where: {
+        ustatus: 'PENDING',
+      },
+      order: [['id', 'DESC']],
+      include: [
+        {
+          model: models.services,
+          as: 'mainService',
+          attributes: ['id', 'name'],
+        },
+      ],
     });
 
     let arrToReturn, loginReturnArr, workplaceReturnArr;
-    if (loginResults){
+    if (loginResults) {
       // Reply with mapped results
-      loginReturnArr = loginResults.map(registration => {
+      loginReturnArr = loginResults.map((registration) => {
         registration = registration.toJSON();
         return {
           name: registration.user.FullNameValue,
@@ -79,13 +119,15 @@ router.route('/').get(async (req, res) => {
             county: registration.user.establishment.County,
             locationId: registration.user.establishment.LocationID,
             provid: registration.user.establishment.ProvID,
-            mainService: registration.user.establishment.mainService.name
-          }
+            mainService: registration.user.establishment.mainService.name,
+            status: registration.user.establishment.Status,
+            uid: registration.user.establishment.EstablishmentUID,
+          },
         };
       });
     }
-    if(workplaceResults){
-      workplaceReturnArr = workplaceResults.map(registration => {
+    if (workplaceResults) {
+      workplaceReturnArr = workplaceResults.map((registration) => {
         registration = registration.toJSON();
         return {
           created: registration.created,
@@ -104,51 +146,62 @@ router.route('/').get(async (req, res) => {
             locationId: registration.LocationID,
             provid: registration.ProvID,
             mainService: registration.mainService.name,
-            parentId: registration.ParentID
-          }
+            parentId: registration.ParentID,
+            status: registration.Status,
+            uid: registration.EstablishmentUID,
+          },
         };
       });
     }
-    if(loginResults && workplaceResults){
-      let loginWorkplaceIds = new Set(loginReturnArr.map(d => d.establishment.id));
-      arrToReturn = [...loginReturnArr, ...workplaceReturnArr.filter(d => !loginWorkplaceIds.has(d.establishment.id))];
 
-      arrToReturn.sort(function(a,b){
+    if (loginResults && workplaceResults) {
+      let loginWorkplaceIds = new Set(loginReturnArr.map((d) => d.establishment.id));
+      arrToReturn = [
+        ...loginReturnArr,
+        ...workplaceReturnArr.filter((d) => !loginWorkplaceIds.has(d.establishment.id)),
+      ];
+
+      arrToReturn.sort(function (a, b) {
         var dateA = new Date(a.created).getTime();
         var dateB = new Date(b.created).getTime();
         return dateB > dateA ? 1 : -1;
       });
 
-      for(let i = 0; i < arrToReturn.length; i++){
+      for (let i = 0; i < arrToReturn.length; i++) {
         arrToReturn[i].created = moment.utc(arrToReturn[i].created).tz(config.get('timezone')).format('D/M/YYYY h:mma');
         //get parent establishment details
-        if(!arrToReturn[i].email){
+        if (!arrToReturn[i].email) {
           let fetchQuery = {
             where: {
               id: arrToReturn[i].establishment.parentId,
             },
           };
           let parentEstablishment = await models.establishment.findOne(fetchQuery);
-          if(parentEstablishment){
+          if (parentEstablishment) {
             arrToReturn[i].establishment.parentEstablishmentId = parentEstablishment.nmdsId;
           }
         }
       }
+      // console.log("ArrToReturn ***************");
+      // console.log(arrToReturn);
       res.status(200).send(arrToReturn);
-    }else if(loginReturnArr && !workplaceReturnArr){
-      loginReturnArr.map(registration => {
+    } else if (loginReturnArr && !workplaceReturnArr) {
+      loginReturnArr.map((registration) => {
         registration.created = moment.utc(registration.created).tz(config.get('timezone')).format('D/M/YYYY h:mma');
       });
+
       res.status(200).send(loginReturnArr);
-    }else if(!loginReturnArr && workplaceReturnArr){
-      workplaceReturnArr.map(registration => {
+    } else if (!loginReturnArr && workplaceReturnArr) {
+      workplaceReturnArr.map((registration) => {
         registration.created = moment.utc(registration.created).tz(config.get('timezone')).format('D/M/YYYY h:mma');
       });
+
       res.status(200).send(workplaceReturnArr);
-    }else{
+    } else {
+      console.log('Else');
       res.status(200);
     }
-  } catch(error) {
+  } catch (error) {
     res.status(503);
   }
 });

--- a/server/routes/admin/registrations/index.js
+++ b/server/routes/admin/registrations/index.js
@@ -1,6 +1,7 @@
 // default route for admin/registrations
 const express = require('express');
 const moment = require('moment-timezone');
+const { Op } = require('sequelize');
 
 const models = require('../../../models');
 const config = require('../../../config/config');
@@ -14,7 +15,7 @@ router.route('/').get(async (req, res) => {
       attributes: ['id', 'username'],
       where: {
         isActive: false,
-        status: 'PENDING',
+        status: { [Op.not]: null },
       },
       order: [['id', 'DESC']],
       include: [
@@ -75,13 +76,14 @@ router.route('/').get(async (req, res) => {
         'NmdsID',
         'EstablishmentID',
         'ParentID',
+        'ParentUID',
         'created',
         'updatedBy',
         'Status',
         'EstablishmentUID',
       ],
       where: {
-        ustatus: 'PENDING',
+        ustatus: { [Op.not]: null },
       },
       order: [['id', 'DESC']],
       include: [
@@ -147,6 +149,7 @@ router.route('/').get(async (req, res) => {
             provid: registration.ProvID,
             mainService: registration.mainService.name,
             parentId: registration.ParentID,
+            parentUid: registration.ParentUID,
             status: registration.Status,
             uid: registration.EstablishmentUID,
           },

--- a/server/routes/admin/registrations/index.js
+++ b/server/routes/admin/registrations/index.js
@@ -185,8 +185,7 @@ router.route('/').get(async (req, res) => {
           }
         }
       }
-      // console.log("ArrToReturn ***************");
-      // console.log(arrToReturn);
+
       res.status(200).send(arrToReturn);
     } else if (loginReturnArr && !workplaceReturnArr) {
       loginReturnArr.map((registration) => {
@@ -201,7 +200,6 @@ router.route('/').get(async (req, res) => {
 
       res.status(200).send(workplaceReturnArr);
     } else {
-      console.log('Else');
       res.status(200);
     }
   } catch (error) {

--- a/src/app/core/breadcrumb/journey.admin.ts
+++ b/src/app/core/breadcrumb/journey.admin.ts
@@ -7,6 +7,11 @@ export const adminJourney: JourneyRoute = {
       title: 'Admin',
       children: [
         {
+          path: '/sfcadmin/registrations',
+          title: 'Registrations',
+          children: [],
+        },
+        {
           path: '/sfcadmin/local-authorities-return',
           title: 'Local authorities return',
           children: [

--- a/src/app/core/model/registrations.model.ts
+++ b/src/app/core/model/registrations.model.ts
@@ -1,29 +1,30 @@
 export interface Registrations {
-  [index: number]: {
+  [index: number]: Registration;
+}
+export interface Registration {
+  name: string;
+  username: string;
+  securityQuestion: string;
+  securityQuestionAnswer: string;
+  email: string;
+  phone: string;
+  created: string;
+  establishment: {
     name: string;
-    username: string;
-    securityQuestion: string;
-    securityQuestionAnswer: string;
-    email: string;
-    phone: string;
-    created: string;
-    establishment: {
-      name: string;
-      isRegulated: boolean;
-      nmdsId: string;
-      address: string;
-      address2: string;
-      address3: string;
-      postcode: string;
-      town: string;
-      county: string;
-      locationId: string;
-      provid: string;
-      parentId: string;
-      parentUID: string;
-      mainService: number;
-      status: string;
-      uid: string;
-    };
+    isRegulated: boolean;
+    nmdsId: string;
+    address: string;
+    address2: string;
+    address3: string;
+    postcode: string;
+    town: string;
+    county: string;
+    locationId: string;
+    provid: string;
+    parentId: string;
+    parentUid: string;
+    mainService: number;
+    status: string;
+    uid: string;
   };
 }

--- a/src/app/core/model/registrations.model.ts
+++ b/src/app/core/model/registrations.model.ts
@@ -19,6 +19,8 @@ export interface Registrations {
       county: string;
       locationId: string;
       provid: string;
+      parentId: string;
+      parentUID: string;
       mainService: number;
       status: string;
       uid: string;

--- a/src/app/core/model/registrations.model.ts
+++ b/src/app/core/model/registrations.model.ts
@@ -20,6 +20,8 @@ export interface Registrations {
       locationId: string;
       provid: string;
       mainService: number;
+      status: string;
+      uid: string;
     };
   };
 }

--- a/src/app/core/resolvers/admin/registration-requests/get-registrations.resolver.spec.ts
+++ b/src/app/core/resolvers/admin/registration-requests/get-registrations.resolver.spec.ts
@@ -1,0 +1,32 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { RegistrationsService } from '@core/services/registrations.service';
+import { AdminModule } from '@features/admin/admin.module';
+
+import { GetRegistrationsResolver } from './get-registrations.resolver';
+
+describe('GetRegistrationsResolver', () => {
+  let resolver: GetRegistrationsResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AdminModule, HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [GetRegistrationsResolver],
+    });
+    resolver = TestBed.inject(GetRegistrationsResolver);
+  });
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy();
+  });
+
+  it('should resolve', () => {
+    const registrationsService = TestBed.inject(RegistrationsService);
+    spyOn(registrationsService, 'getRegistrations').and.callThrough();
+
+    resolver.resolve();
+
+    expect(registrationsService.getRegistrations).toHaveBeenCalled();
+  });
+});

--- a/src/app/core/resolvers/admin/registration-requests/get-registrations.resolver.ts
+++ b/src/app/core/resolvers/admin/registration-requests/get-registrations.resolver.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { Resolve, Router } from '@angular/router';
+import { Registrations } from '@core/model/registrations.model';
+import { RegistrationsService } from '@core/services/registrations.service';
+import { EMPTY, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable()
+export class GetRegistrationsResolver implements Resolve<any> {
+  constructor(private router: Router, private registrationsService: RegistrationsService) {}
+
+  resolve(): Observable<Registrations[]> {
+    return this.registrationsService.getRegistrations().pipe(
+      catchError(() => {
+        this.router.navigate(['/sfcadmin']);
+        return EMPTY;
+      }),
+    );
+  }
+}

--- a/src/app/features/admin/admin.module.ts
+++ b/src/app/features/admin/admin.module.ts
@@ -6,6 +6,7 @@ import { RouterModule } from '@angular/router';
 import { GetDatesResolver } from '@core/resolvers/admin/local-authorities-return/get-dates.resolver';
 import { GetLaResolver } from '@core/resolvers/admin/local-authorities-return/get-la.resolver';
 import { GetLasResolver } from '@core/resolvers/admin/local-authorities-return/get-las.resolver';
+import { GetRegistrationsResolver } from '@core/resolvers/admin/registration-requests/get-registrations.resolver';
 import { LocalAuthoritiesReturnService } from '@core/services/admin/local-authorities-return/local-authorities-return.service';
 import { SharedModule } from '@shared/shared.module';
 
@@ -31,7 +32,7 @@ import { SearchComponent } from './search/search.component';
     LocalAuthorityComponent,
     RegistrationRequestsComponent,
   ],
-  providers: [LocalAuthoritiesReturnService, GetDatesResolver, GetLasResolver, GetLaResolver],
+  providers: [LocalAuthoritiesReturnService, GetDatesResolver, GetLasResolver, GetLaResolver, GetRegistrationsResolver],
   bootstrap: [AdminComponent],
 })
 export class AdminModule {}

--- a/src/app/features/admin/admin.module.ts
+++ b/src/app/features/admin/admin.module.ts
@@ -16,6 +16,7 @@ import { LocalAuthoritiesReturnComponent } from './local-authorities-return/loca
 import { LocalAuthorityComponent } from './local-authorities-return/monitor/local-authority/local-authority.component';
 import { MonitorComponent } from './local-authorities-return/monitor/monitor.component';
 import { SetDatesComponent } from './local-authorities-return/set-dates/set-dates.component';
+import { RegistrationRequestsComponent } from './registration-requests/registration-requests.component';
 import { SearchComponent } from './search/search.component';
 
 @NgModule({
@@ -28,6 +29,7 @@ import { SearchComponent } from './search/search.component';
     SetDatesComponent,
     MonitorComponent,
     LocalAuthorityComponent,
+    RegistrationRequestsComponent,
   ],
   providers: [LocalAuthoritiesReturnService, GetDatesResolver, GetLasResolver, GetLaResolver],
   bootstrap: [AdminComponent],

--- a/src/app/features/admin/admin.routing.module.ts
+++ b/src/app/features/admin/admin.routing.module.ts
@@ -8,6 +8,7 @@ import { LocalAuthoritiesReturnComponent } from './local-authorities-return/loca
 import { LocalAuthorityComponent } from './local-authorities-return/monitor/local-authority/local-authority.component';
 import { MonitorComponent } from './local-authorities-return/monitor/monitor.component';
 import { SetDatesComponent } from './local-authorities-return/set-dates/set-dates.component';
+import { RegistrationRequestsComponent } from './registration-requests/registration-requests.component';
 import { SearchComponent } from './search/search.component';
 
 const routes: Routes = [
@@ -70,6 +71,16 @@ const routes: Routes = [
             },
           },
         ],
+      },
+    ],
+  },
+  {
+    path: 'registrations',
+    children: [
+      {
+        path: '',
+        component: RegistrationRequestsComponent,
+        data: { title: 'Registration Requests' },
       },
     ],
   },

--- a/src/app/features/admin/admin.routing.module.ts
+++ b/src/app/features/admin/admin.routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { GetDatesResolver } from '@core/resolvers/admin/local-authorities-return/get-dates.resolver';
 import { GetLaResolver } from '@core/resolvers/admin/local-authorities-return/get-la.resolver';
 import { GetLasResolver } from '@core/resolvers/admin/local-authorities-return/get-las.resolver';
+import { GetRegistrationsResolver } from '@core/resolvers/admin/registration-requests/get-registrations.resolver';
 
 import { LocalAuthoritiesReturnComponent } from './local-authorities-return/local-authorities-return.component';
 import { LocalAuthorityComponent } from './local-authorities-return/monitor/local-authority/local-authority.component';
@@ -81,6 +82,9 @@ const routes: Routes = [
         path: '',
         component: RegistrationRequestsComponent,
         data: { title: 'Registration Requests' },
+        resolve: {
+          registrations: GetRegistrationsResolver,
+        },
       },
     ],
   },

--- a/src/app/features/admin/registration-requests/registration-requests.component.html
+++ b/src/app/features/admin/registration-requests/registration-requests.component.html
@@ -2,7 +2,39 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Registration requests</h2>
   </div>
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-one-half">
+    <ul class="govuk-list">
+      <!-- <li routerLinkActive="active">
+        <a [routerLink]="'.'" [fragment]="'pending'" class="govuk-link">
+          Pending ({{ pendingRegistrations.length }})
+        </a>
+      </li>
+      <li routerLinkActive="active">
+        <a [routerLink]="'.'" [fragment]="'rejected'" class="govuk-link"> Rejected </a>
+      </li> -->
+      <li [class.active]="showPendingRegistrations" data-testid="pendingLink">
+        <a
+          href="#"
+          (click)="displayPendingRegistrations($event, true)"
+          class="govuk-link"
+          data-testid="pendingLinkAnchor"
+        >
+          Pending ({{ pendingRegistrations.length }})
+        </a>
+      </li>
+      <li [class.active]="!showPendingRegistrations" data-testid="rejectedLink">
+        <a
+          href="#"
+          (click)="displayPendingRegistrations($event, false)"
+          class="govuk-link"
+          data-testid="rejectedLinkAnchor"
+        >
+          Rejected
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="govuk-grid-column-full" *ngIf="showPendingRegistrations; else showRejectedRegistrations">
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -14,7 +46,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <tr class="govuk-table__row" *ngFor="let registration of registrations">
+        <tr class="govuk-table__row" *ngFor="let registration of pendingRegistrations">
           <td class="govuk-table__cell">
             <a [routerLink]="[registration.establishment.uid]">{{ registration.establishment.name }}</a>
           </td>
@@ -22,17 +54,26 @@
             {{ registration.establishment.postcode }}
           </td>
           <td class="govuk-table__cell">
-            {{ registration.establishment.parentId }}
+            <a
+              (click)="
+                setEstablishmentId(
+                  registration.establishment.parentUid,
+                  '',
+                  registration.establishment.parentEstablishmentId,
+                  $event
+                )
+              "
+              href="#"
+              [attr.data-testid]="'parentId-' + registration.establishment.parentEstablishmentId"
+            >
+              {{ registration.establishment.parentEstablishmentId }}
+            </a>
           </td>
           <td class="govuk-table__cell">
             {{ registration.created }}
           </td>
           <td class="govuk-table__cell">
-            <strong
-              class="govuk-tag"
-              [ngClass]="conditionalClass(registration.establishment.status)"
-              [attr.data-testid]="'status-' + registration.establishment.name"
-            >
+            <strong class="govuk-tag" [ngClass]="conditionalClass(registration.establishment.status)">
               {{ registration.establishment.status | uppercase }}
             </strong>
           </td>
@@ -40,4 +81,9 @@
       </tbody>
     </table>
   </div>
+  <ng-template #showRejectedRegistrations>
+    <div class="govuk-grid-column-full">
+      <h1>Rejected Registrations</h1>
+    </div>
+  </ng-template>
 </div>

--- a/src/app/features/admin/registration-requests/registration-requests.component.html
+++ b/src/app/features/admin/registration-requests/registration-requests.component.html
@@ -4,14 +4,6 @@
   </div>
   <div class="govuk-grid-column-one-half">
     <ul class="govuk-list">
-      <!-- <li routerLinkActive="active">
-        <a [routerLink]="'.'" [fragment]="'pending'" class="govuk-link">
-          Pending ({{ pendingRegistrations.length }})
-        </a>
-      </li>
-      <li routerLinkActive="active">
-        <a [routerLink]="'.'" [fragment]="'rejected'" class="govuk-link"> Rejected </a>
-      </li> -->
       <li [class.active]="showPendingRegistrations" data-testid="pendingLink">
         <a
           href="#"
@@ -56,7 +48,7 @@
           <td class="govuk-table__cell">
             <a
               (click)="
-                setEstablishmentId(
+                navigateToParentPage(
                   registration.establishment.parentUid,
                   '',
                   registration.establishment.parentEstablishmentId,
@@ -73,7 +65,7 @@
             {{ registration.created }}
           </td>
           <td class="govuk-table__cell">
-            <strong class="govuk-tag" [ngClass]="conditionalClass(registration.establishment.status)">
+            <strong class="govuk-tag" [ngClass]="setStatusClass(registration.establishment.status)">
               {{ registration.establishment.status | uppercase }}
             </strong>
           </td>

--- a/src/app/features/admin/registration-requests/registration-requests.component.html
+++ b/src/app/features/admin/registration-requests/registration-requests.component.html
@@ -1,1 +1,43 @@
-<div>Registration Requests</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">Registration requests</h2>
+  </div>
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Workplace</th>
+          <th scope="col" class="govuk-table__header">Postcode</th>
+          <th scope="col" class="govuk-table__header">Parent ID</th>
+          <th scope="col" class="govuk-table__header">Received</th>
+          <th scope="col" class="govuk-table__header">Status</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row" *ngFor="let registration of registrations">
+          <td class="govuk-table__cell">
+            <a [routerLink]="[registration.establishment.uid]">{{ registration.establishment.name }}</a>
+          </td>
+          <td class="govuk-table__cell">
+            {{ registration.establishment.postcode }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ registration.establishment.parentId }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ registration.created }}
+          </td>
+          <td class="govuk-table__cell">
+            <strong
+              class="govuk-tag"
+              [ngClass]="conditionalClass(registration.establishment.status)"
+              [attr.data-testid]="'status-' + registration.establishment.name"
+            >
+              {{ registration.establishment.status | uppercase }}
+            </strong>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/app/features/admin/registration-requests/registration-requests.component.html
+++ b/src/app/features/admin/registration-requests/registration-requests.component.html
@@ -1,0 +1,1 @@
+<div>Registration Requests</div>

--- a/src/app/features/admin/registration-requests/registration-requests.component.scss
+++ b/src/app/features/admin/registration-requests/registration-requests.component.scss
@@ -1,0 +1,26 @@
+@import '~govuk-frontend/govuk/base';
+
+ul {
+  display: flex;
+
+  li {
+    padding: 10px 0;
+    flex: 1;
+
+    &.active {
+      a {
+        color: $govuk-link-active-colour;
+      }
+    }
+
+    a {
+      text-decoration: none;
+      font-weight: 600;
+      color: $govuk-link-colour;
+
+      &:hover {
+        color: $govuk-link-hover-colour;
+      }
+    }
+  }
+}

--- a/src/app/features/admin/registration-requests/registration-requests.component.spec.ts
+++ b/src/app/features/admin/registration-requests/registration-requests.component.spec.ts
@@ -136,11 +136,11 @@ describe('RegistrationRequestsComponent', () => {
     expect(workplace2Status).toBeTruthy();
     expect(workplace2Created).toBeTruthy();
 
-    // expect(workplace3Name).toBeFalsy();
-    // expect(workplace3Postcode).toBeFalsy();
-    // expect(workplace3ParentId).toBeFalsy();
-    // expect(workplace3Status).toBeFalsy();
-    // expect(workplace3Created).toBeFalsy();
+    expect(workplace3Name).toBeFalsy();
+    expect(workplace3Postcode).toBeFalsy();
+    expect(workplace3ParentId).toBeFalsy();
+    expect(workplace3Status).toBeFalsy();
+    expect(workplace3Created).toBeFalsy();
   });
 
   it('should give status a conditional class for different values', async () => {

--- a/src/app/features/admin/registration-requests/registration-requests.component.spec.ts
+++ b/src/app/features/admin/registration-requests/registration-requests.component.spec.ts
@@ -1,0 +1,170 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockSwitchWorkplaceService } from '@core/test-utils/MockSwitchWorkplaceService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render } from '@testing-library/angular';
+
+import { RegistrationRequestsComponent } from './registration-requests.component';
+
+describe('RegistrationRequestsComponent', () => {
+  async function setup() {
+    const component = await render(RegistrationRequestsComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: BreadcrumbService, useClass: MockBreadcrumbService },
+        { provide: SwitchWorkplaceService, useClass: MockSwitchWorkplaceService },
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                registrations: [
+                  {
+                    establishment: {
+                      name: 'Workplace 1',
+                      postcode: 'PO5 3CO',
+                      parentEstablishmentId: 'J234567',
+                      parentUid: 'parentUid',
+                      uid: 'someuid',
+                      status: 'PENDING',
+                    },
+                    created: '23/01/2000',
+                  },
+                  {
+                    establishment: {
+                      name: 'Workplace 2',
+                      postcode: 'AS4 8DS',
+                      parentEstablishmentId: null,
+                      uid: 'anotheruid',
+                      status: 'IN PROGRESS',
+                    },
+                    created: '24/01/2001',
+                  },
+                  {
+                    establishment: {
+                      name: 'Workplace 3',
+                      postcode: 'ER4 5XC',
+                      parentEstablishmentId: 'W123456',
+                      parentUid: 'anotherParentUid',
+                      uid: 'uiduid',
+                      status: 'REJECTED',
+                    },
+                    created: '25/01/2002',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const fixture = component.fixture;
+
+    return {
+      component,
+      fixture,
+    };
+  }
+
+  it('should render a RegistrationRequestsComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should show the pending link with an active attribute and rejected link without an active attribute', async () => {
+    const { component } = await setup();
+
+    const pendingLink = component.getByTestId('pendingLink');
+    const rejectedLink = component.getByTestId('rejectedLink');
+
+    expect(pendingLink.getAttribute('class')).toContain('active');
+    expect(rejectedLink.getAttribute('class')).not.toContain('active');
+  });
+
+  it('should show the rejected link with an active attribute when clicked and the pending link without an active attribute', async () => {
+    const { component, fixture } = await setup();
+
+    const rejectedLinkAnchor = component.getByTestId('rejectedLinkAnchor');
+
+    fireEvent.click(rejectedLinkAnchor);
+    fixture.detectChanges();
+
+    const rejectedLink = component.getByTestId('rejectedLink');
+    const pendingLink = component.getByTestId('pendingLink');
+
+    expect(pendingLink.getAttribute('class')).not.toContain('active');
+    expect(rejectedLink.getAttribute('class')).toContain('active');
+  });
+
+  it('should render the pending and in progess registrations when first loading page', async () => {
+    const { component } = await setup();
+
+    const workplace1Name = component.queryByText('Workplace 1');
+    const workplace1Postcode = component.queryByText('PO5 3CO');
+    const workplace1ParentId = component.queryByText('J234567');
+    const workplace1Status = component.queryByText('PENDING');
+    const workplace1Created = component.queryByText('23/01/2000');
+
+    const workplace2Name = component.queryByText('Workplace 2');
+    const workplace2Postcode = component.queryByText('AS4 8DS');
+    const workplace2Status = component.queryByText('IN PROGRESS');
+    const workplace2Created = component.queryByText('24/01/2001');
+
+    const workplace3Name = component.queryByText('Workplace 3');
+    const workplace3Postcode = component.queryByText('ER4 5XC');
+    const workplace3ParentId = component.queryByText('W123456');
+    const workplace3Status = component.queryByText('REJECTED');
+    const workplace3Created = component.queryByText('25/01/2002');
+
+    expect(workplace1Name).toBeTruthy();
+    expect(workplace1Postcode).toBeTruthy();
+    expect(workplace1ParentId).toBeTruthy();
+    expect(workplace1Status).toBeTruthy();
+    expect(workplace1Created).toBeTruthy();
+
+    expect(workplace2Name).toBeTruthy();
+    expect(workplace2Postcode).toBeTruthy();
+    expect(workplace2Status).toBeTruthy();
+    expect(workplace2Created).toBeTruthy();
+
+    // expect(workplace3Name).toBeFalsy();
+    // expect(workplace3Postcode).toBeFalsy();
+    // expect(workplace3ParentId).toBeFalsy();
+    // expect(workplace3Status).toBeFalsy();
+    // expect(workplace3Created).toBeFalsy();
+  });
+
+  it('should give status a conditional class for different values', async () => {
+    const { component } = await setup();
+
+    const workplace1Status = component.getByText('PENDING');
+    const workplace2Status = component.getByText('IN PROGRESS');
+
+    expect(workplace1Status.getAttribute('class')).toContain('govuk-tag--grey');
+    expect(workplace2Status.getAttribute('class')).toContain('govuk-tag--blue');
+  });
+
+  it('should call the parentId link when clicked', async () => {
+    const { component, fixture } = await setup();
+
+    const switchWorkplaceService = TestBed.inject(SwitchWorkplaceService);
+
+    const spy = spyOn(switchWorkplaceService, 'navigateToWorkplace');
+
+    const workplace1ParentId = component.getByTestId('parentId-J234567');
+    fireEvent.click(workplace1ParentId);
+
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/admin/registration-requests/registration-requests.component.ts
+++ b/src/app/features/admin/registration-requests/registration-requests.component.ts
@@ -1,20 +1,58 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Registrations } from '@core/model/registrations.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
 
 @Component({
   selector: 'app-registration-requests',
   templateUrl: './registration-requests.component.html',
+  styleUrls: ['./registration-requests.component.scss'],
 })
 export class RegistrationRequestsComponent implements OnInit {
   public registrations: Registrations[];
+  public pendingRegistrations: Registrations[];
+  public rejectedRegistrations: Registrations[];
+  public showPendingRegistrations: boolean;
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(
+    private route: ActivatedRoute,
+    private breadcrumbService: BreadcrumbService,
+    private switchWorkplaceService: SwitchWorkplaceService,
+  ) {}
 
   ngOnInit(): void {
     this.registrations = this.route.snapshot.data.registrations;
+    this.breadcrumbService.show(JourneyType.ADMIN);
+    this.getPendingRegistrations();
+    this.getRejectedRegistrations();
+    this.showPendingRegistrations = true;
   }
 
+  public getPendingRegistrations(): void {
+    this.pendingRegistrations = this.registrations;
+    // this.pendingRegistrations = this.registrations.filter((registration, index) => {
+    //   return registration.establishment.status === 'PENDING';
+    // });
+  }
+
+  public getRejectedRegistrations(): void {
+    this.rejectedRegistrations = [];
+    // this.rejectedRegistrations = this.registrations.filter((registration, index) => {
+    //   return registration.establishment.status === 'REJECTED';
+    // });
+  }
+
+  public displayPendingRegistrations(event: Event, bool: boolean): void {
+    event.preventDefault();
+    this.showPendingRegistrations = bool;
+  }
+
+  public setEstablishmentId(id: string, username: string, nmdsId: string, event: Event): void {
+    event.preventDefault();
+    this.switchWorkplaceService.navigateToWorkplace(id, username, nmdsId);
+  }
   public conditionalClass(status: string): string {
     return status === 'PENDING' ? 'govuk-tag--grey' : 'govuk-tag--blue';
   }

--- a/src/app/features/admin/registration-requests/registration-requests.component.ts
+++ b/src/app/features/admin/registration-requests/registration-requests.component.ts
@@ -1,7 +1,21 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Registrations } from '@core/model/registrations.model';
 
 @Component({
   selector: 'app-registration-requests',
   templateUrl: './registration-requests.component.html',
 })
-export class RegistrationRequestsComponent {}
+export class RegistrationRequestsComponent implements OnInit {
+  public registrations: Registrations[];
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    this.registrations = this.route.snapshot.data.registrations;
+  }
+
+  public conditionalClass(status: string): string {
+    return status === 'PENDING' ? 'govuk-tag--grey' : 'govuk-tag--blue';
+  }
+}

--- a/src/app/features/admin/registration-requests/registration-requests.component.ts
+++ b/src/app/features/admin/registration-requests/registration-requests.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-registration-requests',
+  templateUrl: './registration-requests.component.html',
+})
+export class RegistrationRequestsComponent {}

--- a/src/app/features/admin/registration-requests/registration-requests.component.ts
+++ b/src/app/features/admin/registration-requests/registration-requests.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { Registration } from '@core/model/registrations.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
 
@@ -10,9 +11,9 @@ import { SwitchWorkplaceService } from '@core/services/switch-workplace.service'
   styleUrls: ['./registration-requests.component.scss'],
 })
 export class RegistrationRequestsComponent implements OnInit {
-  public registrations = [];
-  public pendingRegistrations = [];
-  public rejectedRegistrations = [];
+  public registrations: Registration[];
+  public pendingRegistrations: Registration[];
+  public rejectedRegistrations: Registration[];
   public showPendingRegistrations: boolean;
 
   constructor(
@@ -47,12 +48,12 @@ export class RegistrationRequestsComponent implements OnInit {
     this.showPendingRegistrations = bool;
   }
 
-  public setEstablishmentId(id: string, username: string, nmdsId: string, event: Event): void {
+  public navigateToParentPage(id: string, username: string, nmdsId: string, event: Event): void {
     event.preventDefault();
     this.switchWorkplaceService.navigateToWorkplace(id, username, nmdsId);
   }
 
-  public conditionalClass(status: string): string {
+  public setStatusClass(status: string): string {
     return status === 'PENDING' ? 'govuk-tag--grey' : 'govuk-tag--blue';
   }
 }

--- a/src/app/features/admin/registration-requests/registration-requests.component.ts
+++ b/src/app/features/admin/registration-requests/registration-requests.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
-import { Registrations } from '@core/model/registrations.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
 
@@ -11,9 +10,9 @@ import { SwitchWorkplaceService } from '@core/services/switch-workplace.service'
   styleUrls: ['./registration-requests.component.scss'],
 })
 export class RegistrationRequestsComponent implements OnInit {
-  public registrations: Registrations[];
-  public pendingRegistrations: Registrations[];
-  public rejectedRegistrations: Registrations[];
+  public registrations = [];
+  public pendingRegistrations = [];
+  public rejectedRegistrations = [];
   public showPendingRegistrations: boolean;
 
   constructor(
@@ -32,16 +31,15 @@ export class RegistrationRequestsComponent implements OnInit {
 
   public getPendingRegistrations(): void {
     this.pendingRegistrations = this.registrations;
-    // this.pendingRegistrations = this.registrations.filter((registration, index) => {
-    //   return registration.establishment.status === 'PENDING';
-    // });
+    this.pendingRegistrations = this.registrations.filter((registration) => {
+      return registration.establishment.status === 'PENDING' || registration.establishment.status === 'IN PROGRESS';
+    });
   }
 
   public getRejectedRegistrations(): void {
-    this.rejectedRegistrations = [];
-    // this.rejectedRegistrations = this.registrations.filter((registration, index) => {
-    //   return registration.establishment.status === 'REJECTED';
-    // });
+    this.rejectedRegistrations = this.registrations.filter((registration) => {
+      return registration.establishment.status === 'REJECTED';
+    });
   }
 
   public displayPendingRegistrations(event: Event, bool: boolean): void {
@@ -53,6 +51,7 @@ export class RegistrationRequestsComponent implements OnInit {
     event.preventDefault();
     this.switchWorkplaceService.navigateToWorkplace(id, username, nmdsId);
   }
+
   public conditionalClass(status: string): string {
     return status === 'PENDING' ? 'govuk-tag--grey' : 'govuk-tag--blue';
   }

--- a/src/app/features/search/registrations/registrations.component.ts
+++ b/src/app/features/search/registrations/registrations.component.ts
@@ -18,7 +18,6 @@ export class RegistrationsComponent implements OnInit {
     this.registrationsService.getRegistrations().subscribe(
       (data) => {
         this.registrations = data;
-        console.log(this.registrations);
       },
       (error) => this.onError(error),
     );

--- a/src/app/features/search/registrations/registrations.component.ts
+++ b/src/app/features/search/registrations/registrations.component.ts
@@ -18,6 +18,7 @@ export class RegistrationsComponent implements OnInit {
     this.registrationsService.getRegistrations().subscribe(
       (data) => {
         this.registrations = data;
+        console.log(this.registrations);
       },
       (error) => this.onError(error),
     );


### PR DESCRIPTION
#### Work done
- create registration requests page
- resolver to bring in pending and rejected registrations
- change admin/registrations route to bring back more information
- display info and clicking on parent ID takes you to parent page
- clickable pending and registrations links toggle between info shown

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
