### PR TITLE
Bug: Bulk Upload not uploading full addresses

### DIFF
--- a/server/models/BulkImport/csv/establishments.js
+++ b/server/models/BulkImport/csv/establishments.js
@@ -2574,14 +2574,14 @@ class Establishment {
   // returns an API representation of this Establishment
   toAPI() {
     const fixedProperties = {
-      Address1: this._address1 ? this._address1 : '',
-      Address2: this._address2 ? this._address2 : '',
-      Address3: this._address3 ? this._address3 : '',
-      Town: this._town ? this._town : '',
-      Postcode: this._postcode ? this._postcode : '',
-      LocationId: this._regType ? this._locationID : undefined,
-      ProvId: this._regType ? this._provID : undefined,
-      IsCQCRegulated: this._regType === 2,
+      address1: this._address1 ? this._address1 : '',
+      address2: this._address2 ? this._address2 : '',
+      address3: this._address3 ? this._address3 : '',
+      town: this._town ? this._town : '',
+      postcode: this._postcode ? this._postcode : '',
+      locationId: this._regType ? this._locationID : undefined,
+      provId: this._regType ? this._provID : undefined,
+      isCQCRegulated: this._regType === 2,
     };
 
     // interim solution for reasons for leaving

--- a/server/routes/establishments/bulkUpload/validate/validateEstablishmentCsv.js
+++ b/server/routes/establishments/bulkUpload/validate/validateEstablishmentCsv.js
@@ -25,15 +25,15 @@ const validateEstablishmentCsv = async (
     try {
       const thisApiEstablishment = new Establishment();
       thisApiEstablishment.initialise(
-        thisEstablishmentAsAPI.Address1,
-        thisEstablishmentAsAPI.Address2,
-        thisEstablishmentAsAPI.Address3,
-        thisEstablishmentAsAPI.Town,
+        thisEstablishmentAsAPI.address1,
+        thisEstablishmentAsAPI.address2,
+        thisEstablishmentAsAPI.address3,
+        thisEstablishmentAsAPI.town,
         null,
-        thisEstablishmentAsAPI.LocationId,
-        thisEstablishmentAsAPI.ProvId,
-        thisEstablishmentAsAPI.Postcode,
-        thisEstablishmentAsAPI.IsCQCRegulated,
+        thisEstablishmentAsAPI.locationId,
+        thisEstablishmentAsAPI.provId,
+        thisEstablishmentAsAPI.postcode,
+        thisEstablishmentAsAPI.isCQCRegulated,
       );
 
       const foundCurrentEstablishment = myCurrentEstablishments.find(

--- a/server/test/unit/models/Bulkimport/csv/establishments.spec.js
+++ b/server/test/unit/models/Bulkimport/csv/establishments.spec.js
@@ -10,15 +10,14 @@ const { apiEstablishmentBuilder } = require('../../../../integration/utils/estab
 
 const validateAPIObject = (establishmentRow) => {
   return {
-    Address1: establishmentRow.ADDRESS1,
-    Address2: establishmentRow.ADDRESS2,
-    Address3: '',
-    Town: establishmentRow.POSTTOWN,
-    Postcode: establishmentRow.POSTCODE,
-    LocationId: establishmentRow.LOCATIONID,
+    address1: establishmentRow.ADDRESS1,
+    address2: establishmentRow.ADDRESS2,
+    address3: '',
+    town: establishmentRow.POSTTOWN,
+    postcode: establishmentRow.POSTCODE,
     locationId: establishmentRow.LOCATIONID,
-    ProvId: establishmentRow.PROVNUM,
-    IsCQCRegulated: true,
+    provId: establishmentRow.PROVNUM,
+    isCQCRegulated: true,
     reasonsForLeaving: '',
     status: 'NEW',
     name: establishmentRow.ESTNAME,

--- a/server/test/unit/models/Bulkimport/csv/establishments.spec.js
+++ b/server/test/unit/models/Bulkimport/csv/establishments.spec.js
@@ -243,6 +243,73 @@ describe('Bulk Upload - Establishment CSV', () => {
       expect(apiObject).to.deep.equal(expectedResult);
     });
 
+    describe('CQC Regulated', () => {
+      it('should return isCQCRegulated as false when set to 0 in CSV', async () => {
+        const establishmentRow = buildEstablishmentCSV();
+        establishmentRow.REGTYPE = '0';
+
+        const establishment = await generateEstablishmentFromCsv(establishmentRow);
+
+        const apiObject = establishment.toAPI();
+
+        expect(apiObject.isCQCRegulated).to.equal(false);
+      });
+
+      it('should set isCQCRegulated as false when column empty in CSV', async () => {
+        const establishmentRow = buildEstablishmentCSV();
+        establishmentRow.REGTYPE = '';
+
+        const establishment = await generateEstablishmentFromCsv(establishmentRow);
+
+        const apiObject = establishment.toAPI();
+
+        expect(apiObject.isCQCRegulated).to.equal(false);
+      });
+
+      it('should set isCQCRegulated as true when set to 2 in CSV', async () => {
+        const establishmentRow = buildEstablishmentCSV();
+        establishmentRow.REGTYPE = '2';
+
+        const establishment = await generateEstablishmentFromCsv(establishmentRow);
+
+        const apiObject = establishment.toAPI();
+
+        expect(apiObject.isCQCRegulated).to.equal(true);
+      });
+    });
+
+    describe('Address fields', () => {
+      it('should return address fields in CSV', async () => {
+        const establishmentRow = buildEstablishmentCSV();
+        establishmentRow.ADDRESS1 = 'First Address';
+        establishmentRow.ADDRESS2 = 'Second Address';
+        establishmentRow.ADDRESS3 = 'Third Address';
+
+        const establishment = await generateEstablishmentFromCsv(establishmentRow);
+
+        const apiObject = establishment.toAPI();
+
+        expect(apiObject.address1).to.deep.equal('First Address');
+        expect(apiObject.address2).to.deep.equal('Second Address');
+        expect(apiObject.address3).to.deep.equal('Third Address');
+      });
+
+      it('should return town and postcode fields from CSV', async () => {
+        const establishmentRow = buildEstablishmentCSV();
+
+        establishmentRow.POSTTOWN = 'Wonderland';
+        establishmentRow.POSTCODE = 'CT11AB';
+        const establishment = await generateEstablishmentFromCsv(establishmentRow);
+
+        console.log(establishment);
+        const apiObject = establishment.toAPI();
+        console.log(apiObject);
+
+        expect(apiObject.postcode).to.deep.equal('CT11AB');
+        expect(apiObject.town).to.deep.equal('Wonderland');
+      });
+    });
+
     describe('shareWith', () => {
       it('should return cqc and localAuthorities as true when set as 1 in CSV', async () => {
         const establishmentRow = buildEstablishmentCSV();

--- a/server/test/unit/routes/establishments/bulkUpload.spec.js
+++ b/server/test/unit/routes/establishments/bulkUpload.spec.js
@@ -594,14 +594,14 @@ describe('/server/routes/establishment/bulkUpload.js', () => {
   describe('validateEstablishmentCsv()', () => {
     it('should validate each line of the establishments CSV', async () => {
       const workplace = {
-        Address1: 'First Line',
-        Address2: 'Second Line',
-        Address3: '',
-        Town: 'My Town',
-        Postcode: 'LN11 9JG',
-        LocationId: '1-12345678',
-        ProvId: '1-12345678',
-        IsCQCRegulated: true,
+        address1: 'First Line',
+        address2: 'Second Line',
+        address3: '',
+        town: 'My Town',
+        postcode: 'LN11 9JG',
+        locationId: '1-12345678',
+        provId: '1-12345678',
+        isCQCRegulated: true,
         reasonsForLeaving: '',
         status: null,
         name: 'WOZiTech, with even more care',
@@ -623,16 +623,16 @@ describe('/server/routes/establishment/bulkUpload.js', () => {
       sinon.stub(EstablishmentCsvValidator.Establishment.prototype, 'transform').resolves({});
       sinon
         .stub(Establishment.prototype, 'initialise')
-        .callsFake((Address1, Address2, Address3, Town, test, LocationId, ProvId, Postcode, IsCQCRegulated) => {
-          expect(Address1).to.deep.equal(workplace.Address1);
-          expect(Address2).to.deep.equal(workplace.Address2);
-          expect(Address3).to.deep.equal(workplace.Address3);
-          expect(Town).to.deep.equal(workplace.Town);
+        .callsFake((address1, address2, address3, town, test, locationId, provId, postcode, isCQCRegulated) => {
+          expect(address1).to.deep.equal(workplace.address1);
+          expect(address2).to.deep.equal(workplace.address2);
+          expect(address3).to.deep.equal(workplace.address3);
+          expect(town).to.deep.equal(workplace.town);
           expect(test).to.deep.equal(null);
-          expect(LocationId).to.deep.equal(workplace.LocationId);
-          expect(ProvId).to.deep.equal(workplace.ProvId);
-          expect(Postcode).to.deep.equal(workplace.Postcode);
-          expect(IsCQCRegulated).to.deep.equal(workplace.IsCQCRegulated);
+          expect(locationId).to.deep.equal(workplace.locationId);
+          expect(provId).to.deep.equal(workplace.provId);
+          expect(postcode).to.deep.equal(workplace.postcode);
+          expect(isCQCRegulated).to.deep.equal(workplace.isCQCRegulated);
         });
       sinon.stub(EstablishmentCsvValidator.Establishment.prototype, 'toAPI').callsFake(() => {
         return workplace;


### PR DESCRIPTION
#### Issue
- When doing a Bulk Upload, the address fields other than address1 were not getting updated. This was due to the establishment toAPI function creating fields which were uppercase, meaning the fields were not getting updated in the properties, as the properties restore from the document based on lowercase fields.

#### Work done
- Updated toAPI in bulk import establishments to have lower case fixed properties to match lower case fields in restoreFromJson functions in properties

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
