### PR TITLE
Bug: Registrations updated workplace ID getting overwritten

### DIFF
--- a/src/app/features/admin/registration-requests/registration-request/registration-request.component.spec.ts
+++ b/src/app/features/admin/registration-requests/registration-request/registration-request.component.spec.ts
@@ -205,6 +205,24 @@ describe('RegistrationRequestComponent', () => {
       });
     });
 
+    it('should call getSingleRegistration in registrationService to get updated registration after successfully updating workplace ID', async () => {
+      const { component, fixture, getByText } = await setup();
+
+      spyOn(component.registrationsService, 'updateWorkplaceId').and.returnValue(of({}));
+      const updateRegistrationCall = spyOn(component.registrationsService, 'getSingleRegistration');
+      TestBed.inject(AlertService);
+
+      const form = component.workplaceIdForm;
+
+      form.controls['nmdsId'].setValue('A1234567');
+      form.controls['nmdsId'].markAsDirty();
+
+      fireEvent.click(getByText('Save this ID'));
+      fixture.detectChanges();
+
+      expect(updateRegistrationCall).toHaveBeenCalled();
+    });
+
     describe('Workplace ID validation', () => {
       it('displays enter a valid workplace ID message when box is empty', async () => {
         const { component, fixture, getByText } = await setup();

--- a/src/app/features/admin/registration-requests/registration-request/registration-request.component.ts
+++ b/src/app/features/admin/registration-requests/registration-request/registration-request.component.ts
@@ -11,9 +11,7 @@ import { RegistrationsService } from '@core/services/registrations.service';
 import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
 import { RegistrationRequestDirective } from '@shared/directives/admin/registration-requests/registration-request.directive';
 
-import {
-  RegistrationApprovalOrRejectionDialogComponent,
-} from '../registration-approval-or-rejection-dialog/registration-approval-or-rejection-dialog.component';
+import { RegistrationApprovalOrRejectionDialogComponent } from '../registration-approval-or-rejection-dialog/registration-approval-or-rejection-dialog.component';
 
 @Component({
   selector: 'app-registration-request',
@@ -72,6 +70,7 @@ export class RegistrationRequestComponent extends RegistrationRequestDirective {
 
     this.registrationsService.updateWorkplaceId(body).subscribe(
       () => {
+        this.getUpdatedRegistration();
         this.showWorkplaceIdUpdatedAlert();
       },
       (err) => {


### PR DESCRIPTION
#### Issue
- When an ID was updated and then the registration was approved without going off the page, the workplace ID reverted back to the original. This was due to the registration object not being updated when the workplace ID is changed.

#### Work done
- Added call to getUpdatedRegistration when workplace ID is updated, so registration object is updated to have new nmds ID
- Added test to check for call to update the registration


#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
