### PR TITLE
Added order by to query for admin LA report

### DIFF
--- a/server/routes/reports/localAuthorityReport/admin.js
+++ b/server/routes/reports/localAuthorityReport/admin.js
@@ -86,7 +86,7 @@ Notes' +
       NEWLINE;
 
     const runReport = await models.sequelize.query(
-      'select * from cqc.localAuthorityReportAdmin(:givenFromDate, :givenToDate);',
+      'select * from cqc.localAuthorityReportAdmin(:givenFromDate, :givenToDate) ORDER BY "LocalAuthority" ASC;',
       {
         replacements: {
           givenFromDate: fromDate,

--- a/server/test/unit/routes/reports/localAuthorityReport/admin.spec.js
+++ b/server/test/unit/routes/reports/localAuthorityReport/admin.spec.js
@@ -184,7 +184,7 @@ describe('/server/routes/reports/localAuthorityReport/admin', () => {
       sinon.assert.called(getValue);
       sinon.assert.calledOnce(query);
       expect(queryOutput.query).to.deep.equal(
-        'select * from cqc.localAuthorityReportAdmin(:givenFromDate, :givenToDate);',
+        'select * from cqc.localAuthorityReportAdmin(:givenFromDate, :givenToDate) ORDER BY "LocalAuthority" ASC;',
       );
       expect(queryOutput.options).to.deep.equal({
         replacements: {


### PR DESCRIPTION
#### Work done
- Added `order by` to the admin LA report `SELECT` statement

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
