### PR TITLE
Fix: Multi update

### DIFF
--- a/src/app/features/add-multiple-training/add-multiple-training.module.ts
+++ b/src/app/features/add-multiple-training/add-multiple-training.module.ts
@@ -1,7 +1,7 @@
 import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { WorkersResolver } from '@core/resolvers/workers.resolver';
 import { SharedModule } from '@shared/shared.module';
 
@@ -10,7 +10,14 @@ import { SelectStaffComponent } from './select-staff/select-staff.component';
 import { MultipleTrainingDetailsComponent } from './training-details/training-details.component';
 
 @NgModule({
-  imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, AddMultipleTrainingRoutingModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    SharedModule,
+    OverlayModule,
+    AddMultipleTrainingRoutingModule,
+  ],
   declarations: [SelectStaffComponent, MultipleTrainingDetailsComponent],
   providers: [WorkersResolver],
 })

--- a/src/app/features/add-multiple-training/select-staff/select-staff.component.html
+++ b/src/app/features/add-multiple-training/select-staff/select-staff.component.html
@@ -18,12 +18,13 @@
           <div class="govuk-grid-column-full">
             <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
               <input
-                formControlName="selectAll"
                 class="govuk-checkboxes__input"
                 type="checkbox"
                 id="selectAll"
                 name="selectAll"
-                (change)="selectAllWorkers()"
+                [(ngModel)]="selectAll"
+                [ngModelOptions]="{ standalone: true }"
+                (ngModelChange)="selectAllWorkers($event)"
               />
               <label for="selectAll" class="govuk-label govuk-checkboxes__label"> Select all </label>
             </div>

--- a/src/app/features/add-multiple-training/select-staff/select-staff.component.spec.ts
+++ b/src/app/features/add-multiple-training/select-staff/select-staff.component.spec.ts
@@ -143,7 +143,7 @@ describe('SelectStaffComponent', () => {
 
       component.fixture.componentInstance.updateSelectAllCheckbox();
 
-      expect(form.value.selectAll).toBeTruthy();
+      expect(component.fixture.componentInstance.selectAll).toBeTruthy();
     });
 
     it('should automatically uncheck the `Select all` checkbox when at least one staff checkbox is unchecked', async () => {
@@ -156,7 +156,7 @@ describe('SelectStaffComponent', () => {
 
       component.fixture.componentInstance.updateSelectAllCheckbox();
 
-      expect(form.value.selectAll).toBeFalsy();
+      expect(component.fixture.componentInstance.selectAll).toBeFalsy();
     });
   });
 
@@ -218,6 +218,7 @@ describe('SelectStaffComponent', () => {
       const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
 
       component.fixture.componentInstance.primaryWorkplaceUid = '1234-5678';
+      component.fixture.componentInstance.setReturnLink();
       component.fixture.componentInstance.setBackLink();
       component.fixture.detectChanges();
 
@@ -232,6 +233,7 @@ describe('SelectStaffComponent', () => {
       const backLinkSpy = spyOn(component.fixture.componentInstance.backService, 'setBackLink');
 
       component.fixture.componentInstance.primaryWorkplaceUid = '5678-9001';
+      component.fixture.componentInstance.setReturnLink();
       component.fixture.componentInstance.setBackLink();
       component.fixture.detectChanges();
 

--- a/src/app/features/add-multiple-training/select-staff/select-staff.component.ts
+++ b/src/app/features/add-multiple-training/select-staff/select-staff.component.ts
@@ -19,6 +19,7 @@ export class SelectStaffComponent implements OnInit {
   public submitted: boolean;
   public primaryWorkplaceUid: string;
   public returnLink: Array<string>;
+  public selectAll = false;
   private formErrorsMap: Array<ErrorDetails>;
   private workplaceUid: string;
 
@@ -38,6 +39,7 @@ export class SelectStaffComponent implements OnInit {
     this.workers = this.route.snapshot.data.workers.sort((a, b) => a.nameOrId.localeCompare(b.nameOrId));
     this.setupForm();
     this.setupFormErrorsMap();
+    this.setReturnLink();
     this.setBackLink();
   }
 
@@ -62,11 +64,11 @@ export class SelectStaffComponent implements OnInit {
 
     this.form = this.formBuilder.group(
       {
-        selectAll: null,
         selectStaff: this.formBuilder.array(workerFormArray),
       },
       {
         validator: this.oneCheckboxRequired,
+        updateOn: 'submit',
       },
     );
 
@@ -103,12 +105,10 @@ export class SelectStaffComponent implements OnInit {
   }
 
   public setBackLink(): void {
-    this.setReturnLink();
     this.backService.setBackLink({ url: this.returnLink, fragment: 'training-and-qualifications' });
   }
 
-  public selectAllWorkers(): void {
-    const isChecked = this.form.value.selectAll ? true : false;
+  public selectAllWorkers(isChecked: boolean): void {
     this.selectStaff.controls.forEach((control) => {
       return (control.value.checked = isChecked);
     });
@@ -121,10 +121,7 @@ export class SelectStaffComponent implements OnInit {
 
   public updateSelectAllCheckbox(): void {
     const allWorkersSelected = this.selectStaff.controls.every((control) => control.value.checked === true);
-    const selectAllChecked = allWorkersSelected ? true : false;
-    this.form.patchValue({
-      selectAll: selectAllChecked,
-    });
+    this.selectAll = allWorkersSelected ? true : false;
   }
 
   private updateSelectedStaff(): void {

--- a/src/app/features/add-multiple-training/training-details/training-details.component.spec.ts
+++ b/src/app/features/add-multiple-training/training-details/training-details.component.spec.ts
@@ -151,6 +151,16 @@ describe('MultipleTrainingDetailsComponent', () => {
     } as Alert);
   });
 
+  it('should clear selected staff and navigate when pressing cancel', async () => {
+    const { getByText, spy, trainingSpy } = await setup();
+
+    const cancelButton = getByText('Cancel');
+    fireEvent.click(cancelButton);
+
+    expect(trainingSpy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(['workplace', '1'], { fragment: 'training-and-qualifications' });
+  });
+
   describe('errors', () => {
     it('should show an error when no training category selected', async () => {
       const { component, getByText, fixture, getAllByText } = await setup();

--- a/src/app/features/add-multiple-training/training-details/training-details.component.ts
+++ b/src/app/features/add-multiple-training/training-details/training-details.component.ts
@@ -80,4 +80,9 @@ export class MultipleTrainingDetailsComponent extends AddEditTrainingDirective i
   private onError(error) {
     console.log(error);
   }
+
+  public onCancel(): void {
+    this.trainingService.resetSelectedStaff();
+    this.router.navigate(this.previousUrl, { fragment: 'training-and-qualifications' });
+  }
 }

--- a/src/app/features/add-multiple-training/training-details/training-details.component.ts
+++ b/src/app/features/add-multiple-training/training-details/training-details.component.ts
@@ -78,7 +78,7 @@ export class MultipleTrainingDetailsComponent extends AddEditTrainingDirective i
   }
 
   private onError(error) {
-    console.log(error);
+    console.error(error);
   }
 
   public onCancel(): void {

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -139,7 +139,7 @@
       class="govuk-button govuk-button--link govuk-!-margin-left-9"
       role="button"
       draggable="false"
-      (click)="navigateToPreviousPage()"
+      (click)="onCancel()"
     >
       Cancel
     </a>

--- a/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -246,7 +246,8 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
     }
     return null;
   }
-  public navigateToPreviousPage(): void {
+
+  public onCancel(): void {
     this.router.navigate(this.previousUrl, { fragment: 'training-and-qualifications' });
   }
 }


### PR DESCRIPTION
#### Work done
- Use `[(ngModel)]` in form for select all checkbox instead of reactive form so that validation is updated on submit
- Reset selected staff in training service when pressing cancel on `add-training-details` page

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
