### PR TITLE
Feat/sharing permissions banner

### DIFF
--- a/migrations/20211115143507-addShowSharingPermissionsBannerColumnToEstablishmentTable.js
+++ b/migrations/20211115143507-addShowSharingPermissionsBannerColumnToEstablishmentTable.js
@@ -11,14 +11,14 @@ module.exports = {
       return Promise.all([
         await queryInterface.addColumn(
           table,
-          'showSharingPermissionsBanner',
+          'ShowSharingPermissionsBanner',
           {
             type: Sequelize.DataTypes.BOOLEAN,
             defaultValue: false,
           },
           { transaction },
         ),
-        await queryInterface.sequelize.query('UPDATE cqc."Establishment" SET "showSharingPermissionsBanner" = true;', {
+        await queryInterface.sequelize.query('UPDATE cqc."Establishment" SET "ShowSharingPermissionsBanner" = true;', {
           transaction,
         }),
       ]);
@@ -26,6 +26,6 @@ module.exports = {
   },
 
   down: (queryInterface) => {
-    return queryInterface.removeColumn(table, 'showSharingPerimissionsBanner');
+    return queryInterface.removeColumn(table, 'ShowSharingPermissionsBanner');
   },
 };

--- a/migrations/20211115143507-addShowSharingPermissionsBannerColumnToEstablishmentTable.js
+++ b/migrations/20211115143507-addShowSharingPermissionsBannerColumnToEstablishmentTable.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const table = {
+  tableName: 'Establishment',
+  schema: 'cqc',
+};
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      return Promise.all([
+        await queryInterface.addColumn(
+          table,
+          'showSharingPermissionsBanner',
+          {
+            type: Sequelize.DataTypes.BOOLEAN,
+            defaultValue: false,
+          },
+          { transaction },
+        ),
+        await queryInterface.sequelize.query('UPDATE cqc."Establishment" SET "showSharingPermissionsBanner" = true;', {
+          transaction,
+        }),
+      ]);
+    });
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.removeColumn(table, 'showSharingPerimissionsBanner');
+  },
+};

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -86,6 +86,7 @@ class Establishment extends EntityValidator {
     this._linkToParentRequested = null;
     this._lastBulkUploaded = null;
     this._eightWeeksFromFirstLogin = null;
+    this._showSharingPermissionsBanner = null;
 
     // interim reasons for leaving - https://trello.com/c/vNHbfdms
     this._reasonsForLeaving = null;
@@ -336,6 +337,10 @@ class Establishment extends EntityValidator {
 
   get eightWeeksFromFirstLogin() {
     return this._eightWeeksFromFirstLogin;
+  }
+
+  get showSharingPermissionsBanner() {
+    return this._showSharingPermissionsBanner;
   }
 
   // used by save to initialise a new Establishment; returns true if having initialised this Establishment
@@ -1248,6 +1253,7 @@ class Establishment extends EntityValidator {
         this._linkToParentRequested = fetchResults.linkToParentRequested;
         this._lastBulkUploaded = fetchResults.lastBulkUploaded;
         this._eightWeeksFromFirstLogin = fetchResults.eightWeeksFromFirstLogin;
+        this._showSharingPermissionsBanner = fetchResults.showSharingPermissionsBanner;
         // if history of the User is also required; attach the association
         //  and order in reverse chronological - note, order on id (not when)
         //  because ID is primay key and hence indexed
@@ -1724,6 +1730,7 @@ class Establishment extends EntityValidator {
         myDefaultJSON.reasonsForLeaving = this.reasonsForLeaving;
         myDefaultJSON.lastBulkUploaded = this.lastBulkUploaded;
         myDefaultJSON.eightWeeksFromFirstLogin = this.eightWeeksFromFirstLogin;
+        myDefaultJSON.showSharingPermissionsBanner = this.showSharingPermissionsBanner;
       }
 
       if (this._ustatus) {

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -716,6 +716,12 @@ module.exports = function (sequelize, DataTypes) {
         defaultValue: false,
         field: 'InReview',
       },
+      showSharingPermissionsBanner: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        field: 'ShowSharingPermissionsBanner',
+      },
     },
     {
       defaultScope: {

--- a/src/app/core/model/establishment.model.ts
+++ b/src/app/core/model/establishment.model.ts
@@ -135,6 +135,7 @@ export interface Establishment {
   locationId?: string;
   lastBulkUploaded?: string;
   eightWeeksFromFirstLogin?: string;
+  showSharingPermissionsBanner?: boolean;
 }
 
 export interface UpdateJobsRequest {

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -75,7 +75,7 @@ export class EstablishmentService {
   private returnTo$ = new BehaviorSubject<URLStructure>(null);
   private _primaryWorkplace$: BehaviorSubject<Establishment> = new BehaviorSubject<Establishment>(null);
   private _checkCQCDetailsBanner$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-
+  private _checkSharingPermissionsBanner$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public previousEstablishmentId: string;
   public isSameLoggedInUser: boolean;
   public mainServiceCQC: boolean = null;
@@ -117,6 +117,7 @@ export class EstablishmentService {
       this.setPrimaryWorkplace(this.establishment);
       this.setCheckCQCDetailsBanner(false);
     }
+    this.setCheckSharingPermissionsBanner(establishment.showSharingPermissionsBanner);
   }
 
   public resetState() {
@@ -124,6 +125,7 @@ export class EstablishmentService {
     this._establishment$.next(null);
     this.setPrimaryWorkplace(null);
     this.setCheckCQCDetailsBanner(false);
+    this.setCheckSharingPermissionsBanner(false);
   }
 
   public get establishmentId() {
@@ -164,6 +166,18 @@ export class EstablishmentService {
 
   public setCheckCQCDetailsBanner(data: boolean) {
     this._checkCQCDetailsBanner$.next(data);
+  }
+
+  public get checkSharingPermissionsBanner$(): Observable<boolean> {
+    return this._checkSharingPermissionsBanner$.asObservable();
+  }
+
+  public get checkSharingPermissionsBanner(): boolean {
+    return this._checkSharingPermissionsBanner$.value;
+  }
+
+  public setCheckSharingPermissionsBanner(data: boolean): void {
+    this._checkSharingPermissionsBanner$.next(data);
   }
 
   getEstablishment(id: string, wdf: boolean = false) {

--- a/src/app/core/test-utils/MockEstablishmentService.ts
+++ b/src/app/core/test-utils/MockEstablishmentService.ts
@@ -67,6 +67,7 @@ export class MockEstablishmentService extends EstablishmentService {
       updated: undefined,
       updatedBy: 'mock establishment updatedBy',
       vacancies: undefined,
+      showSharingPermissionsBanner: false,
     };
   }
 

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -68,7 +68,7 @@
       <app-tab
         *ngIf="workplace && canViewEstablishment"
         [title]="'Workplace'"
-        [alert]="workplace?.employerType && showCQCDetailsBanner"
+        [redAlert]="workplace?.employerType && (showCQCDetailsBanner || showSharingPermissionsBanner)"
       >
         <app-workplace-tab [workplace]="workplace" [workerCount]="workerCount"></app-workplace-tab>
       </app-tab>

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -124,6 +124,15 @@ describe('DashboardComponent', () => {
 
       expect(component.getByText('Users')).toBeTruthy();
     });
+
+    it('should display a flag on the workplace tab when the sharing permissions banner flag is true', async () => {
+      const { component } = await setup(true);
+
+      component.fixture.componentInstance.showSharingPermissionsBanner = true;
+      component.fixture.detectChanges();
+
+      expect(component.getByTestId('red-flag')).toBeTruthy();
+    });
   });
 
   describe('Archive Workplace', () => {

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -10,9 +10,7 @@ import { NotificationsService } from '@core/services/notifications/notifications
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
-import {
-  DeleteWorkplaceDialogComponent,
-} from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
+import { DeleteWorkplaceDialogComponent } from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
 import { interval, Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -39,6 +37,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   public showCQCDetailsBanner = false;
   public workers: Worker[];
   public workerCount: number;
+  public showSharingPermissionsBanner = true;
 
   constructor(
     private alertService: AlertService,

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -37,7 +37,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   public showCQCDetailsBanner = false;
   public workers: Worker[];
   public workerCount: number;
-  public showSharingPermissionsBanner = true;
+  public showSharingPermissionsBanner: boolean;
 
   constructor(
     private alertService: AlertService,
@@ -54,6 +54,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.authService.isOnAdminScreen = false;
     this.showCQCDetailsBanner = this.establishmentService.checkCQCDetailsBanner;
+    this.showSharingPermissionsBanner = this.establishmentService.checkSharingPermissionsBanner;
     this.workplace = this.establishmentService.primaryWorkplace;
     this.workplaceUid = this.workplace ? this.workplace.uid : null;
 
@@ -67,6 +68,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       }
 
       this.getShowCQCDetailsBanner();
+      this.getShowSharingPermissionBanner();
 
       if (this.canViewListOfWorkers) {
         this.setWorkersAndTrainingAlert();
@@ -259,6 +261,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.establishmentService.checkCQCDetailsBanner$.subscribe((showBanner) => {
         this.showCQCDetailsBanner = showBanner;
+      }),
+    );
+  }
+
+  private getShowSharingPermissionBanner(): void {
+    this.subscriptions.add(
+      this.establishmentService.checkSharingPermissionsBanner$.subscribe((showBanner) => {
+        this.showSharingPermissionsBanner = showBanner;
       }),
     );
   }

--- a/src/app/shared/components/tabs/tabs.component.html
+++ b/src/app/shared/components/tabs/tabs.component.html
@@ -27,7 +27,7 @@
         [class.govuk-tabs__tab--red-cross]="tab.redCross"
       >
         <span *ngIf="tab.alert" class="govuk-visually-hidden">Orange warning flag</span>
-        <span *ngIf="tab.redAlert" class="govuk-visually-hidden">Red warning flag</span>
+        <span *ngIf="tab.redAlert" class="govuk-visually-hidden" data-testid="red-flag">Red warning flag</span>
         <span *ngIf="tab.redCross" class="govuk-visually-hidden">Red cross</span>
         <span *ngIf="tab.greenTick" class="govuk-visually-hidden">Green tick</span>
       </i>

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.html
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.html
@@ -20,7 +20,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop" *ngIf="showSharingPermissionsBanner">
       <app-inset-text [color]="'todo'" data-testid="check-sharing-permissions">
         <h3 class="govuk-heading-s">You need to review your data sharing permissions</h3>
-        <p>Skills for Care have updated the list of data that wil be shred with local authorities.</p>
+        <p>Skills for Care have updated the list of data that will be shred with local authorities.</p>
         <p>You need to let us know that you're happy for us to share your data.</p>
         <p>
           <a [routerLink]="['/']">Please review your data sharing permissions</a>

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.html
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.html
@@ -18,12 +18,12 @@
       </app-inset-text>
     </div>
     <div class="govuk-grid-column-two-thirds-from-desktop" *ngIf="showSharingPermissionsBanner">
-      <app-inset-text [color]="'todo'" data-testid="check-cqc-details">
+      <app-inset-text [color]="'todo'" data-testid="check-sharing-permissions">
         <h3 class="govuk-heading-s">You need to review your data sharing permissions</h3>
         <p>Skills for Care have updated the list of data that wil be shred with local authorities.</p>
         <p>You need to let us know that you're happy for us to share your data.</p>
         <p>
-          <a href="" target="_blank">Please review your data sharing permissions</a>
+          <a [routerLink]="['/']">Please review your data sharing permissions</a>
         </p>
       </app-inset-text>
     </div>

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.html
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.html
@@ -1,9 +1,9 @@
-<ng-container *ngIf="!updateWorkplaceAlert && showCQCDetailsBanner">
+<ng-container *ngIf="!updateWorkplaceAlert && (showCQCDetailsBanner || showSharingPermissionsBanner)">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Workplace</h2>
     </div>
-    <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div class="govuk-grid-column-two-thirds-from-desktop" *ngIf="showCQCDetailsBanner">
       <app-inset-text [color]="'todo'" data-testid="check-cqc-details">
         <h3 class="govuk-heading-s">You need to check your CQC details</h3>
         <p>
@@ -14,6 +14,16 @@
         <p>
           <a href="https://www.cqc.org.uk/location/{{ locationId }}" target="_blank">Please check your CQC details</a>
           and make sure they match your <br />ASC-WDS details.
+        </p>
+      </app-inset-text>
+    </div>
+    <div class="govuk-grid-column-two-thirds-from-desktop" *ngIf="showSharingPermissionsBanner">
+      <app-inset-text [color]="'todo'" data-testid="check-cqc-details">
+        <h3 class="govuk-heading-s">You need to review your data sharing permissions</h3>
+        <p>Skills for Care have updated the list of data that wil be shred with local authorities.</p>
+        <p>You need to let us know that you're happy for us to share your data.</p>
+        <p>
+          <a href="" target="_blank">Please review your data sharing permissions</a>
         </p>
       </app-inset-text>
     </div>

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.html
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.html
@@ -20,7 +20,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop" *ngIf="showSharingPermissionsBanner">
       <app-inset-text [color]="'todo'" data-testid="check-sharing-permissions">
         <h3 class="govuk-heading-s">You need to review your data sharing permissions</h3>
-        <p>Skills for Care have updated the list of data that will be shred with local authorities.</p>
+        <p>Skills for Care have updated the list of data that will be shared with local authorities.</p>
         <p>You need to let us know that you're happy for us to share your data.</p>
         <p>
           <a [routerLink]="['/']">Please review your data sharing permissions</a>

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.spec.ts
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.spec.ts
@@ -18,22 +18,24 @@ describe('WorkplaceTabComponent', () => {
   let component: WorkplaceTabComponent;
   let fixture: ComponentFixture<WorkplaceTabComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule, RouterTestingModule, HttpClientTestingModule],
-      providers: [
-        {
-          provide: PermissionsService,
-          useFactory: MockPermissionsService.factory(),
-          deps: [HttpClient, Router, UserService],
-        },
-        {
-          provide: EstablishmentService,
-          useClass: MockEstablishmentService,
-        },
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule, RouterTestingModule, HttpClientTestingModule],
+        providers: [
+          {
+            provide: PermissionsService,
+            useFactory: MockPermissionsService.factory(),
+            deps: [HttpClient, Router, UserService],
+          },
+          {
+            provide: EstablishmentService,
+            useClass: MockEstablishmentService,
+          },
+        ],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WorkplaceTabComponent);
@@ -62,5 +64,23 @@ describe('WorkplaceTabComponent', () => {
     const checkCQCDetailsBanner = within(document.body).queryByTestId('check-cqc-details');
 
     expect(checkCQCDetailsBanner).toBeNull();
+  });
+
+  it('should display the Sharing Permissions banner', async () => {
+    component.showSharingPermissionsBanner = true;
+    fixture.detectChanges();
+
+    const checkShowSharingPermissions = within(document.body).queryByTestId('check-sharing-permissions');
+
+    expect(checkShowSharingPermissions.innerHTML).toContain('You need to review your data sharing permissions');
+  });
+
+  it('should not display the Sharing Permissions banner', async () => {
+    component.showSharingPermissionsBanner = false;
+    fixture.detectChanges();
+
+    const checkShowSharingPermissions = within(document.body).queryByTestId('check-sharing-permissions');
+
+    expect(checkShowSharingPermissions).toBeNull();
   });
 });

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.ts
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.ts
@@ -19,20 +19,29 @@ export class WorkplaceTabComponent implements OnInit, OnDestroy {
   public updateWorkplaceAlert: boolean;
   public locationId: string;
   public showCQCDetailsBanner: boolean = this.establishmentService.checkCQCDetailsBanner;
-  public showSharingPermissionsBanner = true;
+  public showSharingPermissionsBanner: boolean = this.establishmentService.checkSharingPermissionsBanner;
 
   constructor(private permissionsService: PermissionsService, private establishmentService: EstablishmentService) {}
 
   ngOnInit(): void {
     this.locationId = this.workplace.locationId;
     this.establishmentService.setCheckCQCDetailsBanner(false);
-
-    this.establishmentService.checkCQCDetailsBanner$.subscribe((showBanner) => {
-      this.showCQCDetailsBanner = showBanner;
-    });
+    this.getShowCQCDetailsBanner();
+    this.getShowSharingPermissionsBanner();
 
     this.updateWorkplaceAlert =
       !this.workplace.employerType && this.permissionsService.can(this.workplace.uid, 'canEditEstablishment');
+  }
+
+  private getShowCQCDetailsBanner(): void {
+    this.establishmentService.checkCQCDetailsBanner$.subscribe((showBanner) => {
+      this.showCQCDetailsBanner = showBanner;
+    });
+  }
+  private getShowSharingPermissionsBanner(): void {
+    this.establishmentService.checkSharingPermissionsBanner$.subscribe((showBanner) => {
+      this.showSharingPermissionsBanner = showBanner;
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.ts
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.ts
@@ -19,6 +19,7 @@ export class WorkplaceTabComponent implements OnInit, OnDestroy {
   public updateWorkplaceAlert: boolean;
   public locationId: string;
   public showCQCDetailsBanner: boolean = this.establishmentService.checkCQCDetailsBanner;
+  public showSharingPermissionsBanner = true;
 
   constructor(private permissionsService: PermissionsService, private establishmentService: EstablishmentService) {}
 


### PR DESCRIPTION
#### Work done
- add migration for new column in establishment table for showingSharingPermissions banner defaulting to false, and set it to true for all esatblishments currently in the database
- add field to the establishment model
- return new field form db call
- add methods for retrieving show banner status in the establishment service
- add banner to the workplace-tab component
- add flag to workplace tab in the dashboard component
- write tests

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
