### PR TITLE
Fixed script to fail if migrations failed

### DIFF
--- a/bin/cf-migrate.js
+++ b/bin/cf-migrate.js
@@ -1,13 +1,26 @@
-const { exec } = require('child_process');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
 
 const instance_index = process.env.CF_INSTANCE_INDEX;
 
-if (instance_index === '0') {
-  const command = 'npm run db:migrate';
+async function runMigrations() {
+  try {
+    const command = 'npm run db:migrate';
+    const { stdout, stderr } = await exec(command);
+    if (stdout) {
+      console.log('stdout', stdout);
+      process.exit(0);
+    }
+    if (stderr) {
+      console.log('stderr', stderr);
+      process.exit(1);
+    }
+  } catch (e) {
+    console.error(e); // should contain code (exit code) and signal (that caused the termination).
+    process.exit(1);
+  }
+}
 
-  exec(command, (err, stdout, stderr) => {
-    if (stdout) console.log(stdout);
-    if (stderr) console.log(stderr);
-    if (err) console.log(err);
-  });
+if (instance_index === '0') {
+  runMigrations();
 }


### PR DESCRIPTION
#### Work done
- Made start command fail if migrations fail.
- Made the function async to wait for the migrations to complete.
- Exited process once completed

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
