### PR TITLE
Fix/resolver permissions

### DIFF
--- a/src/app/core/resolvers/dashboard/all-users-for-establishment.resolver.spec.ts
+++ b/src/app/core/resolvers/dashboard/all-users-for-establishment.resolver.spec.ts
@@ -1,16 +1,20 @@
+import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { PermissionType } from '@core/model/permissions.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
 
 import { AllUsersForEstablishmentResolver } from './all-users-for-establishment.resolver';
 
 describe('AllUsersForEstablishmentResolver', () => {
-  function setup(idInParams = null) {
+  function setup(idInParams = null, permissions = ['canViewListOfUsers']) {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
       providers: [
@@ -26,6 +30,11 @@ describe('AllUsersForEstablishmentResolver', () => {
         {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: convertToParamMap({ establishmentuid: idInParams }) } },
+        },
+        {
+          provide: PermissionsService,
+          useFactory: MockPermissionsService.factory(permissions as PermissionType[]),
+          deps: [HttpClient, Router, UserService],
         },
       ],
     });
@@ -64,5 +73,13 @@ describe('AllUsersForEstablishmentResolver', () => {
     resolver.resolve(route.snapshot);
 
     expect(userService.getAllUsersForEstablishment).toHaveBeenCalledWith('uidInParams');
+  });
+
+  it('should not call getAllUsersForEstablishment when workplace does not have canViewListOfUsers permission', () => {
+    const { resolver, route, userService } = setup('paramUid', []);
+
+    resolver.resolve(route.snapshot);
+
+    expect(userService.getAllUsersForEstablishment).not.toHaveBeenCalled();
   });
 });

--- a/src/app/core/resolvers/dashboard/all-users-for-establishment.resolver.ts
+++ b/src/app/core/resolvers/dashboard/all-users-for-establishment.resolver.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
 import { UserDetails } from '@core/model/userDetails.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -11,6 +12,7 @@ export class AllUsersForEstablishmentResolver implements Resolve<any> {
   constructor(
     private userService: UserService,
     private establishmentService: EstablishmentService,
+    private permissionsService: PermissionsService,
     private router: Router,
   ) {}
 
@@ -18,6 +20,8 @@ export class AllUsersForEstablishmentResolver implements Resolve<any> {
     const workplaceUid = route.paramMap.get('establishmentuid')
       ? route.paramMap.get('establishmentuid')
       : this.establishmentService.establishmentId;
+
+    if (!this.permissionsService.can(workplaceUid, 'canViewListOfUsers')) return of(null);
 
     return this.userService.getAllUsersForEstablishment(workplaceUid).pipe(
       catchError(() => {

--- a/src/app/core/resolvers/dashboard/total-staff-records.resolver.spec.ts
+++ b/src/app/core/resolvers/dashboard/total-staff-records.resolver.spec.ts
@@ -1,16 +1,21 @@
+import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { PermissionType } from '@core/model/permissions.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockWorkerService } from '@core/test-utils/MockWorkerService';
 
 import { TotalStaffRecordsResolver } from './total-staff-records.resolver';
 
 describe('TotalStaffRecordsResolver', () => {
-  function setup(idInParams = null) {
+  function setup(idInParams = null, permissions = ['canViewListOfWorkers']) {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
       providers: [
@@ -26,6 +31,11 @@ describe('TotalStaffRecordsResolver', () => {
         {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: convertToParamMap({ establishmentuid: idInParams }) } },
+        },
+        {
+          provide: PermissionsService,
+          useFactory: MockPermissionsService.factory(permissions as PermissionType[]),
+          deps: [HttpClient, Router, UserService],
         },
       ],
     });
@@ -64,5 +74,13 @@ describe('TotalStaffRecordsResolver', () => {
     resolver.resolve(route.snapshot);
 
     expect(workerService.getTotalStaffRecords).toHaveBeenCalledWith('testParamUid');
+  });
+
+  it('should not call getAllWorkers when workplace does not have canViewListOfWorkers permission', () => {
+    const { resolver, route, workerService } = setup('testParamUid', []);
+
+    resolver.resolve(route.snapshot);
+
+    expect(workerService.getTotalStaffRecords).not.toHaveBeenCalled();
   });
 });

--- a/src/app/core/resolvers/dashboard/total-staff-records.resolver.spec.ts
+++ b/src/app/core/resolvers/dashboard/total-staff-records.resolver.spec.ts
@@ -76,7 +76,7 @@ describe('TotalStaffRecordsResolver', () => {
     expect(workerService.getTotalStaffRecords).toHaveBeenCalledWith('testParamUid');
   });
 
-  it('should not call getAllWorkers when workplace does not have canViewListOfWorkers permission', () => {
+  it('should not call getTotalStaffRecords when workplace does not have canViewListOfWorkers permission', () => {
     const { resolver, route, workerService } = setup('testParamUid', []);
 
     resolver.resolve(route.snapshot);

--- a/src/app/core/resolvers/dashboard/total-staff-records.resolver.ts
+++ b/src/app/core/resolvers/dashboard/total-staff-records.resolver.ts
@@ -2,18 +2,25 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { UserDetails } from '@core/model/userDetails.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class TotalStaffRecordsResolver implements Resolve<any> {
-  constructor(private workerService: WorkerService, private establishmentService: EstablishmentService) {}
+  constructor(
+    private workerService: WorkerService,
+    private establishmentService: EstablishmentService,
+    private permissionsService: PermissionsService,
+  ) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<Array<UserDetails> | null> {
     const workplaceUid = route.paramMap.get('establishmentuid')
       ? route.paramMap.get('establishmentuid')
       : this.establishmentService.establishmentId;
+
+    if (!this.permissionsService.can(workplaceUid, 'canViewListOfWorkers')) return of(null);
 
     return this.workerService.getTotalStaffRecords(workplaceUid).pipe(
       catchError(() => {

--- a/src/app/core/resolvers/workers.resolver.ts
+++ b/src/app/core/resolvers/workers.resolver.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -11,12 +12,15 @@ export class WorkersResolver implements Resolve<any> {
     private router: Router,
     private workerService: WorkerService,
     private establishmentService: EstablishmentService,
+    private permissionsService: PermissionsService,
   ) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<Worker[] | null> {
     const workplaceUid = route.paramMap.get('establishmentuid')
       ? route.paramMap.get('establishmentuid')
       : this.establishmentService.establishmentId;
+
+    if (!this.permissionsService.can(workplaceUid, 'canViewListOfWorkers')) return of(null);
 
     return this.workerService.getAllWorkers(workplaceUid).pipe(
       catchError(() => {


### PR DESCRIPTION
#### Issue
- Users of child workplaces without viewing permissions for Workplace and Staff were getting logged out straight after logging in, this was due to calls to the backend in the dashboard getting moved into resolvers, so these calls would still be made for workplaces which didn't have permission, returning a 403 and logging them out.

#### Work done
- Added permissions checks to resolvers used in dashboard which match the permissions to display tabs where the data is used

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
