### PR TITLE
Bug: archiving rejected workplaces

### DIFF
--- a/migrations/20211214152944-archivingRejectedWorkplaces.js
+++ b/migrations/20211214152944-archivingRejectedWorkplaces.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    return queryInterface.sequelize.query(
+      'UPDATE cqc."Establishment" SET "Archived" = true WHERE "Status" = \'REJECTED\';',
+    );
+  },
+};

--- a/server/routes/admin/approval/index.js
+++ b/server/routes/admin/approval/index.js
@@ -112,6 +112,7 @@ const _rejectNewUser = async (user, workplace, req, res) => {
         reviewer: null,
         updated: new Date(),
         updatedBy: adminUser.FullNameValue,
+        archived: true,
       });
 
       if (deletedUser && rejectedWorkplace) {
@@ -157,6 +158,7 @@ const _rejectNewWorkplace = async (workplace, req, res) => {
       reviewer: null,
       updated: new Date(),
       updatedBy: adminUser.FullNameValue,
+      archived: true,
     });
 
     if (rejectedWorkplace) {

--- a/server/test/unit/routes/admin/approval/index.spec.js
+++ b/server/test/unit/routes/admin/approval/index.spec.js
@@ -316,6 +316,7 @@ describe('adminApproval', async () => {
         inReview: false,
         reviewer: null,
         updatedBy: 'Joe Bloggs',
+        archived: true,
       });
       expect(workplaceUpdateSpy.args[0][0]).to.haveOwnProperty('updated');
     });

--- a/server/test/unit/routes/admin/approval/index.spec.js
+++ b/server/test/unit/routes/admin/approval/index.spec.js
@@ -181,6 +181,7 @@ describe('adminApproval', async () => {
         inReview: false,
         reviewer: null,
         updatedBy: 'Joe Bloggs',
+        archived: true,
       });
     });
 


### PR DESCRIPTION
#### Issue 
- When rejecting a workplace, the status was being set to `REJECTED` but it wasn't being archived, so it still appeared in reports and the CQC location ID wasn't being archived

#### Work done
- Add `archived: true` when rejecting a workplace or user

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
