### PR TITLE
Feat/staffTrainingSearch

### DIFF
--- a/src/app/shared/components/search-input/search-input.component.html
+++ b/src/app/shared/components/search-input/search-input.component.html
@@ -1,13 +1,13 @@
 <div class="govuk-!-width-full input--search">
-  <label for="search" class="govuk-label"
+  <label [for]="ref" class="govuk-label"
     >Search<span *ngIf="accessibleLabel" class="govuk-visually-hidden"> {{ accessibleLabel }}</span></label
   >
   <div class="govuk-grid-row govuk-!-margin-0">
     <div class="govuk-grid-column-two-thirds govuk__flex govuk-util__light-bg govuk-!-padding-2">
       <input
         class="govuk-input"
-        id="search"
-        name="search"
+        [id]="ref"
+        [name]="ref"
         type="text"
         (input)="handleOnInput($event)"
         [value]="searchTerm"

--- a/src/app/shared/components/search-input/search-input.component.spec.ts
+++ b/src/app/shared/components/search-input/search-input.component.spec.ts
@@ -6,11 +6,12 @@ import userEvent from '@testing-library/user-event';
 import { SearchInputComponent } from './search-input.component';
 
 describe('SearchInputComponent', () => {
-  const setup = (accessibleLabel?: string) =>
+  const setup = (accessibleLabel?: string, ref?: string) =>
     render(SearchInputComponent, {
       imports: [HttpClientTestingModule, FormsModule, ReactiveFormsModule],
       componentProperties: {
-        accessibleLabel: accessibleLabel,
+        accessibleLabel,
+        ref,
       },
     });
 
@@ -90,5 +91,13 @@ describe('SearchInputComponent', () => {
     userEvent.click(component.getByRole('button', { name: 'search' }));
 
     expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows a reference to avoid classing of rendered components', async () => {
+    const component = await setup(null, 'my-input-id');
+
+    const searchInput = component.getByLabelText('Search');
+    expect(searchInput).toBeTruthy();
+    expect(searchInput.id).toBe('my-input-id');
   });
 });

--- a/src/app/shared/components/search-input/search-input.component.ts
+++ b/src/app/shared/components/search-input/search-input.component.ts
@@ -6,6 +6,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   styleUrls: ['./search-input.component.scss'],
 })
 export class SearchInputComponent {
+  @Input() ref = 'search';
   @Input() searchButtonName = 'search';
   @Input() accessibleLabel: string;
   @Output() emitInput = new EventEmitter<string>();

--- a/src/app/shared/components/staff-summary/staff-summary.component.html
+++ b/src/app/shared/components/staff-summary/staff-summary.component.html
@@ -1,6 +1,10 @@
 <div class="govuk-grid-row govuk-util__vertical-align-center">
   <div class="govuk-grid-column-three-quarters">
-    <app-search-input accessibleLabel="for staff records" (emitInput)="handleSearch($event)"></app-search-input>
+    <app-search-input
+      ref="trainingRecordSearch"
+      accessibleLabel="for staff records"
+      (emitInput)="handleSearch($event)"
+    ></app-search-input>
   </div>
 
   <div class="govuk-grid-column-one-quarter govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2">

--- a/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
+++ b/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
@@ -135,7 +135,7 @@ describe('StaffSummaryComponent', () => {
       component.fixture.detectChanges();
 
       userEvent.type(component.getByLabelText('Search for staff records'), 'search term here{enter}');
-      expect(getAllWorkersSpy.calls.mostRecent().args[1]).toEqual(jasmine.objectContaining({ pageIndex: 0 }));
+      expect(getAllWorkersSpy.calls.mostRecent().args[1].pageIndex).toEqual(0);
     });
 
     it('should render the message that no workers were found if workerCount is falsy', async () => {

--- a/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
+++ b/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
@@ -128,6 +128,16 @@ describe('StaffSummaryComponent', () => {
       expect(getAllWorkersSpy.calls.mostRecent().args[1]).toEqual(expectedEmit);
     });
 
+    it('should reset the pageIndex before calling getAllWorkers when handling search', async () => {
+      const { component, getAllWorkersSpy } = await setup();
+
+      component.fixture.componentInstance.currentPageIndex = 1;
+      component.fixture.detectChanges();
+
+      userEvent.type(component.getByLabelText('Search for staff records'), 'search term here{enter}');
+      expect(getAllWorkersSpy.calls.mostRecent().args[1]).toEqual(jasmine.objectContaining({ pageIndex: 0 }));
+    });
+
     it('should render the message that no workers were found if workerCount is falsy', async () => {
       const { component } = await setup();
 

--- a/src/app/shared/components/staff-summary/staff-summary.component.ts
+++ b/src/app/shared/components/staff-summary/staff-summary.component.ts
@@ -82,6 +82,7 @@ export class StaffSummaryComponent implements OnInit {
   }
 
   public handleSearch(searchTerm: string): void {
+    this.currentPageIndex = 0;
     this.searchTerm = searchTerm;
     this.getPageOfWorkers();
   }

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
@@ -1,5 +1,5 @@
 <div class="govuk-form-group govuk-!-margin-bottom-6">
-  <div class="govuk__flex govuk__justify-content-space-between govuk-grid-row">
+  <div class="govuk-grid-row govuk-util__vertical-align-center govuk-!-margin-bottom-4 govuk-!-margin-top-4">
     <div class="govuk-grid-column-one-half govuk__flex govuk__align-items-flex-end" *ngIf="showViewByToggle">
       <span class="govuk-list govuk-list--inline govuk-!-margin-bottom-1 govuk-!-margin-right-6"
         >View by staff name</span
@@ -12,8 +12,12 @@
         View by training category
       </a>
     </div>
-    <div class="govuk-grid-column-one-quarter"></div>
-    <div class="govuk-list govuk-list--inline govuk-!-margin-bottom-0 govuk-grid-column-one-quarter">
+  </div>
+  <div class="govuk-grid-row govuk-util__vertical-align-center">
+    <div class="govuk-grid-column-three-quarters">
+      <app-search-input accessibleLabel="staff training records" (emitInput)="handleSearch($event)"></app-search-input>
+    </div>
+    <div class="govuk-grid-column-one-quarter govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2">
       <label class="govuk-label" for="sortByTrainingStaff"> Sort by </label>
       <select
         class="govuk-select govuk-!-width-full"
@@ -32,7 +36,7 @@
     </div>
   </div>
 </div>
-<table class="govuk-table" data-testid="training-worker-table">
+<table *ngIf="workerCount; else noWorkersFound" class="govuk-table" data-testid="training-worker-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">Staff name</th>
@@ -94,6 +98,10 @@
     </tr>
   </tbody>
 </table>
+<ng-template #noWorkersFound>
+  <p class="govuk-util__bold">There are no matching results.</p>
+  <p>Make sure that your spelling is correct.</p>
+</ng-template>
 <app-pagination
   [itemsPerPage]="itemsPerPage"
   [totalNoOfItems]="workerCount"

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.spec.ts
@@ -19,9 +19,11 @@ import {
 import { build, fake, sequence } from '@jackfranklin/test-data-bot';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { fireEvent, render } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 
 import { PaginationComponent } from '../pagination/pagination.component';
+import { SearchInputComponent } from '../search-input/search-input.component';
 import { TrainingAndQualificationsSummaryComponent } from './training-and-qualifications-summary.component';
 
 const establishmentBuilder = build('Establishment', {
@@ -51,7 +53,7 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
       TrainingAndQualificationsSummaryComponent,
       {
         imports: [HttpClientTestingModule, RouterTestingModule],
-        declarations: [PaginationComponent],
+        declarations: [PaginationComponent, SearchInputComponent],
         providers: [
           { provide: PermissionsService, useValue: mockPermissionsService },
           { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
@@ -204,5 +206,34 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
       'training',
       'wdf-summary',
     ]);
+  });
+
+  describe('calls getAllWorkers on workerService when using search', () => {
+    it('should call getAllWorkers with correct search term if passed', async () => {
+      const { getByLabelText, workerServiceSpy } = await setup();
+
+      const searchInput = getByLabelText('Search staff training records');
+      expect(searchInput).toBeTruthy();
+
+      userEvent.type(searchInput, 'search term here{enter}');
+
+      const expectedEmit = {
+        pageIndex: 0,
+        itemsPerPage: 15,
+        sortBy: 'trainingExpired',
+        searchTerm: 'search term here',
+      };
+      expect(workerServiceSpy.calls.mostRecent().args[1]).toEqual(expectedEmit);
+    });
+
+    it('should render the message that no workers were found if workerCount is falsy', async () => {
+      const { fixture, getByText } = await setup();
+
+      fixture.componentInstance.workerCount = 0;
+      fixture.detectChanges();
+
+      expect(getByText('There are no matching results.')).toBeTruthy();
+      expect(getByText('Make sure that your spelling is correct.')).toBeTruthy();
+    });
   });
 });

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.spec.ts
@@ -236,7 +236,7 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
       fixture.detectChanges();
 
       userEvent.type(getByLabelText('Search staff training records'), 'search term here{enter}');
-      expect(workerServiceSpy.calls.mostRecent().args[1]).toEqual(jasmine.objectContaining({ pageIndex: 0 }));
+      expect(workerServiceSpy.calls.mostRecent().args[1].pageIndex).toEqual(0);
     });
 
     it('should render the message that no workers were found if workerCount is falsy', async () => {

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.spec.ts
@@ -79,6 +79,7 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
     const workerServiceSpy = spyOn(workerService, 'getAllWorkers').and.callThrough();
 
     const sortBySpy = spyOn(component, 'handleSortUpdate').and.callThrough();
+    const searchSpy = spyOn(component, 'handleSearch').and.callThrough();
 
     return {
       component,
@@ -89,6 +90,7 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
       spy,
       workerServiceSpy,
       sortBySpy,
+      searchSpy,
     };
   }
 
@@ -210,7 +212,7 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
 
   describe('calls getAllWorkers on workerService when using search', () => {
     it('should call getAllWorkers with correct search term if passed', async () => {
-      const { getByLabelText, workerServiceSpy } = await setup();
+      const { getByLabelText, workerServiceSpy, searchSpy } = await setup();
 
       const searchInput = getByLabelText('Search staff training records');
       expect(searchInput).toBeTruthy();
@@ -224,6 +226,17 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
         searchTerm: 'search term here',
       };
       expect(workerServiceSpy.calls.mostRecent().args[1]).toEqual(expectedEmit);
+      expect(searchSpy).toHaveBeenCalledOnceWith('search term here');
+    });
+
+    it('should reset the pageIndex before calling getAllWorkers when handling search', async () => {
+      const { fixture, getByLabelText, workerServiceSpy } = await setup();
+
+      fixture.componentInstance.currentPageIndex = 1;
+      fixture.detectChanges();
+
+      userEvent.type(getByLabelText('Search staff training records'), 'search term here{enter}');
+      expect(workerServiceSpy.calls.mostRecent().args[1]).toEqual(jasmine.objectContaining({ pageIndex: 0 }));
     });
 
     it('should render the message that no workers were found if workerCount is falsy', async () => {

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
@@ -93,6 +93,7 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
   }
 
   public handleSearch(searchTerm: string): void {
+    this.setPageIndex(0);
     this.searchTerm = searchTerm;
     this.refetchWorkers();
   }

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
@@ -25,6 +25,7 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
   public itemsPerPage = 15;
   public currentPageIndex = 0;
   public paginatedWorkers: Array<Worker>;
+  private searchTerm = '';
 
   constructor(
     private permissionsService: PermissionsService,
@@ -63,6 +64,7 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
         sortBy: sortByParamMap[this.sortByValue],
         pageIndex: this.currentPageIndex,
         itemsPerPage: this.itemsPerPage,
+        ...(this.searchTerm ? { searchTerm: this.searchTerm } : {}),
       })
       .pipe(take(1))
       .subscribe(({ workers, workerCount }) => {
@@ -88,5 +90,10 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
     event.preventDefault();
     const path = ['/workplace', this.workplace.uid, 'training-and-qualifications-record', worker.uid, 'training'];
     this.router.navigate(this.wdfView ? [...path, 'wdf-summary'] : path);
+  }
+
+  public handleSearch(searchTerm: string): void {
+    this.searchTerm = searchTerm;
+    this.refetchWorkers();
   }
 }


### PR DESCRIPTION
#### Work done
- adds search to staff training records
- allows setting of for/id on label and input to avoid clashes
- resets pageIndex when searching 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
