### PR TITLE
Fix: Mandatory training links

### DIFF
--- a/src/app/features/workers/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -167,10 +167,10 @@
 
       <div *ngIf="mandatoryTrainingCount > 0">
         <app-new-training
-          [workplace]="workplace"
           [trainingRecords]="mandatoryTraining"
           [trainingType]="'mandatory'"
           [setReturnRoute]="setReturnRoute"
+          [canEditWorker]="canEditWorker"
           data-testid="mandatory-training"
         ></app-new-training>
       </div>


### PR DESCRIPTION
#### Work done
- Added `canEditWorker` input to `app-new-training` component where it had been missed

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
