### PR TITLE
Add console logs for lastTemplate

### DIFF
--- a/server/services/email-campaigns/inactive-workplaces/nextEmail.js
+++ b/server/services/email-campaigns/inactive-workplaces/nextEmail.js
@@ -1,5 +1,5 @@
 const moment = require('moment');
-const { type } = require('os');
+
 const config = require('../../../config/config');
 
 const lastMonth = moment().subtract(1, 'months');


### PR DESCRIPTION
#### Work done
- Create `lastTemplate` const using `parseInt(inactiveWorkplace.LastTemplate)` to fix `notReceivedTemplate` which is currently comparing a string and a number
- Add extra log for `lastTemplate` for debugging in pre prod

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
