### PR TITLE
Feat/b u unlock button

### DIFF
--- a/src/app/core/resolvers/bulk-upload/bulk-upload-get-lock-status.resolver.spec.ts
+++ b/src/app/core/resolvers/bulk-upload/bulk-upload-get-lock-status.resolver.spec.ts
@@ -1,0 +1,40 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { BulkUploadService } from '@core/services/bulk-upload.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+
+import { BulkUploadGetLockStatusResolver } from './bulk-upload-get-lock-status.resolver';
+
+describe('BulkUploadGetLockStatusResolver', () => {
+  let resolver: BulkUploadGetLockStatusResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [
+        BulkUploadGetLockStatusResolver,
+        {
+          provide: EstablishmentService,
+          useValue: {
+            establishmentId: 'establishmentId',
+          },
+        },
+      ],
+    });
+    resolver = TestBed.inject(BulkUploadGetLockStatusResolver);
+  });
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy();
+  });
+
+  it('should resolve', () => {
+    const bulkUploadService = TestBed.inject(BulkUploadService);
+    spyOn(bulkUploadService, 'getLockStatus').and.callThrough();
+
+    resolver.resolve();
+
+    expect(bulkUploadService.getLockStatus).toHaveBeenCalledWith('establishmentId');
+  });
+});

--- a/src/app/core/resolvers/bulk-upload/bulk-upload-get-lock-status.resolver.ts
+++ b/src/app/core/resolvers/bulk-upload/bulk-upload-get-lock-status.resolver.ts
@@ -1,20 +1,20 @@
 import { Injectable } from '@angular/core';
 import { Resolve, Router } from '@angular/router';
-import { BulkUploadLock } from '@core/model/bulk-upload.model';
+import { BulkUploadStatus } from '@core/model/bulk-upload.model';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { EMPTY, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
-export class BulkUploadGetLockStatusResolver implements Resolve<BulkUploadLock> {
+export class BulkUploadGetLockStatusResolver implements Resolve<BulkUploadStatus> {
   constructor(
     private router: Router,
     private establishmentService: EstablishmentService,
     private bulkUploadService: BulkUploadService,
   ) {}
 
-  resolve(): Observable<BulkUploadLock> {
+  resolve(): Observable<BulkUploadStatus> {
     const establishmentId = this.establishmentService.establishmentId;
 
     return this.bulkUploadService.getLockStatus(establishmentId).pipe(

--- a/src/app/core/resolvers/bulk-upload/bulk-upload-get-lock-status.resolver.ts
+++ b/src/app/core/resolvers/bulk-upload/bulk-upload-get-lock-status.resolver.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { Resolve, Router } from '@angular/router';
+import { BulkUploadLock } from '@core/model/bulk-upload.model';
+import { BulkUploadService } from '@core/services/bulk-upload.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { EMPTY, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable()
+export class BulkUploadGetLockStatusResolver implements Resolve<BulkUploadLock> {
+  constructor(
+    private router: Router,
+    private establishmentService: EstablishmentService,
+    private bulkUploadService: BulkUploadService,
+  ) {}
+
+  resolve(): Observable<BulkUploadLock> {
+    const establishmentId = this.establishmentService.establishmentId;
+
+    return this.bulkUploadService.getLockStatus(establishmentId).pipe(
+      catchError(() => {
+        this.router.navigate(['/problem-with-the-service']);
+        return EMPTY;
+      }),
+    );
+  }
+}

--- a/src/app/core/services/bulk-upload.service.spec.ts
+++ b/src/app/core/services/bulk-upload.service.spec.ts
@@ -1,0 +1,33 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { BulkUploadService } from './bulk-upload.service';
+
+describe('BulkUploadService', () => {
+  let service: BulkUploadService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [BulkUploadService],
+    });
+    service = TestBed.inject(BulkUploadService);
+  });
+
+  afterEach(() => {
+    TestBed.inject(HttpTestingController).verify();
+  });
+
+  it('should create the service', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should get the bulk upload lock status of an establishment', () => {
+    service.getLockStatus('establishmentId').subscribe();
+
+    const http = TestBed.inject(HttpTestingController);
+    const req = http.expectOne('/api/establishment/establishmentId/bulkupload/lockstatus');
+
+    expect(req.request.method).toBe('GET');
+  });
+});

--- a/src/app/core/services/bulk-upload.service.spec.ts
+++ b/src/app/core/services/bulk-upload.service.spec.ts
@@ -5,6 +5,7 @@ import { BulkUploadService } from './bulk-upload.service';
 
 describe('BulkUploadService', () => {
   let service: BulkUploadService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -12,6 +13,8 @@ describe('BulkUploadService', () => {
       providers: [BulkUploadService],
     });
     service = TestBed.inject(BulkUploadService);
+
+    http = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
@@ -25,9 +28,14 @@ describe('BulkUploadService', () => {
   it('should get the bulk upload lock status of an establishment', () => {
     service.getLockStatus('establishmentId').subscribe();
 
-    const http = TestBed.inject(HttpTestingController);
     const req = http.expectOne('/api/establishment/establishmentId/bulkupload/lockstatus');
+    expect(req.request.method).toBe('GET');
+  });
 
+  it('should unlock bulk upload for an establishment', () => {
+    service.unlockBulkUpload('establishmentId').subscribe();
+
+    const req = http.expectOne('/api/establishment/establishmentId/bulkupload/unlock');
     expect(req.request.method).toBe('GET');
   });
 });

--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -235,8 +235,12 @@ export class BulkUploadService {
     this.serverError$.next(null);
   }
 
-  public getLockStatus(workplaceUid: string): Observable<BulkUploadLock> {
-    return this.http.get<BulkUploadLock>(`/api/establishment/${workplaceUid}/bulkupload/lockstatus`);
+  public getLockStatus(workplaceUid: string): Observable<BulkUploadStatus> {
+    return this.http.get<BulkUploadStatus>(`/api/establishment/${workplaceUid}/bulkupload/lockstatus`);
+  }
+
+  public unlockBulkUpload(workplaceUid: string): Observable<any> {
+    return this.http.get<any>(`/api/establishment/${workplaceUid}/bulkupload/unlock`);
   }
 
   public formErrorsMap(): Array<ErrorDetails> {

--- a/src/app/core/services/bulk-upload.service.ts
+++ b/src/app/core/services/bulk-upload.service.ts
@@ -235,6 +235,10 @@ export class BulkUploadService {
     this.serverError$.next(null);
   }
 
+  public getLockStatus(workplaceUid: string): Observable<BulkUploadLock> {
+    return this.http.get<BulkUploadLock>(`/api/establishment/${workplaceUid}/bulkupload/lockstatus`);
+  }
+
   public formErrorsMap(): Array<ErrorDetails> {
     return [
       {

--- a/src/app/features/bulk-upload/bulk-upload-routing.module.ts
+++ b/src/app/features/bulk-upload/bulk-upload-routing.module.ts
@@ -5,6 +5,7 @@ import { BulkUploadStartGuard } from '@core/guards/bulk-upload/bulk-upload-start
 import { RoleGuard } from '@core/guards/role/role.guard';
 import { Roles } from '@core/model/roles.enum';
 import { BulkUploadErrorsResolver } from '@core/resolvers/bulk-upload-errors.resolver';
+import { BulkUploadGetLockStatusResolver } from '@core/resolvers/bulk-upload/bulk-upload-get-lock-status.resolver';
 import { BulkUploadTopTipResolver } from '@core/resolvers/bulk-upload/bulk-upload-top-tip.resolver';
 import { BulkUploadTopTipsListResolver } from '@core/resolvers/bulk-upload/bulk-upload-top-tips-list.resolver';
 import { LastBulkUploadResolver } from '@core/resolvers/last-bulk-upload.resolver';
@@ -78,7 +79,10 @@ const routes: Routes = [
     component: LastBulkUploadComponent,
     data: { title: 'Last bulk upload', roles: [Roles.Admin] },
     canActivate: [RoleGuard],
-    resolve: { lastBulkUpload: LastBulkUploadResolver },
+    resolve: {
+      lastBulkUpload: LastBulkUploadResolver,
+      bulkUploadLocked: BulkUploadGetLockStatusResolver,
+    },
   },
   {
     path: 'missing-workplace-references',

--- a/src/app/features/bulk-upload/bulk-upload.module.ts
+++ b/src/app/features/bulk-upload/bulk-upload.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BulkUploadErrorsResolver } from '@core/resolvers/bulk-upload-errors.resolver';
+import { BulkUploadGetLockStatusResolver } from '@core/resolvers/bulk-upload/bulk-upload-get-lock-status.resolver';
 import { BulkUploadTopTipResolver } from '@core/resolvers/bulk-upload/bulk-upload-top-tip.resolver';
 import { BulkUploadTopTipsListResolver } from '@core/resolvers/bulk-upload/bulk-upload-top-tips-list.resolver';
 import { LastBulkUploadResolver } from '@core/resolvers/last-bulk-upload.resolver';
@@ -92,6 +93,7 @@ import { ValidationErrorMessageComponent } from './validation-error-message/vali
     BulkUploadErrorsResolver,
     BulkUploadTopTipsListResolver,
     BulkUploadTopTipResolver,
+    BulkUploadGetLockStatusResolver,
   ],
 })
 export class BulkUploadModule {}

--- a/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.html
+++ b/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.html
@@ -1,43 +1,62 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l ">
-      <span  class="govuk-caption-l govuk-!-margin-bottom-3">Bulk upload</span>
-       Last bulk upload
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l govuk-!-margin-bottom-3">Bulk upload</span>
+      Last bulk upload
     </h1>
     <table class="govuk-table">
-    <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Type</th>
-      <th class="govuk-table__header" scope="col">Records</th>
-      <th class="govuk-table__header" scope="col">Actioned by</th>
-      <th class="govuk-table__header" scope="col">Date</th>
-      <th class="govuk-table__header" scope="col">Downloads</th>
-    </tr>
-    </thead>
-    <tbody class="govuk-table__body ">
-    <ng-container *ngFor="let file of files">
-      <tr>
-        <td class="govuk-table__cell">{{(file.data.fileType | bulkUploadFileTypePipe )}}</td>
-        <td class="govuk-table__cell">{{file.data.records}}</td>
-        <td class="govuk-table__cell">{{file.username}}</td>
-        <td class="govuk-table__cell">{{(file.lastModified | date: 'd MMM yyyy, h:mm') + (file.lastModified | date: 'a' | lowercase) }}</td>
-        <td class="govuk-table__cell asc-link-download">
-          <div >
-            <a href="/bulk-upload/download/{{ encodeUrl(file.data.filename) }}" (click)="downloadFile($event, file.data.key)">
-              {{(file.data.fileType | bulkUploadFileTypePipe )}}
-            </a>
-          </div>
-        </td>
-      </tr>
-    </ng-container>
-    </tbody>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Type</th>
+          <th class="govuk-table__header" scope="col">Records</th>
+          <th class="govuk-table__header" scope="col">Actioned by</th>
+          <th class="govuk-table__header" scope="col">Date</th>
+          <th class="govuk-table__header" scope="col">Downloads</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <ng-container *ngFor="let file of files">
+          <tr>
+            <td class="govuk-table__cell">{{ file.data.fileType | bulkUploadFileTypePipe }}</td>
+            <td class="govuk-table__cell">{{ file.data.records }}</td>
+            <td class="govuk-table__cell">{{ file.username }}</td>
+            <td class="govuk-table__cell">
+              {{ (file.lastModified | date: 'd MMM yyyy, h:mm') + (file.lastModified | date: 'a' | lowercase) }}
+            </td>
+            <td class="govuk-table__cell asc-link-download">
+              <div>
+                <a
+                  href="/bulk-upload/download/{{ encodeUrl(file.data.filename) }}"
+                  (click)="downloadFile($event, file.data.key)"
+                >
+                  {{ file.data.fileType | bulkUploadFileTypePipe }}
+                </a>
+              </div>
+            </td>
+          </tr>
+        </ng-container>
+      </tbody>
     </table>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full govuk-!-margin-top-6">
-      <a role="button" draggable="false" class="govuk-button govuk-button--primary govuk-!-margin-right-9" [routerLink]="['/bulk-upload']">
-        Return to bulk upload
-      </a>
+        <a
+          role="button"
+          draggable="false"
+          class="govuk-button govuk-button--primary govuk-!-margin-right-9"
+          [routerLink]="['/bulk-upload']"
+        >
+          Return to bulk upload
+        </a>
+        <button
+          *ngIf="locked"
+          role="button"
+          draggable="false"
+          class="govuk-button govuk-button--warning govuk-!-margin-left-9"
+          (click)="unlockBulkUpload()"
+        >
+          Unlock bulk upload
+        </button>
+      </div>
     </div>
-    </div>
-</div>
+  </div>
 </div>

--- a/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.spec.ts
+++ b/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.spec.ts
@@ -1,0 +1,129 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AlertService } from '@core/services/alert.service';
+import { AuthService } from '@core/services/auth.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { BulkUploadService } from '@core/services/bulk-upload.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { WindowRef } from '@core/services/window.ref';
+import { MockActivatedRoute } from '@core/test-utils/MockActivatedRoute';
+import { MockAuthService } from '@core/test-utils/MockAuthService';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render } from '@testing-library/angular';
+import { of, throwError } from 'rxjs';
+
+import { LastBulkUploadComponent } from './last-bulk-upload.component';
+
+describe('LastBulkUploadComponent', () => {
+  const setup = async () => {
+    const { fixture, getByText } = await render(LastBulkUploadComponent, {
+      imports: [SharedModule, RouterTestingModule.withRoutes([]), HttpClientTestingModule],
+      providers: [
+        AlertService,
+        WindowRef,
+        { provide: BreadcrumbService, useClass: MockBreadcrumbService },
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+        { provide: AuthService, useClass: MockAuthService },
+        {
+          provide: EstablishmentService,
+          useValue: {
+            primaryWorkplace: {
+              uid: 'someuid',
+              name: 'Care Home 1',
+            },
+          },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: new MockActivatedRoute({
+            params: [],
+            url: of(['testUrl']),
+            snapshot: {
+              data: {
+                lastBulkUpload: [],
+                bulkUploadLocked: { bulkUploadLockHeld: false },
+              },
+            },
+          }),
+        },
+      ],
+    });
+
+    const alertService = TestBed.inject(AlertService);
+    const alertServiceSpy = spyOn(alertService, 'addAlert').and.callThrough();
+
+    const component = fixture.componentInstance;
+
+    return { component, fixture, getByText, alertServiceSpy };
+  };
+
+  it('should render a BulkUploadTopTipPageComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('shows the unlock bulk upload button when the locked is true', async () => {
+    const { component, fixture, getByText } = await setup();
+
+    component.locked = true;
+    fixture.detectChanges();
+
+    expect(getByText('Unlock bulk upload')).toBeTruthy();
+  });
+
+  it('should call the unlockBulkUpload method in the bulk upload service when unlocking bulk upload', async () => {
+    const { component, fixture, getByText } = await setup();
+
+    const bulkUploadService = TestBed.inject(BulkUploadService) as BulkUploadService;
+    const bulkUploadServiceSpy = spyOn(bulkUploadService, 'unlockBulkUpload').and.callThrough();
+
+    component.locked = true;
+    fixture.detectChanges();
+
+    const unlockButton = getByText('Unlock bulk upload');
+    fireEvent.click(unlockButton);
+
+    expect(bulkUploadServiceSpy).toHaveBeenCalledWith('someuid');
+  });
+
+  it('should display a success banner when the bulk upload unlock is successful', async () => {
+    const { component, fixture, getByText, alertServiceSpy } = await setup();
+
+    const bulkUploadService = TestBed.inject(BulkUploadService) as BulkUploadService;
+    spyOn(bulkUploadService, 'unlockBulkUpload').and.returnValue(of(true));
+
+    component.locked = true;
+    fixture.detectChanges();
+
+    const unlockButton = getByText('Unlock bulk upload');
+    fireEvent.click(unlockButton);
+
+    expect(alertServiceSpy).toHaveBeenCalledWith({
+      type: 'success',
+      message: 'Bulk upload for Care Home 1 has been successfully unlocked',
+    });
+  });
+
+  it('should display a warning banner when the bulk upload unlock is unsuccessful', async () => {
+    const { component, fixture, getByText, alertServiceSpy } = await setup();
+
+    const bulkUploadService = TestBed.inject(BulkUploadService) as BulkUploadService;
+    spyOn(bulkUploadService, 'unlockBulkUpload').and.returnValue(throwError('error'));
+
+    component.locked = true;
+    fixture.detectChanges();
+
+    const unlockButton = getByText('Unlock bulk upload');
+    fireEvent.click(unlockButton);
+
+    expect(alertServiceSpy).toHaveBeenCalledWith({
+      type: 'warning',
+      message: 'Bulk upload for Care Home 1 failed to be unlocked',
+    });
+  });
+});

--- a/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.spec.ts
+++ b/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.spec.ts
@@ -123,7 +123,7 @@ describe('LastBulkUploadComponent', () => {
 
     expect(alertServiceSpy).toHaveBeenCalledWith({
       type: 'warning',
-      message: 'Bulk upload for Care Home 1 failed to be unlocked',
+      message: 'Bulk upload for Care Home 1 failed to unlock',
     });
   });
 });

--- a/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.ts
+++ b/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.ts
@@ -60,7 +60,7 @@ export class LastBulkUploadComponent implements OnInit {
   }
 
   private showBulkUploadUnlockAlert(type): void {
-    const message = type === 'success' ? 'has been successfully unlocked' : 'failed to be unlocked';
+    const message = type === 'success' ? 'has been successfully unlocked' : 'failed to unlock';
     this.alertService.addAlert({
       type,
       message: `Bulk upload for ${this.establishmentService.primaryWorkplace.name} ${message}`,

--- a/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.ts
+++ b/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.ts
@@ -1,38 +1,42 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BulkUploadService } from '@core/services/bulk-upload.service';
-import { lastBulkUploadFile } from '@core/model/bulk-upload.model';
-import { EstablishmentService } from '@core/services/establishment.service';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { lastBulkUploadFile } from '@core/model/bulk-upload.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { BulkUploadService } from '@core/services/bulk-upload.service';
+import { EstablishmentService } from '@core/services/establishment.service';
 
 @Component({
   selector: 'app-last-bulk-upload',
   templateUrl: './last-bulk-upload.component.html',
   providers: [],
 })
-export class LastBulkUploadComponent {
+export class LastBulkUploadComponent implements OnInit {
   constructor(
     private bulkUploadService: BulkUploadService,
     private route: ActivatedRoute,
     protected router: Router,
     private establishmentService: EstablishmentService,
-    private breadcrumbService: BreadcrumbService
+    private breadcrumbService: BreadcrumbService,
   ) {}
 
   public files: [lastBulkUploadFile] = this.route.snapshot.data.lastBulkUpload;
+  public locked: boolean = this.route.snapshot.data.bulkUploadLocked.bulkUploadLockHeld;
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.breadcrumbService.show(JourneyType.BULK_UPLOAD);
+    // this.locked = true;
+    console.log(this.route.snapshot.data.bulkUploadLocked);
   }
-  public returnToStart(){
+  public returnToStart(): void {
     this.router.navigate(['bulk-upload/']);
   }
+
   public encodeUrl(url: string): string {
     return encodeURI(url);
   }
 
-  public downloadFile(event: Event, key: string) {
+  public downloadFile(event: Event, key: string): void {
     event.preventDefault();
 
     this.bulkUploadService
@@ -42,5 +46,7 @@ export class LastBulkUploadComponent {
       });
   }
 
-
+  public unlockBulkUpload(): void {
+    console.log('Unlock bulk upload');
+  }
 }

--- a/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.ts
+++ b/src/app/features/bulk-upload/last-bulk-upload/last-bulk-upload.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { lastBulkUploadFile } from '@core/model/bulk-upload.model';
+import { AlertService } from '@core/services/alert.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -18,6 +19,7 @@ export class LastBulkUploadComponent implements OnInit {
     protected router: Router,
     private establishmentService: EstablishmentService,
     private breadcrumbService: BreadcrumbService,
+    private alertService: AlertService,
   ) {}
 
   public files: [lastBulkUploadFile] = this.route.snapshot.data.lastBulkUpload;
@@ -25,9 +27,8 @@ export class LastBulkUploadComponent implements OnInit {
 
   ngOnInit(): void {
     this.breadcrumbService.show(JourneyType.BULK_UPLOAD);
-    // this.locked = true;
-    console.log(this.route.snapshot.data.bulkUploadLocked);
   }
+
   public returnToStart(): void {
     this.router.navigate(['bulk-upload/']);
   }
@@ -47,6 +48,22 @@ export class LastBulkUploadComponent implements OnInit {
   }
 
   public unlockBulkUpload(): void {
-    console.log('Unlock bulk upload');
+    this.bulkUploadService.unlockBulkUpload(this.establishmentService.primaryWorkplace.uid).subscribe(
+      () => {
+        this.locked = false;
+        this.showBulkUploadUnlockAlert('success');
+      },
+      () => {
+        this.showBulkUploadUnlockAlert('warning');
+      },
+    );
+  }
+
+  private showBulkUploadUnlockAlert(type): void {
+    const message = type === 'success' ? 'has been successfully unlocked' : 'failed to be unlocked';
+    this.alertService.addAlert({
+      type,
+      message: `Bulk upload for ${this.establishmentService.primaryWorkplace.name} ${message}`,
+    });
   }
 }


### PR DESCRIPTION
#### Work done
- add new api call to bulk upload service for retrieving the lock status
- add new api call to the bulk upload service for unlocking the account
- add a new resolver for retrieving the status
- make changes to the component to show the unlock button and a success and failure banner having clicked the button

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
