### PR TITLE
techDebt(removeNewFromWorkplaceNotFoundComponents)

### DIFF
--- a/src/app/features/add-workplace/add-workplace-routing.module.ts
+++ b/src/app/features/add-workplace/add-workplace-routing.module.ts
@@ -17,9 +17,9 @@ import { WorkplaceNameAddressComponent } from '@features/add-workplace/workplace
 
 import { CouldNotFindWorkplaceAddressComponent } from './could-not-find-workplace-address/could-not-find-workplace-address.component';
 import { NameOfWorkplaceComponent } from './name-of-workplace/name-of-workplace.component';
-import { NewWorkplaceNotFoundComponent } from './new-workplace-not-found/new-workplace-not-found.component';
 import { StartComponent } from './start/start.component';
 import { WorkplaceAddedThankYouComponent } from './workplace-added-thank-you/workplace-added-thank-you.component';
+import { WorkplaceNotFoundComponent } from './workplace-not-found/workplace-not-found.component';
 
 const routes: Routes = [
   {
@@ -28,8 +28,8 @@ const routes: Routes = [
     data: { title: 'Add Workplace' },
   },
   {
-    path: 'new-workplace-not-found',
-    component: NewWorkplaceNotFoundComponent,
+    path: 'workplace-not-found',
+    component: WorkplaceNotFoundComponent,
     data: { title: 'Could not find your workplace' },
     canActivate: [AddWorkplaceInProgressGuard],
   },

--- a/src/app/features/add-workplace/add-workplace.module.ts
+++ b/src/app/features/add-workplace/add-workplace.module.ts
@@ -15,13 +15,13 @@ import { FindWorkplaceAddressComponent } from './find-workplace-address/find-wor
 import { FindYourWorkplaceComponent } from './find-your-workplace/find-your-workplace.component';
 import { IsThisYourWorkplaceComponent } from './is-this-your-workplace/is-this-your-workplace.component';
 import { NameOfWorkplaceComponent } from './name-of-workplace/name-of-workplace.component';
-import { NewWorkplaceNotFoundComponent } from './new-workplace-not-found/new-workplace-not-found.component';
 import { RegulatedByCqcComponent } from './regulated-by-cqc/regulated-by-cqc.component';
 import { SelectMainServiceComponent } from './select-main-service/select-main-service.component';
 import { SelectWorkplaceAddressComponent } from './select-workplace-address/select-workplace-address.component';
 import { SelectWorkplaceComponent } from './select-workplace/select-workplace.component';
 import { WorkplaceAddedThankYouComponent } from './workplace-added-thank-you/workplace-added-thank-you.component';
 import { WorkplaceNameAddressComponent } from './workplace-name-address/workplace-name-address.component';
+import { WorkplaceNotFoundComponent } from './workplace-not-found/workplace-not-found.component';
 
 @NgModule({
   imports: [CommonModule, AddWorkplaceRoutingModule, ReactiveFormsModule, SharedModule],
@@ -38,7 +38,7 @@ import { WorkplaceNameAddressComponent } from './workplace-name-address/workplac
     StartComponent,
     WorkplaceNameAddressComponent,
     NameOfWorkplaceComponent,
-    NewWorkplaceNotFoundComponent,
+    WorkplaceNotFoundComponent,
     IsThisYourWorkplaceComponent,
     FindYourWorkplaceComponent,
     SelectMainServiceComponent,

--- a/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/add-workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -195,7 +195,7 @@ describe('FindYourWorkplaceComponent', () => {
 
     fireEvent.click(findWorkplaceButton);
 
-    expect(spy).toHaveBeenCalledWith(['add-workplace', 'new-workplace-not-found']);
+    expect(spy).toHaveBeenCalledWith(['add-workplace', 'workplace-not-found']);
   });
 
   it("should show error if server 500's", async () => {
@@ -243,7 +243,7 @@ describe('FindYourWorkplaceComponent', () => {
       component.fixture.componentInstance.setBackLink();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
-        url: ['add-workplace', 'new-workplace-not-found'],
+        url: ['add-workplace', 'workplace-not-found'],
       });
     });
 

--- a/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/add-workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -218,7 +218,7 @@ describe('WorkplaceNameAddressComponent', () => {
         component.setBackLink();
 
         expect(backLinkSpy).toHaveBeenCalledWith({
-          url: ['/add-workplace', 'new-workplace-not-found'],
+          url: ['/add-workplace', 'workplace-not-found'],
         });
       });
     });

--- a/src/app/features/add-workplace/workplace-not-found/workplace-not-found.component.spec.ts
+++ b/src/app/features/add-workplace/workplace-not-found/workplace-not-found.component.spec.ts
@@ -5,27 +5,27 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { RegistrationService } from '@core/services/registration.service';
+import { WorkplaceService } from '@core/services/workplace.service';
 import { SanitizePostcodeUtil } from '@core/utils/sanitize-postcode-util';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
-import { RegistrationModule } from '../../../registration/registration.module';
-import { NewWorkplaceNotFoundComponent } from './new-workplace-not-found.component';
+import { AddWorkplaceModule } from '../add-workplace.module';
+import { WorkplaceNotFoundComponent } from './workplace-not-found.component';
 
-describe('NewWorkplaceNotFoundComponent', () => {
+describe('WorkplaceNotFoundComponent', () => {
   async function setup(
     postcodeOrLocationId = '',
     searchMethod = '',
     workplaceNotFound = false,
     useDifferentLocationIdOrPostcode = null,
   ) {
-    const component = await render(NewWorkplaceNotFoundComponent, {
-      imports: [SharedModule, RegistrationModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+    const component = await render(WorkplaceNotFoundComponent, {
+      imports: [SharedModule, AddWorkplaceModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
         {
-          provide: RegistrationService,
-          useClass: RegistrationService,
+          provide: WorkplaceService,
+          useClass: WorkplaceService,
           useValue: {
             postcodeOrLocationId$: {
               value: postcodeOrLocationId,
@@ -52,7 +52,7 @@ describe('NewWorkplaceNotFoundComponent', () => {
           provide: EstablishmentService,
           useValue: {
             primaryWorkplace: {
-              isParent: false,
+              isParent: true,
             },
           },
         },
@@ -63,7 +63,7 @@ describe('NewWorkplaceNotFoundComponent', () => {
               parent: {
                 url: [
                   {
-                    path: 'registration',
+                    path: 'add-workplace',
                   },
                 ],
               },
@@ -97,30 +97,30 @@ describe('NewWorkplaceNotFoundComponent', () => {
     expect(component.getByText(inputtedPostcode)).toBeTruthy();
   });
 
-  describe('Registration messages', () => {
-    it('should display registration version of heading', async () => {
+  describe('Parent messages', () => {
+    it('should display add workplace version of heading', async () => {
       const { component } = await setup();
-      const expectedHeading = 'We could not find your workplace';
+      const expectedHeading = 'We could not find the workplace';
 
       expect(component.getByText(expectedHeading)).toBeTruthy();
     });
 
-    it('should display registration version of question', async () => {
+    it('should display add workplace version of question', async () => {
       const { component } = await setup();
-      const expectedQuestion = 'Do you want to try find your workplace with a different CQC location ID or postcode?';
+      const expectedQuestion = 'Do you want to try find the workplace with a different CQC location ID or postcode?';
 
       expect(component.getByText(expectedQuestion)).toBeTruthy();
     });
 
-    it('should display registration version of No answer', async () => {
+    it('should display add workplace version of No answer', async () => {
       const { component } = await setup();
-      const expectedNoAnswer = "No, I'll enter our workplace details myself";
+      const expectedNoAnswer = "No, I'll enter the workplace details myself";
 
       expect(component.getByText(expectedNoAnswer)).toBeTruthy();
     });
   });
 
-  describe('Registration journey', () => {
+  describe('Parent journey', () => {
     it('should navigate to the find workplace page when selecting yes', async () => {
       const { component, spy } = await setup();
       const yesRadioButton = component.fixture.nativeElement.querySelector(`input[ng-reflect-value="yes"]`);
@@ -129,10 +129,10 @@ describe('NewWorkplaceNotFoundComponent', () => {
       const continueButton = component.getByText('Continue');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(['/registration', 'find-workplace']);
+      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'find-workplace']);
     });
 
-    it('should navigate to the workplace name and address page when selecting no', async () => {
+    it('should navigate to the workplace name page when selecting no', async () => {
       const { component, spy } = await setup();
       const noRadioButton = component.fixture.nativeElement.querySelector(`input[ng-reflect-value="no"]`);
       fireEvent.click(noRadioButton);
@@ -140,22 +140,14 @@ describe('NewWorkplaceNotFoundComponent', () => {
       const continueButton = component.getByText('Continue');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(['/registration', 'workplace-name-address']);
-    });
-
-    it('should display an error message when not selecting anything', async () => {
-      const { component } = await setup();
-
-      const continueButton = component.getByText('Continue');
-      fireEvent.click(continueButton);
-
-      const errorMessage = component.getByTestId('errorMessage');
-      expect(errorMessage.innerText).toContain('Select yes if you want to try a different location ID or postcode');
+      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'workplace-name-address']);
     });
 
     it('should display the correct heading', async () => {
       const { component } = await setup();
-      const expectedHeading = 'We could not find your workplace';
+      const expectedHeading = 'We could not find the workplace';
+      component.fixture.componentInstance.isParent = true;
+      component.fixture.detectChanges();
 
       expect(component.getByText(expectedHeading)).toBeTruthy();
     });

--- a/src/app/features/add-workplace/workplace-not-found/workplace-not-found.component.ts
+++ b/src/app/features/add-workplace/workplace-not-found/workplace-not-found.component.ts
@@ -4,24 +4,24 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { RegistrationService } from '@core/services/registration.service';
+import { WorkplaceService } from '@core/services/workplace.service';
 import { NewWorkplaceNotFoundDirective } from '@shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.directive';
 
 @Component({
-  selector: 'app-new-workplace-not-found',
+  selector: 'app-workplace-not-found',
   templateUrl:
-    '../../../../shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.component.html',
+    '../../../shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.component.html',
 })
-export class NewWorkplaceNotFoundComponent extends NewWorkplaceNotFoundDirective {
+export class WorkplaceNotFoundComponent extends NewWorkplaceNotFoundDirective {
   constructor(
     protected establishmentService: EstablishmentService,
     protected formBuilder: FormBuilder,
     public backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
-    protected registrationService: RegistrationService,
+    protected workplaceService: WorkplaceService,
     protected router: Router,
     protected route: ActivatedRoute,
   ) {
-    super(establishmentService, formBuilder, backService, errorSummaryService, registrationService, router, route);
+    super(establishmentService, formBuilder, backService, errorSummaryService, workplaceService, router, route);
   }
 }

--- a/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
+++ b/src/app/features/create-account/workplace/find-your-workplace/find-your-workplace.component.spec.ts
@@ -222,7 +222,7 @@ describe('FindYourWorkplaceComponent', () => {
 
     fireEvent.click(findWorkplaceButton);
 
-    expect(spy).toHaveBeenCalledWith(['registration', 'new-workplace-not-found']);
+    expect(spy).toHaveBeenCalledWith(['registration', 'workplace-not-found']);
   });
 
   it("should show error if server 500's", async () => {
@@ -270,7 +270,7 @@ describe('FindYourWorkplaceComponent', () => {
       component.fixture.componentInstance.setBackLink();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
-        url: ['registration', 'new-workplace-not-found'],
+        url: ['registration', 'workplace-not-found'],
       });
     });
 

--- a/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
+++ b/src/app/features/create-account/workplace/workplace-name-address/workplace-name-address.component.spec.ts
@@ -371,7 +371,7 @@ describe('WorkplaceNameAddressComponent', () => {
         component.setBackLink();
 
         expect(backLinkSpy).toHaveBeenCalledWith({
-          url: ['/registration', 'new-workplace-not-found'],
+          url: ['/registration', 'workplace-not-found'],
         });
       });
     });

--- a/src/app/features/create-account/workplace/workplace-not-found/workplace-not-found.component.spec.ts
+++ b/src/app/features/create-account/workplace/workplace-not-found/workplace-not-found.component.spec.ts
@@ -5,27 +5,27 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { WorkplaceService } from '@core/services/workplace.service';
+import { RegistrationService } from '@core/services/registration.service';
 import { SanitizePostcodeUtil } from '@core/utils/sanitize-postcode-util';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
-import { AddWorkplaceModule } from '../add-workplace.module';
-import { NewWorkplaceNotFoundComponent } from './new-workplace-not-found.component';
+import { RegistrationModule } from '../../../registration/registration.module';
+import { WorkplaceNotFoundComponent } from './workplace-not-found.component';
 
-describe('NewWorkplaceNotFoundComponent', () => {
+describe('WorkplaceNotFoundComponent', () => {
   async function setup(
     postcodeOrLocationId = '',
     searchMethod = '',
     workplaceNotFound = false,
     useDifferentLocationIdOrPostcode = null,
   ) {
-    const component = await render(NewWorkplaceNotFoundComponent, {
-      imports: [SharedModule, AddWorkplaceModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+    const component = await render(WorkplaceNotFoundComponent, {
+      imports: [SharedModule, RegistrationModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
         {
-          provide: WorkplaceService,
-          useClass: WorkplaceService,
+          provide: RegistrationService,
+          useClass: RegistrationService,
           useValue: {
             postcodeOrLocationId$: {
               value: postcodeOrLocationId,
@@ -52,7 +52,7 @@ describe('NewWorkplaceNotFoundComponent', () => {
           provide: EstablishmentService,
           useValue: {
             primaryWorkplace: {
-              isParent: true,
+              isParent: false,
             },
           },
         },
@@ -63,7 +63,7 @@ describe('NewWorkplaceNotFoundComponent', () => {
               parent: {
                 url: [
                   {
-                    path: 'add-workplace',
+                    path: 'registration',
                   },
                 ],
               },
@@ -97,30 +97,30 @@ describe('NewWorkplaceNotFoundComponent', () => {
     expect(component.getByText(inputtedPostcode)).toBeTruthy();
   });
 
-  describe('Parent messages', () => {
-    it('should display add workplace version of heading', async () => {
+  describe('Registration messages', () => {
+    it('should display registration version of heading', async () => {
       const { component } = await setup();
-      const expectedHeading = 'We could not find the workplace';
+      const expectedHeading = 'We could not find your workplace';
 
       expect(component.getByText(expectedHeading)).toBeTruthy();
     });
 
-    it('should display add workplace version of question', async () => {
+    it('should display registration version of question', async () => {
       const { component } = await setup();
-      const expectedQuestion = 'Do you want to try find the workplace with a different CQC location ID or postcode?';
+      const expectedQuestion = 'Do you want to try find your workplace with a different CQC location ID or postcode?';
 
       expect(component.getByText(expectedQuestion)).toBeTruthy();
     });
 
-    it('should display add workplace version of No answer', async () => {
+    it('should display registration version of No answer', async () => {
       const { component } = await setup();
-      const expectedNoAnswer = "No, I'll enter the workplace details myself";
+      const expectedNoAnswer = "No, I'll enter our workplace details myself";
 
       expect(component.getByText(expectedNoAnswer)).toBeTruthy();
     });
   });
 
-  describe('Parent journey', () => {
+  describe('Registration journey', () => {
     it('should navigate to the find workplace page when selecting yes', async () => {
       const { component, spy } = await setup();
       const yesRadioButton = component.fixture.nativeElement.querySelector(`input[ng-reflect-value="yes"]`);
@@ -129,10 +129,10 @@ describe('NewWorkplaceNotFoundComponent', () => {
       const continueButton = component.getByText('Continue');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'find-workplace']);
+      expect(spy).toHaveBeenCalledWith(['/registration', 'find-workplace']);
     });
 
-    it('should navigate to the workplace name page when selecting no', async () => {
+    it('should navigate to the workplace name and address page when selecting no', async () => {
       const { component, spy } = await setup();
       const noRadioButton = component.fixture.nativeElement.querySelector(`input[ng-reflect-value="no"]`);
       fireEvent.click(noRadioButton);
@@ -140,14 +140,22 @@ describe('NewWorkplaceNotFoundComponent', () => {
       const continueButton = component.getByText('Continue');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(['/add-workplace', 'workplace-name-address']);
+      expect(spy).toHaveBeenCalledWith(['/registration', 'workplace-name-address']);
+    });
+
+    it('should display an error message when not selecting anything', async () => {
+      const { component } = await setup();
+
+      const continueButton = component.getByText('Continue');
+      fireEvent.click(continueButton);
+
+      const errorMessage = component.getByTestId('errorMessage');
+      expect(errorMessage.innerText).toContain('Select yes if you want to try a different location ID or postcode');
     });
 
     it('should display the correct heading', async () => {
       const { component } = await setup();
-      const expectedHeading = 'We could not find the workplace';
-      component.fixture.componentInstance.isParent = true;
-      component.fixture.detectChanges();
+      const expectedHeading = 'We could not find your workplace';
 
       expect(component.getByText(expectedHeading)).toBeTruthy();
     });

--- a/src/app/features/create-account/workplace/workplace-not-found/workplace-not-found.component.ts
+++ b/src/app/features/create-account/workplace/workplace-not-found/workplace-not-found.component.ts
@@ -4,24 +4,24 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { WorkplaceService } from '@core/services/workplace.service';
+import { RegistrationService } from '@core/services/registration.service';
 import { NewWorkplaceNotFoundDirective } from '@shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.directive';
 
 @Component({
-  selector: 'app-new-workplace-not-found',
+  selector: 'app-workplace-not-found',
   templateUrl:
-    '../../../shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.component.html',
+    '../../../../shared/directives/create-workplace/new-workplace-not-found/new-workplace-not-found.component.html',
 })
-export class NewWorkplaceNotFoundComponent extends NewWorkplaceNotFoundDirective {
+export class WorkplaceNotFoundComponent extends NewWorkplaceNotFoundDirective {
   constructor(
     protected establishmentService: EstablishmentService,
     protected formBuilder: FormBuilder,
     public backService: BackService,
     protected errorSummaryService: ErrorSummaryService,
-    protected workplaceService: WorkplaceService,
+    protected registrationService: RegistrationService,
     protected router: Router,
     protected route: ActivatedRoute,
   ) {
-    super(establishmentService, formBuilder, backService, errorSummaryService, workplaceService, router, route);
+    super(establishmentService, formBuilder, backService, errorSummaryService, registrationService, router, route);
   }
 }

--- a/src/app/features/registration/registration-routing.module.ts
+++ b/src/app/features/registration/registration-routing.module.ts
@@ -21,8 +21,8 @@ import { RegistrationCompleteComponent } from '@features/registration/registrati
 
 import { FindYourWorkplaceComponent } from '../create-account/workplace/find-your-workplace/find-your-workplace.component';
 import { IsThisYourWorkplaceComponent } from '../create-account/workplace/is-this-your-workplace/is-this-your-workplace.component';
-import { NewWorkplaceNotFoundComponent } from '../create-account/workplace/new-workplace-not-found/new-workplace-not-found.component';
 import { RegulatedByCqcComponent } from '../create-account/workplace/regulated-by-cqc/regulated-by-cqc.component';
+import { WorkplaceNotFoundComponent } from '../create-account/workplace/workplace-not-found/workplace-not-found.component';
 import { AboutUsRegistrationComponent } from './about-us/about-us.component';
 import { CreateAccountComponent } from './create-account/create-account.component';
 
@@ -61,8 +61,8 @@ const routes: Routes = [
     data: { title: 'Service regulated by CQC?' },
   },
   {
-    path: 'new-workplace-not-found',
-    component: NewWorkplaceNotFoundComponent,
+    path: 'workplace-not-found',
+    component: WorkplaceNotFoundComponent,
     canActivate: [RegisterGuard],
     data: { title: 'Could not find your workplace' },
   },

--- a/src/app/features/registration/registration.module.ts
+++ b/src/app/features/registration/registration.module.ts
@@ -9,11 +9,11 @@ import { ConfirmDetailsComponent } from '@features/create-account/workplace/conf
 import { ConfirmWorkplaceDetailsComponent } from '@features/create-account/workplace/confirm-workplace-details/confirm-workplace-details.component';
 import { CouldNotFindWorkplaceAddressComponent } from '@features/create-account/workplace/could-not-find-workplace-address/could-not-find-workplace-address.component';
 import { NameOfWorkplaceComponent } from '@features/create-account/workplace/name-of-workplace/name-of-workplace.component';
-import { NewWorkplaceNotFoundComponent } from '@features/create-account/workplace/new-workplace-not-found/new-workplace-not-found.component';
 import { SelectWorkplaceAddressComponent } from '@features/create-account/workplace/select-workplace-address/select-workplace-address.component';
 import { SelectWorkplaceComponent } from '@features/create-account/workplace/select-workplace/select-workplace.component';
 import { ThankYouComponent } from '@features/create-account/workplace/thank-you/thank-you.component';
 import { WorkplaceNameAddressComponent } from '@features/create-account/workplace/workplace-name-address/workplace-name-address.component';
+import { WorkplaceNotFoundComponent } from '@features/create-account/workplace/workplace-not-found/workplace-not-found.component';
 import { PagesModule } from '@features/pages/pages.module';
 import { ChangeYourDetailsComponent } from '@features/registration/change-your-details/change-your-details.component';
 import { RegistrationCompleteComponent } from '@features/registration/registration-complete/registration-complete.component';
@@ -46,7 +46,7 @@ import { CreateAccountComponent } from './create-account/create-account.componen
     FindYourWorkplaceComponent,
     IsThisYourWorkplaceComponent,
     RegulatedByCqcComponent,
-    NewWorkplaceNotFoundComponent,
+    WorkplaceNotFoundComponent,
     NameOfWorkplaceComponent,
     UsernamePasswordComponent,
     CouldNotFindWorkplaceAddressComponent,

--- a/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive.ts
+++ b/src/app/shared/directives/create-workplace/find-your-workplace/find-your-workplace.directive.ts
@@ -57,7 +57,7 @@ export class FindYourWorkplaceDirective implements OnInit, AfterViewInit, OnDest
       return;
     }
 
-    const backLink = this.returnToWorkplaceNotFound ? 'new-workplace-not-found' : 'regulated-by-cqc';
+    const backLink = this.returnToWorkplaceNotFound ? 'workplace-not-found' : 'regulated-by-cqc';
     this.backService.setBackLink({ url: [this.flow, backLink] });
     this.workplaceInterfaceService.workplaceNotFound$.next(false);
   }
@@ -147,7 +147,7 @@ export class FindYourWorkplaceDirective implements OnInit, AfterViewInit, OnDest
   private onError(error: HttpErrorResponse): void {
     if (error.status === 404) {
       this.workplaceInterfaceService.searchMethod$.next(error.error.searchmethod);
-      this.router.navigate([this.flow, 'new-workplace-not-found']);
+      this.router.navigate([this.flow, 'workplace-not-found']);
       return;
     }
     this.serverError = this.errorSummaryService.getServerErrorMessage(error.status, this.serverErrorsMap);

--- a/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
+++ b/src/app/shared/directives/create-workplace/workplace-name-address/workplace-name-address.ts
@@ -326,7 +326,7 @@ export class WorkplaceNameAddressDirective implements OnInit, OnDestroy, AfterVi
       return;
     }
     if (this.isCqcRegulatedAndWorkplaceNotFound()) {
-      this.backService.setBackLink({ url: [this.flow, 'new-workplace-not-found'] });
+      this.backService.setBackLink({ url: [this.flow, 'workplace-not-found'] });
       return;
     }
     if (this.isNotCqcRegulatedAndWorkplaceNotFound()) {


### PR DESCRIPTION
#### Work done
- Remove new from new-workplace-not-found component names and routing

#### Note
- There's a workplace-not-found directive which is extended by components in different areas and new-workplace-not-found directive, out of scope of this ticket to refactor components to use same directive, will be raised as tech debt.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
