### PR TITLE
Bug - Parent training and quals page

### DIFF
--- a/server/routes/establishments/trainingAndQualifications/getAllTrainingAndQualifications.js
+++ b/server/routes/establishments/trainingAndQualifications/getAllTrainingAndQualifications.js
@@ -21,7 +21,7 @@ const getAllTrainingAndQualifications = async (req, res) => {
   }
 };
 
-router.route('/').get(hasPermission('canEditWorker'), getAllTrainingAndQualifications);
+router.route('/').get(hasPermission('canViewWorker'), getAllTrainingAndQualifications);
 
 module.exports = router;
 module.exports.getAllTrainingAndQualifications = getAllTrainingAndQualifications;

--- a/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/src/app/core/breadcrumb/journey.workplaces.ts
@@ -90,6 +90,14 @@ export const allWorkplacesJourney: JourneyRoute = {
               },
             },
             {
+              title: 'Training and qualifications',
+              path: Path.NEW_TRAINING_AND_QUALIFICATIONS_RECORD,
+              referrer: {
+                path: Path.DASHBOARD,
+                fragment: 'training-and-qualifications',
+              },
+            },
+            {
               title: 'Add a user',
               path: Path.CREATE_ACCOUNT,
             },

--- a/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
@@ -19,12 +19,17 @@
       <ng-container *ngFor="let record of qualificationType.records">
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-font-weight-regular">
-            <a
-              class="govuk-link--no-visited-state"
-              [attr.data-testid]="'Title-' + record.uid"
-              [routerLink]="['../qualification', record.uid]"
-              >{{ record.title }}</a
-            >
+            <ng-container *ngIf="canEditWorker; else viewOnly">
+              <a
+                class="govuk-link--no-visited-state"
+                [attr.data-testid]="'Title-' + record.uid"
+                [routerLink]="['../qualification', record.uid]"
+                >{{ record.title }}</a
+              >
+            </ng-container>
+            <ng-template #viewOnly>
+              <span [attr.data-testid]="'Title-no-link-' + record.uid">{{ record.title }}</span>
+            </ng-template>
           </td>
           <td class="govuk-table__cell">
             {{ record.year }}

--- a/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
@@ -1,10 +1,20 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { Establishment } from '@core/model/establishment.model';
 import { QualificationsByGroup } from '@core/model/qualification.model';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
 
 @Component({
   selector: 'app-new-qualifications',
   templateUrl: './new-qualifications.component.html',
 })
-export class NewQualificationsComponent {
+export class NewQualificationsComponent implements OnInit {
+  @Input() public workplace: Establishment;
   @Input() qualificationsByGroup: QualificationsByGroup;
+  public canEditWorker: boolean;
+
+  constructor(private permissionsService: PermissionsService) {}
+
+  ngOnInit(): void {
+    this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
+  }
 }

--- a/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
@@ -1,20 +1,11 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { Establishment } from '@core/model/establishment.model';
+import { Component, Input } from '@angular/core';
 import { QualificationsByGroup } from '@core/model/qualification.model';
-import { PermissionsService } from '@core/services/permissions/permissions.service';
 
 @Component({
   selector: 'app-new-qualifications',
   templateUrl: './new-qualifications.component.html',
 })
-export class NewQualificationsComponent implements OnInit {
-  @Input() public workplace: Establishment;
+export class NewQualificationsComponent {
   @Input() qualificationsByGroup: QualificationsByGroup;
-  public canEditWorker: boolean;
-
-  constructor(private permissionsService: PermissionsService) {}
-
-  ngOnInit(): void {
-    this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
-  }
+  @Input() canEditWorker: boolean;
 }

--- a/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
@@ -1,27 +1,19 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
-import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { qualificationsByGroup } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
-import { Establishment } from '../../../../../mockdata/establishment';
 import { NewQualificationsComponent } from './new-qualifications.component';
 
 describe('NewQualificationsComponent', () => {
   async function setup() {
     const { fixture, getByText, getAllByText } = await render(NewQualificationsComponent, {
       imports: [SharedModule, RouterTestingModule, HttpClientTestingModule],
-      providers: [
-        {
-          provide: PermissionsService,
-          useClass: MockPermissionsService,
-        },
-      ],
+      providers: [],
       componentProperties: {
-        workplace: Establishment,
+        canEditWorker: true,
         qualificationsByGroup,
       },
     });

--- a/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
@@ -1,18 +1,27 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { qualificationsByGroup } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
+import { Establishment } from '../../../../../mockdata/establishment';
 import { NewQualificationsComponent } from './new-qualifications.component';
 
 describe('NewQualificationsComponent', () => {
   async function setup() {
     const { fixture, getByText, getAllByText } = await render(NewQualificationsComponent, {
       imports: [SharedModule, RouterTestingModule, HttpClientTestingModule],
-      providers: [],
+      providers: [
+        {
+          provide: PermissionsService,
+          useClass: MockPermissionsService,
+        },
+      ],
       componentProperties: {
+        workplace: Establishment,
         qualificationsByGroup,
       },
     });
@@ -54,7 +63,10 @@ describe('NewQualificationsComponent', () => {
   });
 
   it('should contain link in qualification name in first Health table row', async () => {
-    const { fixture } = await setup();
+    const { component, fixture } = await setup();
+
+    component.canEditWorker = true;
+    fixture.detectChanges();
 
     const healthQualificationTitle = fixture.debugElement.query(
       By.css('[data-testid="Title-firstHealthQualUid"]'),
@@ -71,16 +83,6 @@ describe('NewQualificationsComponent', () => {
     expect(getByText('Test notes needed')).toBeTruthy();
   });
 
-  it('should contain link in qualification name in first certificate table row', async () => {
-    const { fixture } = await setup();
-
-    const firstCertificateTitle = fixture.debugElement.query(
-      By.css('[data-testid="Title-firstCertificateUid"]'),
-    ).nativeElement;
-
-    expect(firstCertificateTitle.getAttribute('href')).toBe('/qualification/firstCertificateUid');
-  });
-
   it('should show Certificate table second row with details of record', async () => {
     const { getByText } = await setup();
 
@@ -90,12 +92,43 @@ describe('NewQualificationsComponent', () => {
   });
 
   it('should contain link in qualification name in second certificate table row', async () => {
-    const { fixture } = await setup();
+    const { component, fixture } = await setup();
+
+    component.canEditWorker = true;
+    fixture.detectChanges();
 
     const secondCertificateTitle = fixture.debugElement.query(
       By.css('[data-testid="Title-secondCertificateUid"]'),
     ).nativeElement;
 
     expect(secondCertificateTitle.getAttribute('href')).toBe('/qualification/secondCertificateUid');
+  });
+
+  describe('Link titles', () => {
+    it('should contain link in qualification name in first certificate table row', async () => {
+      const { component, fixture } = await setup();
+
+      component.canEditWorker = true;
+      fixture.detectChanges();
+
+      const firstCertificateTitle = fixture.debugElement.query(
+        By.css('[data-testid="Title-firstCertificateUid"]'),
+      ).nativeElement;
+
+      expect(firstCertificateTitle.getAttribute('href')).toBe('/qualification/firstCertificateUid');
+    });
+
+    it('should not contain a link in qualification name if canEditWorker is false', async () => {
+      const { component, fixture } = await setup();
+
+      component.canEditWorker = false;
+      fixture.detectChanges();
+
+      const firstCertificateTitle = fixture.debugElement.query(
+        By.css('[data-testid="Title-no-link-firstCertificateUid"]'),
+      );
+
+      expect(firstCertificateTitle).toBeTruthy();
+    });
   });
 });

--- a/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
@@ -62,19 +62,6 @@ describe('NewQualificationsComponent', () => {
     expect(getByText('This is a test note for the first row in the Health group')).toBeTruthy();
   });
 
-  it('should contain link in qualification name in first Health table row', async () => {
-    const { component, fixture } = await setup();
-
-    component.canEditWorker = true;
-    fixture.detectChanges();
-
-    const healthQualificationTitle = fixture.debugElement.query(
-      By.css('[data-testid="Title-firstHealthQualUid"]'),
-    ).nativeElement;
-
-    expect(healthQualificationTitle.getAttribute('href')).toBe('/qualification/firstHealthQualUid');
-  });
-
   it('should show Certificate table first row with details of record', async () => {
     const { getByText } = await setup();
 
@@ -91,20 +78,20 @@ describe('NewQualificationsComponent', () => {
     expect(getByText('These are some more notes in the second row of the cert table')).toBeTruthy();
   });
 
-  it('should contain link in qualification name in second certificate table row', async () => {
-    const { component, fixture } = await setup();
-
-    component.canEditWorker = true;
-    fixture.detectChanges();
-
-    const secondCertificateTitle = fixture.debugElement.query(
-      By.css('[data-testid="Title-secondCertificateUid"]'),
-    ).nativeElement;
-
-    expect(secondCertificateTitle.getAttribute('href')).toBe('/qualification/secondCertificateUid');
-  });
-
   describe('Link titles', () => {
+    it('should contain link in qualification name in first Health table row', async () => {
+      const { component, fixture } = await setup();
+
+      component.canEditWorker = true;
+      fixture.detectChanges();
+
+      const healthQualificationTitle = fixture.debugElement.query(
+        By.css('[data-testid="Title-firstHealthQualUid"]'),
+      ).nativeElement;
+
+      expect(healthQualificationTitle.getAttribute('href')).toBe('/qualification/firstHealthQualUid');
+    });
+
     it('should contain link in qualification name in first certificate table row', async () => {
       const { component, fixture } = await setup();
 
@@ -116,6 +103,19 @@ describe('NewQualificationsComponent', () => {
       ).nativeElement;
 
       expect(firstCertificateTitle.getAttribute('href')).toBe('/qualification/firstCertificateUid');
+    });
+
+    it('should contain link in qualification name in second certificate table row', async () => {
+      const { component, fixture } = await setup();
+
+      component.canEditWorker = true;
+      fixture.detectChanges();
+
+      const secondCertificateTitle = fixture.debugElement.query(
+        By.css('[data-testid="Title-secondCertificateUid"]'),
+      ).nativeElement;
+
+      expect(secondCertificateTitle.getAttribute('href')).toBe('/qualification/secondCertificateUid');
     });
 
     it('should not contain a link in qualification name if canEditWorker is false', async () => {

--- a/src/app/features/workers/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -205,7 +205,11 @@
         No qualification records have been added for this person yet.
       </p>
       <ng-template #qualificationTable>
-        <app-new-qualifications [qualificationsByGroup]="qualificationsByGroup" data-testid="qualification">
+        <app-new-qualifications
+          [workplace]="workplace"
+          [qualificationsByGroup]="qualificationsByGroup"
+          data-testid="qualification"
+        >
         </app-new-qualifications>
       </ng-template>
     </div>

--- a/src/app/features/workers/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -187,10 +187,10 @@
       </p>
       <ng-template #nonMandatoryTrainingTable>
         <app-new-training
-          [workplace]="workplace"
           [trainingRecords]="nonMandatoryTraining"
           [trainingType]="'nonMandatory'"
           [setReturnRoute]="setReturnRoute"
+          [canEditWorker]="canEditWorker"
           data-testid="non-mandatory-training"
         ></app-new-training>
       </ng-template>
@@ -206,7 +206,7 @@
       </p>
       <ng-template #qualificationTable>
         <app-new-qualifications
-          [workplace]="workplace"
+          [canEditWorker]="canEditWorker"
           [qualificationsByGroup]="qualificationsByGroup"
           data-testid="qualification"
         >

--- a/src/app/features/workers/new-training-qualifications-record/new-training/new-training.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/new-training/new-training.component.html
@@ -21,14 +21,21 @@
         <ng-container>
           <tr class="govuk-table__row govuk-util__vertical-align-top">
             <td class="govuk-table__cell">
-              <a
-                class="govuk-link--no-visited-state"
-                [routerLink]="['../training', records.uid]"
-                [attr.data-testid]="'Title-' + records.uid"
-                [state]="trainingType === 'mandatory' && { training: 'mandatory' }"
-                (click)="setReturnRoute()"
-                >{{ records.title ? records.title : 'Missing training name - Add' }}</a
-              >
+              <ng-container *ngIf="canEditWorker; else viewOnly">
+                <a
+                  class="govuk-link--no-visited-state"
+                  [routerLink]="['../training', records.uid]"
+                  [attr.data-testid]="'Title-' + records.uid"
+                  [state]="trainingType === 'mandatory' && { training: 'mandatory' }"
+                  (click)="setReturnRoute()"
+                  >{{ records.title ? records.title : 'Missing training name - Add' }}</a
+                >
+              </ng-container>
+              <ng-template #viewOnly>
+                <span [attr.data-testid]="'Title-no-link-' + records.uid">{{
+                  records.title ? records.title : 'Missing training name - Add'
+                }}</span>
+              </ng-template>
             </td>
             <td class="govuk-table__cell">{{ records.accredited ? records.accredited : '-' }}</td>
             <td class="govuk-table__cell">{{ records.completed ? (records.completed | date: 'dd MMM y') : '-' }}</td>

--- a/src/app/features/workers/new-training-qualifications-record/new-training/new-training.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/new-training/new-training.component.spec.ts
@@ -147,6 +147,9 @@ describe('NewTrainingComponent', () => {
     });
 
     it('should render missing training name when there is no title for a training record', async () => {
+      component.canEditWorker = true;
+      fixture.detectChanges();
+
       const healthTrainingTitle = fixture.debugElement.query(
         By.css('[data-testid="Title-someHealthUid"]'),
       ).nativeElement;
@@ -160,7 +163,10 @@ describe('NewTrainingComponent', () => {
   });
 
   describe('training record links', () => {
-    it('training title should have link to training records', () => {
+    it('training title should have link to training records if you are an edit user', () => {
+      component.canEditWorker = true;
+      fixture.detectChanges();
+
       const autismTrainingTitleLink = fixture.debugElement.query(
         By.css('[data-testid="Title-someAutismUid"]'),
       ).nativeElement;
@@ -182,6 +188,30 @@ describe('NewTrainingComponent', () => {
       expect(communicationTrainingTitleLink.getAttribute('href')).toBe('/training/someCommunicationUid');
       expect(healthTrainingTitleLink.getAttribute('href')).toBe('/training/someHealthUid');
       expect(healthTraining2TitleLink.getAttribute('href')).toBe('/training/someHealthUid2');
+    });
+
+    it('training title should not link to training records if you are a read only user', () => {
+      component.canEditWorker = false;
+      fixture.detectChanges();
+
+      const autismTrainingTitleLink = fixture.debugElement.query(By.css('[data-testid="Title-no-link-someAutismUid"]'));
+      const autismTraining2TitleLink = fixture.debugElement.query(
+        By.css('[data-testid="Title-no-link-someAutismUid2"]'),
+      );
+      const communicationTrainingTitleLink = fixture.debugElement.query(
+        By.css('[data-testid="Title-no-link-someCommunicationUid"]'),
+      );
+      const healthTrainingTitleLink = fixture.debugElement.query(By.css('[data-testid="Title-no-link-someHealthUid"]'));
+      const healthTraining2TitleLink = fixture.debugElement.query(
+        By.css('[data-testid="Title-no-link-someHealthUid2"]'),
+      );
+
+      expect(autismTrainingTitleLink).toBeTruthy();
+      expect(autismTrainingTitleLink).toBeTruthy();
+      expect(autismTraining2TitleLink).toBeTruthy();
+      expect(communicationTrainingTitleLink).toBeTruthy();
+      expect(healthTrainingTitleLink).toBeTruthy();
+      expect(healthTraining2TitleLink).toBeTruthy();
     });
   });
 });

--- a/src/app/features/workers/new-training-qualifications-record/new-training/new-training.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/new-training/new-training.component.spec.ts
@@ -2,10 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
-import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 
-import { Establishment } from '../../../../../mockdata/establishment';
 import { NewTrainingComponent } from './new-training.component';
 
 describe('NewTrainingComponent', () => {
@@ -97,14 +94,14 @@ describe('NewTrainingComponent', () => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, HttpClientTestingModule],
       declarations: [],
-      providers: [{ provide: PermissionsService, useClass: MockPermissionsService }],
+      providers: [],
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NewTrainingComponent);
     component = fixture.componentInstance;
-    component.workplace = Establishment;
+    component.canEditWorker = true;
     component.trainingRecords = trainingRecords;
     fixture.detectChanges();
   });

--- a/src/app/features/workers/new-training-qualifications-record/new-training/new-training.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/new-training/new-training.component.ts
@@ -1,28 +1,16 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { Establishment } from '@core/model/establishment.model';
+import { Component, Input } from '@angular/core';
 import { TrainingRecordCategory } from '@core/model/training.model';
-import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TrainingStatusService } from '@core/services/trainingStatus.service';
-import { WorkerService } from '@core/services/worker.service';
 
 @Component({
   selector: 'app-new-training',
   templateUrl: './new-training.component.html',
 })
-export class NewTrainingComponent implements OnInit {
-  @Input() public workplace: Establishment;
+export class NewTrainingComponent {
   @Input() public trainingRecords: TrainingRecordCategory[];
   @Input() public trainingType: string;
   @Input() public setReturnRoute: () => void;
-  public canEditWorker: boolean;
+  @Input() public canEditWorker: boolean;
 
-  constructor(
-    private permissionsService: PermissionsService,
-    private trainingStatusService: TrainingStatusService,
-    private workerService: WorkerService,
-  ) {}
-
-  ngOnInit(): void {
-    this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
-  }
+  constructor(private trainingStatusService: TrainingStatusService) {}
 }


### PR DESCRIPTION
#### Issue
- Parents viewing a sub's training and quals information when they don't have edit worker permissions meant they couldn't access the new training and quals page
- Once accessing the page, they could still click on the training title to go to the edit page

#### Work done
- Changed `getAllTrainingAndQualifications` endpoint to check `canViewWorker` instead of `canEditWorker`
- Add new training page to `allWorkplacesJourney` breadcrumbs
- Changed the title in `new-training` and `new-qualifications` components to only be a link if you are an edit user

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
