### PR TITLE
Bug/staff record nav

### DIFF
--- a/src/app/features/workers/main-job-start-date/main-job-start-date.component.spec.ts
+++ b/src/app/features/workers/main-job-start-date/main-job-start-date.component.spec.ts
@@ -1,0 +1,189 @@
+import { getTestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { WorkerService } from '@core/services/worker.service';
+import { MockWorkerService } from '@core/test-utils/MockWorkerService';
+import { WorkplaceService } from '@core/services/workplace.service';
+import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
+import { DatePickerComponent } from '@shared/components/date-picker/date-picker.component';
+import { SubmitButtonComponent } from '@shared/components/submit-button/submit-button.component';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { BackService } from '@core/services/back.service';
+import { QuestionComponent } from '../question/question.component';
+import { ErrorSummaryComponent } from '@shared/components/error-summary/error-summary.component';
+import { ErrorSummaryService } from '@core/services/error-summary.service';
+
+import { render } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+import { MainJobStartDateComponent } from './main-job-start-date.component';
+
+describe('MainJobStartDateComponent', () => {
+  const setup = async (navigatedFrom = null) => {
+    if (navigatedFrom) history.pushState({ navigatedFrom }, '', '');
+
+    const component = await render(MainJobStartDateComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+      declarations: [DatePickerComponent, SubmitButtonComponent, ErrorSummaryComponent],
+      providers: [
+        BackService,
+        FormBuilder,
+        ReactiveFormsModule,
+        ErrorSummaryService,
+        QuestionComponent,
+        {
+          provide: WorkerService,
+          useClass: MockWorkerService,
+        },
+        {
+          provide: WorkplaceService,
+          useClass: MockWorkplaceService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            parent: {
+              snapshot: {
+                data: {
+                  workplace: { uid: 123 },
+                  primaryWorkplace: { uid: 345 },
+                  establishment: {
+                    uid: 123,
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          provide: PermissionsService,
+          useClass: MockPermissionsService,
+        },
+      ],
+    });
+
+    const injector = getTestBed();
+    const router = injector.inject(Router) as Router;
+
+    const submitSpy = spyOn(component.fixture.componentInstance, 'onSubmit').and.callThrough();
+    const navigateSpy = spyOn(router, 'navigate');
+
+    return { ...component, submitSpy, navigateSpy };
+  };
+
+  afterEach(() => {
+    window.history.replaceState(undefined, '');
+  });
+
+  it('renders without error', async () => {
+    const component = await setup();
+
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the correct default fields', async () => {
+    const { getByText, getByLabelText } = await setup();
+
+    expect(getByText('When did they start in their main job role?')).toBeTruthy();
+
+    expect(getByLabelText('Day')).toBeTruthy();
+    expect(getByLabelText('Month')).toBeTruthy();
+    expect(getByLabelText('Year')).toBeTruthy();
+
+    expect(getByText('Save and return')).toBeTruthy();
+    expect(getByText('Exit')).toBeTruthy();
+  });
+
+  it('renders "Save and continue" if clicking through from staff-records section of dashhboard', async () => {
+    const { getByText } = await setup('dashboard');
+
+    expect(getByText('Save and continue')).toBeTruthy();
+    expect(getByText('View this staff record')).toBeTruthy();
+  });
+
+  it('allows the user to complete the fields and update the form data - (return flow)', async () => {
+    const { getByRole, getByLabelText, fixture, submitSpy } = await setup();
+
+    const formData = fixture.componentInstance.form.value;
+    expect(formData).toEqual({ mainJobStartDate: { day: null, month: null, year: null } });
+
+    const day = getByLabelText('Day');
+    const month = getByLabelText('Month');
+    const year = getByLabelText('Year');
+
+    expect(day).toBeTruthy();
+    expect(month).toBeTruthy();
+    expect(year).toBeTruthy();
+
+    userEvent.type(day, '11');
+    userEvent.type(month, '11');
+    userEvent.type(year, '1999');
+
+    userEvent.click(getByRole('button', { name: 'Save and return' }));
+
+    const updatedFormData = fixture.componentInstance.form.value;
+    expect(updatedFormData).toEqual({ mainJobStartDate: { day: 11, month: 11, year: 1999 } });
+
+    expect(submitSpy).toHaveBeenCalledWith({ action: 'return', save: true });
+  });
+
+  it('allows the user to complete the fields and update the form data - (continue flow)', async () => {
+    const { getByRole, getByLabelText, fixture, submitSpy } = await setup('dashboard');
+
+    const formData = fixture.componentInstance.form.value;
+    expect(formData).toEqual({ mainJobStartDate: { day: null, month: null, year: null } });
+
+    const day = getByLabelText('Day');
+    const month = getByLabelText('Month');
+    const year = getByLabelText('Year');
+
+    expect(day).toBeTruthy();
+    expect(month).toBeTruthy();
+    expect(year).toBeTruthy();
+
+    userEvent.type(day, '22');
+    userEvent.type(month, '12');
+    userEvent.type(year, '2000');
+
+    userEvent.click(getByRole('button', { name: 'Save and continue' }));
+
+    const updatedFormData = fixture.componentInstance.form.value;
+    expect(updatedFormData).toEqual({ mainJobStartDate: { day: 22, month: 12, year: 2000 } });
+
+    expect(submitSpy).toHaveBeenCalledWith({ action: 'continue', save: true });
+  });
+
+  it('allows the user to the staff record summary', async () => {
+    const { fixture, getByText, submitSpy, navigateSpy } = await setup('dashboardd');
+
+    userEvent.click(getByText('View this staff record'));
+    expect(submitSpy).toHaveBeenCalledWith({ action: 'summary', save: false });
+    expect(navigateSpy).toHaveBeenCalledWith(['/workplace', 123, 'staff-record', fixture.componentInstance.worker.uid]);
+  });
+
+  it('allows the user to exit the flow', async () => {
+    const { getByText, submitSpy, navigateSpy } = await setup();
+
+    userEvent.click(getByText('Exit'));
+    expect(submitSpy).toHaveBeenCalledOnceWith({ action: 'return', save: false });
+    expect(navigateSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
+  });
+
+  it('renders an error message component has invalid date', async () => {
+    const { getAllByText, getByLabelText, fixture } = await setup();
+
+    userEvent.type(getByLabelText('Day'), '11');
+    userEvent.type(getByLabelText('Month'), '11');
+    userEvent.type(getByLabelText('Year'), '11');
+
+    fixture.componentInstance.submitted = true;
+    fixture.componentInstance.form.value.errors = true;
+    fixture.detectChanges();
+
+    const errors = getAllByText('Main job start date is not a valid date');
+    expect(errors.length).toBe(2);
+  });
+});

--- a/src/app/features/workers/main-job-start-date/main-job-start-date.component.ts
+++ b/src/app/features/workers/main-job-start-date/main-job-start-date.component.ts
@@ -16,7 +16,7 @@ import { QuestionComponent } from '../question/question.component';
 })
 export class MainJobStartDateComponent extends QuestionComponent {
   private dateMin = dayjs().subtract(100, 'years');
-  public returnThis?: { url: string[] } | null = this.return;
+  public return: { url: string[] } | null = this.return;
 
   constructor(
     protected formBuilder: FormBuilder,

--- a/src/app/features/workers/main-job-start-date/main-job-start-date.component.ts
+++ b/src/app/features/workers/main-job-start-date/main-job-start-date.component.ts
@@ -16,7 +16,6 @@ import { QuestionComponent } from '../question/question.component';
 })
 export class MainJobStartDateComponent extends QuestionComponent {
   private dateMin = dayjs().subtract(100, 'years');
-  public return: { url: string[] } | null = this.return;
 
   constructor(
     protected formBuilder: FormBuilder,

--- a/src/app/features/workers/main-job-start-date/main-job-start-date.component.ts
+++ b/src/app/features/workers/main-job-start-date/main-job-start-date.component.ts
@@ -16,6 +16,7 @@ import { QuestionComponent } from '../question/question.component';
 })
 export class MainJobStartDateComponent extends QuestionComponent {
   private dateMin = dayjs().subtract(100, 'years');
+  public returnThis?: { url: string[] } | null = this.return;
 
   constructor(
     protected formBuilder: FormBuilder,
@@ -51,6 +52,8 @@ export class MainJobStartDateComponent extends QuestionComponent {
 
     this.next = this.getRoutePath('other-job-roles');
     this.previous = this.getReturnPath();
+
+    if (history.state?.navigatedFrom) this.return = null;
   }
 
   public setupFormErrorsMap(): void {

--- a/src/app/shared/components/staff-summary/staff-summary.component.html
+++ b/src/app/shared/components/staff-summary/staff-summary.component.html
@@ -46,6 +46,7 @@
             worker.uid,
             worker.mainJob?.jobId === 27 ? 'mental-health-professional' : 'main-job-start-date'
           ]"
+          [state]="{ navigatedFrom: 'staff-records' }"
           >Provide more information <span class="govuk-visually-hidden"> for {{ worker.nameOrId }}</span></a
         >
       </td>


### PR DESCRIPTION
#### Work done
- Adds tests for main-job-start-date component
- Passes reference from staff-records to ensure user is taken back into the 'Save and continue' journey.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
