### PR TITLE
Feat: Change expires soon alerts

### DIFF
--- a/migrations/20211208143300-expiresSoonAlertDates.js
+++ b/migrations/20211208143300-expiresSoonAlertDates.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const table = {
+  tableName: 'Establishment',
+  schema: 'cqc',
+};
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((transaction) => {
+      return queryInterface.addColumn(
+        table,
+        'ExpiresSoonAlertDate',
+        {
+          type: Sequelize.DataTypes.ENUM,
+          allowNull: false,
+          defaultValue: '90',
+          values: ['90', '60', '30'],
+        },
+        { transaction },
+      );
+    });
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.sequelize.transaction((transaction) => {
+      return Promise.all([
+        queryInterface.removeColumn(table, 'ExpiresSoonAlertDate', { transaction }),
+        queryInterface.sequelize.query(`DROP TYPE IF EXISTS cqc."enum_Establishment_ExpiresSoonAlertDate";`, {
+          transaction,
+        }),
+      ]);
+    });
+  },
+};

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -1812,5 +1812,15 @@ module.exports = function (sequelize, DataTypes) {
       ],
     });
   };
+
+  Establishment.getExpiresSoonAlertDate = async function (establishmentId) {
+    return this.findOne({
+      attributes: ['ExpiresSoonAlertDate'],
+      where: {
+        id: establishmentId,
+      },
+    });
+  };
+
   return Establishment;
 };

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -697,6 +697,13 @@ module.exports = function (sequelize, DataTypes) {
         defaultValue: false,
         field: 'ShowSharingPermissionsBanner',
       },
+      expiresSoonAlertDate: {
+        type: DataTypes.ENUM,
+        allowNull: false,
+        values: ['90', '60', '30'],
+        default: '90',
+        field: 'ExpiresSoonAlertDate',
+      },
     },
     {
       defaultScope: {

--- a/server/routes/establishments/expiresSoonAlertDates.js
+++ b/server/routes/establishments/expiresSoonAlertDates.js
@@ -6,7 +6,7 @@ const { hasPermission } = require('../../utils/security/hasPermission');
 
 const getExpiresSoonAlertDate = async (req, res) => {
   try {
-    const expiresSoonAlertDate = await models.establishment.getExpiresSoonAlertDate(req.establishment.id);
+    const expiresSoonAlertDate = await models.establishment.getExpiresSoonAlertDate(req.establishmentId);
     res.status(200);
     return res.json({
       expiresSoonAlertDate: expiresSoonAlertDate.get('ExpiresSoonAlertDate'),

--- a/server/routes/establishments/expiresSoonAlertDates.js
+++ b/server/routes/establishments/expiresSoonAlertDates.js
@@ -20,8 +20,8 @@ const getExpiresSoonAlertDate = async (req, res) => {
 const setExpiresSoonAlertDate = async (req, res) => {
   try {
     const expiresSoonAlertDate = req.body.expiresSoonAlertDate;
-    await models.establishment.updateEstablishment(req.establishment.id, {
-      expiresSoonAlertDate: expiresSoonAlertDate,
+    await models.establishment.updateEstablishment(req.establishmentId, {
+      expiresSoonAlertDate,
     });
     return res.status(200).send();
   } catch (error) {

--- a/server/routes/establishments/expiresSoonAlertDates.js
+++ b/server/routes/establishments/expiresSoonAlertDates.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+// const { hasPermission } = require('../../utils/security/hasPermission');
+
+const getExpiresSoonAlertDate = async (req, res) => {
+  try {
+    // const expiresSoonAlertDate = models.establishment.getExpiresSoonAlertDate;
+    const expiresSoonAlertDate = '90';
+    res.status(200);
+    return res.json({
+      expiresSoonAlertDate,
+    });
+  } catch (error) {
+    console.err(error);
+    return res.status(500).send();
+  }
+};
+
+router.route('/').get(getExpiresSoonAlertDate);
+
+module.exports = router;
+module.exports.getExpiresSoonAlertDate = getExpiresSoonAlertDate;

--- a/server/routes/establishments/expiresSoonAlertDates.js
+++ b/server/routes/establishments/expiresSoonAlertDates.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router({ mergeParams: true });
 const models = require('../../models');
-// const { hasPermission } = require('../../utils/security/hasPermission');
+const { celebrate, Joi, errors } = require('celebrate');
+const { hasPermission } = require('../../utils/security/hasPermission');
 
 const getExpiresSoonAlertDate = async (req, res) => {
   try {
@@ -30,7 +31,17 @@ const setExpiresSoonAlertDate = async (req, res) => {
 };
 
 router.route('/').get(getExpiresSoonAlertDate);
-router.route('/').post(setExpiresSoonAlertDate);
+router.route('/').post(
+  celebrate({
+    body: Joi.object().keys({
+      expiresSoonAlertDate: Joi.string().valid('30', '60', '90'),
+    }),
+  }),
+  hasPermission('canEditEstablishment'),
+  setExpiresSoonAlertDate,
+);
+
+router.use('/', errors());
 
 module.exports = router;
 module.exports.getExpiresSoonAlertDate = getExpiresSoonAlertDate;

--- a/server/routes/establishments/expiresSoonAlertDates.js
+++ b/server/routes/establishments/expiresSoonAlertDates.js
@@ -1,17 +1,17 @@
 const express = require('express');
 const router = express.Router({ mergeParams: true });
+const models = require('../../models');
 // const { hasPermission } = require('../../utils/security/hasPermission');
 
 const getExpiresSoonAlertDate = async (req, res) => {
   try {
-    // const expiresSoonAlertDate = models.establishment.getExpiresSoonAlertDate;
-    const expiresSoonAlertDate = '90';
+    const expiresSoonAlertDate = await models.establishment.getExpiresSoonAlertDate(req.establishment.id);
     res.status(200);
     return res.json({
-      expiresSoonAlertDate,
+      expiresSoonAlertDate: expiresSoonAlertDate.get('ExpiresSoonAlertDate'),
     });
   } catch (error) {
-    console.err(error);
+    console.error(error);
     return res.status(500).send();
   }
 };

--- a/server/routes/establishments/expiresSoonAlertDates.js
+++ b/server/routes/establishments/expiresSoonAlertDates.js
@@ -16,7 +16,22 @@ const getExpiresSoonAlertDate = async (req, res) => {
   }
 };
 
+const setExpiresSoonAlertDate = async (req, res) => {
+  try {
+    const expiresSoonAlertDate = req.body.expiresSoonAlertDate;
+    await models.establishment.updateEstablishment(req.establishment.id, {
+      expiresSoonAlertDate: expiresSoonAlertDate,
+    });
+    return res.status(200).send();
+  } catch (error) {
+    console.error(error);
+    return res.status(500).send();
+  }
+};
+
 router.route('/').get(getExpiresSoonAlertDate);
+router.route('/').post(setExpiresSoonAlertDate);
 
 module.exports = router;
 module.exports.getExpiresSoonAlertDate = getExpiresSoonAlertDate;
+module.exports.setExpiresSoonAlertDate = setExpiresSoonAlertDate;

--- a/server/routes/establishments/index.js
+++ b/server/routes/establishments/index.js
@@ -32,6 +32,7 @@ const MandatoryTraining = require('./mandatoryTraining');
 const Workers = require('./workers');
 const Benchmarks = require('./benchmarks');
 const SharingPermissionsBanner = require('./sharingPermissionsBanner');
+const ExpiresSoonAlertDates = require('./expiresSoonAlertDates');
 
 const OTHER_MAX_LENGTH = 120;
 
@@ -83,6 +84,7 @@ router.use('/:id/mandatoryTraining', MandatoryTraining);
 router.use('/:id/workers', Workers);
 router.use('/:id/benchmarks', Benchmarks);
 router.use('/:id/updateSharingPermissionsBanner', SharingPermissionsBanner);
+router.use('/:id/expiresSoonAlertDates', ExpiresSoonAlertDates);
 
 const addEstablishment = async (req, res) => {
   if (!req.body.isRegulated) {

--- a/server/routes/longTermAbsence.js
+++ b/server/routes/longTermAbsence.js
@@ -5,15 +5,15 @@ const models = require('../models');
 const longTermAbsence = (req, res) => {
   try {
     const reasons = models.worker.rawAttributes.LongTermAbsence.values;
-    res.status(200)
+    res.status(200);
     return res.json({
       reasons,
     });
   } catch (error) {
-    console.err(error)
+    console.error(error);
     return res.status(500).send();
   }
-}
+};
 
 router.route('/').get(longTermAbsence);
 module.exports = router;

--- a/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
+++ b/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
@@ -6,7 +6,13 @@ const models = require('../../../../models');
 const expiresSoonAlertDates = require('../../../../routes/establishments/expiresSoonAlertDates');
 
 describe('server/routes/establishments/expiresSoonAlertDates', () => {
-  beforeEach(() => {});
+  beforeEach(() => {
+    sinon.stub(models.establishment, 'getExpiresSoonAlertDate').returns({
+      get: () => {
+        return '90';
+      },
+    });
+  });
 
   afterEach(() => {
     sinon.restore();
@@ -14,12 +20,6 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
 
   describe('getExpiresSoonAlertDates', () => {
     it('should return 200 with the current expires soon alert date', async () => {
-      sinon.stub(models.establishment, 'getExpiresSoonAlertDate').returns({
-        get: () => {
-          return '90';
-        },
-      });
-
       const establishmentId = 'a131313dasd123325453bac';
 
       const request = {

--- a/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
+++ b/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
@@ -23,9 +23,7 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
       const request = {
         method: 'GET',
         url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
-        establishment: {
-          id: 1,
-        },
+        establishmentId,
       };
 
       const req = httpMocks.createRequest(request);
@@ -43,9 +41,7 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
       const request = {
         method: 'GET',
         url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
-        establishment: {
-          id: 1,
-        },
+        establishmentId,
       };
 
       const req = httpMocks.createRequest(request);
@@ -64,9 +60,7 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
       const request = {
         method: 'POST',
         url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
-        establishment: {
-          id: 1,
-        },
+        establishmentId,
         body: {
           expiresSoonAlertDate: '90',
         },
@@ -86,9 +80,7 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
       const request = {
         method: 'GET',
         url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
-        establishment: {
-          id: 1,
-        },
+        establishmentId,
         body: {
           expiresSoonAlertDate: '90',
         },

--- a/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
+++ b/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
@@ -67,6 +67,9 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
         establishment: {
           id: 1,
         },
+        body: {
+          expiresSoonAlertDate: '90',
+        },
       };
 
       const req = httpMocks.createRequest(request);
@@ -85,6 +88,9 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
         url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
         establishment: {
           id: 1,
+        },
+        body: {
+          expiresSoonAlertDate: '90',
         },
       };
 

--- a/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
+++ b/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
@@ -1,0 +1,32 @@
+const expect = require('chai').expect;
+const httpMocks = require('node-mocks-http');
+const sinon = require('sinon');
+
+const expiresSoonAlertDates = require('../../../../routes/establishments/expiresSoonAlertDates');
+
+describe.only('server/routes/establishments/expiresSoonAlertDates', () => {
+  afterEach(async () => {
+    sinon.restore();
+  });
+
+  describe('getExpiresSoonAlertDates', () => {
+    it('should return 200 with the current expires soon alert date', async () => {
+      const establishmentId = 'a131313dasd123325453bac';
+
+      const request = {
+        method: 'GET',
+        url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
+      };
+
+      const req = httpMocks.createRequest(request);
+      const res = httpMocks.createResponse();
+
+      await expiresSoonAlertDates.getExpiresSoonAlertDate(req, res);
+      const response = res._getJSONData();
+
+      expect(res.statusCode).to.deep.equal(200);
+      expect(response.expiresSoonAlertDate).to.deep.equal('90');
+    });
+
+  });
+});

--- a/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
+++ b/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
@@ -6,7 +6,7 @@ const models = require('../../../../models');
 const expiresSoonAlertDates = require('../../../../routes/establishments/expiresSoonAlertDates');
 
 describe('server/routes/establishments/expiresSoonAlertDates', () => {
-  beforeEach(() => {});
+  const establishmentId = 'a131313dasd123325453bac';
 
   afterEach(() => {
     sinon.restore();
@@ -19,8 +19,6 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
           return '90';
         },
       });
-
-      const establishmentId = 'a131313dasd123325453bac';
 
       const request = {
         method: 'GET',
@@ -42,8 +40,6 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
 
     it('should return 500 when there is an error', async () => {
       sinon.stub(models.establishment, 'getExpiresSoonAlertDate').throws();
-
-      const establishmentId = 'a131313dasd123325453bac';
       const request = {
         method: 'GET',
         url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
@@ -56,6 +52,46 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
       const res = httpMocks.createResponse();
 
       await expiresSoonAlertDates.getExpiresSoonAlertDate(req, res);
+
+      expect(res.statusCode).to.deep.equal(500);
+    });
+  });
+
+  describe('setExpiresSoonAlertDates', () => {
+    it('should return 200 when setting the expires soon alert dates', async () => {
+      sinon.stub(models.establishment, 'updateEstablishment').callsFake();
+
+      const request = {
+        method: 'POST',
+        url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
+        establishment: {
+          id: 1,
+        },
+      };
+
+      const req = httpMocks.createRequest(request);
+      const res = httpMocks.createResponse();
+
+      await expiresSoonAlertDates.setExpiresSoonAlertDate(req, res);
+
+      expect(res.statusCode).to.deep.equal(200);
+    });
+
+    it('should return 500 when there is an error', async () => {
+      sinon.stub(models.establishment, 'updateEstablishment').throws();
+
+      const request = {
+        method: 'GET',
+        url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
+        establishment: {
+          id: 1,
+        },
+      };
+
+      const req = httpMocks.createRequest(request);
+      const res = httpMocks.createResponse();
+
+      await expiresSoonAlertDates.setExpiresSoonAlertDate(req, res);
 
       expect(res.statusCode).to.deep.equal(500);
     });

--- a/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
+++ b/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
@@ -6,13 +6,7 @@ const models = require('../../../../models');
 const expiresSoonAlertDates = require('../../../../routes/establishments/expiresSoonAlertDates');
 
 describe('server/routes/establishments/expiresSoonAlertDates', () => {
-  beforeEach(() => {
-    sinon.stub(models.establishment, 'getExpiresSoonAlertDate').returns({
-      get: () => {
-        return '90';
-      },
-    });
-  });
+  beforeEach(() => {});
 
   afterEach(() => {
     sinon.restore();
@@ -20,6 +14,12 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
 
   describe('getExpiresSoonAlertDates', () => {
     it('should return 200 with the current expires soon alert date', async () => {
+      sinon.stub(models.establishment, 'getExpiresSoonAlertDate').returns({
+        get: () => {
+          return '90';
+        },
+      });
+
       const establishmentId = 'a131313dasd123325453bac';
 
       const request = {
@@ -38,6 +38,26 @@ describe('server/routes/establishments/expiresSoonAlertDates', () => {
 
       expect(res.statusCode).to.deep.equal(200);
       expect(response.expiresSoonAlertDate).to.deep.equal('90');
+    });
+
+    it('should return 500 when there is an error', async () => {
+      sinon.stub(models.establishment, 'getExpiresSoonAlertDate').throws();
+
+      const establishmentId = 'a131313dasd123325453bac';
+      const request = {
+        method: 'GET',
+        url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
+        establishment: {
+          id: 1,
+        },
+      };
+
+      const req = httpMocks.createRequest(request);
+      const res = httpMocks.createResponse();
+
+      await expiresSoonAlertDates.getExpiresSoonAlertDate(req, res);
+
+      expect(res.statusCode).to.deep.equal(500);
     });
   });
 });

--- a/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
+++ b/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
@@ -1,11 +1,20 @@
 const expect = require('chai').expect;
 const httpMocks = require('node-mocks-http');
 const sinon = require('sinon');
+const models = require('../../../../models');
 
 const expiresSoonAlertDates = require('../../../../routes/establishments/expiresSoonAlertDates');
 
 describe.only('server/routes/establishments/expiresSoonAlertDates', () => {
-  afterEach(async () => {
+  beforeEach(() => {
+    sinon.stub(models.establishment, 'getExpiresSoonAlertDate').returns({
+      get: () => {
+        return '90';
+      },
+    });
+  });
+
+  afterEach(() => {
     sinon.restore();
   });
 
@@ -16,6 +25,9 @@ describe.only('server/routes/establishments/expiresSoonAlertDates', () => {
       const request = {
         method: 'GET',
         url: `/api/establishment/${establishmentId}/updateSharingPermissionsBanner`,
+        establishment: {
+          id: 1,
+        },
       };
 
       const req = httpMocks.createRequest(request);
@@ -27,6 +39,5 @@ describe.only('server/routes/establishments/expiresSoonAlertDates', () => {
       expect(res.statusCode).to.deep.equal(200);
       expect(response.expiresSoonAlertDate).to.deep.equal('90');
     });
-
   });
 });

--- a/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
+++ b/server/test/unit/routes/establishments/expiresSoonAlertDates.spec.js
@@ -5,14 +5,8 @@ const models = require('../../../../models');
 
 const expiresSoonAlertDates = require('../../../../routes/establishments/expiresSoonAlertDates');
 
-describe.only('server/routes/establishments/expiresSoonAlertDates', () => {
-  beforeEach(() => {
-    sinon.stub(models.establishment, 'getExpiresSoonAlertDate').returns({
-      get: () => {
-        return '90';
-      },
-    });
-  });
+describe('server/routes/establishments/expiresSoonAlertDates', () => {
+  beforeEach(() => {});
 
   afterEach(() => {
     sinon.restore();
@@ -20,6 +14,12 @@ describe.only('server/routes/establishments/expiresSoonAlertDates', () => {
 
   describe('getExpiresSoonAlertDates', () => {
     it('should return 200 with the current expires soon alert date', async () => {
+      sinon.stub(models.establishment, 'getExpiresSoonAlertDate').returns({
+        get: () => {
+          return '90';
+        },
+      });
+
       const establishmentId = 'a131313dasd123325453bac';
 
       const request = {

--- a/src/app/core/resolvers/expiresSoonAlertDates.resolver.ts
+++ b/src/app/core/resolvers/expiresSoonAlertDates.resolver.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable()
+export class ExpiresSoonAlertDatesResolver implements Resolve<any> {
+  constructor(private router: Router, private establishmentService: EstablishmentService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.establishmentService.getExpiresSoonAlertDates(route.paramMap.get('establishmentuid')).pipe(
+      catchError(() => {
+        this.router.navigate(['/problem-with-the-service']);
+        return of(null);
+      }),
+    );
+  }
+}

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -14,7 +14,7 @@ import {
 } from '@core/model/establishment.model';
 import { AllServicesResponse, ServiceGroup } from '@core/model/services.model';
 import { URLStructure } from '@core/model/url.model';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 
 import { ShareWithRequest } from '../model/data-sharing.model';
@@ -320,5 +320,15 @@ export class EstablishmentService {
     params = params.set('mainService', `${requestParams.mainService}`);
 
     return this.http.get<any>(`/api/cqcStatusCheck/${locationID}`, { params });
+  }
+
+  public getExpiresSoonAlertDates(establishmentId: string): Observable<string> {
+    return of('90');
+    // return this.http.get<string>(`/api/workplace/${establishmentId}/training`);
+  }
+
+  public setExpiresSoonAlertDates(establishmentId: string, data): Observable<string> {
+    return of('');
+    // return this.http.post<string>(`/api/workplace/${establishmentId}/training`);
   }
 }

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -14,7 +14,7 @@ import {
 } from '@core/model/establishment.model';
 import { AllServicesResponse, ServiceGroup } from '@core/model/services.model';
 import { URLStructure } from '@core/model/url.model';
-import { BehaviorSubject, Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 
 import { ShareWithRequest } from '../model/data-sharing.model';
@@ -326,8 +326,7 @@ export class EstablishmentService {
     return this.http.get<any>(`/api/establishment/${establishmentId}/expiresSoonAlertDates`);
   }
 
-  public setExpiresSoonAlertDates(establishmentId: string, data): Observable<string> {
-    return of('');
-    // return this.http.post<string>(`/api/workplace/${establishmentId}/training`);
+  public setExpiresSoonAlertDates(establishmentId: string, expiresSoonAlertDate: string): Observable<any> {
+    return this.http.post<any>(`/api/establishment/${establishmentId}/expiresSoonAlertDates`, { expiresSoonAlertDate });
   }
 }

--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -322,9 +322,8 @@ export class EstablishmentService {
     return this.http.get<any>(`/api/cqcStatusCheck/${locationID}`, { params });
   }
 
-  public getExpiresSoonAlertDates(establishmentId: string): Observable<string> {
-    return of('90');
-    // return this.http.get<string>(`/api/workplace/${establishmentId}/training`);
+  public getExpiresSoonAlertDates(establishmentId: string): Observable<any> {
+    return this.http.get<any>(`/api/establishment/${establishmentId}/expiresSoonAlertDates`);
   }
 
   public setExpiresSoonAlertDates(establishmentId: string, data): Observable<string> {

--- a/src/app/core/test-utils/MockEstablishmentService.ts
+++ b/src/app/core/test-utils/MockEstablishmentService.ts
@@ -115,4 +115,12 @@ export class MockEstablishmentService extends EstablishmentService {
       vacancies: undefined,
     };
   }
+
+  public getExpiresSoonAlertDates(): Observable<string> {
+    return of('90');
+  }
+
+  public setExpiresSoonAlertDates(establishmentUid, data): Observable<string> {
+    return of('');
+  }
 }

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.html
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.html
@@ -1,5 +1,58 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Change when you get 'expires soon' alerts</h1>
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Change when you get 'expires soon' alerts</h1>
+    <p class="govuk-inset-text">
+      Training records have a default 'expires soon' alert that displays 90 days before the training expires. You can
+      change the alert to display 60 or 30 days before expiry or leave it set to 90 days.
+    </p>
+
+    <form #formEl novalidate [formGroup]="form" id="server-error">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend">When do you want to get 'expires soon' alerts?</legend>
+          <div class="govuk-radios">
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="expiresSoonAlerts-90"
+                name="expiresSoonAlerts"
+                type="radio"
+                formControlName="expiresSoonAlerts"
+                value="90"
+              />
+              <label for="expiresSoonAlerts-90" class="govuk-label govuk-radios__label">
+                90 days before the training expires
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="expiresSoonAlerts-60"
+                name="expiresSoonAlerts"
+                type="radio"
+                formControlName="expiresSoonAlerts"
+                value="60"
+              />
+              <label for="expiresSoonAlerts-60" class="govuk-label govuk-radios__label">
+                60 days before the training expires
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="expiresSoonAlerts-30"
+                name="expiresSoonAlerts"
+                type="radio"
+                formControlName="expiresSoonAlerts"
+                value="30"
+              />
+              <label for="expiresSoonAlerts-30" class="govuk-label govuk-radios__label">
+                30 days before the training expires
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </form>
   </div>
 </div>

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.html
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.html
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Change when you get 'expires soon' alerts</h1>
+  </div>
+</div>

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.html
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.html
@@ -6,7 +6,7 @@
       change the alert to display 60 or 30 days before expiry or leave it set to 90 days.
     </p>
 
-    <form #formEl novalidate [formGroup]="form" id="server-error">
+    <form #formEl novalidate (submit)="onSubmit()" [formGroup]="form" id="server-error">
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend">When do you want to get 'expires soon' alerts?</legend>
@@ -52,6 +52,16 @@
             </div>
           </div>
         </fieldset>
+      </div>
+      <div class="govuk-button-group">
+        <button class="govuk-button govuk-!-margin-right-9 govuk-!-margin-top-6" type="submit">Save and return</button>
+        <a
+          role="button"
+          class="govuk-button govuk-button--link govuk-!-margin-left-9"
+          [routerLink]="['/dashboard']"
+          [fragment]="'training-and-qualifications'"
+          >Cancel</a
+        >
       </div>
     </form>
   </div>

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.html
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.html
@@ -58,8 +58,8 @@
         <a
           role="button"
           class="govuk-button govuk-button--link govuk-!-margin-left-9"
-          [routerLink]="['/dashboard']"
-          [fragment]="'training-and-qualifications'"
+          [routerLink]="returnUrl.url"
+          [fragment]="returnUrl.fragment"
           >Cancel</a
         >
       </div>

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -13,7 +13,7 @@ import { fireEvent, render } from '@testing-library/angular';
 import { WorkplaceModule } from '../workplace.module';
 import { ChangeExpiresSoonAlertsComponent } from './change-expires-soon-alerts.component';
 
-fdescribe('ChangeExpiresSoonAlertsComponent', () => {
+describe('ChangeExpiresSoonAlertsComponent', () => {
   async function setup() {
     const { fixture, getByText, getAllByText } = await render(ChangeExpiresSoonAlertsComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkplaceModule],

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -3,6 +3,7 @@ import { getTestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AlertService } from '@core/services/alert.service';
+import { BackService } from '@core/services/back.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WindowRef } from '@core/services/window.ref';
 import { MockActivatedRoute } from '@core/test-utils/MockActivatedRoute';
@@ -59,6 +60,10 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
     const alertSpy = spyOn(alert, 'addAlert');
     alertSpy.and.callThrough();
 
+    const backService = injector.inject(BackService) as BackService;
+    const backServiceSpy = spyOn(backService, 'setBackLink');
+    backServiceSpy.and.callThrough();
+
     return {
       component,
       fixture,
@@ -67,6 +72,7 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
       routerSpy,
       establishmentSpy,
       alertSpy,
+      backServiceSpy,
     };
   }
 
@@ -119,7 +125,7 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
       fireEvent.click(saveAndReturnButton);
 
       expect(component.form.valid).toBeTruthy();
-      expect(routerSpy).toHaveBeenCalledWith(['dashboard'], { fragment: 'training-and-qualifications' });
+      expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'training-and-qualifications' });
     });
 
     it(`should navigate to the sub's training and quals tab on submit if user is not primary user`, async () => {
@@ -129,7 +135,7 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
       fireEvent.click(saveAndReturnButton);
 
       expect(component.form.valid).toBeTruthy();
-      expect(routerSpy).toHaveBeenCalledWith(['workplace', component.workplaceUid], {
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', component.workplaceUid], {
         fragment: 'training-and-qualifications',
       });
     });
@@ -147,6 +153,27 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
       expect(alertSpy).toHaveBeenCalledWith({
         type: 'success',
         message: `'Expires soon' alerts set to 60 days`,
+      });
+    });
+  });
+
+  describe('Back link', () => {
+    it('should set the back link to the training and quals tab if user is primary user', async () => {
+      const { component, backServiceSpy } = await setup();
+
+      component.setBackLink();
+
+      expect(backServiceSpy).toHaveBeenCalledWith({ url: ['/dashboard'], fragment: 'training-and-qualifications' });
+    });
+
+    it(`should set the back link to the sub's training and quals tab if user is not primary user`, async () => {
+      const { component, backServiceSpy } = await setup(false);
+
+      component.setBackLink();
+
+      expect(backServiceSpy).toHaveBeenCalledWith({
+        url: ['/workplace', component.workplaceUid],
+        fragment: 'training-and-qualifications',
       });
     });
   });

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -24,6 +24,9 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
           useValue: new MockActivatedRoute({
             snapshot: {
               data: {
+                expiresSoonAlertDate: {
+                  expiresSoonAlertDate: '90',
+                },
                 establishment: {
                   uid: '1',
                 },

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -28,7 +28,7 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
                   expiresSoonAlertDate: '90',
                 },
                 establishment: {
-                  uid: '1',
+                  uid: '1446-uid-54638',
                 },
               },
             },
@@ -106,7 +106,7 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
       fireEvent.click(saveAndReturnButton);
 
       expect(component.form.valid).toBeTruthy();
-      expect(establishmentSpy).toHaveBeenCalledWith('1', { expiresSoonAlertDates: '60' });
+      expect(establishmentSpy).toHaveBeenCalledWith('1446-uid-54638', '60');
     });
 
     it('should navigate to the training and quals tab on submit', async () => {

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -14,7 +14,7 @@ import { WorkplaceModule } from '../workplace.module';
 import { ChangeExpiresSoonAlertsComponent } from './change-expires-soon-alerts.component';
 
 describe('ChangeExpiresSoonAlertsComponent', () => {
-  async function setup() {
+  async function setup(isPrimary = true) {
     const { fixture, getByText, getAllByText } = await render(ChangeExpiresSoonAlertsComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkplaceModule],
       providers: [
@@ -29,6 +29,9 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
                 },
                 establishment: {
                   uid: '1446-uid-54638',
+                },
+                primaryWorkplace: {
+                  uid: isPrimary ? '1446-uid-54638' : '4678-otheruid-5436',
                 },
               },
             },
@@ -109,7 +112,7 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
       expect(establishmentSpy).toHaveBeenCalledWith('1446-uid-54638', '60');
     });
 
-    it('should navigate to the training and quals tab on submit', async () => {
+    it('should navigate to the training and quals tab on submit if user is primary user', async () => {
       const { component, routerSpy, getByText } = await setup();
 
       const saveAndReturnButton = getByText('Save and return');
@@ -117,6 +120,18 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
 
       expect(component.form.valid).toBeTruthy();
       expect(routerSpy).toHaveBeenCalledWith(['dashboard'], { fragment: 'training-and-qualifications' });
+    });
+
+    it(`should navigate to the sub's training and quals tab on submit if user is not primary user`, async () => {
+      const { component, routerSpy, getByText } = await setup(false);
+
+      const saveAndReturnButton = getByText('Save and return');
+      fireEvent.click(saveAndReturnButton);
+
+      expect(component.form.valid).toBeTruthy();
+      expect(routerSpy).toHaveBeenCalledWith(['workplace', component.workplaceUid], {
+        fragment: 'training-and-qualifications',
+      });
     });
 
     it('should display an alert when the "Save and return" button is clicked', async () => {

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -94,12 +94,8 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
     expect(getByText('30 days before the training expires')).toBeTruthy();
   });
 
-  it('should prefill the form with the current expires soon date', async () => {
-    const { component, fixture } = await setup();
-
-    component.expiresSoonDate = '90';
-    component.ngOnInit();
-    fixture.detectChanges();
+  it('should prefill the form with the current expires soon date from the resolver', async () => {
+    const { component } = await setup();
 
     expect(component.form.value.expiresSoonAlerts).toBe('90');
   });

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -1,9 +1,9 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
 
 import { WorkplaceModule } from '../workplace.module';
 import { ChangeExpiresSoonAlertsComponent } from './change-expires-soon-alerts.component';
@@ -36,9 +36,9 @@ fdescribe('ChangeExpiresSoonAlertsComponent', () => {
     const component = fixture.componentInstance;
     const injector = getTestBed();
 
-    // const router = injector.inject(Router) as Router;
-    // const spy = spyOn(router, 'navigate');
-    // spy.and.returnValue(Promise.resolve(true));
+    const router = injector.inject(Router) as Router;
+    const routerSpy = spyOn(router, 'navigate');
+    routerSpy.and.returnValue(Promise.resolve(true));
 
     // const alert = injector.inject(AlertService) as AlertService;
     // const alertSpy = spyOn(alert, 'addAlert');
@@ -49,7 +49,7 @@ fdescribe('ChangeExpiresSoonAlertsComponent', () => {
       fixture,
       getByText,
       getAllByText,
-      // spy,
+      routerSpy,
       // alertSpy,
     };
   }
@@ -80,5 +80,15 @@ fdescribe('ChangeExpiresSoonAlertsComponent', () => {
     fixture.detectChanges();
 
     expect(component.form.value.expiresSoonAlerts).toBe('90');
+  });
+
+  it('should navigate to the training and quals tab on submit', async () => {
+    const { component, routerSpy, getByText } = await setup();
+
+    const saveAndReturnButton = getByText('Save and return');
+    fireEvent.click(saveAndReturnButton);
+
+    expect(component.form.valid).toBeTruthy();
+    expect(routerSpy).toHaveBeenCalledWith(['dashboard'], { fragment: 'training-and-qualifications' });
   });
 });

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -63,4 +63,22 @@ fdescribe('ChangeExpiresSoonAlertsComponent', () => {
     const { getByText } = await setup();
     expect(getByText(`Change when you get 'expires soon' alerts`)).toBeTruthy();
   });
+
+  it('should display the different radio options', async () => {
+    const { getByText } = await setup();
+
+    expect(getByText('90 days before the training expires')).toBeTruthy();
+    expect(getByText('60 days before the training expires')).toBeTruthy();
+    expect(getByText('30 days before the training expires')).toBeTruthy();
+  });
+
+  it('should prefill the form with the current expires soon date', async () => {
+    const { component, fixture } = await setup();
+
+    component.expiresSoonDate = '90';
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(component.form.value.expiresSoonAlerts).toBe('90');
+  });
 });

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -1,0 +1,66 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { WorkplaceModule } from '../workplace.module';
+import { ChangeExpiresSoonAlertsComponent } from './change-expires-soon-alerts.component';
+
+fdescribe('ChangeExpiresSoonAlertsComponent', () => {
+  async function setup() {
+    const { fixture, getByText, getAllByText } = await render(ChangeExpiresSoonAlertsComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkplaceModule],
+      providers: [
+        // {
+        //   provide: ActivatedRoute,
+        //   useValue: new MockActivatedRoute({
+        //     snapshot: {
+        //       params: { trainingRecordId: '1' },
+        //     },
+        //     parent: {
+        //       snapshot: {
+        //         data: {
+        //           establishment: {
+        //             uid: '1',
+        //           },
+        //         },
+        //       },
+        //     },
+        //   }),
+        // },
+      ],
+    });
+
+    const component = fixture.componentInstance;
+    const injector = getTestBed();
+
+    // const router = injector.inject(Router) as Router;
+    // const spy = spyOn(router, 'navigate');
+    // spy.and.returnValue(Promise.resolve(true));
+
+    // const alert = injector.inject(AlertService) as AlertService;
+    // const alertSpy = spyOn(alert, 'addAlert');
+    // alertSpy.and.callThrough();
+
+    return {
+      component,
+      fixture,
+      getByText,
+      getAllByText,
+      // spy,
+      // alertSpy,
+    };
+  }
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the title', async () => {
+    const { getByText } = await setup();
+    expect(getByText(`Change when you get 'expires soon' alerts`)).toBeTruthy();
+  });
+});

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-change-expires-soon-alerts',
+  templateUrl: './change-expires-soon-alerts.component.html',
+})
+export class ChangeExpiresSoonAlertsComponent implements OnInit {
+  constructor() {}
+
+  public ngOnInit(): void {}
+}

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
@@ -16,8 +16,8 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   public form: FormGroup;
   public expiresSoonDate: string;
   public workplaceUid: string;
+  public returnUrl: URLStructure;
   private isPrimary: boolean;
-  private returnUrl: URLStructure;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -45,12 +45,12 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   }
 
   private setReturnUrl(): void {
-    const url = this.isPrimary ? ['dashboard'] : ['workplace', this.workplaceUid];
+    const url = this.isPrimary ? ['/dashboard'] : ['/workplace', this.workplaceUid];
     this.returnUrl = { url, fragment: 'training-and-qualifications' };
   }
 
   public setBackLink(): void {
-    this.backService.setBackLink({ url: ['dashboard'], fragment: 'training-and-qualifications' });
+    this.backService.setBackLink(this.returnUrl);
   }
 
   public onSubmit(): void {

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
@@ -1,5 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+import { BackService } from '@core/services/back.service';
 
 @Component({
   selector: 'app-change-expires-soon-alerts',
@@ -10,16 +12,25 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   public form: FormGroup;
   public expiresSoonDate: string;
 
-  constructor(private formBuilder: FormBuilder) {}
+  constructor(private formBuilder: FormBuilder, private backService: BackService, private router: Router) {}
 
   public ngOnInit(): void {
     this.expiresSoonDate = '90';
     this.setupForm();
+    this.setBackLink();
   }
 
   public setupForm(): void {
     this.form = this.formBuilder.group({
       expiresSoonAlerts: this.formBuilder.control(this.expiresSoonDate),
     });
+  }
+
+  public setBackLink(): void {
+    this.backService.setBackLink({ url: ['dashboard'], fragment: 'training-and-qualifications' });
+  }
+
+  public onSubmit(): void {
+    this.router.navigate(['dashboard'], { fragment: 'training-and-qualifications' });
   }
 }

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
@@ -1,11 +1,25 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'app-change-expires-soon-alerts',
   templateUrl: './change-expires-soon-alerts.component.html',
 })
 export class ChangeExpiresSoonAlertsComponent implements OnInit {
-  constructor() {}
+  @ViewChild('formEl') formEl: ElementRef;
+  public form: FormGroup;
+  public expiresSoonDate: string;
 
-  public ngOnInit(): void {}
+  constructor(private formBuilder: FormBuilder) {}
+
+  public ngOnInit(): void {
+    this.expiresSoonDate = '90';
+    this.setupForm();
+  }
+
+  public setupForm(): void {
+    this.form = this.formBuilder.group({
+      expiresSoonAlerts: this.formBuilder.control(this.expiresSoonDate),
+    });
+  }
 }

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
@@ -46,12 +46,10 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   public onSubmit(): void {
     const formValue = this.form.value.expiresSoonAlerts;
     this.subscriptions.add(
-      this.establishmentService
-        .setExpiresSoonAlertDates(this.workplaceUid, { expiresSoonAlertDates: formValue })
-        .subscribe(
-          () => this.onSuccess(formValue),
-          (error) => this.onError(error),
-        ),
+      this.establishmentService.setExpiresSoonAlertDates(this.workplaceUid, formValue).subscribe(
+        () => this.onSuccess(formValue),
+        (error) => this.onError(error),
+      ),
     );
   }
 

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { URLStructure } from '@core/model/url.model';
 import { AlertService } from '@core/services/alert.service';
 import { BackService } from '@core/services/back.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -14,7 +15,9 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   @ViewChild('formEl') formEl: ElementRef;
   public form: FormGroup;
   public expiresSoonDate: string;
-  private workplaceUid: string;
+  public workplaceUid: string;
+  private isPrimary: boolean;
+  private returnUrl: URLStructure;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -29,7 +32,9 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   public ngOnInit(): void {
     this.workplaceUid = this.route.snapshot.data.establishment.uid;
     this.expiresSoonDate = this.route.snapshot.data.expiresSoonAlertDate.expiresSoonAlertDate;
+    this.isPrimary = this.route.snapshot.data.primaryWorkplace.uid === this.workplaceUid;
     this.setupForm();
+    this.setReturnUrl();
     this.setBackLink();
   }
 
@@ -37,6 +42,11 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
     this.form = this.formBuilder.group({
       expiresSoonAlerts: this.formBuilder.control(this.expiresSoonDate),
     });
+  }
+
+  private setReturnUrl(): void {
+    const url = this.isPrimary ? ['dashboard'] : ['workplace', this.workplaceUid];
+    this.returnUrl = { url, fragment: 'training-and-qualifications' };
   }
 
   public setBackLink(): void {
@@ -54,7 +64,7 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   }
 
   private async onSuccess(formValue: string): Promise<void> {
-    await this.router.navigate(['dashboard'], { fragment: 'training-and-qualifications' });
+    await this.router.navigate(this.returnUrl.url, { fragment: this.returnUrl.fragment });
 
     this.alertService.addAlert({
       type: 'success',

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
@@ -28,11 +28,7 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
 
   public ngOnInit(): void {
     this.workplaceUid = this.route.snapshot.data.establishment.uid;
-    this.subscriptions.add(
-      this.establishmentService.getExpiresSoonAlertDates(this.workplaceUid).subscribe((value) => {
-        this.expiresSoonDate = value;
-      }),
-    );
+    this.expiresSoonDate = this.route.snapshot.data.expiresSoonAlertDate.expiresSoonAlertDate;
     this.setupForm();
     this.setBackLink();
   }

--- a/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
+++ b/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
+import { AlertService } from '@core/services/alert.service';
 import { BackService } from '@core/services/back.service';
 
 @Component({
@@ -12,7 +13,12 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   public form: FormGroup;
   public expiresSoonDate: string;
 
-  constructor(private formBuilder: FormBuilder, private backService: BackService, private router: Router) {}
+  constructor(
+    private formBuilder: FormBuilder,
+    private backService: BackService,
+    private router: Router,
+    private alertService: AlertService,
+  ) {}
 
   public ngOnInit(): void {
     this.expiresSoonDate = '90';
@@ -31,6 +37,12 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   }
 
   public onSubmit(): void {
+    const formValue = this.form.value.expiresSoonAlerts;
     this.router.navigate(['dashboard'], { fragment: 'training-and-qualifications' });
+
+    this.alertService.addAlert({
+      type: 'success',
+      message: `'Expires soon' alerts set to ${formValue} days`,
+    });
   }
 }

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -9,14 +9,19 @@ import { Roles } from '@core/model/roles.enum';
 import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
 import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
 import { CreateUserAccountComponent } from '@features/workplace/create-user-account/create-user-account.component';
-import { SelectMainServiceCqcConfirmComponent } from '@features/workplace/select-main-service/select-main-service-cqc-confirm.component';
+import {
+  SelectMainServiceCqcConfirmComponent,
+} from '@features/workplace/select-main-service/select-main-service-cqc-confirm.component';
 import { SelectMainServiceCqcComponent } from '@features/workplace/select-main-service/select-main-service-cqc.component';
-import { UserAccountEditDetailsComponent } from '@features/workplace/user-account-edit-details/user-account-edit-details.component';
+import {
+  UserAccountEditDetailsComponent,
+} from '@features/workplace/user-account-edit-details/user-account-edit-details.component';
 import { UserAccountSavedComponent } from '@features/workplace/user-account-saved/user-account-saved.component';
 import { UserAccountViewComponent } from '@features/workplace/user-account-view/user-account-view.component';
 import { ViewMyWorkplacesComponent } from '@features/workplace/view-my-workplaces/view-my-workplaces.component';
 import { ViewWorkplaceComponent } from '@features/workplace/view-workplace/view-workplace.component';
 
+import { ChangeExpiresSoonAlertsComponent } from './change-expires-soon-alerts/change-expires-soon-alerts.component';
 import { CheckAnswersComponent } from './check-answers/check-answers.component';
 import { ConfirmLeaversComponent } from './confirm-leavers/confirm-leavers.component';
 import { ConfirmStartersComponent } from './confirm-starters/confirm-starters.component';
@@ -38,7 +43,9 @@ import { StartersComponent } from './starters/starters.component';
 import { SuccessComponent } from './success/success.component';
 import { TotalStaffQuestionComponent } from './total-staff-question/total-staff-question.component';
 import { TypeOfEmployerComponent } from './type-of-employer/type-of-employer.component';
-import { UserAccountEditPermissionsComponent } from './user-account-edit-permissions/user-account-edit-permissions.component';
+import {
+  UserAccountEditPermissionsComponent,
+} from './user-account-edit-permissions/user-account-edit-permissions.component';
 import { VacanciesComponent } from './vacancies/vacancies.component';
 import { WorkplaceNameAddressComponent } from './workplace-name-address/workplace-name-address.component';
 import { WorkplaceNotFoundComponent } from './workplace-not-found/workplace-not-found.component';
@@ -393,6 +400,11 @@ const routes: Routes = [
             (m) => m.AddMultipleTrainingModule,
           ),
         data: { title: 'Add Multiple Training' },
+      },
+      {
+        path: 'change-expires-soon-alerts',
+        component: ChangeExpiresSoonAlertsComponent,
+        data: { permissions: ['canEditEstablishment'], title: 'Change expires soon alerts' },
       },
     ],
   },

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -6,6 +6,7 @@ import { CheckPermissionsGuard } from '@core/guards/permissions/check-permission
 import { HasPermissionsGuard } from '@core/guards/permissions/has-permissions/has-permissions.guard';
 import { RoleGuard } from '@core/guards/role/role.guard';
 import { Roles } from '@core/model/roles.enum';
+import { ExpiresSoonAlertDatesResolver } from '@core/resolvers/expiresSoonAlertDates.resolver';
 import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
 import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
 import { CreateUserAccountComponent } from '@features/workplace/create-user-account/create-user-account.component';
@@ -404,6 +405,9 @@ const routes: Routes = [
       {
         path: 'change-expires-soon-alerts',
         component: ChangeExpiresSoonAlertsComponent,
+        resolve: {
+          expiresSoonAlertDate: ExpiresSoonAlertDatesResolver,
+        },
         data: { permissions: ['canEditEstablishment'], title: 'Change expires soon alerts' },
       },
     ],

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -405,6 +405,7 @@ const routes: Routes = [
       {
         path: 'change-expires-soon-alerts',
         component: ChangeExpiresSoonAlertsComponent,
+        canActivate: [CheckPermissionsGuard],
         resolve: {
           expiresSoonAlertDate: ExpiresSoonAlertDatesResolver,
         },

--- a/src/app/features/workplace/workplace.module.ts
+++ b/src/app/features/workplace/workplace.module.ts
@@ -2,6 +2,7 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ExpiresSoonAlertDatesResolver } from '@core/resolvers/expiresSoonAlertDates.resolver';
 import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
 import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
 import { DialogService } from '@core/services/dialog.service';
@@ -90,6 +91,6 @@ import { WorkplaceRoutingModule } from './workplace-routing.module';
     SelectPrimaryUserDeleteComponent,
     ChangeExpiresSoonAlertsComponent,
   ],
-  providers: [DialogService, WorkplaceResolver, UserAccountResolver],
+  providers: [DialogService, WorkplaceResolver, UserAccountResolver, ExpiresSoonAlertDatesResolver],
 })
 export class WorkplaceModule {}

--- a/src/app/features/workplace/workplace.module.ts
+++ b/src/app/features/workplace/workplace.module.ts
@@ -6,7 +6,9 @@ import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
 import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
 import { DialogService } from '@core/services/dialog.service';
 import { CreateUserAccountComponent } from '@features/workplace/create-user-account/create-user-account.component';
-import { SelectMainServiceCqcConfirmComponent } from '@features/workplace/select-main-service/select-main-service-cqc-confirm.component';
+import {
+  SelectMainServiceCqcConfirmComponent,
+} from '@features/workplace/select-main-service/select-main-service-cqc-confirm.component';
 import { SelectMainServiceCqcComponent } from '@features/workplace/select-main-service/select-main-service-cqc.component';
 import { StartComponent } from '@features/workplace/start/start.component';
 import { UserAccountSavedComponent } from '@features/workplace/user-account-saved/user-account-saved.component';
@@ -14,6 +16,7 @@ import { UserAccountViewComponent } from '@features/workplace/user-account-view/
 import { BenchmarksModule } from '@shared/components/benchmarks-tab/benchmarks.module';
 import { SharedModule } from '@shared/shared.module';
 
+import { ChangeExpiresSoonAlertsComponent } from './change-expires-soon-alerts/change-expires-soon-alerts.component';
 import { CheckAnswersComponent } from './check-answers/check-answers.component';
 import { ConfirmLeaversComponent } from './confirm-leavers/confirm-leavers.component';
 import { ConfirmStartersComponent } from './confirm-starters/confirm-starters.component';
@@ -36,7 +39,9 @@ import { TotalStaffQuestionComponent } from './total-staff-question/total-staff-
 import { TypeOfEmployerComponent } from './type-of-employer/type-of-employer.component';
 import { UserAccountDeleteDialogComponent } from './user-account-delete-dialog/user-account-delete-dialog.component';
 import { UserAccountEditDetailsComponent } from './user-account-edit-details/user-account-edit-details.component';
-import { UserAccountEditPermissionsComponent } from './user-account-edit-permissions/user-account-edit-permissions.component';
+import {
+  UserAccountEditPermissionsComponent,
+} from './user-account-edit-permissions/user-account-edit-permissions.component';
 import { VacanciesComponent } from './vacancies/vacancies.component';
 import { ViewMyWorkplacesComponent } from './view-my-workplaces/view-my-workplaces.component';
 import { ViewWorkplaceComponent } from './view-workplace/view-workplace.component';
@@ -83,6 +88,7 @@ import { WorkplaceRoutingModule } from './workplace-routing.module';
     DeleteUserAccountComponent,
     SelectPrimaryUserComponent,
     SelectPrimaryUserDeleteComponent,
+    ChangeExpiresSoonAlertsComponent,
   ],
   providers: [DialogService, WorkplaceResolver, UserAccountResolver],
 })


### PR DESCRIPTION
#### Work done
- New migration to add `ExpiresSoonAlertDate` column and set default to `'90'`
- Create db call to get the expires soon alert date
- Create `getExpiresSoonAlertDate` and `setExpiresSoonAlertDate` endpoints
- Create new component and resolver

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
