### PR TITLE
Feat: Qualifications delete button

### DIFF
--- a/src/app/core/resolvers/qualification.resolver.ts
+++ b/src/app/core/resolvers/qualification.resolver.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
+import { WorkerService } from '@core/services/worker.service';
+import { of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable()
+export class QualificationResolver implements Resolve<any> {
+  constructor(private router: Router, private workerService: WorkerService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.workerService
+      .getQualification(
+        route.paramMap.get('establishmentuid'),
+        route.paramMap.get('id'),
+        route.paramMap.get('qualificationId'),
+      )
+      .pipe(
+        catchError(() => {
+          this.router.navigate(['/problem-with-the-service']);
+          return of(null);
+        }),
+      );
+  }
+}

--- a/src/app/core/test-utils/MockWorkerService.ts
+++ b/src/app/core/test-utils/MockWorkerService.ts
@@ -203,6 +203,18 @@ export const trainingRecord = {
   expires: '01/02/2021',
 };
 
+export const qualificationRecord = {
+  uid: '1234-5678',
+  created: '01/01/2021',
+  updated: '01/02/2021',
+  updatedBy: 'user',
+  qualification: {
+    id: 1,
+  },
+  year: 2021,
+  notes: 'Notes',
+};
+
 @Injectable()
 export class MockWorkerService extends WorkerService {
   private _worker;

--- a/src/app/core/test-utils/MockWorkerService.ts
+++ b/src/app/core/test-utils/MockWorkerService.ts
@@ -210,6 +210,8 @@ export const qualificationRecord = {
   updatedBy: 'user',
   qualification: {
     id: 1,
+    group: 'Degree',
+    title: 'Health Care Degree',
   },
   year: 2021,
   notes: 'Notes',

--- a/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
+++ b/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
@@ -1,4 +1,13 @@
 <app-error-summary *ngIf="submitted && form.invalid" [formErrorsMap]="formErrorsMap" [form]="form"></app-error-summary>
+<ng-container *ngIf="worker">
+  <div class="govuk-grid-row govuk-!-margin-bottom-0">
+    <div class="govuk-grid-column-full">
+      <span class="govuk-caption-xl govuk-!-margin-right-3" data-testid="workerNameAndRole">
+        {{ worker.nameOrId }}: {{ worker.mainJob?.other ? worker.mainJob.other : worker.mainJob.title }}
+      </span>
+    </div>
+  </div>
+</ng-container>
 
 <form *ngIf="!qualificationId || (qualificationId && record)" (ngSubmit)="onSubmit()" [formGroup]="form">
   <div class="govuk-grid-row">
@@ -7,7 +16,7 @@
         <fieldset class="govuk-fieldset" aria-describedby="qualification-conditional-hint" role="group">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
-              {{ qualificationId ? 'Edit qualification details' : 'Add qualification details' }}
+              {{ qualificationId ? 'Qualification details' : 'Add qualification details' }}
             </h1>
           </legend>
 
@@ -54,8 +63,9 @@
   </div>
 
   <div class="govuk-button-group">
-    <button type="submit" class="govuk-button">
-      {{ qualificationId ? 'Update qualification' : 'Add qualification' }}
+    <button type="submit" class="govuk-button govuk-!-margin-right-5">
+      {{ qualificationId ? 'Save and return' : 'Add qualification' }}
+    </button>
     </button>
     <a
       class="govuk-button govuk-button--link govuk-util__float-right"

--- a/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
+++ b/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
@@ -66,6 +66,21 @@
     <button type="submit" class="govuk-button govuk-!-margin-right-5">
       {{ qualificationId ? 'Save and return' : 'Add qualification' }}
     </button>
+    <button
+      *ngIf="qualificationId"
+      type="button"
+      class="govuk-button govuk-button--warning govuk-!-margin-right-8"
+      [routerLink]="[
+        '/workplace',
+        workplace.uid,
+        'training-and-qualifications-record',
+        worker.uid,
+        'qualification',
+        qualificationId,
+        'delete'
+      ]"
+    >
+      Delete
     </button>
     <a
       class="govuk-button govuk-button--link govuk-util__float-right"

--- a/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
+++ b/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
@@ -70,15 +70,7 @@
       *ngIf="qualificationId"
       type="button"
       class="govuk-button govuk-button--warning govuk-!-margin-right-8"
-      [routerLink]="[
-        '/workplace',
-        workplace.uid,
-        'training-and-qualifications-record',
-        worker.uid,
-        'qualification',
-        qualificationId,
-        'delete'
-      ]"
+      [routerLink]="['../delete']"
     >
       Delete
     </button>

--- a/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
+++ b/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.html
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.invalid">
         <fieldset class="govuk-fieldset" aria-describedby="qualification-conditional-hint" role="group">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
               {{ qualificationId ? 'Qualification details' : 'Add qualification details' }}
             </h1>

--- a/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.spec.ts
+++ b/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.spec.ts
@@ -1,0 +1,108 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { WorkerService } from '@core/services/worker.service';
+import { MockActivatedRoute } from '@core/test-utils/MockActivatedRoute';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { qualificationRecord } from '@core/test-utils/MockWorkerService';
+import { MockWorkerServiceWithWorker } from '@core/test-utils/MockWorkerServiceWithWorker';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { AddEditQualificationComponent } from './add-edit-qualification.component';
+
+describe('AddEditQualificationComponent', () => {
+  async function setup() {
+    const { fixture, getByText, getByTestId, queryByText } = await render(AddEditQualificationComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: new MockActivatedRoute({
+            snapshot: {
+              params: { qualificationId: '1' },
+            },
+            parent: {
+              snapshot: {
+                data: {
+                  establishment: {
+                    uid: '1',
+                  },
+                },
+              },
+            },
+          }),
+        },
+        { provide: WorkerService, useClass: MockWorkerServiceWithWorker },
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+      ],
+    });
+
+    const component = fixture.componentInstance;
+
+    return {
+      component,
+      fixture,
+      getByText,
+      getByTestId,
+      queryByText,
+    };
+  }
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the workers name', async () => {
+    const { component, getByText } = await setup();
+    expect(getByText(component.worker.nameOrId, { exact: false })).toBeTruthy();
+  });
+
+  it('should display the workers job role', async () => {
+    const { component, getByTestId } = await setup();
+
+    expect(getByTestId('workerNameAndRole').textContent).toContain(component.worker.mainJob.title);
+  });
+
+  describe('title', () => {
+    it('should render the Add qualification details title', async () => {
+      const { component, fixture, getByText } = await setup();
+
+      component.qualificationId = null;
+      fixture.detectChanges();
+
+      expect(getByText('Add qualification details')).toBeTruthy();
+    });
+
+    it('should render the Qualification details title when there is a qualification id and record', async () => {
+      const { component, fixture, getByText } = await setup();
+
+      component.record = qualificationRecord;
+      fixture.detectChanges();
+
+      expect(getByText('Qualification details')).toBeTruthy();
+    });
+  });
+
+  describe('delete button', () => {
+    it('should render the delete button when editing qualification', async () => {
+      const { component, fixture, getByText } = await setup();
+
+      component.record = qualificationRecord;
+      fixture.detectChanges();
+
+      expect(getByText('Delete')).toBeTruthy();
+    });
+
+    it('should not render the delete button when there is no training id', async () => {
+      const { component, fixture, queryByText } = await setup();
+
+      component.qualificationId = null;
+      fixture.detectChanges();
+
+      expect(queryByText('Delete')).toBeFalsy();
+    });
+  });
+});

--- a/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.spec.ts
+++ b/src/app/features/workers/add-edit-qualification/add-edit-qualification.component.spec.ts
@@ -96,7 +96,7 @@ describe('AddEditQualificationComponent', () => {
       expect(getByText('Delete')).toBeTruthy();
     });
 
-    it('should not render the delete button when there is no training id', async () => {
+    it('should not render the delete button when there is no qualification id', async () => {
       const { component, fixture, queryByText } = await setup();
 
       component.qualificationId = null;

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
@@ -3,7 +3,9 @@
     <span class="govuk-caption-xl govuk-!-margin-right-3" data-testid="workerNameAndRole">
       {{ worker.nameOrId }}: {{ worker.mainJob?.other ? worker.mainJob.other : worker.mainJob.title }}
     </span>
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">You're about to delete this training trainingRecord</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">
+      You're about to delete this {{ trainingOrQualification }} record
+    </h1>
 
     <dl class="govuk-summary-list govuk-summary-list--no-border govuk-summary-list--wide-key">
       <div class="govuk-summary-list__row">

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
@@ -15,12 +15,12 @@
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Training category</dt>
         <dd class="govuk-summary-list__value" data-testid="trainingCategory">
-          {{ trainingRecord.trainingCategory.category }}
+          {{ record.trainingCategory.category }}
         </dd>
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Training name</dt>
-        <dd class="govuk-summary-list__value" data-testid="trainingName">{{ trainingRecord.title }}</dd>
+        <dd class="govuk-summary-list__value" data-testid="trainingName">{{ record.title }}</dd>
       </div>
     </dl>
 

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
@@ -7,24 +7,49 @@
       You're about to delete this {{ trainingOrQualification }} record
     </h1>
 
-    <dl class="govuk-summary-list govuk-summary-list--no-border govuk-summary-list--wide-key">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Name or ID number</dt>
-        <dd class="govuk-summary-list__value" data-testid="workerName">
-          {{ worker.nameOrId }}
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Training category</dt>
-        <dd class="govuk-summary-list__value" data-testid="trainingCategory">
-          {{ trainingRecord.trainingCategory.category }}
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Training name</dt>
-        <dd class="govuk-summary-list__value" data-testid="trainingName">{{ trainingRecord.title }}</dd>
-      </div>
-    </dl>
+    <ng-container *ngIf="trainingView; else qualificationView">
+      <dl class="govuk-summary-list govuk-summary-list--no-border govuk-summary-list--wide-key">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Name or ID number</dt>
+          <dd class="govuk-summary-list__value" data-testid="workerName">
+            {{ worker.nameOrId }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Training category</dt>
+          <dd class="govuk-summary-list__value" data-testid="trainingCategory">
+            {{ trainingRecord.trainingCategory.category }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Training name</dt>
+          <dd class="govuk-summary-list__value" data-testid="trainingName">{{ trainingRecord.title }}</dd>
+        </div>
+      </dl>
+    </ng-container>
+
+    <ng-template #qualificationView>
+      <dl class="govuk-summary-list govuk-summary-list--no-border govuk-summary-list--wide-key">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Name or ID number</dt>
+          <dd class="govuk-summary-list__value" data-testid="workerName">
+            {{ worker.nameOrId }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Type of qualification</dt>
+          <dd class="govuk-summary-list__value" data-testid="qualificationType">
+            {{ qualificationRecord.qualification.group }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Qualification name</dt>
+          <dd class="govuk-summary-list__value" data-testid="qualificationName">
+            {{ qualificationRecord.qualification.title }}
+          </dd>
+        </div>
+      </dl>
+    </ng-template>
 
     <div class="govuk-button-group govuk-!-margin-top-7">
       <button type="button" class="govuk-button govuk-button--warning govuk-!-margin-right-2" (click)="deleteRecord()">

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
@@ -3,7 +3,7 @@
     <span class="govuk-caption-xl govuk-!-margin-right-3" data-testid="workerNameAndRole">
       {{ worker.nameOrId }}: {{ worker.mainJob?.other ? worker.mainJob.other : worker.mainJob.title }}
     </span>
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">You're about to delete this training record</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">You're about to delete this training trainingRecord</h1>
 
     <dl class="govuk-summary-list govuk-summary-list--no-border govuk-summary-list--wide-key">
       <div class="govuk-summary-list__row">
@@ -15,12 +15,12 @@
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Training category</dt>
         <dd class="govuk-summary-list__value" data-testid="trainingCategory">
-          {{ record.trainingCategory.category }}
+          {{ trainingRecord.trainingCategory.category }}
         </dd>
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Training name</dt>
-        <dd class="govuk-summary-list__value" data-testid="trainingName">{{ record.title }}</dd>
+        <dd class="govuk-summary-list__value" data-testid="trainingName">{{ trainingRecord.title }}</dd>
       </div>
     </dl>
 

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.html
@@ -53,7 +53,7 @@
 
     <div class="govuk-button-group govuk-!-margin-top-7">
       <button type="button" class="govuk-button govuk-button--warning govuk-!-margin-right-2" (click)="deleteRecord()">
-        Delete this training record
+        Delete this {{ trainingOrQualification }} record
       </button>
       <a
         class="govuk-button govuk-button--link govuk-!-margin-left-9"

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -102,6 +102,12 @@ fdescribe('DeleteRecordComponent', () => {
   });
 
   describe('Training', () => {
+    it('should display the correct title', async () => {
+      const { getByText } = await setup();
+
+      expect(getByText("You're about to delete this training record")).toBeTruthy();
+    });
+
     it('should navigate to the edit training page when pressing cancel if in training view', async () => {
       const { component, getByText, routerSpy } = await setup();
 
@@ -184,7 +190,13 @@ fdescribe('DeleteRecordComponent', () => {
   });
 
   describe('Qualification', () => {
-    xit('should navigate to the edit qualification page when pressing cancel if in qualifications view', async () => {
+    it('should display the correct title', async () => {
+      const { getByText } = await setup(false, false);
+
+      expect(getByText("You're about to delete this qualification record")).toBeTruthy();
+    });
+
+    it('should navigate to the edit qualification page when pressing cancel if in qualifications view', async () => {
       const { component, getByText, routerSpy } = await setup(false, false);
 
       const cancelButton = getByText('Cancel');

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -59,8 +59,11 @@ describe('DeleteRecordComponent', () => {
     routerSpy.and.returnValue(Promise.resolve(true));
 
     const workerService = injector.inject(WorkerService) as WorkerService;
-    const workerSpy = spyOn(workerService, 'deleteTrainingRecord');
-    workerSpy.and.returnValue(of({}));
+    const workerTrainingSpy = spyOn(workerService, 'deleteTrainingRecord');
+    workerTrainingSpy.and.returnValue(of({}));
+
+    const workerQualificationSpy = spyOn(workerService, 'deleteQualification');
+    workerQualificationSpy.and.returnValue(of({}));
 
     const alertService = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alertService, 'addAlert');
@@ -69,7 +72,8 @@ describe('DeleteRecordComponent', () => {
       component,
       fixture,
       routerSpy,
-      workerSpy,
+      workerTrainingSpy,
+      workerQualificationSpy,
       alertSpy,
       getByText,
       getAllByText,
@@ -151,12 +155,12 @@ describe('DeleteRecordComponent', () => {
       });
 
       it('should call the deleteTrainingRecord function when pressing the delete button', async () => {
-        const { component, getByText, workerSpy } = await setup();
+        const { component, getByText, workerTrainingSpy } = await setup();
 
         const deleteButton = getByText('Delete this training record');
         fireEvent.click(deleteButton);
 
-        expect(workerSpy).toHaveBeenCalledWith(
+        expect(workerTrainingSpy).toHaveBeenCalledWith(
           component.workplace.uid,
           component.worker.uid,
           component.trainingRecord.uid,
@@ -230,6 +234,51 @@ describe('DeleteRecordComponent', () => {
         expect(getByTestId('qualificationName').textContent).toContain(
           component.qualificationRecord.qualification.title,
         );
+      });
+    });
+
+    describe('Delete button', () => {
+      it('should display the delete button', async () => {
+        const { getByText } = await setup(false);
+
+        expect(getByText('Delete this qualification record')).toBeTruthy();
+      });
+
+      it('should call the deleteQualificationRecord function when pressing the delete button', async () => {
+        const { component, getByText, workerQualificationSpy } = await setup(false);
+
+        const deleteButton = getByText('Delete this qualification record');
+        fireEvent.click(deleteButton);
+
+        expect(workerQualificationSpy).toHaveBeenCalledWith(
+          component.workplace.uid,
+          component.worker.uid,
+          component.qualificationRecord.uid,
+        );
+      });
+
+      it('should navigate to the new-training page when pressing the delete button', async () => {
+        const { component, getByText, routerSpy } = await setup(false);
+
+        const deleteButton = getByText('Delete this qualification record');
+        fireEvent.click(deleteButton);
+
+        expect(routerSpy).toHaveBeenCalledWith([
+          `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
+          'new-training',
+        ]);
+      });
+
+      it('should display an alert when the delete button is clicked', async () => {
+        const { getByText, alertSpy } = await setup(false);
+
+        const deleteButton = getByText('Delete this qualification record');
+        fireEvent.click(deleteButton);
+
+        expect(alertSpy).toHaveBeenCalledWith({
+          type: 'success',
+          message: 'Qualification record has been deleted',
+        });
       });
     });
   });

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -18,7 +18,7 @@ import { DeleteRecordComponent } from './delete-record.component';
 describe('DeleteRecordComponent', () => {
   const workplace = establishmentBuilder() as Establishment;
 
-  async function setup(otherJob = false) {
+  async function setup(otherJob = false, trainingView = true) {
     const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(DeleteRecordComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkersModule],
       providers: [
@@ -38,7 +38,7 @@ describe('DeleteRecordComponent', () => {
                     other: otherJob ? 'Care taker' : undefined,
                   },
                 },
-                trainingRecord: trainingRecord,
+                trainingRecord: trainingView ? trainingRecord : null,
               },
             },
           },
@@ -100,7 +100,7 @@ describe('DeleteRecordComponent', () => {
     expect(getByTestId('workerNameAndRole').textContent).toContain(component.worker.mainJob.other);
   });
 
-  it('should navigate to the edit training page when pressing cancel', async () => {
+  it('should navigate to the edit training page when pressing cancel if in training view', async () => {
     const { component, getByText, routerSpy } = await setup();
 
     const cancelButton = getByText('Cancel');
@@ -109,7 +109,20 @@ describe('DeleteRecordComponent', () => {
     expect(routerSpy).toHaveBeenCalledWith([
       `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
       'training',
-      component.trainingRecord.uid,
+      component.record.uid,
+    ]);
+  });
+
+  xit('should navigate to the edit qualification page when pressing cancel if in qualifications view', async () => {
+    const { component, getByText, routerSpy } = await setup(false, false);
+
+    const cancelButton = getByText('Cancel');
+    fireEvent.click(cancelButton);
+
+    expect(routerSpy).toHaveBeenCalledWith([
+      `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
+      'qualification',
+      component.record.uid,
     ]);
   });
 
@@ -123,13 +136,13 @@ describe('DeleteRecordComponent', () => {
     it('should display the training category', async () => {
       const { component, getByTestId } = await setup();
 
-      expect(getByTestId('trainingCategory').textContent).toContain(component.trainingRecord.trainingCategory.category);
+      expect(getByTestId('trainingCategory').textContent).toContain(component.record.trainingCategory.category);
     });
 
     it('should display the training name', async () => {
       const { component, getByTestId } = await setup();
 
-      expect(getByTestId('trainingName').textContent).toContain(String(component.trainingRecord.title));
+      expect(getByTestId('trainingName').textContent).toContain(String(component.record.title));
     });
   });
 
@@ -146,11 +159,7 @@ describe('DeleteRecordComponent', () => {
       const deleteButton = getByText('Delete this training record');
       fireEvent.click(deleteButton);
 
-      expect(workerSpy).toHaveBeenCalledWith(
-        component.workplace.uid,
-        component.worker.uid,
-        component.trainingRecord.uid,
-      );
+      expect(workerSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, component.record.uid);
     });
 
     it('should navigate to the new-training page when pressing the delete button', async () => {

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -6,7 +6,7 @@ import { Establishment } from '@core/model/establishment.model';
 import { AlertService } from '@core/services/alert.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
-import { MockWorkerService, trainingRecord } from '@core/test-utils/MockWorkerService';
+import { MockWorkerService, qualificationRecord, trainingRecord } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { of } from 'rxjs';
@@ -15,7 +15,7 @@ import { establishmentBuilder } from '../../../../../../server/test/factories/mo
 import { WorkersModule } from '../../workers.module';
 import { DeleteRecordComponent } from './delete-record.component';
 
-describe('DeleteRecordComponent', () => {
+fdescribe('DeleteRecordComponent', () => {
   const workplace = establishmentBuilder() as Establishment;
 
   async function setup(otherJob = false, trainingView = true) {
@@ -39,6 +39,7 @@ describe('DeleteRecordComponent', () => {
                   },
                 },
                 trainingRecord: trainingView ? trainingRecord : null,
+                qualificationRecord: trainingView ? null : qualificationRecord,
               },
             },
           },
@@ -100,90 +101,100 @@ describe('DeleteRecordComponent', () => {
     expect(getByTestId('workerNameAndRole').textContent).toContain(component.worker.mainJob.other);
   });
 
-  it('should navigate to the edit training page when pressing cancel if in training view', async () => {
-    const { component, getByText, routerSpy } = await setup();
-
-    const cancelButton = getByText('Cancel');
-    fireEvent.click(cancelButton);
-
-    expect(routerSpy).toHaveBeenCalledWith([
-      `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
-      'training',
-      component.record.uid,
-    ]);
-  });
-
-  xit('should navigate to the edit qualification page when pressing cancel if in qualifications view', async () => {
-    const { component, getByText, routerSpy } = await setup(false, false);
-
-    const cancelButton = getByText('Cancel');
-    fireEvent.click(cancelButton);
-
-    expect(routerSpy).toHaveBeenCalledWith([
-      `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
-      'qualification',
-      component.record.uid,
-    ]);
-  });
-
-  describe('Summary table', () => {
-    it('should display the worker name or ID number', async () => {
-      const { component, getByTestId } = await setup();
-
-      expect(getByTestId('workerName').textContent).toContain(component.worker.nameOrId);
-    });
-
-    it('should display the training category', async () => {
-      const { component, getByTestId } = await setup();
-
-      expect(getByTestId('trainingCategory').textContent).toContain(component.record.trainingCategory.category);
-    });
-
-    it('should display the training name', async () => {
-      const { component, getByTestId } = await setup();
-
-      expect(getByTestId('trainingName').textContent).toContain(String(component.record.title));
-    });
-  });
-
-  describe('Delete button', () => {
-    it('should display the delete button', async () => {
-      const { getByText } = await setup();
-
-      expect(getByText('Delete this training record')).toBeTruthy();
-    });
-
-    it('should call the deleteTrainingRecord function when pressing the delete button', async () => {
-      const { component, getByText, workerSpy } = await setup();
-
-      const deleteButton = getByText('Delete this training record');
-      fireEvent.click(deleteButton);
-
-      expect(workerSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, component.record.uid);
-    });
-
-    it('should navigate to the new-training page when pressing the delete button', async () => {
+  describe('Training', () => {
+    it('should navigate to the edit training page when pressing cancel if in training view', async () => {
       const { component, getByText, routerSpy } = await setup();
 
-      const deleteButton = getByText('Delete this training record');
-      fireEvent.click(deleteButton);
+      const cancelButton = getByText('Cancel');
+      fireEvent.click(cancelButton);
 
       expect(routerSpy).toHaveBeenCalledWith([
         `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
-        'new-training',
+        'training',
+        component.trainingRecord.uid,
       ]);
     });
 
-    it('should display an alert when the delete button is clicked', async () => {
-      const { getByText, alertSpy } = await setup();
+    describe('Summary table', () => {
+      it('should display the worker name or ID number', async () => {
+        const { component, getByTestId } = await setup();
 
-      const deleteButton = getByText('Delete this training record');
-      fireEvent.click(deleteButton);
-
-      expect(alertSpy).toHaveBeenCalledWith({
-        type: 'success',
-        message: 'Training record has been deleted',
+        expect(getByTestId('workerName').textContent).toContain(component.worker.nameOrId);
       });
+
+      it('should display the training category', async () => {
+        const { component, getByTestId } = await setup();
+
+        expect(getByTestId('trainingCategory').textContent).toContain(
+          component.trainingRecord.trainingCategory.category,
+        );
+      });
+
+      it('should display the training name', async () => {
+        const { component, getByTestId } = await setup();
+
+        expect(getByTestId('trainingName').textContent).toContain(component.trainingRecord.title);
+      });
+    });
+
+    describe('Delete button', () => {
+      it('should display the delete button', async () => {
+        const { getByText } = await setup();
+
+        expect(getByText('Delete this training record')).toBeTruthy();
+      });
+
+      it('should call the deleteTrainingRecord function when pressing the delete button', async () => {
+        const { component, getByText, workerSpy } = await setup();
+
+        const deleteButton = getByText('Delete this training record');
+        fireEvent.click(deleteButton);
+
+        expect(workerSpy).toHaveBeenCalledWith(
+          component.workplace.uid,
+          component.worker.uid,
+          component.trainingRecord.uid,
+        );
+      });
+
+      it('should navigate to the new-training page when pressing the delete button', async () => {
+        const { component, getByText, routerSpy } = await setup();
+
+        const deleteButton = getByText('Delete this training record');
+        fireEvent.click(deleteButton);
+
+        expect(routerSpy).toHaveBeenCalledWith([
+          `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
+          'new-training',
+        ]);
+      });
+
+      it('should display an alert when the delete button is clicked', async () => {
+        const { getByText, alertSpy } = await setup();
+
+        const deleteButton = getByText('Delete this training record');
+        fireEvent.click(deleteButton);
+
+        expect(alertSpy).toHaveBeenCalledWith({
+          type: 'success',
+          message: 'Training record has been deleted',
+        });
+      });
+    });
+  });
+
+  describe('Qualification', () => {
+    xit('should navigate to the edit qualification page when pressing cancel if in qualifications view', async () => {
+      const { component, getByText, routerSpy } = await setup(false, false);
+
+      const cancelButton = getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(routerSpy).toHaveBeenCalledWith([
+        `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
+        'qualification',
+        component.qualificationRecord.uid,
+      ]);
     });
   });
 });

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -15,10 +15,10 @@ import { establishmentBuilder } from '../../../../../../server/test/factories/mo
 import { WorkersModule } from '../../workers.module';
 import { DeleteRecordComponent } from './delete-record.component';
 
-fdescribe('DeleteRecordComponent', () => {
+describe('DeleteRecordComponent', () => {
   const workplace = establishmentBuilder() as Establishment;
 
-  async function setup(otherJob = false, trainingView = true) {
+  async function setup(trainingView = true, otherJob = false) {
     const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(DeleteRecordComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkersModule],
       providers: [
@@ -96,7 +96,7 @@ fdescribe('DeleteRecordComponent', () => {
   });
 
   it('should display the other worker job role', async () => {
-    const { component, getByTestId } = await setup(true);
+    const { component, getByTestId } = await setup(true, true);
 
     expect(getByTestId('workerNameAndRole').textContent).toContain(component.worker.mainJob.other);
   });
@@ -191,13 +191,13 @@ fdescribe('DeleteRecordComponent', () => {
 
   describe('Qualification', () => {
     it('should display the correct title', async () => {
-      const { getByText } = await setup(false, false);
+      const { getByText } = await setup(false);
 
       expect(getByText("You're about to delete this qualification record")).toBeTruthy();
     });
 
     it('should navigate to the edit qualification page when pressing cancel if in qualifications view', async () => {
-      const { component, getByText, routerSpy } = await setup(false, false);
+      const { component, getByText, routerSpy } = await setup(false);
 
       const cancelButton = getByText('Cancel');
       fireEvent.click(cancelButton);
@@ -207,6 +207,30 @@ fdescribe('DeleteRecordComponent', () => {
         'qualification',
         component.qualificationRecord.uid,
       ]);
+    });
+
+    describe('Summary table', () => {
+      it('should display the worker name or ID number', async () => {
+        const { component, getByTestId } = await setup(false);
+
+        expect(getByTestId('workerName').textContent).toContain(component.worker.nameOrId);
+      });
+
+      it('should display the type of qualification', async () => {
+        const { component, getByTestId } = await setup(false);
+
+        expect(getByTestId('qualificationType').textContent).toContain(
+          component.qualificationRecord.qualification.group,
+        );
+      });
+
+      it('should display the qualification name', async () => {
+        const { component, getByTestId } = await setup(false);
+
+        expect(getByTestId('qualificationName').textContent).toContain(
+          component.qualificationRecord.qualification.title,
+        );
+      });
     });
   });
 });

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -19,8 +19,8 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   public trainingRecord: TrainingRecord;
   public qualificationRecord: QualificationResponse;
   public trainingOrQualification: string;
+  public trainingView: boolean;
   private trainingPageUrl: string;
-  private trainingView: boolean;
   private recordUid: string;
   private subscriptions: Subscription = new Subscription();
 

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -69,15 +69,26 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
 
   public deleteRecord(): void {
     this.subscriptions.add(
-      this.workerService.deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.recordUid).subscribe(() => {
+      this.deleteTrainingOrQualificationRecord().subscribe(() => {
         this.router.navigate([this.trainingPageUrl, 'new-training']);
 
         this.alertService.addAlert({
           type: 'success',
-          message: 'Training record has been deleted',
+          message: `${this.capitalizeFirstLetter(this.trainingOrQualification)} record has been deleted`,
         });
       }),
     );
+  }
+
+  private deleteTrainingOrQualificationRecord() {
+    if (this.trainingView) {
+      return this.workerService.deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.recordUid);
+    }
+    return this.workerService.deleteQualification(this.workplace.uid, this.worker.uid, this.recordUid);
+  }
+
+  private capitalizeFirstLetter(string: string): string {
+    return string.charAt(0).toUpperCase() + string.slice(1);
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
+import { QualificationResponse } from '@core/model/qualification.model';
 import { TrainingRecord } from '@core/model/training.model';
 import { Worker } from '@core/model/worker.model';
 import { AlertService } from '@core/services/alert.service';
@@ -15,10 +16,12 @@ import { Subscription } from 'rxjs';
 export class DeleteRecordComponent implements OnInit, OnDestroy {
   public workplace: Establishment;
   public worker: Worker;
-  public record: TrainingRecord;
+  public trainingRecord: TrainingRecord;
+  public qualificationRecord: QualificationResponse;
   private trainingPageUrl: string;
   private trainingView: boolean;
   private trainingOrQualification: string;
+  private recordUid: string;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -39,30 +42,34 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   private setTrainingView(): void {
     this.trainingView = this.route.snapshot.data.trainingRecord ? true : false;
     this.trainingOrQualification = this.trainingView ? 'training' : 'qualification';
+    if (this.trainingView) {
+      this.trainingRecord = this.route.snapshot.data.trainingRecord;
+      this.recordUid = this.trainingRecord.uid;
+    } else {
+      this.qualificationRecord = this.route.snapshot.data.qualificationRecord;
+      this.recordUid = this.qualificationRecord.uid;
+    }
   }
 
   private setVariables(): void {
     this.workplace = this.route.snapshot.data.establishment;
     this.worker = this.route.snapshot.data.worker;
-    this.record = this.trainingView
-      ? this.route.snapshot.data.trainingRecord
-      : this.route.snapshot.data.qualificationRecord;
   }
 
   private setBackLink(): void {
     this.backService.setBackLink({
-      url: [this.trainingPageUrl, this.trainingOrQualification, this.record.uid],
+      url: [this.trainingPageUrl, this.trainingOrQualification, this.recordUid],
     });
   }
 
   public returnToEditPage(event: Event): void {
     event.preventDefault();
-    this.router.navigate([this.trainingPageUrl, this.trainingOrQualification, this.record.uid]);
+    this.router.navigate([this.trainingPageUrl, this.trainingOrQualification, this.recordUid]);
   }
 
   public deleteRecord(): void {
     this.subscriptions.add(
-      this.workerService.deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.record.uid).subscribe(() => {
+      this.workerService.deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.recordUid).subscribe(() => {
         this.router.navigate([this.trainingPageUrl, 'new-training']);
 
         this.alertService.addAlert({

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -18,9 +18,9 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   public worker: Worker;
   public trainingRecord: TrainingRecord;
   public qualificationRecord: QualificationResponse;
+  public trainingOrQualification: string;
   private trainingPageUrl: string;
   private trainingView: boolean;
-  private trainingOrQualification: string;
   private recordUid: string;
   private subscriptions: Subscription = new Subscription();
 

--- a/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -15,8 +15,10 @@ import { Subscription } from 'rxjs';
 export class DeleteRecordComponent implements OnInit, OnDestroy {
   public workplace: Establishment;
   public worker: Worker;
-  public trainingRecord: TrainingRecord;
+  public record: TrainingRecord;
   private trainingPageUrl: string;
+  private trainingView: boolean;
+  private trainingOrQualification: string;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -28,40 +30,46 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.setTrainingView();
     this.setVariables();
     this.trainingPageUrl = `workplace/${this.workplace.uid}/training-and-qualifications-record/${this.worker.uid}`;
     this.setBackLink();
   }
 
+  private setTrainingView(): void {
+    this.trainingView = this.route.snapshot.data.trainingRecord ? true : false;
+    this.trainingOrQualification = this.trainingView ? 'training' : 'qualification';
+  }
+
   private setVariables(): void {
     this.workplace = this.route.snapshot.data.establishment;
     this.worker = this.route.snapshot.data.worker;
-    this.trainingRecord = this.route.snapshot.data.trainingRecord;
+    this.record = this.trainingView
+      ? this.route.snapshot.data.trainingRecord
+      : this.route.snapshot.data.qualificationRecord;
   }
 
   private setBackLink(): void {
     this.backService.setBackLink({
-      url: [this.trainingPageUrl, 'training', this.trainingRecord.uid],
+      url: [this.trainingPageUrl, this.trainingOrQualification, this.record.uid],
     });
   }
 
   public returnToEditPage(event: Event): void {
     event.preventDefault();
-    this.router.navigate([this.trainingPageUrl, 'training', this.trainingRecord.uid]);
+    this.router.navigate([this.trainingPageUrl, this.trainingOrQualification, this.record.uid]);
   }
 
   public deleteRecord(): void {
     this.subscriptions.add(
-      this.workerService
-        .deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.trainingRecord.uid)
-        .subscribe(() => {
-          this.router.navigate([this.trainingPageUrl, 'new-training']);
+      this.workerService.deleteTrainingRecord(this.workplace.uid, this.worker.uid, this.record.uid).subscribe(() => {
+        this.router.navigate([this.trainingPageUrl, 'new-training']);
 
-          this.alertService.addAlert({
-            type: 'success',
-            message: 'Training record has been deleted',
-          });
-        }),
+        this.alertService.addAlert({
+          type: 'success',
+          message: 'Training record has been deleted',
+        });
+      }),
     );
   }
 

--- a/src/app/features/workers/select-record-type/select-record-type.component.html
+++ b/src/app/features/workers/select-record-type/select-record-type.component.html
@@ -9,10 +9,8 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <form #formEl novalidate (ngSubmit)="onSubmit()" [formGroup]="form" id="server-error">
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            Select the type of record
-          </h1>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h1 class="govuk-fieldset__heading">Select the type of record</h1>
         </legend>
 
         <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && (form.invalid || serverError)">

--- a/src/app/features/workers/workers-routing.module.ts
+++ b/src/app/features/workers/workers-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CheckPermissionsGuard } from '@core/guards/permissions/check-permissions/check-permissions.guard';
 import { LongTermAbsenceResolver } from '@core/resolvers/long-term-absence.resolver';
+import { QualificationResolver } from '@core/resolvers/qualification.resolver';
 import { QualificationsResolver } from '@core/resolvers/qualifications.resolver';
 import { TrainingAndQualificationRecordsResolver } from '@core/resolvers/training-and-qualification-records.resolver';
 import { TrainingRecordResolver } from '@core/resolvers/training-record.resolver';
@@ -291,7 +292,10 @@ const routes: Routes = [
           {
             path: 'delete',
             component: DeleteRecordComponent,
-            data: { title: 'Delete Training' },
+            data: { title: 'Delete Qualification' },
+            resolve: {
+              qualificationRecord: QualificationResolver,
+            },
           },
         ],
       },

--- a/src/app/features/workers/workers-routing.module.ts
+++ b/src/app/features/workers/workers-routing.module.ts
@@ -282,8 +282,18 @@ const routes: Routes = [
       },
       {
         path: 'qualification/:qualificationId',
-        component: AddEditQualificationComponent,
-        data: { title: 'Qualification' },
+        children: [
+          {
+            path: '',
+            component: AddEditQualificationComponent,
+            data: { title: 'Qualification' },
+          },
+          {
+            path: 'delete',
+            component: DeleteRecordComponent,
+            data: { title: 'Delete Training' },
+          },
+        ],
       },
       {
         path: 'add-training',

--- a/src/app/features/workers/workers.module.ts
+++ b/src/app/features/workers/workers.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { LongTermAbsenceResolver } from '@core/resolvers/long-term-absence.resolver';
+import { QualificationResolver } from '@core/resolvers/qualification.resolver';
 import { QualificationsResolver } from '@core/resolvers/qualifications.resolver';
 import { TrainingAndQualificationRecordsResolver } from '@core/resolvers/training-and-qualification-records.resolver';
 import { TrainingRecordResolver } from '@core/resolvers/training-record.resolver';
@@ -137,6 +138,7 @@ import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.compon
     DialogService,
     WorkerResolver,
     LongTermAbsenceResolver,
+    QualificationResolver,
     QualificationsResolver,
     TrainingRecordResolver,
     TrainingRecordsResolver,

--- a/src/app/features/workers/workers.module.ts
+++ b/src/app/features/workers/workers.module.ts
@@ -42,6 +42,7 @@ import { MentalHealthProfessionalComponent } from './mental-health-professional/
 import { MoveWorkerDialogComponent } from './move-worker-dialog/move-worker-dialog.component';
 import { NationalInsuranceNumberComponent } from './national-insurance-number/national-insurance-number.component';
 import { NationalityComponent } from './nationality/nationality.component';
+import { DeleteRecordComponent } from './new-training-qualifications-record/delete-record/delete-record.component';
 import {
   NewQualificationsComponent,
 } from './new-training-qualifications-record/new-qualifications/new-qualifications.component';
@@ -96,6 +97,7 @@ import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.compon
     DeleteQualificationDialogComponent,
     DeleteTrainingDialogComponent,
     DeleteWorkerDialogComponent,
+    DeleteRecordComponent,
     DisabilityComponent,
     EditWorkerComponent,
     EthnicityComponent,

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -148,15 +148,7 @@
       *ngIf="trainingRecordId && newTrainingAndQualificationsRecordsFlag"
       type="button"
       class="govuk-button govuk-button--warning govuk-!-margin-right-8"
-      [routerLink]="[
-        '/workplace',
-        workplace.uid,
-        'training-and-qualifications-record',
-        worker.uid,
-        'training',
-        trainingRecordId,
-        'delete'
-      ]"
+      [routerLink]="['../delete']"
     >
       Delete
     </button>


### PR DESCRIPTION
#### Work done
- Create `QualificationResolver`
- Change heading titles and sizes for consistency on `add-edit-qualification` and `select-record-type` components
- Adapt `delete-record` component for deleting a qualification record

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
