### PR TITLE
Fix: Allow null in ShareWithCqc and LA 

### DIFF
--- a/migrations/20211115163843-allowNullInShareLaAndLocalAuthorities.js
+++ b/migrations/20211115163843-allowNullInShareLaAndLocalAuthorities.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const establishmentTable = {
+  tableName: 'Establishment',
+  schema: 'cqc',
+};
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await Promise.all([
+        queryInterface.changeColumn(
+          establishmentTable,
+          'ShareDataWithCQC',
+          {
+            type: Sequelize.DataTypes.BOOLEAN,
+            allowNull: true,
+          },
+          { transaction },
+        ),
+        queryInterface.changeColumn(
+          establishmentTable,
+          'ShareDataWithLA',
+          {
+            type: Sequelize.DataTypes.BOOLEAN,
+            allowNull: true,
+          },
+          { transaction },
+        ),
+      ]);
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await Promise.all([
+        queryInterface.changeColumn(
+          establishmentTable,
+          'ShareDataWithCQC',
+          {
+            type: Sequelize.DataTypes.BOOLEAN,
+            allowNull: false,
+          },
+          { transaction },
+        ),
+        queryInterface.changeColumn(
+          establishmentTable,
+          'ShareDataWithLA',
+          {
+            type: Sequelize.DataTypes.BOOLEAN,
+            allowNull: false,
+          },
+          { transaction },
+        ),
+      ]);
+    });
+  },
+};

--- a/server/models/classes/establishment/properties/shareWithProperty.js
+++ b/server/models/classes/establishment/properties/shareWithProperty.js
@@ -39,6 +39,7 @@ exports.ShareWithProperty = class ShareWithProperty extends ChangePropertyProtot
   }
 
   isEqual(currentValue, newValue) {
+    if (!currentValue) return false;
     if (currentValue.cqc !== newValue.cqc) return false;
     if (currentValue.localAuthorities !== newValue.localAuthorities) return false;
 

--- a/server/models/classes/establishment/properties/shareWithProperty.js
+++ b/server/models/classes/establishment/properties/shareWithProperty.js
@@ -17,7 +17,10 @@ exports.ShareWithProperty = class ShareWithProperty extends ChangePropertyProtot
     if (document.shareWith) {
       this.property = document.shareWith;
     } else {
-      this.property = null;
+      this.property = {
+        cqc: null,
+        localAuthorities: null,
+      };
     }
   }
 

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -496,12 +496,12 @@ module.exports = function (sequelize, DataTypes) {
       },
       shareWithCQC: {
         type: DataTypes.BOOLEAN,
-        allowNull: false,
+        allowNull: true,
         field: '"ShareDataWithCQC"',
       },
       shareWithLA: {
         type: DataTypes.BOOLEAN,
-        allowNull: false,
+        allowNull: true,
         field: '"ShareDataWithLA"',
       },
       ShareWithLASavedAt: {

--- a/server/test/unit/models/classes/establishment/properties/shareWithProperty.spec.js
+++ b/server/test/unit/models/classes/establishment/properties/shareWithProperty.spec.js
@@ -19,14 +19,14 @@ describe('ShareWithProperty', () => {
       expect(shareWithProperty.property).to.deep.equal(document.shareWith);
     });
 
-    it('should return null when document does not contain shareWith', async () => {
+    it('should return object with cqc and localAuthorities set to null when document does not contain shareWith', async () => {
       const shareWithProperty = new ShareWithProperty();
       const document = {
         differentProperty: 'Test',
       };
 
       await shareWithProperty.restoreFromJson(document);
-      expect(shareWithProperty.property).to.deep.equal(null);
+      expect(shareWithProperty.property).to.deep.equal({ cqc: null, localAuthorities: null });
     });
   });
 


### PR DESCRIPTION
#### Work done
- Added migration to allow null for ShareDataWithLA and ShareDataWithCQC
- Updated restoreFromJson in shareData property to return object with null values for cqc and localAuthorities

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
