### PR TITLE
Feat: Sharing permissions in workplace summary

### DIFF
--- a/server/test/factories/models.js
+++ b/server/test/factories/models.js
@@ -43,6 +43,13 @@ const establishmentWithWdfBuilder = build('Establishment', {
   },
 });
 
+const establishmentWithShareWith = (shareWith) => {
+  const establishment = establishmentBuilder();
+  establishment.shareWith = shareWith;
+  establishment.otherServices = { value: 'Yes', services: [{ category: 'Adult community care', services: [] }] };
+  return establishment;
+};
+
 const categoryBuilder = build('Category', {
   fields: {
     id: sequence(),
@@ -151,3 +158,4 @@ module.exports.categoryBuilder = categoryBuilder;
 module.exports.trainingBuilder = trainingBuilder;
 module.exports.mandatoryTrainingBuilder = mandatoryTrainingBuilder;
 module.exports.workerBuilderWithWdf = workerBuilderWithWdf;
+module.exports.establishmentWithShareWith = establishmentWithShareWith;

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -257,7 +257,15 @@
     <dt class="govuk-summary-list__key">Data sharing</dt>
     <dd class="govuk-summary-list__value">
       <ng-container *ngIf="!workplace.shareWith?.cqc && !workplace.shareWith?.localAuthorities; else sharing">
-        -
+        <ng-container
+          *ngIf="
+            workplace.shareWith?.cqc === false || workplace.shareWith?.localAuthorities === false;
+            else notProvided
+          "
+        >
+          Not sharing
+        </ng-container>
+        <ng-template #notProvided> - </ng-template>
       </ng-container>
       <ng-template #sharing>
         <p *ngIf="workplace.shareWith?.cqc">Care Quality Commission (CQC)</p>
@@ -268,7 +276,7 @@
       <app-summary-record-change
         [explanationText]="' data sharing'"
         [link]="['/workplace', workplace.uid, 'sharing-data']"
-        [hasData]="workplace.shareWith?.cqc || workplace.shareWith?.localAuthorities"
+        [hasData]="workplace.shareWith?.cqc !== null || workplace.shareWith?.localAuthorities !== null"
         (setReturnClicked)="this.setReturn()"
       ></app-summary-record-change>
     </dd>

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -253,7 +253,7 @@
     </dd>
   </div>
 
-  <div class="govuk-summary-list__row">
+  <div class="govuk-summary-list__row" data-testid="data-sharing">
     <dt class="govuk-summary-list__key">Data sharing</dt>
     <dd class="govuk-summary-list__value">
       <ng-container *ngIf="!workplace.shareWith?.cqc && !workplace.shareWith?.localAuthorities; else sharing">

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -186,6 +186,17 @@ describe('WorkplaceSummaryComponent', async () => {
       expect(dataSharing.innerHTML).toContain('Change');
       expect(dataSharing.innerHTML).toContain('Not sharing');
     });
+
+    it('should not show Not sharing when one of cqc and localAuthorities is false and one is true', async () => {
+      const { component, fixture } = await setup({ cqc: true, localAuthorities: false });
+
+      component.canEditEstablishment = true;
+      fixture.detectChanges();
+
+      const dataSharing = within(document.body).queryByTestId('data-sharing');
+      expect(dataSharing.innerHTML).toContain('Change');
+      expect(dataSharing.innerHTML).not.toContain('Not sharing');
+    });
   });
 
   describe('Staff records banner', async () => {

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -153,6 +153,39 @@ describe('WorkplaceSummaryComponent', async () => {
       expect(dataSharing.innerHTML).toContain('Add information');
       expect(dataSharing.innerHTML).toContain('-');
     });
+
+    it('should show Not sharing and have Change button on Data sharing when cqc and localAuthorities are set to false', async () => {
+      const { component, fixture } = await setup({ cqc: false, localAuthorities: false });
+
+      component.canEditEstablishment = true;
+      fixture.detectChanges();
+
+      const dataSharing = within(document.body).queryByTestId('data-sharing');
+      expect(dataSharing.innerHTML).toContain('Change');
+      expect(dataSharing.innerHTML).toContain('Not sharing');
+    });
+
+    it('should show Not sharing and have Change button on Data sharing when cqc is set to false and localAuthorities is null', async () => {
+      const { component, fixture } = await setup({ cqc: false, localAuthorities: null });
+
+      component.canEditEstablishment = true;
+      fixture.detectChanges();
+
+      const dataSharing = within(document.body).queryByTestId('data-sharing');
+      expect(dataSharing.innerHTML).toContain('Change');
+      expect(dataSharing.innerHTML).toContain('Not sharing');
+    });
+
+    it('should show Not sharing and have Change button on Data sharing when localAuthorities is set to false and cqc is null', async () => {
+      const { component, fixture } = await setup({ cqc: null, localAuthorities: false });
+
+      component.canEditEstablishment = true;
+      fixture.detectChanges();
+
+      const dataSharing = within(document.body).queryByTestId('data-sharing');
+      expect(dataSharing.innerHTML).toContain('Change');
+      expect(dataSharing.innerHTML).toContain('Not sharing');
+    });
   });
 
   describe('Staff records banner', async () => {

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -111,7 +111,7 @@ describe('WorkplaceSummaryComponent', async () => {
   });
 
   describe('Data sharing states', async () => {
-    it('should show Add information on Data sharing when cqc and localAuthorities are both set to null', async () => {
+    it('should show dash and have Add information button on Data sharing when cqc and localAuthorities set to null (not answered)', async () => {
       const { component, fixture } = await setup({ cqc: null, localAuthorities: null });
 
       component.canEditEstablishment = true;
@@ -119,6 +119,7 @@ describe('WorkplaceSummaryComponent', async () => {
 
       const dataSharing = within(document.body).queryByTestId('data-sharing');
       expect(dataSharing.innerHTML).toContain('Add information');
+      expect(dataSharing.innerHTML).toContain('-');
     });
 
     it('should show Local authorities and have Change button on Data sharing when localAuthorities set to true', async () => {
@@ -143,17 +144,6 @@ describe('WorkplaceSummaryComponent', async () => {
       expect(dataSharing.innerHTML).toContain('Care Quality Commission (CQC)');
     });
 
-    it('should show dash and have Add information button on Data sharing when cqc and localAuthorities set to null', async () => {
-      const { component, fixture } = await setup({ cqc: null, localAuthorities: null });
-
-      component.canEditEstablishment = true;
-      fixture.detectChanges();
-
-      const dataSharing = within(document.body).queryByTestId('data-sharing');
-      expect(dataSharing.innerHTML).toContain('Add information');
-      expect(dataSharing.innerHTML).toContain('-');
-    });
-
     it('should show Not sharing and have Change button on Data sharing when cqc and localAuthorities are set to false', async () => {
       const { component, fixture } = await setup({ cqc: false, localAuthorities: false });
 
@@ -165,7 +155,7 @@ describe('WorkplaceSummaryComponent', async () => {
       expect(dataSharing.innerHTML).toContain('Not sharing');
     });
 
-    it('should show Not sharing and have Change button on Data sharing when cqc is set to false and localAuthorities is null', async () => {
+    it('should show Not sharing and have Change button on Data sharing when cqc is set to false and localAuthorities is null (not answered)', async () => {
       const { component, fixture } = await setup({ cqc: false, localAuthorities: null });
 
       component.canEditEstablishment = true;
@@ -176,7 +166,7 @@ describe('WorkplaceSummaryComponent', async () => {
       expect(dataSharing.innerHTML).toContain('Not sharing');
     });
 
-    it('should show Not sharing and have Change button on Data sharing when localAuthorities is set to false and cqc is null', async () => {
+    it('should show Not sharing and have Change button on Data sharing when localAuthorities is set to false and cqc is null (not answered)', async () => {
       const { component, fixture } = await setup({ cqc: null, localAuthorities: false });
 
       component.canEditEstablishment = true;

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -18,7 +18,7 @@ import { NumericAnswerPipe } from '@shared/pipes/numeric-answer.pipe';
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 
-import { establishmentWithWdfBuilder } from '../../../../../server/test/factories/models';
+import { establishmentWithShareWith, establishmentWithWdfBuilder } from '../../../../../server/test/factories/models';
 import { Establishment } from '../../../../mockdata/establishment';
 import { EligibilityIconComponent } from '../eligibility-icon/eligibility-icon.component';
 import { InsetTextComponent } from '../inset-text/inset-text.component';
@@ -26,7 +26,7 @@ import { SummaryRecordValueComponent } from '../summary-record-value/summary-rec
 import { WorkplaceSummaryComponent } from './workplace-summary.component';
 
 describe('WorkplaceSummaryComponent', async () => {
-  const setup = async () => {
+  const setup = async (shareWith = null) => {
     const { fixture, getByText, queryByText } = await render(WorkplaceSummaryComponent, {
       imports: [SharedModule, RouterTestingModule, HttpClientTestingModule, BrowserModule, WdfModule],
       providers: [
@@ -48,7 +48,7 @@ describe('WorkplaceSummaryComponent', async () => {
       ],
       componentProperties: {
         wdfView: true,
-        workplace: establishmentWithWdfBuilder() as Establishment,
+        workplace: shareWith ? establishmentWithShareWith(shareWith) : (establishmentWithWdfBuilder() as Establishment),
       },
     });
 
@@ -107,6 +107,51 @@ describe('WorkplaceSummaryComponent', async () => {
       const mainServiceName = within(document.body).queryByTestId('main-service-name');
       expect(mainServiceName.innerHTML).toContain(component.workplace.mainService.name);
       expect(mainServiceName.innerHTML).not.toContain(component.requestedServiceName);
+    });
+  });
+
+  describe('Data sharing states', async () => {
+    it('should show Add information on Data sharing when cqc and localAuthorities are both set to null', async () => {
+      const { component, fixture } = await setup({ cqc: null, localAuthorities: null });
+
+      component.canEditEstablishment = true;
+      fixture.detectChanges();
+
+      const dataSharing = within(document.body).queryByTestId('data-sharing');
+      expect(dataSharing.innerHTML).toContain('Add information');
+    });
+
+    it('should show Local authorities and have Change button on Data sharing when localAuthorities set to true', async () => {
+      const { component, fixture } = await setup({ cqc: null, localAuthorities: true });
+
+      component.canEditEstablishment = true;
+      fixture.detectChanges();
+
+      const dataSharing = within(document.body).queryByTestId('data-sharing');
+      expect(dataSharing.innerHTML).toContain('Change');
+      expect(dataSharing.innerHTML).toContain('Local authorities');
+    });
+
+    it('should show CQC and have Change button on Data sharing when cqc set to true', async () => {
+      const { component, fixture } = await setup({ cqc: true, localAuthorities: false });
+
+      component.canEditEstablishment = true;
+      fixture.detectChanges();
+
+      const dataSharing = within(document.body).queryByTestId('data-sharing');
+      expect(dataSharing.innerHTML).toContain('Change');
+      expect(dataSharing.innerHTML).toContain('Care Quality Commission (CQC)');
+    });
+
+    it('should show dash and have Add information button on Data sharing when cqc and localAuthorities set to null', async () => {
+      const { component, fixture } = await setup({ cqc: null, localAuthorities: null });
+
+      component.canEditEstablishment = true;
+      fixture.detectChanges();
+
+      const dataSharing = within(document.body).queryByTestId('data-sharing');
+      expect(dataSharing.innerHTML).toContain('Add information');
+      expect(dataSharing.innerHTML).toContain('-');
     });
   });
 


### PR DESCRIPTION
#### Work done
- Added Not sharing to Data sharing section of workplace summary to display when user has selected No to sharing data with the CQC or local authorities 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
