### PR TITLE
Feat/remove wdf link from dashboard

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -161,7 +161,7 @@ const routes: Routes = [
         component: AdminComponent,
       },
       {
-        path: 'wdf/data',
+        path: 'wdf',
         loadChildren: () => import('@features/wdf/wdf-data-change/wdf.module').then((m) => m.WdfModule),
         data: { title: 'Workforce Development Fund Data' },
       },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -161,7 +161,7 @@ const routes: Routes = [
         component: AdminComponent,
       },
       {
-        path: 'wdf',
+        path: 'wdf/data',
         loadChildren: () => import('@features/wdf/wdf-data-change/wdf.module').then((m) => m.WdfModule),
         data: { title: 'Workforce Development Fund Data' },
       },

--- a/src/app/core/breadcrumb/journey.wdf.ts
+++ b/src/app/core/breadcrumb/journey.wdf.ts
@@ -1,7 +1,7 @@
 import { JourneyRoute } from './breadcrumb.model';
 
 enum Path {
-  OVERVIEW = '/wdf',
+  DASHBOARD = '/dashboard',
   DATA = '/wdf/data',
   STAFF_RECORD = 'wdf/data/staff-record/:id',
   WORKPLACES = 'wdf/workplaces',
@@ -12,22 +12,25 @@ enum Path {
 export const wdfJourney: JourneyRoute = {
   children: [
     {
-      title: 'WDF',
-      path: Path.OVERVIEW,
+      title: 'WDF data',
+      path: Path.DATA,
+      referrer: {
+        path: Path.DASHBOARD,
+        fragment: 'wdf',
+      },
+      fragment: 'staff-records',
       children: [
         {
-          title: 'WDF data',
-          path: Path.DATA,
-          children: [
-            {
-              title: 'Staff record',
-              path: Path.STAFF_RECORD,
-              referrer: {
-                path: Path.DATA,
-                fragment: 'staff-records',
-              },
-            },
-          ],
+          title: 'Staff record',
+          path: Path.STAFF_RECORD,
+          referrer: {
+            path: Path.DATA,
+            fragment: 'staff-records',
+          },
+          // referrer: {
+          //   path: Path.DASHBOARD,
+          //   fragment: 'wdf',
+          // },
         },
       ],
     },
@@ -37,26 +40,24 @@ export const wdfJourney: JourneyRoute = {
 export const wdfParentJourney: JourneyRoute = {
   children: [
     {
-      title: 'WDF',
-      path: Path.OVERVIEW,
+      title: 'Workplaces',
+      path: Path.WORKPLACES,
+      referrer: {
+        path: Path.DASHBOARD,
+        fragment: 'wdf',
+      },
       children: [
         {
-          title: 'Workplaces',
-          path: Path.WORKPLACES,
+          title: 'WDF data',
+          path: Path.PARENT_DATA,
           children: [
             {
-              title: 'WDF data',
-              path: Path.PARENT_DATA,
-              children: [
-                {
-                  title: 'Staff record',
-                  path: Path.PARENT_STAFF_RECORD,
-                  referrer: {
-                    path: Path.PARENT_DATA,
-                    fragment: 'staff-records',
-                  },
-                },
-              ],
+              title: 'Staff record',
+              path: Path.PARENT_STAFF_RECORD,
+              referrer: {
+                path: Path.PARENT_DATA,
+                fragment: 'staff-records',
+              },
             },
           ],
         },

--- a/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -48,12 +48,6 @@
         </h3>
         <p>Access all your special offers and discounts across Skills for Care's product range.</p>
       </div>
-      <div *ngIf="canViewReports">
-        <h3 class="govuk-heading-m govuk-!-font-weight-regular govuk-!-margin-bottom-0">
-          <a [routerLink]="['/wdf']"> Check your WDF data </a>
-        </h3>
-        <p class="govuk-!-margin-top-4">Check if your data meets Workforce Development Fund (WDF) requirements.</p>
-      </div>
       <div *ngIf="canBulkUpload">
         <h3 class="govuk-heading-m govuk-!-font-weight-regular govuk-!-margin-bottom-0">
           <a [routerLink]="['/bulk-upload']" (click)="setReturn()"> Bulk upload your data </a>

--- a/src/app/features/dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/dashboard/home-tab/home-tab.component.ts
@@ -49,7 +49,6 @@ export class HomeTabComponent implements OnInit, OnDestroy {
   public canBulkUpload: boolean;
   public canEditEstablishment: boolean;
   public canViewWorkplaces: boolean;
-  public canViewReports: boolean;
   public isParent: boolean;
   public updateStaffRecords: boolean;
   public user: UserDetails;
@@ -332,9 +331,6 @@ export class HomeTabComponent implements OnInit, OnDestroy {
       this.workplace.parentUid != null &&
       this.workplace.dataOwner === 'Workplace' &&
       this.user.role != 'Read';
-    this.canViewReports =
-      this.permissionsService.can(workplaceUid, 'canViewWdfReport') ||
-      this.permissionsService.can(workplaceUid, 'canRunLocalAuthorityReport');
 
     if (this.canViewChangeDataOwner && this.workplace.dataOwnershipRequested) {
       this.isOwnershipRequested = true;

--- a/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
@@ -3,16 +3,10 @@ import { RouterModule, Routes } from '@angular/router';
 import { HasPermissionsGuard } from '@core/guards/permissions/has-permissions/has-permissions.guard';
 
 import { WdfDataComponent } from './wdf-data/wdf-data.component';
-import { WdfOverviewComponent } from './wdf-overview/wdf-overview.component';
 import { WdfStaffRecordComponent } from './wdf-staff-record/wdf-staff-record.component';
 import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary/wdf-workplaces-summary.component';
 
 const routes: Routes = [
-  {
-    path: '',
-    component: WdfOverviewComponent,
-    data: { title: 'Workforce Development Fund' },
-  },
   {
     path: 'data',
     component: WdfDataComponent,

--- a/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
@@ -8,7 +8,7 @@ import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary/wdf-work
 
 const routes: Routes = [
   {
-    path: 'data',
+    path: '',
     component: WdfDataComponent,
     canActivate: [HasPermissionsGuard],
     data: { permissions: ['canViewWdfReport'], title: 'WDF data' },

--- a/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
@@ -9,6 +9,11 @@ import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary/wdf-work
 const routes: Routes = [
   {
     path: '',
+    redirectTo: 'data',
+    pathMatch: 'full',
+  },
+  {
+    path: 'data',
     component: WdfDataComponent,
     canActivate: [HasPermissionsGuard],
     data: { permissions: ['canViewWdfReport'], title: 'WDF data' },

--- a/src/app/features/wdf/wdf-data-change/wdf.module.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf.module.ts
@@ -6,7 +6,6 @@ import { SharedModule } from '@shared/shared.module';
 
 import { WdfDataStatusMessageComponent } from './wdf-data-status-message/wdf-data-status-message.component';
 import { WdfDataComponent } from './wdf-data/wdf-data.component';
-import { WdfOverviewComponent } from './wdf-overview/wdf-overview.component';
 import { WdfParentStatusMessageComponent } from './wdf-parent-status-message/wdf-parent-status-message.component';
 import { WdfRequirementsStateComponent } from './wdf-requirements-state/wdf-requirements-state.component';
 import { WdfRoutingModule } from './wdf-routing.module';
@@ -20,7 +19,6 @@ import { WdfWorkplacesSummaryComponent } from './wdf-workplaces-summary/wdf-work
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, WdfRoutingModule],
   declarations: [
-    WdfOverviewComponent,
     WdfDataComponent,
     WdfStaffSummaryComponent,
     WdfStaffRecordComponent,

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
@@ -13,7 +13,7 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
 
   constructor(private breadcrumbService: BreadcrumbService) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.subscriptions.add(
       this.breadcrumbService.routes$.subscribe((routes) => {
         this.breadcrumbs = routes ? this.getBreadcrumbs(routes) : null;
@@ -21,12 +21,12 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
     );
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
   }
 
   private getBreadcrumbs(routes: JourneyRoute[]) {
-    const currentPath = routes[routes.length - 1];
+    const routesWithReferrers = routes.filter((route) => route.referrer);
 
     routes = [
       {
@@ -36,17 +36,18 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
       ...routes,
     ];
 
-    if (currentPath.referrer) {
+    routesWithReferrers.forEach((referrerRoute) => {
       routes = routes.map((route) => {
-        if (route.path === currentPath.referrer.path) {
+        if (route.path === referrerRoute.referrer.path) {
           return {
             ...route,
-            fragment: currentPath.referrer.fragment,
+            fragment: referrerRoute.referrer.fragment,
           };
         }
         return route;
       });
-    }
+    });
+
     return routes;
   }
 }


### PR DESCRIPTION
#### Work done
- remove wdf link and text from home tab
- remove the wdf overview component
- create a redirect so that url '/wdf' redirects to '/wdf/data'
- alter breadcrumbs, to add fragments to all breadcrumb links if required

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
