### PR TITLE
Fix: Handle CanManageWdfClaims in user creation

### DIFF
--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -437,6 +437,7 @@ const partAddUser = async (req, res) => {
 
     // force email to be lowercase
     req.body.email = req.body.email ? req.body.email.toLowerCase() : req.body.email;
+    req.body.canManageWdfClaims = req.body.canManageWdfClaims || false;
 
     // only those properties defined in the POST body will be updated (peristed)
     const isValidUser = await thisUser.load(req.body);
@@ -669,8 +670,6 @@ const addUser = async (req, res) => {
       const thisUser = new User.User(trackingResponse.user.establishmentId, addUserUUID);
 
       if (await thisUser.restore(trackingResponse.user.uid, null, null)) {
-        // TODO: JSON validation
-
         // only those properties defined in the POST body will be updated (peristed) along with
         //   the additional role property - ovverwrites against that could be passed in the body
         const newUserProperties = {
@@ -679,6 +678,7 @@ const addUser = async (req, res) => {
           status: null,
           agreedUpdatedTerms: true,
           role: trackingResponse.user.UserRoleValue,
+          canManageWdfClaims: req.body[0].user.canManageWdfClaims || false,
         };
 
         // force the username and email to be lowercase

--- a/server/routes/accounts/user.js
+++ b/server/routes/accounts/user.js
@@ -672,13 +672,14 @@ const addUser = async (req, res) => {
       if (await thisUser.restore(trackingResponse.user.uid, null, null)) {
         // only those properties defined in the POST body will be updated (peristed) along with
         //   the additional role property - ovverwrites against that could be passed in the body
+        req.body.canManageWdfClaims = req.body.canManageWdfClaims || false;
+
         const newUserProperties = {
           ...req.body,
           isActive: true,
           status: null,
           agreedUpdatedTerms: true,
           role: trackingResponse.user.UserRoleValue,
-          canManageWdfClaims: req.body[0].user.canManageWdfClaims || false,
         };
 
         // force the username and email to be lowercase

--- a/server/routes/registration.js
+++ b/server/routes/registration.js
@@ -354,6 +354,7 @@ router
         DateCreated: new Date(),
         EstablishmentID: 0,
         AdminUser: true,
+        CanManageWdfClaims: req.body[0].user.canManageWdfClaims || false,
       };
       // Check if the user is allowed to be active based on wether they are CQC registered   - this does work but temporarily we don't want to auto approve anyone
       // let CQCpostcode = false;
@@ -516,6 +517,7 @@ router
             isActive: Logindata.Active,
             status: Logindata.Status,
             registrationSurveyCompleted: false,
+            canManageWdfClaims: Userdata.CanManageWdfClaims,
           });
           if (newUser.isValid) {
             await newUser.save(Logindata.UserName, 0, t);


### PR DESCRIPTION
#### Work done
- Added CanManageWdfClaims to user creation in user and registration files to default to false when not in req
- Issue - CanManageWdfClaims does not allow null in user table, so field must be set on creation of user

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [X] No, I found it difficult to test
- [ ] No, they are not required for this change
