### PR TITLE
Bug: Registrations expires soon date

### DIFF
--- a/server/models/classes/establishment.js
+++ b/server/models/classes/establishment.js
@@ -87,6 +87,7 @@ class Establishment extends EntityValidator {
     this._lastBulkUploaded = null;
     this._eightWeeksFromFirstLogin = null;
     this._showSharingPermissionsBanner = null;
+    this._expiresSoonAlertDate = null;
 
     // interim reasons for leaving - https://trello.com/c/vNHbfdms
     this._reasonsForLeaving = null;
@@ -319,6 +320,10 @@ class Establishment extends EntityValidator {
     return this._status;
   }
 
+  get expiresSoonAlertDate() {
+    return this._expiresSoonAlertDate;
+  }
+
   get key() {
     return (
       this._properties.get('LocalIdentifier') && this._properties.get('LocalIdentifier').property
@@ -513,6 +518,10 @@ class Establishment extends EntityValidator {
 
         if ('showSharingPermissionsBanner' in document) {
           this._showSharingPermissionsBanner = document.showSharingPermissionsBanner;
+        }
+
+        if (document.expiresSoonAlertDate) {
+          this._expiresSoonAlertDate = document.expiresSoonAlertDate;
         }
       }
 
@@ -763,6 +772,7 @@ class Establishment extends EntityValidator {
           source: bulkUploaded ? 'Bulk' : 'Online',
           attributes: ['id', 'created', 'updated'],
           ustatus: this._ustatus,
+          expiresSoonAlertDate: '90',
         };
 
         // need to create the Establishment record and the Establishment Audit event

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -340,6 +340,7 @@ router
         MainServiceOther: req.body[0].mainServiceOther,
         IsRegulated: req.body[0].isRegulated,
         Status: 'PENDING',
+        ExpiresSoonAlertDate: '90',
       };
       const Userdata = {
         FullName: req.body[0].user.fullname,
@@ -479,6 +480,7 @@ router
               other: Estblistmentdata.MainServiceOther,
             },
             ustatus: Estblistmentdata.Status,
+            expiresSoonAlertDate: Estblistmentdata.ExpiresSoonAlertDate,
           }); // no Establishment properties on registration
           if (newEstablishment.hasMandatoryProperties && newEstablishment.isValid) {
             await newEstablishment.save(Logindata.UserName, false, t);


### PR DESCRIPTION
#### Issue
- When creating a new workplace, the `ExpiresSoonAlertDate` column was being set to null instead of 90

#### Work done
- Set ExpiresSoonAlertDate to `'90'` when creating new account

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
