### PR TITLE
Fix/pagination snagging list

### DIFF
--- a/server/routes/establishments/childWorkplaces.js
+++ b/server/routes/establishments/childWorkplaces.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router({ mergeParams: true });
 const models = require('../../models');
+const Authorization = require('../../utils/security/isAuthenticated');
 
 const getChildWorkplaces = async (req, res) => {
   try {
@@ -43,7 +44,7 @@ const formatChildWorkplaces = (childWorkplaces) => {
   });
 };
 
-router.route('/').get(getChildWorkplaces);
+router.route('/').get(Authorization.isAuthorised, getChildWorkplaces);
 
 module.exports = router;
 module.exports.getChildWorkplaces = getChildWorkplaces;

--- a/server/routes/reports/trainingAndQualifications/summaryTab.js
+++ b/server/routes/reports/trainingAndQualifications/summaryTab.js
@@ -13,7 +13,9 @@ const models = require('../../../models');
 
 const generateSummaryTab = async (workbook, establishmentId) => {
   const rawEstablishmentTrainingBreakdowns = await models.establishment.workersAndTraining(establishmentId, true);
-  const workerTrainingBreakdowns = convertWorkerTrainingBreakdowns(rawEstablishmentTrainingBreakdowns.rows[0].workers);
+  const workerTrainingBreakdowns = rawEstablishmentTrainingBreakdowns.rows.length
+    ? convertWorkerTrainingBreakdowns(rawEstablishmentTrainingBreakdowns.rows[0].workers)
+    : [];
   const trainingRecordTotals = getTrainingTotals(workerTrainingBreakdowns);
 
   const summaryTab = workbook.addWorksheet('Training (summary)', { views: [{ showGridLines: false }] });

--- a/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
+++ b/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
@@ -18,45 +18,50 @@
   </div>
 </div>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-5">
-  <div class="govuk-grid-column-three-quarters">
-    <app-search-input accessibleLabel="child workplace records" (emitInput)="handleSearch($event)"></app-search-input>
+<div *ngIf="totalWorkplaceCount; else noWorkplaces">
+  <div class="govuk-grid-row govuk-!-margin-bottom-5">
+    <div class="govuk-grid-column-three-quarters">
+      <app-search-input accessibleLabel="child workplace records" (emitInput)="handleSearch($event)"></app-search-input>
+    </div>
   </div>
-</div>
 
-<div *ngIf="workplacesCount; else noWorkplacesFound">
-  <ul class="govuk-list">
-    <ng-container *ngFor="let workplace of workplaces">
-      <li
-        class="govuk-util__list-record govuk-!-margin-bottom-0 govuk-panel--light-blue"
-        *ngIf="workplace.ustatus === 'PENDING' || workplace.ustatus === 'IN PROGRESS'"
-      >
-        <div>
-          <span class="govuk-!-padding-left-3"
-            >Your application for {{ workplace.name }} is being reviewed by Skills for Care.</span
-          >
-          <span class="govuk-util__float-right govuk-!-padding-right-3">Pending</span>
-        </div>
-      </li>
-      <li class="govuk-util__list-record govuk-!-margin-bottom-0" *ngIf="workplace.ustatus === null">
-        <app-workplace-info-panel
-          [workplace]="workplace"
-          (changeOwnershipAndPermissionsEvent)="changeOwnershipAndPermissions($event)"
+  <div *ngIf="workplaceCount; else noWorkplacesFoundInSearch">
+    <ul class="govuk-list">
+      <ng-container *ngFor="let workplace of workplaces">
+        <li
+          class="govuk-util__list-record govuk-!-margin-bottom-0 govuk-panel--light-blue"
+          *ngIf="workplace.ustatus === 'PENDING' || workplace.ustatus === 'IN PROGRESS'"
         >
-        </app-workplace-info-panel>
-      </li>
-    </ng-container>
-  </ul>
-</div>
-<ng-template #noWorkplacesFound>
-  <p class="govuk-util__bold">There are no matching results.</p>
-  <p>Make sure that your spelling is correct.</p>
-</ng-template>
+          <div>
+            <span class="govuk-!-padding-left-3"
+              >Your application for {{ workplace.name }} is being reviewed by Skills for Care.</span
+            >
+            <span class="govuk-util__float-right govuk-!-padding-right-3">Pending</span>
+          </div>
+        </li>
+        <li class="govuk-util__list-record govuk-!-margin-bottom-0" *ngIf="workplace.ustatus === null">
+          <app-workplace-info-panel
+            [workplace]="workplace"
+            (changeOwnershipAndPermissionsEvent)="changeOwnershipAndPermissions($event)"
+          >
+          </app-workplace-info-panel>
+        </li>
+      </ng-container>
+    </ul>
+  </div>
+  <ng-template #noWorkplacesFoundInSearch>
+    <p class="govuk-util__bold">There are no matching results.</p>
+    <p>Make sure that your spelling is correct.</p>
+  </ng-template>
 
-<p *ngIf="workplaces.length === 0">There are no workplaces.</p>
-<app-pagination
-  [itemsPerPage]="itemsPerPage"
-  [totalNoOfItems]="workplacesCount"
-  (currentPageIndexChange)="handlePageUpdate($event)"
-  [currentPageIndex]="currentPageIndex"
-></app-pagination>
+  <app-pagination
+    [itemsPerPage]="itemsPerPage"
+    [totalNoOfItems]="workplaceCount"
+    (currentPageIndexChange)="handlePageUpdate($event)"
+    [currentPageIndex]="currentPageIndex"
+  ></app-pagination>
+</div>
+
+<ng-template #noWorkplaces>
+  <p>There are no workplaces.</p>
+</ng-template>

--- a/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
+++ b/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
@@ -23,7 +23,8 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
   public serverError: string;
   public serverErrorsMap: ErrorDefinition[] = [];
   public workplaces: Workplace[] = [];
-  public workplacesCount: number;
+  public workplaceCount: number;
+  public totalWorkplaceCount: number;
   public activeWorkplaceCount: number;
   public itemsPerPage = 12;
   public currentPageIndex = 0;
@@ -43,6 +44,7 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
     this.canAddEstablishment = this.permissionsService.can(this.primaryWorkplace.uid, 'canAddEstablishment');
 
     const childWorkplaces = this.route.snapshot.data.childWorkplaces;
+    this.totalWorkplaceCount = childWorkplaces.count;
     this.activeWorkplaceCount = childWorkplaces.activeWorkplaceCount;
     this.setWorkplaceVariables(childWorkplaces);
 
@@ -91,7 +93,7 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
 
   private setWorkplaceVariables(data: GetChildWorkplacesResponse): void {
     this.workplaces = data.childWorkplaces;
-    this.workplacesCount = data.count;
+    this.workplaceCount = data.count;
   }
 
   public handleSearch(searchTerm: string): void {

--- a/src/app/shared/components/pagination/pagination.component.ts
+++ b/src/app/shared/components/pagination/pagination.component.ts
@@ -54,6 +54,6 @@ export class PaginationComponent implements OnInit {
 
   @HostListener('window:resize')
   private setIsBigWindow(): void {
-    this.isBigWindow = window.innerWidth > 1000;
+    this.isBigWindow = window.innerWidth > 768;
   }
 }

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.html
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<table *ngIf="workerCount; else noWorkersFound" class="govuk-table" data-testid="training-worker-table">
+<table *ngIf="workerCount; else noWorkersFoundInSearch" class="govuk-table" data-testid="training-worker-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">Staff name</th>
@@ -98,7 +98,7 @@
     </tr>
   </tbody>
 </table>
-<ng-template #noWorkersFound>
+<ng-template #noWorkersFoundInSearch>
   <p class="govuk-util__bold">There are no matching results.</p>
   <p>Make sure that your spelling is correct.</p>
 </ng-template>

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
@@ -49,7 +49,7 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
     this.refetchWorkers();
   }
 
-  private refetchWorkers() {
+  private refetchWorkers(): void {
     const sortByParamMap = {
       '0_expired': 'trainingExpired',
       '1_expires_soon': 'trainingExpiringSoon',

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
@@ -14,7 +14,7 @@
 </div>
 
 <app-training-link-panel [workplace]="workplace" [workers]="workers"></app-training-link-panel>
-<ng-container *ngIf="workers; else noStaffRecords">
+<ng-container *ngIf="workers && workers.length; else noStaffRecords">
   <div class="govuk-grid-row" *ngIf="totalRecords === 0">
     <div class="govuk-grid-column-two-thirds">
       <app-inset-text color="warning">You have not added any training or qualification records yet.</app-inset-text>
@@ -40,7 +40,7 @@
   ></app-training-and-qualifications-categories>
 
   <app-training-and-qualifications-summary
-    *ngIf="workers && viewTrainingByCategory === false"
+    *ngIf="viewTrainingByCategory === false"
     [workplace]="workplace"
     [workers]="workers"
     [workerCount]="workerCount"


### PR DESCRIPTION
#### Work done
- Handle differentiation between no staff/workplace records and no results returned from search in training tab and view all workplaces page
- Update page width for small screen version of pagination component
- Add isAuthorised check to getChildWorkplaces endpoint
- Add check for rows.length to fix issue where training report didn't download when no staff records

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
