### PR TITLE
Fix: Set showSharingPermissionsBanner to false when establishment updated in bulk upload

### DIFF
--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -951,7 +951,7 @@ class Establishment extends EntityValidator {
             updated: updatedTimestamp,
             updatedBy: savedBy.toLowerCase(),
             ustatus: this._ustatus,
-            showSharingPermissionsBanner: this._showSharingPermissionsBanner,
+            showSharingPermissionsBanner: bulkUploaded ? false : this._showSharingPermissionsBanner,
           };
 
           // Every time the establishment is saved, need to calculate


### PR DESCRIPTION
#### Issue
- When a user updated an establishment in bulk upload, they would still have the update your sharing permissions banner when they go onto the workplace tab

#### Work done
- Set showSharingPermissionsBanner to false when establishment updated in bulk upload

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [x] No, I found it difficult to test
- [ ] No, they are not required for this change
