### PR TITLE
Feat/show training category on record page

### DIFF
--- a/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
@@ -23,7 +23,7 @@ describe('AddEditTrainingComponent', () => {
           provide: ActivatedRoute,
           useValue: new MockActivatedRoute({
             snapshot: {
-              params: { trainingRecordId: '1' },
+              params: { trainingRecordId: '1', category: 'testCategory', id: 5 },
             },
             parent: {
               snapshot: {
@@ -73,6 +73,11 @@ describe('AddEditTrainingComponent', () => {
     const { component, getByTestId } = await setup();
 
     expect(getByTestId('workerNameAndRole').textContent).toContain(component.worker.mainJob.title);
+  });
+
+  it('should display the missing mandatory training category as a sub-heading', async () => {
+    const { getByText } = await setup();
+    expect(getByText('Training category: testCategory')).toBeTruthy();
   });
 
   describe('title', () => {

--- a/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
@@ -15,7 +15,11 @@ import { fireEvent, render } from '@testing-library/angular';
 import { AddEditTrainingComponent } from './add-edit-training.component';
 
 describe('AddEditTrainingComponent', () => {
-  async function setup() {
+  async function setup(isMandatory = false, trainingRecordId = '1') {
+    if (isMandatory) {
+      window.history.pushState({ training: 'mandatory', missingRecord: { category: 'testCategory', id: 5 } }, '');
+    }
+
     const { fixture, getByText, getByTestId, queryByText } = await render(AddEditTrainingComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       providers: [
@@ -23,7 +27,7 @@ describe('AddEditTrainingComponent', () => {
           provide: ActivatedRoute,
           useValue: new MockActivatedRoute({
             snapshot: {
-              params: { trainingRecordId: '1', category: 'testCategory', id: 5 },
+              params: { trainingRecordId },
             },
             parent: {
               snapshot: {
@@ -59,6 +63,10 @@ describe('AddEditTrainingComponent', () => {
     };
   }
 
+  afterEach(() => {
+    window.history.replaceState(undefined, '');
+  });
+
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
@@ -76,26 +84,26 @@ describe('AddEditTrainingComponent', () => {
   });
 
   it('should display the missing mandatory training category as a sub-heading', async () => {
-    const { getByText } = await setup();
+    const { getByText } = await setup(true);
     expect(getByText('Training category: testCategory')).toBeTruthy();
   });
 
   describe('title', () => {
     it('should render the Enter training details title', async () => {
-      const { component, fixture, getByText } = await setup();
-      component.trainingRecordId = null;
-      component.setTitle();
-      fixture.detectChanges();
+      const trainingRecordId = null;
+      const { getByText } = await setup(false, trainingRecordId);
+
       expect(getByText('Enter training details')).toBeTruthy();
     });
 
     it('should render the Training details title, when there is a training record id', async () => {
       const { getByText } = await setup();
+
       expect(getByText('Training details')).toBeTruthy();
     });
 
     it('should render the Add mandatory training record title, when accessed from add mandatory training link', async () => {
-      const { component, fixture, getByText } = await setup();
+      const { component, fixture, getByText } = await setup(true);
 
       component.mandatoryTraining = true;
       component.trainingRecordId = null;
@@ -106,11 +114,7 @@ describe('AddEditTrainingComponent', () => {
     });
 
     it('should render the Mandatory training record title, when accessed from mandatory training title', async () => {
-      const { component, fixture, getByText } = await setup();
-
-      component.mandatoryTraining = true;
-      component.setTitle();
-      fixture.detectChanges();
+      const { getByText } = await setup(true);
 
       expect(getByText('Mandatory training record')).toBeTruthy();
     });
@@ -118,7 +122,7 @@ describe('AddEditTrainingComponent', () => {
 
   describe('delete button', () => {
     it('should render the delete button when editing training', async () => {
-      const { component, fixture, getByText } = await setup();
+      const { fixture, getByText } = await setup();
 
       fixture.detectChanges();
 

--- a/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
+++ b/src/app/features/workers/add-edit-training/add-edit-training.component.spec.ts
@@ -20,7 +20,7 @@ describe('AddEditTrainingComponent', () => {
       window.history.pushState({ training: 'mandatory', missingRecord: { category: 'testCategory', id: 5 } }, '');
     }
 
-    const { fixture, getByText, getByTestId, queryByText } = await render(AddEditTrainingComponent, {
+    const { fixture, getByText, getByTestId, queryByText, queryByTestId } = await render(AddEditTrainingComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       providers: [
         {
@@ -60,6 +60,7 @@ describe('AddEditTrainingComponent', () => {
       getByText,
       getByTestId,
       queryByText,
+      queryByTestId,
     };
   }
 
@@ -83,9 +84,24 @@ describe('AddEditTrainingComponent', () => {
     expect(getByTestId('workerNameAndRole').textContent).toContain(component.worker.mainJob.title);
   });
 
-  it('should display the missing mandatory training category as a sub-heading', async () => {
-    const { getByText } = await setup(true);
-    expect(getByText('Training category: testCategory')).toBeTruthy();
+  describe('Training category select/display', async () => {
+    it('should display the missing mandatory training category as text when a manadatoryTraining object is passed', async () => {
+      const { getByText } = await setup(true);
+
+      expect(getByText('Training category: testCategory')).toBeTruthy();
+    });
+
+    it('should display the missing mandatory training category as text when a manadatoryTraining object is passed', async () => {
+      const { queryByTestId } = await setup(true);
+
+      expect(queryByTestId('trainingSelect')).toBeFalsy();
+    });
+
+    it('should have dropdown of training categories when a manadatoryTraining object is not passed', async () => {
+      const { getByTestId } = await setup();
+
+      expect(getByTestId('trainingSelect')).toBeTruthy();
+    });
   });
 
   describe('title', () => {

--- a/src/app/features/workers/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component.html
@@ -9,7 +9,7 @@
           *ngIf="canEditWorker"
           draggable="false"
           role="button"
-          [routerLink]="['../add-training']"
+          [routerLink]="['../add-training', missingRecord]"
           [state]="{ training: 'mandatory' }"
           (click)="addButtonClicked()"
         >

--- a/src/app/features/workers/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component.html
+++ b/src/app/features/workers/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component.html
@@ -10,8 +10,8 @@
           [attr.data-testid]="missingRecord.id"
           draggable="false"
           role="button"
-          [routerLink]="['../add-training', missingRecord]"
-          [state]="{ training: 'mandatory' }"
+          [routerLink]="['../add-training']"
+          [state]="{ training: 'mandatory', missingRecord }"
           (click)="addButtonClicked()"
         >
           Add

--- a/src/app/features/workers/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component.spec.ts
@@ -77,7 +77,7 @@ describe('MissingMandatoryTrainingComponent', () => {
 
     const message = getByTestId('1');
     expect(message).toBeTruthy();
-    expect(message.getAttribute('href')).toContain('/add-training');
+    expect(message.getAttribute('href')).toEqual('/add-training');
   });
 
   it('should show a multiple messages saying what training is missing', async () => {

--- a/src/app/features/workers/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component.spec.ts
+++ b/src/app/features/workers/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component.spec.ts
@@ -77,7 +77,7 @@ describe('MissingMandatoryTrainingComponent', () => {
 
     const message = getByTestId('1');
     expect(message).toBeTruthy();
-    expect(message.getAttribute('href')).toEqual('/add-training');
+    expect(message.getAttribute('href')).toContain('/add-training');
   });
 
   it('should show a multiple messages saying what training is missing', async () => {

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -44,9 +44,7 @@
           </div>
         </ng-template>
         <ng-template #missingTrainingCategoryLabelBlock>
-          <p class="govuk-body govuk-!-margin-bottom-5" data-testid="missingTrainingCategory">
-            Training category: {{ missingTrainingCategory }}
-          </p>
+          <p class="govuk-body govuk-!-margin-bottom-5">Training category: {{ missingTrainingCategory }}</p>
         </ng-template>
 
         <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('title').invalid">

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -22,24 +22,8 @@
           <span class="govuk-!-font-weight-bold">Number of staff selected:</span> {{ workerCount }}
           <a class="govuk-link govuk-!-margin-left-4" [routerLink]="['..', 'select-staff']">Change</a>
         </p>
-        <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('category').invalid">
-          <label class="govuk-label" for="category"> Training category </label>
-          <span *ngIf="submitted && form.get('category').invalid" id="category-error" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('category') }}
-          </span>
-          <select
-            class="govuk-select"
-            [class.govuk-select--error]="submitted && form.get('category').invalid"
-            [formControlName]="'category'"
-            id="category"
-            name="category"
-          >
-            <option [ngValue]="null">Select a training category</option>
-            <option *ngFor="let category of categories" [value]="category.id">
-              {{ category.category }}
-            </option>
-          </select>
-        </div>
+
+        <p class="govuk-body govuk-!-margin-bottom-5">Training category: {{ missingTrainingCategory }}</p>
 
         <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('title').invalid">
           <label class="govuk-label" for="title"> Training name </label>

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -35,6 +35,7 @@
               [formControlName]="'category'"
               id="category"
               name="category"
+              data-testid="trainingSelect"
             >
               <option [ngValue]="null">Select a training category</option>
               <option *ngFor="let category of categories" [value]="category.id">

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -22,8 +22,32 @@
           <span class="govuk-!-font-weight-bold">Number of staff selected:</span> {{ workerCount }}
           <a class="govuk-link govuk-!-margin-left-4" [routerLink]="['..', 'select-staff']">Change</a>
         </p>
-
-        <p class="govuk-body govuk-!-margin-bottom-5">Training category: {{ missingTrainingCategory }}</p>
+        <div *ngIf="missingTrainingCategory; then missingTrainingCategoryLabelBlock; else categoryListBLock"></div>
+        <ng-template #categoryListBLock>
+          <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('category').invalid">
+            <label class="govuk-label" for="category"> Training category </label>
+            <span *ngIf="submitted && form.get('category').invalid" id="category-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('category') }}
+            </span>
+            <select
+              class="govuk-select"
+              [class.govuk-select--error]="submitted && form.get('category').invalid"
+              [formControlName]="'category'"
+              id="category"
+              name="category"
+            >
+              <option [ngValue]="null">Select a training category</option>
+              <option *ngFor="let category of categories" [value]="category.id">
+                {{ category.category }}
+              </option>
+            </select>
+          </div>
+        </ng-template>
+        <ng-template #missingTrainingCategoryLabelBlock>
+          <p class="govuk-body govuk-!-margin-bottom-5" data-testid="missingTrainingCategory">
+            Training category: {{ missingTrainingCategory }}
+          </p>
+        </ng-template>
 
         <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('title').invalid">
           <label class="govuk-label" for="title"> Training name </label>

--- a/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -22,7 +22,7 @@
           <span class="govuk-!-font-weight-bold">Number of staff selected:</span> {{ workerCount }}
           <a class="govuk-link govuk-!-margin-left-4" [routerLink]="['..', 'select-staff']">Change</a>
         </p>
-        <div *ngIf="missingTrainingCategory; then missingTrainingCategoryLabelBlock; else categoryListBLock"></div>
+        <div *ngIf="missingTrainingRecord; then missingTrainingCategoryLabelBlock; else categoryListBLock"></div>
         <ng-template #categoryListBLock>
           <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('category').invalid">
             <label class="govuk-label" for="category"> Training category </label>
@@ -44,7 +44,7 @@
           </div>
         </ng-template>
         <ng-template #missingTrainingCategoryLabelBlock>
-          <p class="govuk-body govuk-!-margin-bottom-5">Training category: {{ missingTrainingCategory }}</p>
+          <p class="govuk-body govuk-!-margin-bottom-5">Training category: {{ missingTrainingRecord.category }}</p>
         </ng-template>
 
         <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('title').invalid">

--- a/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -78,7 +78,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
     this.form = this.formBuilder.group(
       {
         title: [null, [Validators.minLength(this.titleMinLength), Validators.maxLength(this.titleMaxLength)]],
-        category: [null],
+        category: this.missingTrainingCategory ? [null] : [null, Validators.required],
         accredited: null,
         completed: this.formBuilder.group({
           day: null,

--- a/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -78,7 +78,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
     this.form = this.formBuilder.group(
       {
         title: [null, [Validators.minLength(this.titleMinLength), Validators.maxLength(this.titleMaxLength)]],
-        category: [null, Validators.required],
+        category: [null],
         accredited: null,
         completed: this.formBuilder.group({
           day: null,
@@ -208,9 +208,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
 
     const record: TrainingRecordRequest = {
       trainingCategory: {
-        id: !this.missingTrainingCategoryId
-          ? parseInt(category.value, 10)
-          : parseInt(this.missingTrainingCategoryId, 10),
+        id: !this.missingTrainingCategory ? parseInt(category.value, 10) : parseInt(this.missingTrainingCategoryId, 10),
       },
       title: title.value,
       accredited: accredited.value,

--- a/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -24,8 +24,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
   public trainingRecordId: string;
   public worker: Worker;
   public workplace: Establishment;
-  public missingTrainingCategory: MandatoryTraining;
-  public missingTrainingCategoryId: string;
+  public missingTrainingRecord: MandatoryTraining;
   public formErrorsMap: Array<ErrorDetails>;
   public notesMaxLength = 1000;
   private titleMaxLength = 120;
@@ -48,8 +47,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
 
   ngOnInit(): void {
     this.workplace = this.route.parent.snapshot.data.establishment;
-    this.missingTrainingCategory = history.state?.missingRecord?.category;
-    this.missingTrainingCategoryId = history.state?.missingRecord?.id;
+    this.missingTrainingRecord = history.state?.missingRecord;
 
     this.init();
     this.setupForm();
@@ -78,7 +76,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
     this.form = this.formBuilder.group(
       {
         title: [null, [Validators.minLength(this.titleMinLength), Validators.maxLength(this.titleMaxLength)]],
-        category: this.missingTrainingCategory ? [null] : [null, Validators.required],
+        category: this.missingTrainingRecord ? [null] : [null, Validators.required],
         accredited: null,
         completed: this.formBuilder.group({
           day: null,
@@ -208,7 +206,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
 
     const record: TrainingRecordRequest = {
       trainingCategory: {
-        id: !this.missingTrainingCategory ? parseInt(category.value, 10) : parseInt(this.missingTrainingCategoryId, 10),
+        id: !this.missingTrainingRecord ? parseInt(category.value) : this.missingTrainingRecord.id,
       },
       title: title.value,
       accredited: accredited.value,

--- a/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -48,8 +48,8 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
 
   async ngOnInit(): Promise<void> {
     this.workplace = this.route.parent.snapshot.data.establishment;
-    this.missingTrainingCategory = this.route.snapshot.params.category;
-    this.missingTrainingCategoryId = this.route.snapshot.params.id;
+    this.missingTrainingCategory = history.state?.missingRecord?.category;
+    this.missingTrainingCategoryId = history.state?.missingRecord?.id;
 
     this.init();
     this.setupForm();

--- a/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -46,7 +46,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
     protected workerService: WorkerService,
   ) {}
 
-  async ngOnInit(): Promise<void> {
+  ngOnInit(): void {
     this.workplace = this.route.parent.snapshot.data.establishment;
     this.missingTrainingCategory = history.state?.missingRecord?.category;
     this.missingTrainingCategoryId = history.state?.missingRecord?.id;


### PR DESCRIPTION
#### Work done
- Passes missingTrainingCategory into add/edit training component if available
- Added logic to determine whether to display a drop-down of categories or to display the passed missingTrainingCategory

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
