### PR TITLE
Spike: Bulk Upload - Workplace status

### DIFF
--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -1,7 +1,7 @@
 const BUDI = require('../BUDI').BUDI;
 const moment = require('moment');
 const get = require('lodash/get');
-const models = require('../../../models')
+const models = require('../../../models');
 
 const STOP_VALIDATING_ON = ['UNCHECKED', 'DELETE', 'NOCHANGE'];
 

--- a/server/models/BulkImport/csv/workers.js
+++ b/server/models/BulkImport/csv/workers.js
@@ -1,6 +1,7 @@
 const BUDI = require('../BUDI').BUDI;
 const moment = require('moment');
 const get = require('lodash/get');
+const models = require('../../../models')
 
 const STOP_VALIDATING_ON = ['UNCHECKED', 'DELETE', 'NOCHANGE'];
 
@@ -3095,11 +3096,15 @@ class Worker {
       if (this.establishmentKey === establishment.key) {
         switch (establishment.status) {
           case 'NEW':
-          case 'UPDATE': {
+          case 'UPDATE':
             cqcRegEstablishment = establishment.regType === 2;
-          }
-          /* fall through */
-
+            break;
+          case 'UNCHECKED':
+            cqcRegEstablishment = this.checkEstablishmentRegulated(establishment.id);
+            break;
+          case 'NOCHANGE':
+            cqcRegEstablishment = this.checkEstablishmentRegulated(establishment.id);
+            break;
           case 'DELETE':
             break;
         }
@@ -3108,6 +3113,11 @@ class Worker {
 
     // ensure worker jobs tally up on TOTALPERMTEMP field, but only do it for new or updated establishments
     this._crossValidateMainJobRole(csvWorkerSchemaErrors, cqcRegEstablishment);
+  }
+
+  async checkEstablishmentRegulated(establishmentId) {
+    const establishment = await models.establishment.findbyId(establishmentId);
+    return establishment.isRegulated;
   }
 
   // returns true on success, false is any attribute of Worker fails

--- a/server/test/unit/models/Bulkimport/csv/workers.spec.js
+++ b/server/test/unit/models/Bulkimport/csv/workers.spec.js
@@ -13,6 +13,7 @@ const testUtils = require('../../../../../utils/testUtils');
 const { build } = require('@jackfranklin/test-data-bot');
 const { apiWorkerBuilder } = require('../../../../integration/utils/worker');
 const get = require('lodash/get');
+const models = require('../../../../../models');
 
 const sandbox = require('sinon').createSandbox();
 
@@ -158,6 +159,7 @@ const getUnitInstance = () => {
           moment,
         },
         'lodash/get': get,
+        '../../../models': models,
       }),
     },
   });
@@ -169,6 +171,13 @@ const getUnitInstance = () => {
   return new bulkUpload.Worker();
 };
 describe('/server/models/Bulkimport/csv/workers.js', () => {
+  beforeEach(() => {
+    sinon.stub(models.establishment, 'findbyId').returns({ isRegulated: true });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
   describe('get headers', () => {
     it('should return a string of headers seperated by a comma', () => {
       const bulkUpload = getUnitInstance();
@@ -197,6 +206,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
             },
             moment: moment,
             'lodash/get': get,
+            '../../../models': models,
           }),
         },
       }).Worker)(buildWorkerCsv(), 2, [buildEstablishmentRecord(), buildSecondEstablishmentRecord()]);
@@ -237,6 +247,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
           'Workers MAINJOBROLE is Registered Manager but you are not providing a CQC regulated service. Please change to another Job Role',
       });
     });
+
     it('should not emit an error if REGTYPE is 2 (CQC) but worker has registered manager main job role', async () => {
       const bulkUpload = new (testUtils.sandBox(filename, {
         locals: {
@@ -246,6 +257,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
             },
             moment: moment,
             'lodash/get': get,
+            '../../../models': models,
           }),
         },
       }).Worker)(buildWorkerCsv(), 2, [
@@ -283,52 +295,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
 
       expect(csvWorkerSchemaErrors).to.deep.equal([]);
     });
-    it('should not emit an error if REGTYPE is 2 (CQC) but worker has registered manager main job role', async () => {
-      const bulkUpload = new (testUtils.sandBox(filename, {
-        locals: {
-          require: testUtils.wrapRequire({
-            '../BUDI': {
-              BUDI,
-            },
-            moment: moment,
-            'lodash/get': get,
-          }),
-        },
-      }).Worker)(buildWorkerCsv(), 2, [
-        buildEstablishmentRecord({
-          overrides: {
-            _isRegulated: true,
-          },
-        }),
-        buildSecondEstablishmentRecord(),
-      ]);
 
-      expect(bulkUpload).to.have.property('crossValidate');
-
-      const csvWorkerSchemaErrors = [];
-
-      const myEstablishments = [
-        {
-          key: 'MARMA',
-          status: 'UPDATE',
-          regType: 2,
-        },
-      ];
-
-      // Regular validation has to run first for the establishment to populate the internal properties correctly
-      await bulkUpload.validate();
-
-      // call the method
-      await bulkUpload.crossValidate({
-        csvWorkerSchemaErrors,
-        myEstablishments,
-      });
-
-      // assert a error was returned
-      expect(csvWorkerSchemaErrors.length).to.equal(0);
-
-      expect(csvWorkerSchemaErrors).to.deep.equal([]);
-    });
     it("should not emit an error if REGTYPE is 2 (CQC) but worker doesn't have registered manager main job role", async () => {
       const bulkUpload = new (testUtils.sandBox(filename, {
         locals: {
@@ -338,6 +305,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
             },
             moment: moment,
             'lodash/get': get,
+            '../../../models': models,
           }),
         },
       }).Worker)(
@@ -392,6 +360,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
             },
             moment: moment,
             'lodash/get': get,
+            '../../../models': models,
           }),
         },
       }).Worker)(
@@ -448,6 +417,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(buildWorkerCsv(), 2, [buildEstablishmentRecord()]);
@@ -480,6 +450,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(buildWorkerCsv(), 2, [buildEstablishmentRecord()]);
@@ -507,6 +478,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
                 },
                 moment: moment,
                 'lodash/get': get,
+                '../../../models': models,
               }),
             },
           }).Worker)(
@@ -540,6 +512,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(
@@ -587,6 +560,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(
@@ -616,6 +590,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(
@@ -657,6 +632,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(
@@ -699,6 +675,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(
@@ -743,6 +720,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(
@@ -778,6 +756,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(
@@ -813,6 +792,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(
@@ -861,6 +841,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(
@@ -909,6 +890,7 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
               },
               moment: moment,
               'lodash/get': get,
+              '../../../models': models,
             }),
           },
         }).Worker)(

--- a/server/test/unit/models/Bulkimport/csv/workers.spec.js
+++ b/server/test/unit/models/Bulkimport/csv/workers.spec.js
@@ -171,13 +171,6 @@ const getUnitInstance = () => {
   return new bulkUpload.Worker();
 };
 describe('/server/models/Bulkimport/csv/workers.js', () => {
-  beforeEach(() => {
-    sinon.stub(models.establishment, 'findbyId').returns({ isRegulated: true });
-  });
-
-  afterEach(() => {
-    sinon.restore();
-  });
   describe('get headers', () => {
     it('should return a string of headers seperated by a comma', () => {
       const bulkUpload = getUnitInstance();

--- a/server/test/unit/models/Bulkimport/csv/workers.spec.js
+++ b/server/test/unit/models/Bulkimport/csv/workers.spec.js
@@ -296,6 +296,102 @@ describe('/server/models/Bulkimport/csv/workers.js', () => {
       expect(csvWorkerSchemaErrors).to.deep.equal([]);
     });
 
+    it('should not emit an error if REGTYPE is 2 (CQC) and establishment is UNCHECKED but worker has registered manager main job role', async () => {
+      const bulkUpload = new (testUtils.sandBox(filename, {
+        locals: {
+          require: testUtils.wrapRequire({
+            '../BUDI': {
+              BUDI,
+            },
+            moment: moment,
+            'lodash/get': get,
+            '../../../models': models,
+          }),
+        },
+      }).Worker)(buildWorkerCsv(), 2, [
+        buildEstablishmentRecord({
+          overrides: {
+            _isRegulated: true,
+          },
+        }),
+        buildSecondEstablishmentRecord(),
+      ]);
+
+      expect(bulkUpload).to.have.property('crossValidate');
+
+      const csvWorkerSchemaErrors = [];
+
+      const myEstablishments = [
+        {
+          key: 'MARMA',
+          status: 'UNCHECKED',
+          regType: 2,
+        },
+      ];
+
+      // Regular validation has to run first for the establishment to populate the internal properties correctly
+      await bulkUpload.validate();
+
+      // call the method
+      await bulkUpload.crossValidate({
+        csvWorkerSchemaErrors,
+        myEstablishments,
+      });
+
+      // assert a error was returned
+      expect(csvWorkerSchemaErrors.length).to.equal(0);
+
+      expect(csvWorkerSchemaErrors).to.deep.equal([]);
+    });
+
+    it('should not emit an error if REGTYPE is 2 (CQC) and establishment is NOCHANGE but worker has registered manager main job role', async () => {
+      const bulkUpload = new (testUtils.sandBox(filename, {
+        locals: {
+          require: testUtils.wrapRequire({
+            '../BUDI': {
+              BUDI,
+            },
+            moment: moment,
+            'lodash/get': get,
+            '../../../models': models,
+          }),
+        },
+      }).Worker)(buildWorkerCsv(), 2, [
+        buildEstablishmentRecord({
+          overrides: {
+            _isRegulated: true,
+          },
+        }),
+        buildSecondEstablishmentRecord(),
+      ]);
+
+      expect(bulkUpload).to.have.property('crossValidate');
+
+      const csvWorkerSchemaErrors = [];
+
+      const myEstablishments = [
+        {
+          key: 'MARMA',
+          status: 'NOCHANGE',
+          regType: 2,
+        },
+      ];
+
+      // Regular validation has to run first for the establishment to populate the internal properties correctly
+      await bulkUpload.validate();
+
+      // call the method
+      await bulkUpload.crossValidate({
+        csvWorkerSchemaErrors,
+        myEstablishments,
+      });
+
+      // assert a error was returned
+      expect(csvWorkerSchemaErrors.length).to.equal(0);
+
+      expect(csvWorkerSchemaErrors).to.deep.equal([]);
+    });
+
     it("should not emit an error if REGTYPE is 2 (CQC) but worker doesn't have registered manager main job role", async () => {
       const bulkUpload = new (testUtils.sandBox(filename, {
         locals: {


### PR DESCRIPTION
#### Issue
- If a user updates a worker to be a registered manager but uploads the workplace file with the establishment as `UNCHECKED` or `NOCHANGE`, we get the error `Workers MAINJOBROLE is Registered Manager but you are not providing a CQC regulated service` even if the establishment is CQC regulated

#### Work done
- Create `checkEstablishmentRegulated` function which checks if the workplace is regulated in the database
- Add `UNCHECKED` and `NOCHANGE` to switch statement so that in these cases, we can still verify that the establishment is regulated
- Remove duplicate test

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
