### PR TITLE
Fix: Remove message from care certificate tab in parent training report

### DIFF
--- a/server/routes/reports/trainingAndQualifications/careCertificateTab.js
+++ b/server/routes/reports/trainingAndQualifications/careCertificateTab.js
@@ -9,7 +9,6 @@ const {
   fitColumnsToSize,
   alignColumnToLeft,
   addBlankRowIfTableEmpty,
-  addQuestion,
 } = require('../../../utils/excelUtils');
 const models = require('../../../models');
 
@@ -27,19 +26,17 @@ const addContentToCareCertificateTab = (careCertificateTab, establishments, isPa
   alignColumnToLeft(careCertificateTab, 2);
   if (isParent) alignColumnToLeft(careCertificateTab, 3);
 
-  isParent && addQuestion(careCertificateTab, 'B6', 'E6', 'Have they started or completed the Care Certificate?');
-
   const careCertificateTable = createCareCertificateTable(careCertificateTab, isParent);
   addRowsToCareCertificateTable(careCertificateTable, establishments, isParent);
 
   fitColumnsToSize(careCertificateTab, 2, 5.5);
-  addBordersToAllFilledCells(careCertificateTab, isParent ? 8 : 5);
+  addBordersToAllFilledCells(careCertificateTab, 5);
 };
 
 const createCareCertificateTable = (careCertificateTab, isParent) => {
   setTableHeadingsStyle(
     careCertificateTab,
-    isParent ? 9 : 6,
+    6,
     backgroundColours.blue,
     textColours.white,
     isParent ? ['B', 'C', 'D', 'E'] : ['B', 'C', 'D'],
@@ -55,7 +52,7 @@ const createCareCertificateTable = (careCertificateTab, isParent) => {
 
   return careCertificateTab.addTable({
     name: 'careCertificateTable',
-    ref: isParent ? 'B9' : 'B6',
+    ref: 'B6',
     columns,
     rows: [],
   });

--- a/server/test/unit/routes/reports/trainingAndQualificationsReport/careCertificateTab.spec.js
+++ b/server/test/unit/routes/reports/trainingAndQualificationsReport/careCertificateTab.spec.js
@@ -109,28 +109,18 @@ describe('generateCareCertificateTab', () => {
       expect(mockCareCertificateTab.getCell('B2').value).to.equal('Care Certificate');
     });
 
-    it('should add question to cell B6', async () => {
-      addContentToCareCertificateTab(
-        mockCareCertificateTab,
-        mockParentWorkplaceWorkersWithCareCerticateStatus,
-        isParent,
-      );
-      const question = 'Have they started or completed the Care Certificate?';
-      expect(mockCareCertificateTab.getCell('B6').value).to.equal(question);
-    });
-
     describe('Care Certificate table', () => {
-      it('should add care certificate records table headings to row 9', async () => {
+      it('should add care certificate records table headings to row 6', async () => {
         addContentToCareCertificateTab(
           mockCareCertificateTab,
           mockParentWorkplaceWorkersWithCareCerticateStatus,
           isParent,
         );
 
-        expect(mockCareCertificateTab.getCell('B9').value).to.equal('Workplace');
-        expect(mockCareCertificateTab.getCell('C9').value).to.equal('Worker ID');
-        expect(mockCareCertificateTab.getCell('D9').value).to.equal('Job role');
-        expect(mockCareCertificateTab.getCell('E9').value).to.equal('Status');
+        expect(mockCareCertificateTab.getCell('B6').value).to.equal('Workplace');
+        expect(mockCareCertificateTab.getCell('C6').value).to.equal('Worker ID');
+        expect(mockCareCertificateTab.getCell('D6').value).to.equal('Job role');
+        expect(mockCareCertificateTab.getCell('E6').value).to.equal('Status');
       });
 
       it('should add first worker with care certificate and workplace for first workplace to care certificate table', async () => {
@@ -140,12 +130,12 @@ describe('generateCareCertificateTab', () => {
           isParent,
         );
 
-        expect(mockCareCertificateTab.getCell('B10').value).to.equal(
+        expect(mockCareCertificateTab.getCell('B7').value).to.equal(
           mockParentWorkplaceWorkersWithCareCerticateStatus[0].establishmentName,
         );
-        expect(mockCareCertificateTab.getCell('C10').value).to.equal(mockWorkersWithCareCertificateStatus[0].workerId);
-        expect(mockCareCertificateTab.getCell('D10').value).to.equal(mockWorkersWithCareCertificateStatus[0].jobRole);
-        expect(mockCareCertificateTab.getCell('E10').value).to.equal(mockWorkersWithCareCertificateStatus[0].status);
+        expect(mockCareCertificateTab.getCell('C7').value).to.equal(mockWorkersWithCareCertificateStatus[0].workerId);
+        expect(mockCareCertificateTab.getCell('D7').value).to.equal(mockWorkersWithCareCertificateStatus[0].jobRole);
+        expect(mockCareCertificateTab.getCell('E7').value).to.equal(mockWorkersWithCareCertificateStatus[0].status);
       });
 
       it('should add second worker with care certificate and workplace for first workplace to care certificate table', async () => {
@@ -155,12 +145,12 @@ describe('generateCareCertificateTab', () => {
           isParent,
         );
 
-        expect(mockCareCertificateTab.getCell('B11').value).to.equal(
+        expect(mockCareCertificateTab.getCell('B8').value).to.equal(
           mockParentWorkplaceWorkersWithCareCerticateStatus[0].establishmentName,
         );
-        expect(mockCareCertificateTab.getCell('C11').value).to.equal(mockWorkersWithCareCertificateStatus[1].workerId);
-        expect(mockCareCertificateTab.getCell('D11').value).to.equal(mockWorkersWithCareCertificateStatus[1].jobRole);
-        expect(mockCareCertificateTab.getCell('E11').value).to.equal(mockWorkersWithCareCertificateStatus[1].status);
+        expect(mockCareCertificateTab.getCell('C8').value).to.equal(mockWorkersWithCareCertificateStatus[1].workerId);
+        expect(mockCareCertificateTab.getCell('D8').value).to.equal(mockWorkersWithCareCertificateStatus[1].jobRole);
+        expect(mockCareCertificateTab.getCell('E8').value).to.equal(mockWorkersWithCareCertificateStatus[1].status);
       });
 
       it('should add first worker with care certificate and workplace for second workplace to care certificate table', async () => {
@@ -170,16 +160,16 @@ describe('generateCareCertificateTab', () => {
           isParent,
         );
 
-        expect(mockCareCertificateTab.getCell('B12').value).to.equal(
+        expect(mockCareCertificateTab.getCell('B9').value).to.equal(
           mockParentWorkplaceWorkersWithCareCerticateStatus[1].establishmentName,
         );
-        expect(mockCareCertificateTab.getCell('C12').value).to.equal(
+        expect(mockCareCertificateTab.getCell('C9').value).to.equal(
           secondMockWorkersWithCareCertificateStatus[0].workerId,
         );
-        expect(mockCareCertificateTab.getCell('D12').value).to.equal(
+        expect(mockCareCertificateTab.getCell('D9').value).to.equal(
           secondMockWorkersWithCareCertificateStatus[0].jobRole,
         );
-        expect(mockCareCertificateTab.getCell('E12').value).to.equal(
+        expect(mockCareCertificateTab.getCell('E9').value).to.equal(
           secondMockWorkersWithCareCertificateStatus[0].status,
         );
       });
@@ -191,16 +181,16 @@ describe('generateCareCertificateTab', () => {
           isParent,
         );
 
-        expect(mockCareCertificateTab.getCell('B13').value).to.equal(
+        expect(mockCareCertificateTab.getCell('B10').value).to.equal(
           mockParentWorkplaceWorkersWithCareCerticateStatus[1].establishmentName,
         );
-        expect(mockCareCertificateTab.getCell('C13').value).to.equal(
+        expect(mockCareCertificateTab.getCell('C10').value).to.equal(
           secondMockWorkersWithCareCertificateStatus[1].workerId,
         );
-        expect(mockCareCertificateTab.getCell('D13').value).to.equal(
+        expect(mockCareCertificateTab.getCell('D10').value).to.equal(
           secondMockWorkersWithCareCertificateStatus[1].jobRole,
         );
-        expect(mockCareCertificateTab.getCell('E13').value).to.equal(
+        expect(mockCareCertificateTab.getCell('E10').value).to.equal(
           secondMockWorkersWithCareCertificateStatus[1].status,
         );
       });
@@ -213,7 +203,7 @@ describe('generateCareCertificateTab', () => {
             isParent,
           );
 
-          const expectedLine = 14;
+          const expectedLine = 11;
 
           expect(mockCareCertificateTab.getCell(`B${expectedLine}`).value).to.equal(null);
           expect(mockCareCertificateTab.getCell(`C${expectedLine}`).value).to.equal(null);
@@ -223,7 +213,7 @@ describe('generateCareCertificateTab', () => {
         it('should add empty row to table when no data', async () => {
           addContentToCareCertificateTab(mockCareCertificateTab, [], isParent);
 
-          const expectedLine = 10;
+          const expectedLine = 7;
 
           expect(mockCareCertificateTab.getCell(`B${expectedLine}`).value).to.equal('');
           expect(mockCareCertificateTab.getCell(`C${expectedLine}`).value).to.equal('');

--- a/server/utils/excelUtils.js
+++ b/server/utils/excelUtils.js
@@ -138,16 +138,6 @@ exports.addHeading = (tab, startCell, endCell, content) => {
   };
 };
 
-exports.addQuestion = (tab, startCell, endCell, content) => {
-  tab.mergeCells(`${startCell}:${endCell}`);
-  tab.getCell(startCell).value = content;
-  tab.getCell(startCell).font = {
-    family: 4,
-    size: 25,
-    bold: true,
-  };
-};
-
 exports.addLine = (worksheet, startCell, endCell) => {
   worksheet.mergeCells(`${startCell}:${endCell}`);
   worksheet.getCell(startCell).border = {
@@ -214,4 +204,4 @@ exports.textColours = {
 
 exports.makeRowBold = (tab, rowNumber) => {
   tab.getRow(rowNumber).font = { bold: true };
-}
+};


### PR DESCRIPTION
#### Work done
- Removed message from care certificate tab in parent training report

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
