### PR TITLE
feat: addSuccessAlertsForRegistrationApprovalAndRejection

### DIFF
--- a/src/app/features/admin/registration-requests/registration-request/registration-request.component.spec.ts
+++ b/src/app/features/admin/registration-requests/registration-request/registration-request.component.spec.ts
@@ -739,6 +739,29 @@ describe('RegistrationRequestComponent', () => {
 
       expect(getByText(approvalServerErrorMessage, { exact: false })).toBeTruthy();
     });
+
+    it('should show approval alert when approval confirmed', async () => {
+      const { component, fixture, getByText } = await setup();
+
+      const registrationsService = TestBed.inject(RegistrationsService);
+      spyOn(registrationsService, 'registrationApproval').and.returnValue(of(true));
+      const alertService = TestBed.inject(AlertService);
+      const alertServiceSpy = spyOn(alertService, 'addAlert').and.callThrough();
+      const approveButton = getByText('Approve');
+
+      fireEvent.click(approveButton);
+      fixture.detectChanges();
+
+      const dialog = await within(document.body).findByRole('dialog');
+      const approvalConfirmButton = within(dialog).getByText('Approve this request');
+
+      fireEvent.click(approvalConfirmButton);
+
+      expect(alertServiceSpy).toHaveBeenCalledWith({
+        type: 'success',
+        message: `The workplace '${component.registration.establishment.name}' has been approved`,
+      });
+    });
   });
 
   describe('Rejecting registration', () => {
@@ -834,6 +857,29 @@ describe('RegistrationRequestComponent', () => {
       fireEvent.click(rejectionConfirmButton);
 
       expect(getByText(rejectionServerErrorMessage, { exact: false })).toBeTruthy();
+    });
+
+    it('should show rejection alert when rejection confirmed', async () => {
+      const { component, fixture, getByText } = await setup();
+
+      const registrationsService = TestBed.inject(RegistrationsService);
+      spyOn(registrationsService, 'registrationApproval').and.returnValue(of(true));
+      const alertService = TestBed.inject(AlertService);
+      const alertServiceSpy = spyOn(alertService, 'addAlert').and.callThrough();
+      const rejectButton = getByText('Reject');
+
+      fireEvent.click(rejectButton);
+      fixture.detectChanges();
+
+      const dialog = await within(document.body).findByRole('dialog');
+      const rejectionConfirmButton = within(dialog).getByText('Reject this request');
+
+      fireEvent.click(rejectionConfirmButton);
+
+      expect(alertServiceSpy).toHaveBeenCalledWith({
+        type: 'success',
+        message: `The workplace '${component.registration.establishment.name}' has been rejected`,
+      });
     });
   });
 

--- a/src/app/features/admin/registration-requests/registration-request/registration-request.component.ts
+++ b/src/app/features/admin/registration-requests/registration-request/registration-request.component.ts
@@ -10,9 +10,7 @@ import { Dialog, DialogService } from '@core/services/dialog.service';
 import { RegistrationsService } from '@core/services/registrations.service';
 import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
 
-import {
-  RegistrationApprovalOrRejectionDialogComponent,
-} from '../registration-approval-or-rejection-dialog/registration-approval-or-rejection-dialog.component';
+import { RegistrationApprovalOrRejectionDialogComponent } from '../registration-approval-or-rejection-dialog/registration-approval-or-rejection-dialog.component';
 
 @Component({
   selector: 'app-registration-request',
@@ -126,13 +124,6 @@ export class RegistrationRequestComponent implements OnInit {
     );
   }
 
-  private showWorkplaceIdUpdatedAlert(): void {
-    this.alertService.addAlert({
-      type: 'success',
-      message: `The workplace ID has been successfully updated to ${this.nmdsId.value}`,
-    });
-  }
-
   public setStatusClass(status: string): string {
     return status === 'PENDING' ? 'govuk-tag--grey' : 'govuk-tag--blue';
   }
@@ -222,6 +213,7 @@ export class RegistrationRequestComponent implements OnInit {
         this.registrationsService.registrationApproval(body).subscribe(
           () => {
             this.router.navigate(['/sfcadmin', 'registrations']);
+            this.showApprovalOrRejectionConfirmationAlert(isApproval);
           },
           (err) => {
             this.approvalOrRejectionServerError = `There was an error completing the ${
@@ -252,6 +244,22 @@ export class RegistrationRequestComponent implements OnInit {
     return this.dialogService.open(RegistrationApprovalOrRejectionDialogComponent, {
       workplaceName: this.registration.establishment.name,
       isApproval,
+    });
+  }
+
+  private showWorkplaceIdUpdatedAlert(): void {
+    this.alertService.addAlert({
+      type: 'success',
+      message: `The workplace ID has been successfully updated to ${this.nmdsId.value}`,
+    });
+  }
+
+  private showApprovalOrRejectionConfirmationAlert(isApproval: boolean): void {
+    this.alertService.addAlert({
+      type: 'success',
+      message: `The workplace '${this.registration.establishment.name}' has been ${
+        isApproval ? 'approved' : 'rejected'
+      }`,
     });
   }
 }


### PR DESCRIPTION
#### Work done
- Add success alerts when registration is approved or rejected

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
