### PR TITLE
Fix: Multi Update - Snagging list

### DIFF
--- a/src/app/core/services/training.service.ts
+++ b/src/app/core/services/training.service.ts
@@ -22,4 +22,8 @@ export class TrainingService {
   public updateSelectedStaff(formValue) {
     this.selectedStaff = formValue;
   }
+
+  public resetSelectedStaff(): void {
+    this.selectedStaff = [];
+  }
 }

--- a/src/app/features/add-multiple-training/select-staff/select-staff.component.html
+++ b/src/app/features/add-multiple-training/select-staff/select-staff.component.html
@@ -40,7 +40,7 @@
                   [checked]="worker.value.checked"
                   [value]="worker.value.name"
                 />
-                <label for="selectedStaff-{{ i }}" class="govuk-label govuk-checkboxes__label">
+                <label for="selectStaff-{{ i }}" class="govuk-label govuk-checkboxes__label">
                   {{ worker.value.name }}
                 </label>
               </div>
@@ -50,9 +50,7 @@
       </div>
       <div class="govuk-button-group">
         <button class="govuk-button govuk-!-margin-right-9 govuk-!-margin-top-7" type="submit">Continue</button>
-        <a class="govuk-link govuk-!-margin-left-9" [routerLink]="returnLink" fragment="training-and-qualifications"
-          >Cancel</a
-        >
+        <a role="button" class="govuk-button govuk-button--link govuk-!-margin-left-9" (click)="onCancel()">Cancel</a>
       </div>
     </fieldset>
   </div>

--- a/src/app/features/add-multiple-training/select-staff/select-staff.component.spec.ts
+++ b/src/app/features/add-multiple-training/select-staff/select-staff.component.spec.ts
@@ -50,10 +50,16 @@ describe('SelectStaffComponent', () => {
     const spy = spyOn(router, 'navigate');
     spy.and.returnValue(Promise.resolve(true));
 
+    const trainingService = injector.inject(TrainingService) as TrainingService;
+
+    const trainingSpy = spyOn(trainingService, 'resetSelectedStaff');
+    trainingSpy.and.callThrough();
+
     return {
       component,
       router,
       spy,
+      trainingSpy,
     };
   }
 
@@ -151,6 +157,36 @@ describe('SelectStaffComponent', () => {
       component.fixture.componentInstance.updateSelectAllCheckbox();
 
       expect(form.value.selectAll).toBeFalsy();
+    });
+  });
+
+  describe('onCancel()', () => {
+    it('should reset selected staff in training service and navigate to dashboard if primary user', async () => {
+      const { component, spy, trainingSpy } = await setup();
+
+      component.fixture.componentInstance.primaryWorkplaceUid = '1234-5678';
+      component.fixture.componentInstance.setReturnLink();
+      component.fixture.detectChanges();
+
+      const cancelButton = component.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(trainingSpy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'training-and-qualifications' });
+    });
+
+    it(`should reset selected staff in training service and navigate to subsidiary's dashboard if not primary user`, async () => {
+      const { component, spy, trainingSpy } = await setup();
+
+      component.fixture.componentInstance.primaryWorkplaceUid = '5678-9001';
+      component.fixture.componentInstance.setReturnLink();
+      component.fixture.detectChanges();
+
+      const cancelButton = component.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(trainingSpy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(['/workplace', '1234-5678'], { fragment: 'training-and-qualifications' });
     });
   });
 

--- a/src/app/features/add-multiple-training/select-staff/select-staff.component.ts
+++ b/src/app/features/add-multiple-training/select-staff/select-staff.component.ts
@@ -41,7 +41,7 @@ export class SelectStaffComponent implements OnInit {
     this.setBackLink();
   }
 
-  ngAfterContentInit() {
+  ngAfterViewInit(): void {
     this.errorSummaryService.formEl$.next(this.formEl);
   }
 

--- a/src/app/features/add-multiple-training/select-staff/select-staff.component.ts
+++ b/src/app/features/add-multiple-training/select-staff/select-staff.component.ts
@@ -155,4 +155,9 @@ export class SelectStaffComponent implements OnInit {
     const errorType = Object.keys(this.form.get(item).errors)[0];
     return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
   }
+
+  public onCancel(): void {
+    this.trainingService.resetSelectedStaff();
+    this.router.navigate(this.returnLink, { fragment: 'training-and-qualifications' });
+  }
 }

--- a/src/app/features/add-multiple-training/training-details/training-details.component.spec.ts
+++ b/src/app/features/add-multiple-training/training-details/training-details.component.spec.ts
@@ -72,6 +72,11 @@ describe('MultipleTrainingDetailsComponent', () => {
     const workerSpy = spyOn(workerService, 'createMultipleTrainingRecords');
     workerSpy.and.callThrough();
 
+    const trainingService = injector.inject(TrainingService) as TrainingService;
+
+    const trainingSpy = spyOn(trainingService, 'resetSelectedStaff');
+    trainingSpy.and.callThrough();
+
     return {
       component,
       fixture,
@@ -80,6 +85,7 @@ describe('MultipleTrainingDetailsComponent', () => {
       spy,
       alertSpy,
       workerSpy,
+      trainingSpy,
     };
   }
 
@@ -117,7 +123,7 @@ describe('MultipleTrainingDetailsComponent', () => {
   });
 
   it('should submit, navigate and add alert when complete', async () => {
-    const { component, getByText, fixture, spy, alertSpy, workerSpy } = await setup();
+    const { component, getByText, fixture, spy, alertSpy, workerSpy, trainingSpy } = await setup();
     component.form.markAsDirty();
     component.form.get('category').setValue('1');
     component.form.get('category').markAsDirty();
@@ -127,6 +133,7 @@ describe('MultipleTrainingDetailsComponent', () => {
     fixture.detectChanges();
 
     expect(component.form.valid).toBeTruthy();
+    expect(trainingSpy).toHaveBeenCalled();
     expect(workerSpy).toHaveBeenCalledWith('1', ['1234'], {
       trainingCategory: { id: 1 },
       title: null,

--- a/src/app/features/add-multiple-training/training-details/training-details.component.ts
+++ b/src/app/features/add-multiple-training/training-details/training-details.component.ts
@@ -68,7 +68,7 @@ export class MultipleTrainingDetailsComponent extends AddEditTrainingDirective i
   }
 
   private async onSuccess(response: MultipleTrainingResponse) {
-    this.trainingService.selectedStaff = [];
+    this.trainingService.resetSelectedStaff();
     this.trainingService.addMultipleTrainingInProgress$.next(false);
 
     await this.router.navigate(this.previousUrl, { fragment: 'training-and-qualifications' });

--- a/src/app/features/add-multiple-training/training-details/training-details.component.ts
+++ b/src/app/features/add-multiple-training/training-details/training-details.component.ts
@@ -51,8 +51,7 @@ export class MultipleTrainingDetailsComponent extends AddEditTrainingDirective i
 
   protected setBackLink(): void {
     this.backService.setBackLink({
-      url: this.previousUrl,
-      fragment: 'training-and-qualifications',
+      url: ['workplace', this.workplace.uid, 'add-multiple-training', 'select-staff'],
     });
   }
 

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -132,11 +132,11 @@
   </div>
 
   <div class="govuk-button-group">
-    <button type="submit" class="govuk-button">
+    <button type="submit" class="govuk-button govuk-!-margin-right-9">
       {{ buttonText }}
     </button>
     <a
-      class="govuk-button govuk-button--link govuk-util__float-right"
+      class="govuk-button govuk-button--link govuk-!-margin-left-9"
       role="button"
       draggable="false"
       (click)="navigateToPreviousPage()"


### PR DESCRIPTION
#### Work done
- Reset `selectedStaff` in training service when pressing cancel on `Select staff` page
- Fix spacing between buttons on `Add training details` page
- Set back button to `Select staff` page from `Add training details` page
- Change `ngAfterContentInit()` to `ngAfterViewInit()` to fix validation highlighting not working

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
