### PR TITLE
Feat: Training delete button

### DIFF
--- a/src/app/core/resolvers/training-record.resolver.ts
+++ b/src/app/core/resolvers/training-record.resolver.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
+import { WorkerService } from '@core/services/worker.service';
+import { of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable()
+export class TrainingRecordResolver implements Resolve<any> {
+  constructor(private router: Router, private workerService: WorkerService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.workerService
+      .getTrainingRecord(
+        route.paramMap.get('establishmentuid'),
+        route.paramMap.get('id'),
+        route.paramMap.get('trainingRecordId'),
+      )
+      .pipe(
+        catchError(() => {
+          this.router.navigate(['/problem-with-the-service']);
+          return of(null);
+        }),
+      );
+  }
+}

--- a/src/app/core/test-utils/MockWorkerService.ts
+++ b/src/app/core/test-utils/MockWorkerService.ts
@@ -252,3 +252,22 @@ export class MockWorkerServiceWithUpdateWorker extends MockWorkerService {
     return of({ uid: '1' } as WorkerEditResponse);
   }
 }
+
+@Injectable()
+export class MockWorkerServiceWithTrainingRecord extends MockWorkerService {
+  getTrainingRecord(workplaceUid: string, workerId: string, trainingRecordId: string) {
+    return of({
+      id: 10,
+      uid: 'someuid',
+      workerUid: '6787fgfghfghghjjg',
+      created: '01/02/2020',
+      updated: '01/02/2020',
+      updatedBy: 'admin',
+      trainingCategory: { id: 1, category: 'Communication' },
+      title: 'Communication Training 1',
+      accredited: true,
+      completed: '01/02/2020',
+      expires: '01/02/2021',
+    });
+  }
+}

--- a/src/app/core/test-utils/MockWorkerService.ts
+++ b/src/app/core/test-utils/MockWorkerService.ts
@@ -189,6 +189,20 @@ export const qualificationsByGroup = {
   ],
 } as QualificationsByGroup;
 
+export const trainingRecord = {
+  id: 10,
+  uid: 'someuid',
+  workerUid: '6787fgfghfghghjjg',
+  created: '01/02/2020',
+  updated: '01/02/2020',
+  updatedBy: 'admin',
+  trainingCategory: { id: 1, category: 'Communication' },
+  title: 'Communication Training 1',
+  accredited: true,
+  completed: '01/02/2020',
+  expires: '01/02/2021',
+};
+
 @Injectable()
 export class MockWorkerService extends WorkerService {
   private _worker;
@@ -250,24 +264,5 @@ export class MockWorkerService extends WorkerService {
 export class MockWorkerServiceWithUpdateWorker extends MockWorkerService {
   updateWorker(workplaceUid: string, workerId: string, props): Observable<WorkerEditResponse> {
     return of({ uid: '1' } as WorkerEditResponse);
-  }
-}
-
-@Injectable()
-export class MockWorkerServiceWithTrainingRecord extends MockWorkerService {
-  getTrainingRecord(workplaceUid: string, workerId: string, trainingRecordId: string) {
-    return of({
-      id: 10,
-      uid: 'someuid',
-      workerUid: '6787fgfghfghghjjg',
-      created: '01/02/2020',
-      updated: '01/02/2020',
-      updatedBy: 'admin',
-      trainingCategory: { id: 1, category: 'Communication' },
-      title: 'Communication Training 1',
-      accredited: true,
-      completed: '01/02/2020',
-      expires: '01/02/2021',
-    });
   }
 }

--- a/src/app/core/test-utils/MockWorkerService.ts
+++ b/src/app/core/test-utils/MockWorkerService.ts
@@ -191,7 +191,7 @@ export const qualificationsByGroup = {
 
 export const trainingRecord = {
   id: 10,
-  uid: 'someuid',
+  uid: 'someTrainingUid',
   workerUid: '6787fgfghfghghjjg',
   created: '01/02/2020',
   updated: '01/02/2020',

--- a/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
@@ -109,7 +109,10 @@ describe('AddEditTrainingComponent', () => {
 
   describe('delete button', () => {
     it('should render the delete button when editing training', async () => {
-      const { getByText } = await setup();
+      const { component, fixture, getByText } = await setup();
+
+      component.newTrainingAndQualificationsRecordsFlag = true;
+      fixture.detectChanges();
 
       expect(getByText('Delete')).toBeTruthy();
     });
@@ -117,6 +120,7 @@ describe('AddEditTrainingComponent', () => {
     it('should not render the delete button when there is no training id', async () => {
       const { component, fixture, queryByText } = await setup();
 
+      component.newTrainingAndQualificationsRecordsFlag = true;
       component.trainingRecordId = null;
       fixture.detectChanges();
 

--- a/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
@@ -79,9 +79,9 @@ describe('AddEditTrainingComponent', () => {
       expect(getByText('Enter training details')).toBeTruthy();
     });
 
-    it('should render the Edit training details title, when there is a training record id', async () => {
+    it('should render the Training details title, when there is a training record id', async () => {
       const { getByText } = await setup();
-      expect(getByText('Edit training details')).toBeTruthy();
+      expect(getByText('Training details')).toBeTruthy();
     });
 
     it('should render the Add mandatory training record title, when accessed from add mandatory training link', async () => {
@@ -95,14 +95,14 @@ describe('AddEditTrainingComponent', () => {
       expect(getByText('Add mandatory training record')).toBeTruthy();
     });
 
-    it('should render the Edit mandatory training record title, when accessed from mandatory training title', async () => {
+    it('should render the Mandatory training record title, when accessed from mandatory training title', async () => {
       const { component, fixture, getByText } = await setup();
 
       component.mandatoryTraining = true;
       component.setTitle();
       fixture.detectChanges();
 
-      expect(getByText('Edit mandatory training record')).toBeTruthy();
+      expect(getByText('Mandatory training record')).toBeTruthy();
     });
   });
 });

--- a/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
@@ -105,4 +105,12 @@ describe('AddEditTrainingComponent', () => {
       expect(getByText('Mandatory training record')).toBeTruthy();
     });
   });
+
+  describe('delete button', () => {
+    it('should render the delete button when editing training', async () => {
+      const { getByText } = await setup();
+
+      expect(getByText('Delete')).toBeTruthy();
+    });
+  });
 });

--- a/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
@@ -17,7 +17,7 @@ import { AddEditTrainingComponent } from './add-edit-training.component';
 
 describe('AddEditTrainingComponent', () => {
   async function setup() {
-    const { fixture, getByText, getByTestId } = await render(AddEditTrainingComponent, {
+    const { fixture, getByText, getByTestId, queryByText } = await render(AddEditTrainingComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       providers: [
         {
@@ -51,6 +51,7 @@ describe('AddEditTrainingComponent', () => {
       fixture,
       getByText,
       getByTestId,
+      queryByText,
     };
   }
 
@@ -111,6 +112,15 @@ describe('AddEditTrainingComponent', () => {
       const { getByText } = await setup();
 
       expect(getByText('Delete')).toBeTruthy();
+    });
+
+    it('should not render the delete button when there is no training id', async () => {
+      const { component, fixture, queryByText } = await setup();
+
+      component.trainingRecordId = null;
+      fixture.detectChanges();
+
+      expect(queryByText('Delete')).toBeFalsy();
     });
   });
 });

--- a/src/app/features/workers/add-edit-training/add-edit-training.component.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.ts
@@ -71,7 +71,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
   }
 
   protected setButtonText(): void {
-    this.buttonText = this.trainingRecordId ? 'Update training' : 'Add training';
+    this.buttonText = this.trainingRecordId ? 'Save and return' : 'Add training';
   }
 
   protected setBackLink(): void {

--- a/src/app/features/workers/add-edit-training/add-edit-training.component.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.ts
@@ -64,9 +64,9 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
 
   public setTitle(): void {
     if (this.mandatoryTraining) {
-      this.title = this.trainingRecordId ? 'Edit mandatory training record' : 'Add mandatory training record';
+      this.title = this.trainingRecordId ? 'Mandatory training record' : 'Add mandatory training record';
     } else {
-      this.title = this.trainingRecordId ? 'Edit training details' : 'Enter training details';
+      this.title = this.trainingRecordId ? 'Training details' : 'Enter training details';
     }
   }
 

--- a/src/app/features/workers/add-edit-training/add-edit-training.component.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.ts
@@ -16,7 +16,6 @@ import { AddEditTrainingDirective } from '../../../shared/directives/add-edit-tr
   templateUrl: '../../../shared/directives/add-edit-training/add-edit-training.component.html',
 })
 export class AddEditTrainingComponent extends AddEditTrainingDirective implements OnInit, AfterViewInit {
-  private newTrainingAndQualificationsRecordsFlag: boolean;
   private trainingPath: string;
   public mandatoryTraining: boolean;
 

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
@@ -1,0 +1,1 @@
+<p>hellooo</p>

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
@@ -24,10 +24,10 @@
       </div>
     </dl>
 
-    <div class="govuk-button-group">
-      <!-- <button type="button" class="govuk-button govuk-button--warning govuk-!-margin-right-8">
+    <div class="govuk-button-group govuk-!-margin-top-7">
+      <button type="button" class="govuk-button govuk-button--warning govuk-!-margin-right-2" (click)="deleteRecord()">
         Delete this training record
-      </button> -->
+      </button>
       <a
         class="govuk-button govuk-button--link govuk-!-margin-left-9"
         role="button"

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
@@ -1,1 +1,9 @@
-<p>hellooo</p>
+<div class="govuk-grid-row govuk-!-margin-bottom-0">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-list--inline govuk-list govuk__flex">
+      <span class="govuk-caption-xl govuk-!-margin-right-3" data-testid="workerNameAndRole">
+        {{ worker.nameOrId }}: {{ worker.mainJob?.other ? worker.mainJob.other : worker.mainJob.title }}
+      </span>
+    </div>
+  </div>
+</div>

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
@@ -1,9 +1,42 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-0">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-list--inline govuk-list govuk__flex">
-      <span class="govuk-caption-xl govuk-!-margin-right-3" data-testid="workerNameAndRole">
-        {{ worker.nameOrId }}: {{ worker.mainJob?.other ? worker.mainJob.other : worker.mainJob.title }}
-      </span>
+    <span class="govuk-caption-xl govuk-!-margin-right-3" data-testid="workerNameAndRole">
+      {{ worker.nameOrId }}: {{ worker.mainJob?.other ? worker.mainJob.other : worker.mainJob.title }}
+    </span>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">You're about to delete this training record</h1>
+
+    <dl class="govuk-summary-list govuk-summary-list--no-border govuk-summary-list--wide-key">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Name or ID number</dt>
+        <dd class="govuk-summary-list__value" data-testid="workerName">
+          {{ worker.nameOrId }}
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Training category</dt>
+        <dd class="govuk-summary-list__value" data-testid="trainingCategory">
+          {{ trainingRecord.trainingCategory.category }}
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Training name</dt>
+        <dd class="govuk-summary-list__value" data-testid="trainingName">{{ trainingRecord.title }}</dd>
+      </div>
+    </dl>
+
+    <div class="govuk-button-group">
+      <!-- <button type="button" class="govuk-button govuk-button--warning govuk-!-margin-right-8">
+        Delete this training record
+      </button> -->
+      <a
+        class="govuk-button govuk-button--link govuk-!-margin-left-9"
+        role="button"
+        draggable="false"
+        href="#"
+        (click)="returnToEditPage($event)"
+      >
+        Cancel
+      </a>
     </div>
   </div>
 </div>

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -6,7 +6,7 @@ import { Establishment } from '@core/model/establishment.model';
 import { AlertService } from '@core/services/alert.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
-import { MockWorkerService, trainingRecord, workerBuilder } from '@core/test-utils/MockWorkerService';
+import { MockWorkerService, trainingRecord } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { of } from 'rxjs';
@@ -17,7 +17,6 @@ import { DeleteRecordComponent } from './delete-record.component';
 
 describe('DeleteRecordComponent', () => {
   const workplace = establishmentBuilder() as Establishment;
-  const worker = workerBuilder() as Worker;
 
   async function setup(otherJob = false) {
     const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(DeleteRecordComponent, {
@@ -40,9 +39,6 @@ describe('DeleteRecordComponent', () => {
                   },
                 },
                 trainingRecord: trainingRecord,
-              },
-              params: {
-                trainingRecordId: '1',
               },
             },
           },
@@ -113,7 +109,7 @@ describe('DeleteRecordComponent', () => {
     expect(routerSpy).toHaveBeenCalledWith([
       `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
       'training',
-      component.trainingRecordId,
+      component.trainingRecord.uid,
     ]);
   });
 
@@ -150,7 +146,11 @@ describe('DeleteRecordComponent', () => {
       const deleteButton = getByText('Delete this training record');
       fireEvent.click(deleteButton);
 
-      expect(workerSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, component.trainingRecordId);
+      expect(workerSpy).toHaveBeenCalledWith(
+        component.workplace.uid,
+        component.worker.uid,
+        component.trainingRecord.uid,
+      );
     });
 
     it('should navigate to the new-training page when pressing the delete button', async () => {

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -6,7 +6,7 @@ import { Establishment } from '@core/model/establishment.model';
 import { AlertService } from '@core/services/alert.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
-import { MockWorkerServiceWithTrainingRecord, workerBuilder } from '@core/test-utils/MockWorkerService';
+import { MockWorkerService, trainingRecord, workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { of } from 'rxjs';
@@ -39,6 +39,7 @@ describe('DeleteRecordComponent', () => {
                     other: otherJob ? 'Care taker' : undefined,
                   },
                 },
+                trainingRecord: trainingRecord,
               },
               params: {
                 trainingRecordId: '1',
@@ -48,7 +49,7 @@ describe('DeleteRecordComponent', () => {
         },
         {
           provide: WorkerService,
-          useClass: MockWorkerServiceWithTrainingRecord,
+          useClass: MockWorkerService,
         },
       ],
     });

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -1,0 +1,95 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
+import { AlertService } from '@core/services/alert.service';
+import { WindowRef } from '@core/services/window.ref';
+import { WorkerService } from '@core/services/worker.service';
+import { MockWorkerService, workerBuilder } from '@core/test-utils/MockWorkerService';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { establishmentBuilder } from '../../../../../../server/test/factories/models';
+import { WorkersModule } from '../../workers.module';
+import { DeleteRecordComponent } from './delete-record.component';
+
+describe('DeleteRecordComponent', () => {
+  const workplace = establishmentBuilder() as Establishment;
+  const worker = workerBuilder() as Worker;
+
+  async function setup(otherJob = false) {
+    const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(DeleteRecordComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkersModule],
+      providers: [
+        AlertService,
+        WindowRef,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                establishment: workplace,
+                worker: {
+                  uid: 123,
+                  nameOrId: 'John',
+                  mainJob: {
+                    title: 'Care Worker',
+                    other: otherJob ? 'Care taker' : undefined,
+                  },
+                },
+              },
+              params: {
+                trainingRecordId: '1',
+              },
+            },
+          },
+        },
+        {
+          provide: WorkerService,
+          useClass: MockWorkerService,
+        },
+      ],
+    });
+
+    const component = fixture.componentInstance;
+
+    const injector = getTestBed();
+    const router = injector.inject(Router) as Router;
+    const routerSpy = spyOn(router, 'navigate');
+    routerSpy.and.returnValue(Promise.resolve(true));
+
+    return {
+      component,
+      fixture,
+      routerSpy,
+      getByText,
+      getAllByText,
+      getByTestId,
+      queryByText,
+    };
+  }
+
+  it('should render a TrainingAndQualificationsRecordComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the worker name', async () => {
+    const { component, getByText } = await setup();
+
+    expect(getByText(component.worker.nameOrId, { exact: false })).toBeTruthy();
+  });
+
+  it('should display the worker job role', async () => {
+    const { component, getByTestId } = await setup();
+
+    expect(getByTestId('workerNameAndRole').textContent).toContain(component.worker.mainJob.title);
+  });
+
+  it('should display the other worker job role', async () => {
+    const { component, getByTestId } = await setup(true);
+
+    expect(getByTestId('workerNameAndRole').textContent).toContain(component.worker.mainJob.other);
+  });
+});

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -64,11 +64,15 @@ describe('DeleteRecordComponent', () => {
     const workerSpy = spyOn(workerService, 'deleteTrainingRecord');
     workerSpy.and.returnValue(of({}));
 
+    const alertService = injector.inject(AlertService) as AlertService;
+    const alertSpy = spyOn(alertService, 'addAlert');
+
     return {
       component,
       fixture,
       routerSpy,
       workerSpy,
+      alertSpy,
       getByText,
       getAllByText,
       getByTestId,
@@ -114,19 +118,19 @@ describe('DeleteRecordComponent', () => {
 
   describe('Summary table', () => {
     it('should display the worker name or ID number', async () => {
-      const { component, getByTestId } = await setup(true);
+      const { component, getByTestId } = await setup();
 
       expect(getByTestId('workerName').textContent).toContain(component.worker.nameOrId);
     });
 
     it('should display the training category', async () => {
-      const { component, getByTestId } = await setup(true);
+      const { component, getByTestId } = await setup();
 
       expect(getByTestId('trainingCategory').textContent).toContain(component.trainingRecord.trainingCategory.category);
     });
 
     it('should display the training name', async () => {
-      const { component, getByTestId } = await setup(true);
+      const { component, getByTestId } = await setup();
 
       expect(getByTestId('trainingName').textContent).toContain(String(component.trainingRecord.title));
     });
@@ -134,13 +138,13 @@ describe('DeleteRecordComponent', () => {
 
   describe('Delete button', () => {
     it('should display the delete button', async () => {
-      const { getByText } = await setup(true);
+      const { getByText } = await setup();
 
       expect(getByText('Delete this training record')).toBeTruthy();
     });
 
     it('should call the deleteTrainingRecord function when pressing the delete button', async () => {
-      const { component, getByText, workerSpy } = await setup(true);
+      const { component, getByText, workerSpy } = await setup();
 
       const deleteButton = getByText('Delete this training record');
       fireEvent.click(deleteButton);
@@ -149,7 +153,7 @@ describe('DeleteRecordComponent', () => {
     });
 
     it('should navigate to the new-training page when pressing the delete button', async () => {
-      const { component, getByText, routerSpy } = await setup(true);
+      const { component, getByText, routerSpy } = await setup();
 
       const deleteButton = getByText('Delete this training record');
       fireEvent.click(deleteButton);
@@ -158,6 +162,18 @@ describe('DeleteRecordComponent', () => {
         `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
         'new-training',
       ]);
+    });
+
+    it('should display an alert when the delete button is clicked', async () => {
+      const { getByText, alertSpy } = await setup();
+
+      const deleteButton = getByText('Delete this training record');
+      fireEvent.click(deleteButton);
+
+      expect(alertSpy).toHaveBeenCalledWith({
+        type: 'success',
+        message: 'Training record has been deleted',
+      });
     });
   });
 });

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { TrainingRecord } from '@core/model/training.model';
 import { Worker } from '@core/model/worker.model';
+import { AlertService } from '@core/services/alert.service';
 import { BackService } from '@core/services/back.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Subscription } from 'rxjs';
@@ -24,6 +25,7 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
     private router: Router,
     private workerService: WorkerService,
     private backService: BackService,
+    private alertService: AlertService,
   ) {}
 
   ngOnInit(): void {
@@ -63,6 +65,11 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
       .deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.trainingRecordId)
       .subscribe(() => {
         this.router.navigate([this.trainingPageUrl, 'new-training']);
+
+        this.alertService.addAlert({
+          type: 'success',
+          message: 'Training record has been deleted',
+        });
       });
   }
 

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
+import { TrainingRecord } from '@core/model/training.model';
 import { Worker } from '@core/model/worker.model';
+import { BackService } from '@core/services/back.service';
 import { WorkerService } from '@core/services/worker.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-delete-record',
@@ -11,13 +14,59 @@ import { WorkerService } from '@core/services/worker.service';
 export class DeleteRecordComponent implements OnInit {
   public workplace: Establishment;
   public worker: Worker;
-  private trainingRecordId: string;
+  public trainingRecord: TrainingRecord;
+  public trainingRecordId: string;
+  private subscriptions: Subscription = new Subscription();
 
-  constructor(private route: ActivatedRoute, private workerService: WorkerService) {}
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private workerService: WorkerService,
+    private backService: BackService,
+  ) {}
 
   async ngOnInit(): Promise<void> {
     this.workplace = this.route.snapshot.data.establishment;
     this.trainingRecordId = this.route.snapshot.params.trainingRecordId;
     this.worker = this.route.snapshot.data.worker;
+    this.getTrainingRecord();
+    this.setBackLink();
+  }
+
+  private getTrainingRecord(): void {
+    this.subscriptions.add(
+      this.workerService
+        .getTrainingRecord(this.workplace.uid, this.worker.uid, this.trainingRecordId)
+        .subscribe((trainingRecord) => {
+          if (trainingRecord) {
+            this.trainingRecord = trainingRecord;
+          }
+        }),
+    );
+  }
+
+  private setBackLink(): void {
+    this.backService.setBackLink({
+      url: [
+        'workplace',
+        this.workplace.uid,
+        'training-and-qualifications-record',
+        this.worker.uid,
+        'training',
+        this.trainingRecordId,
+      ],
+    });
+  }
+
+  public returnToEditPage(event: Event): void {
+    event.preventDefault();
+    this.router.navigate([
+      '/workplace',
+      this.workplace.uid,
+      'training-and-qualifications-record',
+      this.worker.uid,
+      'training',
+      this.trainingRecordId,
+    ]);
   }
 }

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { TrainingRecord } from '@core/model/training.model';
@@ -11,11 +11,12 @@ import { Subscription } from 'rxjs';
   selector: 'app-delete-record',
   templateUrl: './delete-record.component.html',
 })
-export class DeleteRecordComponent implements OnInit {
+export class DeleteRecordComponent implements OnInit, OnDestroy {
   public workplace: Establishment;
   public worker: Worker;
   public trainingRecord: TrainingRecord;
   public trainingRecordId: string;
+  private trainingPageUrl: string;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -25,10 +26,11 @@ export class DeleteRecordComponent implements OnInit {
     private backService: BackService,
   ) {}
 
-  async ngOnInit(): Promise<void> {
+  ngOnInit(): void {
     this.workplace = this.route.snapshot.data.establishment;
     this.trainingRecordId = this.route.snapshot.params.trainingRecordId;
     this.worker = this.route.snapshot.data.worker;
+    this.trainingPageUrl = `workplace/${this.workplace.uid}/training-and-qualifications-record/${this.worker.uid}`;
     this.getTrainingRecord();
     this.setBackLink();
   }
@@ -47,26 +49,24 @@ export class DeleteRecordComponent implements OnInit {
 
   private setBackLink(): void {
     this.backService.setBackLink({
-      url: [
-        'workplace',
-        this.workplace.uid,
-        'training-and-qualifications-record',
-        this.worker.uid,
-        'training',
-        this.trainingRecordId,
-      ],
+      url: [this.trainingPageUrl, 'training', this.trainingRecordId],
     });
   }
 
   public returnToEditPage(event: Event): void {
     event.preventDefault();
-    this.router.navigate([
-      '/workplace',
-      this.workplace.uid,
-      'training-and-qualifications-record',
-      this.worker.uid,
-      'training',
-      this.trainingRecordId,
-    ]);
+    this.router.navigate([this.trainingPageUrl, 'training', this.trainingRecordId]);
+  }
+
+  public deleteRecord(): void {
+    this.workerService
+      .deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.trainingRecordId)
+      .subscribe(() => {
+        this.router.navigate([this.trainingPageUrl, 'new-training']);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -1,7 +1,23 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Establishment } from '@core/model/establishment.model';
+import { Worker } from '@core/model/worker.model';
+import { WorkerService } from '@core/services/worker.service';
 
 @Component({
   selector: 'app-delete-record',
   templateUrl: './delete-record.component.html',
 })
-export class DeleteRecordComponent {}
+export class DeleteRecordComponent implements OnInit {
+  public workplace: Establishment;
+  public worker: Worker;
+  private trainingRecordId: string;
+
+  constructor(private route: ActivatedRoute, private workerService: WorkerService) {}
+
+  async ngOnInit(): Promise<void> {
+    this.workplace = this.route.snapshot.data.establishment;
+    this.trainingRecordId = this.route.snapshot.params.trainingRecordId;
+    this.worker = this.route.snapshot.data.worker;
+  }
+}

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -16,7 +16,6 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   public workplace: Establishment;
   public worker: Worker;
   public trainingRecord: TrainingRecord;
-  public trainingRecordId: string;
   private trainingPageUrl: string;
   private subscriptions: Subscription = new Subscription();
 
@@ -29,29 +28,32 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.workplace = this.route.snapshot.data.establishment;
-    this.trainingRecordId = this.route.snapshot.params.trainingRecordId;
-    this.worker = this.route.snapshot.data.worker;
+    this.setVariables();
     this.trainingPageUrl = `workplace/${this.workplace.uid}/training-and-qualifications-record/${this.worker.uid}`;
-    this.trainingRecord = this.route.snapshot.data.trainingRecord;
     this.setBackLink();
+  }
+
+  private setVariables(): void {
+    this.workplace = this.route.snapshot.data.establishment;
+    this.worker = this.route.snapshot.data.worker;
+    this.trainingRecord = this.route.snapshot.data.trainingRecord;
   }
 
   private setBackLink(): void {
     this.backService.setBackLink({
-      url: [this.trainingPageUrl, 'training', this.trainingRecordId],
+      url: [this.trainingPageUrl, 'training', this.trainingRecord.uid],
     });
   }
 
   public returnToEditPage(event: Event): void {
     event.preventDefault();
-    this.router.navigate([this.trainingPageUrl, 'training', this.trainingRecordId]);
+    this.router.navigate([this.trainingPageUrl, 'training', this.trainingRecord.uid]);
   }
 
   public deleteRecord(): void {
     this.subscriptions.add(
       this.workerService
-        .deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.trainingRecordId)
+        .deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.trainingRecord.uid)
         .subscribe(() => {
           this.router.navigate([this.trainingPageUrl, 'new-training']);
 

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-delete-record',
+  templateUrl: './delete-record.component.html',
+})
+export class DeleteRecordComponent {}

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -33,20 +33,8 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
     this.trainingRecordId = this.route.snapshot.params.trainingRecordId;
     this.worker = this.route.snapshot.data.worker;
     this.trainingPageUrl = `workplace/${this.workplace.uid}/training-and-qualifications-record/${this.worker.uid}`;
-    this.getTrainingRecord();
+    this.trainingRecord = this.route.snapshot.data.trainingRecord;
     this.setBackLink();
-  }
-
-  private getTrainingRecord(): void {
-    this.subscriptions.add(
-      this.workerService
-        .getTrainingRecord(this.workplace.uid, this.worker.uid, this.trainingRecordId)
-        .subscribe((trainingRecord) => {
-          if (trainingRecord) {
-            this.trainingRecord = trainingRecord;
-          }
-        }),
-    );
   }
 
   private setBackLink(): void {
@@ -61,16 +49,18 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   }
 
   public deleteRecord(): void {
-    this.workerService
-      .deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.trainingRecordId)
-      .subscribe(() => {
-        this.router.navigate([this.trainingPageUrl, 'new-training']);
+    this.subscriptions.add(
+      this.workerService
+        .deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.trainingRecordId)
+        .subscribe(() => {
+          this.router.navigate([this.trainingPageUrl, 'new-training']);
 
-        this.alertService.addAlert({
-          type: 'success',
-          message: 'Training record has been deleted',
-        });
-      });
+          this.alertService.addAlert({
+            type: 'success',
+            message: 'Training record has been deleted',
+          });
+        }),
+    );
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/workers/workers-routing.module.ts
+++ b/src/app/features/workers/workers-routing.module.ts
@@ -4,6 +4,7 @@ import { CheckPermissionsGuard } from '@core/guards/permissions/check-permission
 import { LongTermAbsenceResolver } from '@core/resolvers/long-term-absence.resolver';
 import { QualificationsResolver } from '@core/resolvers/qualifications.resolver';
 import { TrainingAndQualificationRecordsResolver } from '@core/resolvers/training-and-qualification-records.resolver';
+import { TrainingRecordResolver } from '@core/resolvers/training-record.resolver';
 import { TrainingRecordsResolver } from '@core/resolvers/training-records.resolver';
 import { WorkerResolver } from '@core/resolvers/worker.resolver';
 
@@ -301,6 +302,9 @@ const routes: Routes = [
             path: 'delete',
             component: DeleteRecordComponent,
             data: { title: 'Delete Training' },
+            resolve: {
+              trainingRecord: TrainingRecordResolver,
+            },
           },
         ],
       },

--- a/src/app/features/workers/workers-routing.module.ts
+++ b/src/app/features/workers/workers-routing.module.ts
@@ -32,7 +32,10 @@ import { MandatoryDetailsComponent } from './mandatory-details/mandatory-details
 import { MentalHealthProfessionalComponent } from './mental-health-professional/mental-health-professional.component';
 import { NationalInsuranceNumberComponent } from './national-insurance-number/national-insurance-number.component';
 import { NationalityComponent } from './nationality/nationality.component';
-import { NewTrainingAndQualificationsRecordComponent } from './new-training-qualifications-record/new-training-and-qualifications-record.component';
+import { DeleteRecordComponent } from './new-training-qualifications-record/delete-record/delete-record.component';
+import {
+  NewTrainingAndQualificationsRecordComponent,
+} from './new-training-qualifications-record/new-training-and-qualifications-record.component';
 import { NursingCategoryComponent } from './nursing-category/nursing-category.component';
 import { NursingSpecialismComponent } from './nursing-specialism/nursing-specialism.component';
 import { OtherJobRolesComponent } from './other-job-roles/other-job-roles.component';
@@ -41,12 +44,16 @@ import { OtherQualificationsComponent } from './other-qualifications/other-quali
 import { RecruitedFromComponent } from './recruited-from/recruited-from.component';
 import { SalaryComponent } from './salary/salary.component';
 import { SelectRecordTypeComponent } from './select-record-type/select-record-type.component';
-import { SocialCareQualificationLevelComponent } from './social-care-qualification-level/social-care-qualification-level.component';
+import {
+  SocialCareQualificationLevelComponent,
+} from './social-care-qualification-level/social-care-qualification-level.component';
 import { SocialCareQualificationComponent } from './social-care-qualification/social-care-qualification.component';
 import { StaffDetailsComponent } from './staff-details/staff-details.component';
 import { StaffRecordComponent } from './staff-record/staff-record.component';
 import { TotalStaffChangeComponent } from './total-staff-change/total-staff-change.component';
-import { TrainingAndQualificationsRecordComponent } from './training-qualifications-record/training-and-qualifications-record.component';
+import {
+  TrainingAndQualificationsRecordComponent,
+} from './training-qualifications-record/training-and-qualifications-record.component';
 import { WeeklyContractedHoursComponent } from './weekly-contracted-hours/weekly-contracted-hours.component';
 import { WorkerSaveSuccessComponent } from './worker-save-success/worker-save-success.component';
 import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.component';
@@ -284,8 +291,18 @@ const routes: Routes = [
       },
       {
         path: 'training/:trainingRecordId',
-        component: AddEditTrainingComponent,
-        data: { title: 'Training' },
+        children: [
+          {
+            path: '',
+            component: AddEditTrainingComponent,
+            data: { title: 'Training' },
+          },
+          {
+            path: 'delete',
+            component: DeleteRecordComponent,
+            data: { title: 'Delete Training' },
+          },
+        ],
       },
       {
         path: 'training',

--- a/src/app/features/workers/workers.module.ts
+++ b/src/app/features/workers/workers.module.ts
@@ -41,6 +41,7 @@ import { MentalHealthProfessionalComponent } from './mental-health-professional/
 import { MoveWorkerDialogComponent } from './move-worker-dialog/move-worker-dialog.component';
 import { NationalInsuranceNumberComponent } from './national-insurance-number/national-insurance-number.component';
 import { NationalityComponent } from './nationality/nationality.component';
+import { DeleteRecordComponent } from './new-training-qualifications-record/delete-record/delete-record.component';
 import {
   NewQualificationsComponent,
 } from './new-training-qualifications-record/new-qualifications/new-qualifications.component';
@@ -95,6 +96,7 @@ import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.compon
     DeleteQualificationDialogComponent,
     DeleteTrainingDialogComponent,
     DeleteWorkerDialogComponent,
+    DeleteRecordComponent,
     DisabilityComponent,
     EditWorkerComponent,
     EthnicityComponent,

--- a/src/app/features/workers/workers.module.ts
+++ b/src/app/features/workers/workers.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { LongTermAbsenceResolver } from '@core/resolvers/long-term-absence.resolver';
 import { QualificationsResolver } from '@core/resolvers/qualifications.resolver';
 import { TrainingAndQualificationRecordsResolver } from '@core/resolvers/training-and-qualification-records.resolver';
+import { TrainingRecordResolver } from '@core/resolvers/training-record.resolver';
 import { TrainingRecordsResolver } from '@core/resolvers/training-records.resolver';
 import { WorkerResolver } from '@core/resolvers/worker.resolver';
 import { DialogService } from '@core/services/dialog.service';
@@ -137,6 +138,7 @@ import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.compon
     WorkerResolver,
     LongTermAbsenceResolver,
     QualificationsResolver,
+    TrainingRecordResolver,
     TrainingRecordsResolver,
     TrainingAndQualificationRecordsResolver,
   ],

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
             {{ title }}
           </h1>

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -141,9 +141,10 @@
   </div>
 
   <div class="govuk-button-group">
-    <button type="submit" class="govuk-button govuk-!-margin-right-9">
+    <button type="submit" class="govuk-button govuk-!-margin-right-5">
       {{ buttonText }}
     </button>
+    <button *ngIf="trainingRecordId" class="govuk-button govuk-button--warning govuk-!-margin-right-8">Delete</button>
     <a
       class="govuk-button govuk-button--link govuk-!-margin-left-9"
       role="button"

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -145,7 +145,7 @@
       {{ buttonText }}
     </button>
     <button
-      *ngIf="trainingRecordId"
+      *ngIf="trainingRecordId && newTrainingAndQualificationsRecordsFlag"
       type="button"
       class="govuk-button govuk-button--warning govuk-!-margin-right-8"
       [routerLink]="[

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -144,7 +144,22 @@
     <button type="submit" class="govuk-button govuk-!-margin-right-5">
       {{ buttonText }}
     </button>
-    <button *ngIf="trainingRecordId" class="govuk-button govuk-button--warning govuk-!-margin-right-8">Delete</button>
+    <button
+      *ngIf="trainingRecordId"
+      type="button"
+      class="govuk-button govuk-button--warning govuk-!-margin-right-8"
+      [routerLink]="[
+        '/workplace',
+        workplace.uid,
+        'training-and-qualifications-record',
+        worker.uid,
+        'training',
+        trainingRecordId,
+        'delete'
+      ]"
+    >
+      Delete
+    </button>
     <a
       class="govuk-button govuk-button--link govuk-!-margin-left-9"
       role="button"

--- a/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -33,6 +33,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
   public title: string;
   public buttonText: string;
   public showWorkerCount = false;
+  public newTrainingAndQualificationsRecordsFlag: boolean;
 
   constructor(
     protected formBuilder: FormBuilder,


### PR DESCRIPTION
#### Work done
- Create `TrainingRecordResolver` for individual training record
- Rename titles in `add-edit-training` component to remove "Edit"
- Rename "Update training" button to "Save and return"
- Create `delete-record` component

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
