### PR TITLE
create getAllRegistrations api call that uses the old endpoint to all…

### DIFF
--- a/server/routes/admin/registrations/index.js
+++ b/server/routes/admin/registrations/index.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const router = express.Router();
 
+router.use('/', require('./getAllRegistrations'));
 router.use('/', require('./getRegistrations'));
 router.use('/status', require('./getSingleRegistration'));
 router.use('/updateWorkplaceId', require('./updateWorkplaceId'));

--- a/src/app/core/resolvers/admin/registration-requests/single-registration/get-registration-notes-resolver.spec.ts
+++ b/src/app/core/resolvers/admin/registration-requests/single-registration/get-registration-notes-resolver.spec.ts
@@ -7,7 +7,7 @@ import { AdminModule } from '@features/admin/admin.module';
 
 import { GetRegistrationNotesResolver } from './get-registration-notes.resolver';
 
-describe('GetRegistrationResolver', () => {
+describe('GetRegistrationNotesResolver', () => {
   let resolver: GetRegistrationNotesResolver;
 
   beforeEach(() => {

--- a/src/app/core/services/registrations.service.ts
+++ b/src/app/core/services/registrations.service.ts
@@ -14,6 +14,9 @@ import { Observable } from 'rxjs';
 })
 export class RegistrationsService {
   constructor(private http: HttpClient) {}
+  public getAllRegistrations(): Observable<Registrations[]> {
+    return this.http.get<Registrations[]>('/api/admin/registrations');
+  }
 
   public getRegistrations(status: string): Observable<any> {
     return this.http.get<Registrations[]>(`/api/admin/registrations/${status}`);

--- a/src/app/features/search/registrations/registrations.component.ts
+++ b/src/app/features/search/registrations/registrations.component.ts
@@ -15,7 +15,7 @@ export class RegistrationsComponent implements OnInit {
   }
 
   public getRegistrations() {
-    this.registrationsService.getRegistrations('pending').subscribe(
+    this.registrationsService.getAllRegistrations().subscribe(
       (data) => {
         this.registrations = data;
       },


### PR DESCRIPTION
…ow the existing registration page to work

#### Work done
- create a getAllRegistrations API call that uses the old endpoint, for existing registrations page

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
