### PR TITLE
Fix: Match training and quals report to updated DB call

### DIFF
--- a/server/routes/reports/trainingAndQualifications/parentReport/parentSummaryTab.js
+++ b/server/routes/reports/trainingAndQualifications/parentReport/parentSummaryTab.js
@@ -18,7 +18,7 @@ const models = require('../../../../models');
 const generateSummaryTab = async (workbook, establishmentId) => {
   const rawEstablishmentTrainingBreakdowns = await models.establishment.workersAndTraining(establishmentId, true, true);
 
-  const establishmentRecordTotals = rawEstablishmentTrainingBreakdowns.map((establishment) => {
+  const establishmentRecordTotals = rawEstablishmentTrainingBreakdowns.rows.map((establishment) => {
     const trainingBreakdowns = convertWorkerTrainingBreakdowns(establishment.workers);
     return {
       establishmentName: establishment.get('NameValue'),

--- a/server/routes/reports/trainingAndQualifications/summaryTab.js
+++ b/server/routes/reports/trainingAndQualifications/summaryTab.js
@@ -13,7 +13,7 @@ const models = require('../../../models');
 
 const generateSummaryTab = async (workbook, establishmentId) => {
   const rawEstablishmentTrainingBreakdowns = await models.establishment.workersAndTraining(establishmentId, true);
-  const workerTrainingBreakdowns = convertWorkerTrainingBreakdowns(rawEstablishmentTrainingBreakdowns[0].workers);
+  const workerTrainingBreakdowns = convertWorkerTrainingBreakdowns(rawEstablishmentTrainingBreakdowns.rows[0].workers);
   const trainingRecordTotals = getTrainingTotals(workerTrainingBreakdowns);
 
   const summaryTab = workbook.addWorksheet('Training (summary)', { views: [{ showGridLines: false }] });

--- a/server/test/unit/routes/reports/trainingAndQualificationsReport/parentReport/parentTrainingAndQualificationsReport.spec.js
+++ b/server/test/unit/routes/reports/trainingAndQualificationsReport/parentReport/parentTrainingAndQualificationsReport.spec.js
@@ -14,14 +14,17 @@ describe('generateParentTrainingAndQualificationsReport', () => {
       return [];
     });
 
-    sinon.stub(models.establishment, 'workersAndTraining').returns([
-      {
-        id: 1234,
-        name: 'Test',
-        workers: [],
-        get: () => {},
-      },
-    ]);
+    sinon.stub(models.establishment, 'workersAndTraining').returns({
+      count: 1,
+      rows: [
+        {
+          id: 1234,
+          name: 'Test',
+          workers: [],
+          get: () => {},
+        },
+      ],
+    });
 
     sinon.stub(models.establishment, 'getWorkersWithCareCertificateStatus').returns([
       {

--- a/server/test/unit/routes/reports/trainingAndQualificationsReport/trainingAndQualificationsReport.spec.js
+++ b/server/test/unit/routes/reports/trainingAndQualificationsReport/trainingAndQualificationsReport.spec.js
@@ -10,14 +10,17 @@ describe('generateTrainingAndQualificationsReport', () => {
   beforeEach(() => {
     sinon.stub(models.establishment, 'findByUid').returns({ id: 1234 });
 
-    sinon.stub(models.establishment, 'workersAndTraining').returns([
-      {
-        id: 1234,
-        name: 'Test',
-        workers: [],
-        get: () => {},
-      },
-    ]);
+    sinon.stub(models.establishment, 'workersAndTraining').returns({
+      count: 1,
+      rows: [
+        {
+          id: 1234,
+          name: 'Test',
+          workers: [],
+          get: () => {},
+        },
+      ],
+    });
     sinon.stub(models.establishment, 'getEstablishmentTrainingRecords').callsFake(() => {
       return [];
     });


### PR DESCRIPTION
#### Work done
- Update trainingAndQualificationsReport summaryTabs to include rows in returned data from workersAndTraining database call

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
