### PR TITLE
Bug/rejected workplaces visible on all workplaces page

### DIFF
--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -2130,6 +2130,12 @@ class Establishment extends EntityValidator {
               },
             },
           ],
+          ustatus: {
+            [models.Sequelize.Op.or]: {
+              [models.Sequelize.Op.ne]: 'REJECTED',
+              [models.Sequelize.Op.is]: null,
+            },
+          },
         }
       : { id: primaryEstablishmentId };
 
@@ -2236,7 +2242,7 @@ class Establishment extends EntityValidator {
 
     // first - get the user's primary establishment (every user will have a primary establishment)
     const fetchResults = await models.establishment.findAll(params);
-
+    console.log(fetchResults);
     // if no results return false?! whatever. It's what it did before
     if (fetchResults.length === 0) {
       return false;

--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -2242,7 +2242,7 @@ class Establishment extends EntityValidator {
 
     // first - get the user's primary establishment (every user will have a primary establishment)
     const fetchResults = await models.establishment.findAll(params);
-    console.log(fetchResults);
+
     // if no results return false?! whatever. It's what it did before
     if (fetchResults.length === 0) {
       return false;

--- a/src/app/core/test-utils/MockUserService.ts
+++ b/src/app/core/test-utils/MockUserService.ts
@@ -50,6 +50,7 @@ const workplaceBuilder = build('Workplace', {
     dataOwnerPermissions: '',
     isParent: bool(),
     postCode: 'xxxxx',
+    ustatus: null,
   },
 });
 
@@ -73,7 +74,7 @@ const subsid1Builder = () =>
       dataOwner: 'Parent',
       dataPermissions: 'Workplace',
       parentUid: '98a83eef-e1e1-49f3-89c5-b1287a3cc8dd',
-      name: 'Subsid Workplace',
+      name: 'First Subsid Workplace',
       postCode: 'WA1 1BQ',
     },
   });
@@ -88,10 +89,15 @@ const subsid2Builder = () =>
       parentUid: '98a83eef-e1e1-49f3-89c5-b1287a3cc8dd',
       name: 'Another Subsid Workplace',
       postCode: 'WA8 9LW',
+      ustatus: 'PENDING',
     },
   });
 
 const subsid2 = subsid2Builder();
+
+const subsid3 = Object.assign({}, subsid2);
+subsid3.ustatus = 'IN PROGRESS';
+subsid3.name = 'Third Subsid';
 
 @Injectable()
 export class MockUserService extends UserService {
@@ -134,7 +140,7 @@ export class MockUserService extends UserService {
       primary: primary,
       subsidaries: {
         count: this.subsidiaries,
-        establishments: [subsid1, subsid2],
+        establishments: [subsid1, subsid2, subsid3],
       },
     } as GetWorkplacesResponse);
   }

--- a/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
+++ b/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
@@ -95,4 +95,9 @@ describe('ViewMyWorkplacesComponent', () => {
     const { queryByText } = await setup();
     expect(queryByText('Your application for Third Subsid is being reviewed by Skills for Care.')).toBeTruthy();
   });
+
+  it('should display all workplaces number which is number of active accounts (1)', async () => {
+    const { queryByText } = await setup();
+    expect(queryByText('All workplaces (1)')).toBeTruthy();
+  });
 });

--- a/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
+++ b/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
@@ -1,0 +1,98 @@
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AlertService } from '@core/services/alert.service';
+import { AuthService } from '@core/services/auth.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { UserService } from '@core/services/user.service';
+import { WindowRef } from '@core/services/window.ref';
+import { MockAuthService } from '@core/test-utils/MockAuthService';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { MockUserService } from '@core/test-utils/MockUserService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { WorkplaceInfoPanelComponent } from '../workplace-info-panel/workplace-info-panel.component';
+import { ViewMyWorkplacesComponent } from './view-my-workplaces.component';
+
+describe('ViewMyWorkplacesComponent', () => {
+  async function setup() {
+    const { fixture, getByText, getByTestId, queryByText } = await render(ViewMyWorkplacesComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+      declarations: [WorkplaceInfoPanelComponent],
+      providers: [
+        AlertService,
+        WindowRef,
+        {
+          provide: PermissionsService,
+          useFactory: MockPermissionsService.factory(['canAddEstablishment']),
+          deps: [HttpClient, Router, UserService],
+        },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
+        },
+        {
+          provide: UserService,
+          useClass: MockUserService,
+          deps: [HttpClient],
+        },
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
+        },
+        {
+          provide: BreadcrumbService,
+          useClass: MockBreadcrumbService,
+        },
+        {
+          provide: FeatureFlagsService,
+          useClass: MockFeatureFlagsService,
+        },
+      ],
+    });
+
+    const component = fixture.componentInstance;
+    const injector = getTestBed();
+    const permissionsService = injector.inject(PermissionsService) as PermissionsService;
+
+    return {
+      component,
+      fixture,
+      permissionsService,
+      getByText,
+      getByTestId,
+      queryByText,
+    };
+  }
+
+  it('should render a ViewMyWorkplacesComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should display approved workplace (ustatus set to null)', async () => {
+    const { getByText } = await setup();
+    expect(getByText('First Subsid Workplace')).toBeTruthy();
+  });
+
+  it('should display pending workplace message for workplaces with ustatus set to PENDING', async () => {
+    const { queryByText } = await setup();
+    expect(
+      queryByText('Your application for Another Subsid Workplace is being reviewed by Skills for Care.'),
+    ).toBeTruthy();
+  });
+
+  it('should display pending workplace message for workplaces with ustatus set to IN PROGRESS', async () => {
+    const { queryByText } = await setup();
+    expect(queryByText('Your application for Third Subsid is being reviewed by Skills for Care.')).toBeTruthy();
+  });
+});

--- a/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
+++ b/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
@@ -56,17 +56,16 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
         (workplaces: GetWorkplacesResponse) => {
           if (workplaces.subsidaries) {
             this.workplaces = workplaces.subsidaries.establishments;
-            this.workplaces = this.workplaces.filter((item) => item.ustatus !== 'PENDING');
-            this.pendingWorkplaces = workplaces.subsidaries.establishments.filter((item) => item.ustatus === 'PENDING');
+            this.workplaces = this.workplaces.filter((item) => item.ustatus === null);
+            this.pendingWorkplaces = workplaces.subsidaries.establishments.filter(
+              (item) => item.ustatus === 'PENDING' || item.ustatus === 'IN PROGRESS',
+            );
             this.pendingWorkplaces.sort((a: any, b: any) => {
               const dateA = new Date(a.updated).getTime();
               const dateB = new Date(b.updated).getTime();
               return dateB > dateA ? 1 : -1;
             });
-            this.workplacesCount =
-              workplaces.subsidaries.count > this.pendingWorkplaces.length
-                ? workplaces.subsidaries.count - this.pendingWorkplaces.length
-                : this.pendingWorkplaces.length - workplaces.subsidaries.count;
+            this.workplacesCount = this.workplaces.length;
           }
         },
         (error: HttpErrorResponse) => {


### PR DESCRIPTION
#### Work done
- Updated fetchMyEstablishments to filter out rejected workplaces
- Added filtering of new status types in view-my-workplaces 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
