### PR TITLE
Bug: Training cancel button

### DIFF
--- a/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
-import { ActivatedRoute, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { TrainingService } from '@core/services/training.service';
@@ -11,7 +12,7 @@ import { MockTrainingService } from '@core/test-utils/MockTrainingService';
 import { MockWorkerServiceWithWorker } from '@core/test-utils/MockWorkerServiceWithWorker';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
 
 import { AddEditTrainingComponent } from './add-edit-training.component';
 
@@ -45,10 +46,16 @@ describe('AddEditTrainingComponent', () => {
       ],
     });
 
+    const injector = getTestBed();
+    const router = injector.inject(Router) as Router;
+    const routerSpy = spyOn(router, 'navigateByUrl');
+    routerSpy.and.returnValue(Promise.resolve(true));
+
     const component = fixture.componentInstance;
     return {
       component,
       fixture,
+      routerSpy,
       getByText,
       getByTestId,
       queryByText,
@@ -125,6 +132,20 @@ describe('AddEditTrainingComponent', () => {
       fixture.detectChanges();
 
       expect(queryByText('Delete')).toBeFalsy();
+    });
+  });
+
+  describe('Cancel button', () => {
+    it('should call navigateByUrl when pressing cancel', async () => {
+      const { component, fixture, getByText, routerSpy } = await setup();
+
+      component.previousUrl = ['/dashboard?view=categories#training-and-qualifications'];
+
+      const cancelButton = getByText('Cancel');
+      fireEvent.click(cancelButton);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith('/dashboard?view=categories#training-and-qualifications');
     });
   });
 });

--- a/src/app/features/workers/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/src/app/features/workers/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -77,6 +77,7 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.filterTrainingByDefault = '0_showall';
     this.filterTrainingByStatus = FilterTrainingAndQualsOptions;
     this.getFilterByStatus(this.filterTrainingByDefault);
+    this.setReturnRoute();
   }
 
   public setTrainingAndQualifications(): void {

--- a/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -252,6 +252,6 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
   }
 
   public onCancel(): void {
-    this.router.navigate(this.previousUrl, { fragment: 'training-and-qualifications' });
+    this.router.navigateByUrl(this.previousUrl[0]);
   }
 }


### PR DESCRIPTION
#### Issue
- When clicking the cancel button after being on the training categories page, `previousUrl` was being set correctly to the `/dashboard?view=categories#training-and-qualifications` url but Angular was converting special characters like `=` to `%3D` when navigating which meant the page didn't exist 

#### Work done
- Use `navigateByUrl` instead of `navigate` to prevent special characters from changing
- Add `setReturnRoute` to `OnInit` in new training component

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
