### PR TITLE
Feat/wdf claim add learners start page

### DIFF
--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
@@ -23,4 +23,7 @@
       </ul>
     </ng-template>
   </div>
+  <div class="govuk-grid-column-one-third govuk-!-margin-top-8">
+    <app-make-a-claim-progress-bar></app-make-a-claim-progress-bar>
+  </div>
 </div>

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
@@ -9,5 +9,18 @@
       Staff records will need to include a name that matches the one shown on their learning award certificate, not an
       ID number<ng-container *ngIf="dobRequired">, and a date of birth</ng-container>.
     </p>
+
+    <p *ngIf="['learningProgramme', 'digitalModule'].includes(claimType); else claimWithMultipleRequirements">
+      You'll need to know the amount of money you want to claim for each learner.
+    </p>
+    <ng-template #claimWithMultipleRequirements>
+      <p>For each learner, you'll need to know:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>their Unique Learner Number</li>
+        <li *ngIf="claimType == 'qualification'">their Candidate Registration Number</li>
+        <li>the amount of money you want to claim</li>
+        <li *ngIf="claimType == 'qualification'">whether the qualification is part of an apprenticeship</li>
+      </ul>
+    </ng-template>
   </div>
 </div>

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
@@ -1,0 +1,9 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
+      <span class="govuk-caption-xl govuk-!-margin-bottom-3">Add learners</span>
+      Now you need to add learners to your claim
+    </h1>
+    <p>There needs to be a staff record in ASC-WDS for each learner that you want to add.</p>
+  </div>
+</div>

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters govuk-!-padding-right-9">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
       <span class="govuk-caption-xl govuk-!-margin-bottom-3">Add learners</span>
       Now you need to add learners to your claim
@@ -23,7 +23,7 @@
       </ul>
     </ng-template>
   </div>
-  <div class="govuk-grid-column-one-third govuk-!-margin-top-8">
+  <div class="govuk-grid-column-one-quarter govuk-!-margin-top-8">
     <app-make-a-claim-progress-bar stepIndex="1"></app-make-a-claim-progress-bar>
   </div>
 </div>

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
@@ -5,5 +5,9 @@
       Now you need to add learners to your claim
     </h1>
     <p>There needs to be a staff record in ASC-WDS for each learner that you want to add.</p>
+    <p class="govuk-inset-text">
+      Staff records will need to include a name that matches the one shown on their learning award certificate, not an
+      ID number<ng-container *ngIf="dobRequired">, and a date of birth</ng-container>.
+    </p>
   </div>
 </div>

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.html
@@ -24,6 +24,6 @@
     </ng-template>
   </div>
   <div class="govuk-grid-column-one-third govuk-!-margin-top-8">
-    <app-make-a-claim-progress-bar></app-make-a-claim-progress-bar>
+    <app-make-a-claim-progress-bar stepIndex="1"></app-make-a-claim-progress-bar>
   </div>
 </div>

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.spec.ts
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.spec.ts
@@ -58,4 +58,38 @@ describe('AddLearnersStartPageComponent', () => {
       expect(getByText(messageWithoutDOB)).toBeTruthy();
     });
   });
+
+  describe('Claim requirements message', () => {
+    const claimAmountMessage = "You'll need to know the amount of money you want to claim for each learner.";
+
+    it('should show amount message when claimType is learningProgramme', async () => {
+      const { getByText } = await setup('learningProgramme');
+
+      expect(getByText(claimAmountMessage)).toBeTruthy();
+    });
+
+    it('should show amount message when claimType is digitalModule', async () => {
+      const { getByText } = await setup('digitalModule');
+
+      expect(getByText(claimAmountMessage)).toBeTruthy();
+    });
+
+    it('should include learner number and amount in message when claimType is apprenticeship', async () => {
+      const { getByText } = await setup('apprenticeship');
+
+      expect(getByText("For each learner, you'll need to know:")).toBeTruthy();
+      expect(getByText('their Unique Learner Number')).toBeTruthy();
+      expect(getByText('the amount of money you want to claim')).toBeTruthy();
+    });
+
+    it('should not include DOB when claimType is qualification', async () => {
+      const { getByText } = await setup('qualification');
+
+      expect(getByText("For each learner, you'll need to know:")).toBeTruthy();
+      expect(getByText('their Unique Learner Number')).toBeTruthy();
+      expect(getByText('their Candidate Registration Number')).toBeTruthy();
+      expect(getByText('the amount of money you want to claim')).toBeTruthy();
+      expect(getByText('whether the qualification is part of an apprenticeship')).toBeTruthy();
+    });
+  });
 });

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.spec.ts
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.spec.ts
@@ -7,18 +7,55 @@ import { render } from '@testing-library/angular';
 import { AddLearnersStartPageComponent } from './add-learners-start-page.component';
 
 describe('AddLearnersStartPageComponent', () => {
-  const setup = async () => {
-    const { fixture } = await render(AddLearnersStartPageComponent, {
+  const setup = async (claimType = 'learningProgramme') => {
+    window.history.pushState({ claimType }, '');
+
+    const { fixture, getByText } = await render(AddLearnersStartPageComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
     });
 
     const component = fixture.componentInstance;
 
-    return { component };
+    return { component, getByText };
   };
+
+  afterEach(() => {
+    window.history.replaceState(undefined, '');
+  });
 
   it('should render a WdfGrantLetterComponent', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  describe('Staff record requirements message', () => {
+    const messageWithDOB =
+      'Staff records will need to include a name that matches the one shown on their learning award certificate, not an ID number, and a date of birth.';
+    const messageWithoutDOB =
+      'Staff records will need to include a name that matches the one shown on their learning award certificate, not an ID number.';
+
+    it('should include DOB when claimType is learningProgramme', async () => {
+      const { getByText } = await setup('learningProgramme');
+
+      expect(getByText(messageWithDOB)).toBeTruthy();
+    });
+
+    it('should include DOB when claimType is digitalModule', async () => {
+      const { getByText } = await setup('digitalModule');
+
+      expect(getByText(messageWithDOB)).toBeTruthy();
+    });
+
+    it('should not include DOB when claimType is apprenticeship', async () => {
+      const { getByText } = await setup('apprenticeship');
+
+      expect(getByText(messageWithoutDOB)).toBeTruthy();
+    });
+
+    it('should not include DOB when claimType is qualification', async () => {
+      const { getByText } = await setup('qualification');
+
+      expect(getByText(messageWithoutDOB)).toBeTruthy();
+    });
   });
 });

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.spec.ts
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.spec.ts
@@ -1,0 +1,24 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { AddLearnersStartPageComponent } from './add-learners-start-page.component';
+
+describe('AddLearnersStartPageComponent', () => {
+  const setup = async () => {
+    const { fixture } = await render(AddLearnersStartPageComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
+    });
+
+    const component = fixture.componentInstance;
+
+    return { component };
+  };
+
+  it('should render a WdfGrantLetterComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.ts
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.ts
@@ -1,7 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-add-learners-start-page',
   templateUrl: './add-learners-start-page.component.html',
 })
-export class AddLearnersStartPageComponent {}
+export class AddLearnersStartPageComponent implements OnInit {
+  public claimType: string;
+  public dobRequired: boolean;
+
+  ngOnInit(): void {
+    this.claimType = history.state?.claimType;
+    this.dobRequired = ['learningProgramme', 'digitalModule'].includes(this.claimType);
+  }
+}

--- a/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.ts
+++ b/src/app/features/wdf/wdf-claims/add-learners-start-page/add-learners-start-page.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-add-learners-start-page',
+  templateUrl: './add-learners-start-page.component.html',
+})
+export class AddLearnersStartPageComponent {}

--- a/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.html
+++ b/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.html
@@ -1,7 +1,7 @@
 <h3 class="govuk-!-margin-bottom-0">Make a claim</h3>
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 <ng-container *ngFor="let step of steps; index as i">
-  <p>
+  <p class="govuk-!-display-block govuk-!-margin-bottom-0">
     <img
       *ngIf="i < stepIndex"
       [attr.data-testid]="'completed-' + i"
@@ -25,4 +25,18 @@
     />
     {{ step }}
   </p>
+  <img
+    *ngIf="i < stepIndex"
+    [attr.data-testid]="'blackLine-' + i"
+    class="govuk-!-display-block govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-margin-left-2"
+    src="/assets/images/progress-bar/black-line.svg"
+    alt=""
+  />
+  <img
+    *ngIf="i >= stepIndex && i != steps.length - 1"
+    [attr.data-testid]="'greyLine-' + i"
+    class="govuk-!-display-block govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-margin-left-2"
+    src="/assets/images/progress-bar/grey-line.svg"
+    alt=""
+  />
 </ng-container>

--- a/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.html
+++ b/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.html
@@ -1,6 +1,10 @@
 <h3 class="govuk-!-margin-bottom-0">Make a claim</h3>
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-<p>Select qualification</p>
-<p>Add learners</p>
-<p>Upload certificate</p>
-<p>Review and submit</p>
+<ng-container *ngFor="let step of steps; index as i">
+  <p>
+    <span *ngIf="i < stepIndex" [attr.data-testid]="'completed-' + i">Completed </span>
+    <span *ngIf="i == stepIndex" [attr.data-testid]="'currentStep-' + i">Current </span>
+    <span *ngIf="i > stepIndex" [attr.data-testid]="'notCompleted-' + i">Not done </span>
+    {{ step }}
+  </p>
+</ng-container>

--- a/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.html
+++ b/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.html
@@ -2,9 +2,27 @@
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 <ng-container *ngFor="let step of steps; index as i">
   <p>
-    <span *ngIf="i < stepIndex" [attr.data-testid]="'completed-' + i">Completed </span>
-    <span *ngIf="i == stepIndex" [attr.data-testid]="'currentStep-' + i">Current </span>
-    <span *ngIf="i > stepIndex" [attr.data-testid]="'notCompleted-' + i">Not done </span>
+    <img
+      *ngIf="i < stepIndex"
+      [attr.data-testid]="'completed-' + i"
+      class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
+      src="/assets/images/progress-bar/done.svg"
+      alt=""
+    />
+    <img
+      *ngIf="i == stepIndex"
+      [attr.data-testid]="'currentStep-' + i"
+      class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
+      src="/assets/images/progress-bar/doing.svg"
+      alt=""
+    />
+    <img
+      *ngIf="i > stepIndex"
+      [attr.data-testid]="'notCompleted-' + i"
+      class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
+      src="/assets/images/progress-bar/to-do.svg"
+      alt=""
+    />
     {{ step }}
   </p>
 </ng-container>

--- a/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.html
+++ b/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.html
@@ -1,0 +1,6 @@
+<h3 class="govuk-!-margin-bottom-0">Make a claim</h3>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+<p>Select qualification</p>
+<p>Add learners</p>
+<p>Upload certificate</p>
+<p>Review and submit</p>

--- a/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.spec.ts
+++ b/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.spec.ts
@@ -8,7 +8,7 @@ import { MakeAClaimProgressBarComponent } from './make-a-claim-progress-bar.comp
 
 describe('MakeAClaimProgressBarComponent', () => {
   const setup = async (stepIndex = 0) => {
-    const { fixture, getByText, getByTestId } = await render(MakeAClaimProgressBarComponent, {
+    const { fixture, getByText, queryByTestId } = await render(MakeAClaimProgressBarComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
       componentProperties: {
         stepIndex,
@@ -17,7 +17,7 @@ describe('MakeAClaimProgressBarComponent', () => {
 
     const component = fixture.componentInstance;
 
-    return { component, getByText, getByTestId };
+    return { component, getByText, queryByTestId };
   };
 
   it('should render a MakeAClaimProgressBarComponent', async () => {
@@ -36,75 +36,119 @@ describe('MakeAClaimProgressBarComponent', () => {
 
   describe('First step in progress', () => {
     it('should show currentStep icon next to first step name', async () => {
-      const { getByTestId } = await setup();
+      const { queryByTestId } = await setup();
 
-      expect(getByTestId('currentStep-0')).toBeTruthy();
+      expect(queryByTestId('currentStep-0')).toBeTruthy();
     });
 
     it('should show notCompleted icon next to second, third and fourth steps', async () => {
-      const { getByTestId } = await setup();
+      const { queryByTestId } = await setup();
 
-      expect(getByTestId('notCompleted-1')).toBeTruthy();
-      expect(getByTestId('notCompleted-2')).toBeTruthy();
-      expect(getByTestId('notCompleted-3')).toBeTruthy();
+      expect(queryByTestId('notCompleted-1')).toBeTruthy();
+      expect(queryByTestId('notCompleted-2')).toBeTruthy();
+      expect(queryByTestId('notCompleted-3')).toBeTruthy();
+    });
+
+    it('should show grey lines after each step icon, nothing after fourth', async () => {
+      const { queryByTestId } = await setup();
+
+      expect(queryByTestId('greyLine-0')).toBeTruthy();
+      expect(queryByTestId('greyLine-1')).toBeTruthy();
+      expect(queryByTestId('greyLine-2')).toBeTruthy();
+
+      expect(queryByTestId('blackLine-3')).toBeFalsy();
+      expect(queryByTestId('greyLine-3')).toBeFalsy();
     });
   });
 
   describe('Second step in progress', () => {
     it('should show completed icon next to first step name', async () => {
-      const { getByTestId } = await setup(1);
+      const { queryByTestId } = await setup(1);
 
-      expect(getByTestId('completed-0')).toBeTruthy();
+      expect(queryByTestId('completed-0')).toBeTruthy();
     });
 
     it('should show currentStep icon next to second step name', async () => {
-      const { getByTestId } = await setup(1);
+      const { queryByTestId } = await setup(1);
 
-      expect(getByTestId('currentStep-1')).toBeTruthy();
+      expect(queryByTestId('currentStep-1')).toBeTruthy();
     });
 
     it('should show notCompleted icon next to second, third and fourth steps', async () => {
-      const { getByTestId } = await setup(1);
+      const { queryByTestId } = await setup(1);
 
-      expect(getByTestId('notCompleted-2')).toBeTruthy();
-      expect(getByTestId('notCompleted-3')).toBeTruthy();
+      expect(queryByTestId('notCompleted-2')).toBeTruthy();
+      expect(queryByTestId('notCompleted-3')).toBeTruthy();
+    });
+
+    it('should show black line after first icon and grey lines after rest, nothing after fourth', async () => {
+      const { queryByTestId } = await setup(1);
+
+      expect(queryByTestId('blackLine-0')).toBeTruthy();
+      expect(queryByTestId('greyLine-1')).toBeTruthy();
+      expect(queryByTestId('greyLine-2')).toBeTruthy();
+
+      expect(queryByTestId('blackLine-3')).toBeFalsy();
+      expect(queryByTestId('greyLine-3')).toBeFalsy();
     });
   });
 
   describe('Third step in progress', () => {
     it('should show completed icon next to first and second step names', async () => {
-      const { getByTestId } = await setup(2);
+      const { queryByTestId } = await setup(2);
 
-      expect(getByTestId('completed-0')).toBeTruthy();
-      expect(getByTestId('completed-1')).toBeTruthy();
+      expect(queryByTestId('completed-0')).toBeTruthy();
+      expect(queryByTestId('completed-1')).toBeTruthy();
     });
 
     it('should show currentStep icon next to third step name', async () => {
-      const { getByTestId } = await setup(2);
+      const { queryByTestId } = await setup(2);
 
-      expect(getByTestId('currentStep-2')).toBeTruthy();
+      expect(queryByTestId('currentStep-2')).toBeTruthy();
     });
 
     it('should show notCompleted icon next to fourth step name', async () => {
-      const { getByTestId } = await setup(2);
+      const { queryByTestId } = await setup(2);
 
-      expect(getByTestId('notCompleted-3')).toBeTruthy();
+      expect(queryByTestId('notCompleted-3')).toBeTruthy();
+    });
+
+    it('should show black line after first two icons, grey line after third, nothing after fourth', async () => {
+      const { queryByTestId } = await setup(2);
+
+      expect(queryByTestId('blackLine-0')).toBeTruthy();
+      expect(queryByTestId('blackLine-1')).toBeTruthy();
+      expect(queryByTestId('greyLine-2')).toBeTruthy();
+
+      expect(queryByTestId('blackLine-3')).toBeFalsy();
+      expect(queryByTestId('greyLine-3')).toBeFalsy();
     });
   });
 
   describe('Fourth step in progress', () => {
     it('should show completed icon next to first and second step names', async () => {
-      const { getByTestId } = await setup(3);
+      const { queryByTestId } = await setup(3);
 
-      expect(getByTestId('completed-0')).toBeTruthy();
-      expect(getByTestId('completed-1')).toBeTruthy();
-      expect(getByTestId('completed-2')).toBeTruthy();
+      expect(queryByTestId('completed-0')).toBeTruthy();
+      expect(queryByTestId('completed-1')).toBeTruthy();
+      expect(queryByTestId('completed-2')).toBeTruthy();
     });
 
     it('should show currentStep icon next to third step name', async () => {
-      const { getByTestId } = await setup(3);
+      const { queryByTestId } = await setup(3);
 
-      expect(getByTestId('currentStep-3')).toBeTruthy();
+      expect(queryByTestId('currentStep-3')).toBeTruthy();
+    });
+
+    it('should show black lines after all icons and nothing after fourth', async () => {
+      const { queryByTestId } = await setup(3);
+
+      expect(queryByTestId('blackLine-0')).toBeTruthy();
+      expect(queryByTestId('blackLine-1')).toBeTruthy();
+      expect(queryByTestId('blackLine-2')).toBeTruthy();
+
+      expect(queryByTestId('blackLine-3')).toBeFalsy();
+      expect(queryByTestId('greyLine-3')).toBeFalsy();
     });
   });
 });

--- a/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.spec.ts
+++ b/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.spec.ts
@@ -7,18 +7,104 @@ import { render } from '@testing-library/angular';
 import { MakeAClaimProgressBarComponent } from './make-a-claim-progress-bar.component';
 
 describe('MakeAClaimProgressBarComponent', () => {
-  const setup = async () => {
-    const { fixture, getByText } = await render(MakeAClaimProgressBarComponent, {
+  const setup = async (stepIndex = 0) => {
+    const { fixture, getByText, getByTestId } = await render(MakeAClaimProgressBarComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
+      componentProperties: {
+        stepIndex,
+      },
     });
 
     const component = fixture.componentInstance;
 
-    return { component, getByText };
+    return { component, getByText, getByTestId };
   };
 
   it('should render a MakeAClaimProgressBarComponent', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should render all step names', async () => {
+    const { getByText } = await setup();
+
+    expect(getByText('Select qualification')).toBeTruthy();
+    expect(getByText('Add learners')).toBeTruthy();
+    expect(getByText('Upload certificate')).toBeTruthy();
+    expect(getByText('Review and submit')).toBeTruthy();
+  });
+
+  describe('First step in progress', () => {
+    it('should show currentStep icon next to first step name', async () => {
+      const { getByTestId } = await setup();
+
+      expect(getByTestId('currentStep-0')).toBeTruthy();
+    });
+
+    it('should show notCompleted icon next to second, third and fourth steps', async () => {
+      const { getByTestId } = await setup();
+
+      expect(getByTestId('notCompleted-1')).toBeTruthy();
+      expect(getByTestId('notCompleted-2')).toBeTruthy();
+      expect(getByTestId('notCompleted-3')).toBeTruthy();
+    });
+  });
+
+  describe('Second step in progress', () => {
+    it('should show completed icon next to first step name', async () => {
+      const { getByTestId } = await setup(1);
+
+      expect(getByTestId('completed-0')).toBeTruthy();
+    });
+
+    it('should show currentStep icon next to second step name', async () => {
+      const { getByTestId } = await setup(1);
+
+      expect(getByTestId('currentStep-1')).toBeTruthy();
+    });
+
+    it('should show notCompleted icon next to second, third and fourth steps', async () => {
+      const { getByTestId } = await setup(1);
+
+      expect(getByTestId('notCompleted-2')).toBeTruthy();
+      expect(getByTestId('notCompleted-3')).toBeTruthy();
+    });
+  });
+
+  describe('Third step in progress', () => {
+    it('should show completed icon next to first and second step names', async () => {
+      const { getByTestId } = await setup(2);
+
+      expect(getByTestId('completed-0')).toBeTruthy();
+      expect(getByTestId('completed-1')).toBeTruthy();
+    });
+
+    it('should show currentStep icon next to third step name', async () => {
+      const { getByTestId } = await setup(2);
+
+      expect(getByTestId('currentStep-2')).toBeTruthy();
+    });
+
+    it('should show notCompleted icon next to fourth step name', async () => {
+      const { getByTestId } = await setup(2);
+
+      expect(getByTestId('notCompleted-3')).toBeTruthy();
+    });
+  });
+
+  describe('Fourth step in progress', () => {
+    it('should show completed icon next to first and second step names', async () => {
+      const { getByTestId } = await setup(3);
+
+      expect(getByTestId('completed-0')).toBeTruthy();
+      expect(getByTestId('completed-1')).toBeTruthy();
+      expect(getByTestId('completed-2')).toBeTruthy();
+    });
+
+    it('should show currentStep icon next to third step name', async () => {
+      const { getByTestId } = await setup(3);
+
+      expect(getByTestId('currentStep-3')).toBeTruthy();
+    });
   });
 });

--- a/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.spec.ts
+++ b/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.spec.ts
@@ -1,0 +1,24 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { MakeAClaimProgressBarComponent } from './make-a-claim-progress-bar.component';
+
+describe('MakeAClaimProgressBarComponent', () => {
+  const setup = async () => {
+    const { fixture, getByText } = await render(MakeAClaimProgressBarComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
+    });
+
+    const component = fixture.componentInstance;
+
+    return { component, getByText };
+  };
+
+  it('should render a MakeAClaimProgressBarComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.ts
+++ b/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-make-a-claim-progress-bar',
+  templateUrl: './make-a-claim-progress-bar.component.html',
+})
+export class MakeAClaimProgressBarComponent {}

--- a/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.ts
+++ b/src/app/features/wdf/wdf-claims/make-a-claim-progress-bar/make-a-claim-progress-bar.component.ts
@@ -1,7 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-make-a-claim-progress-bar',
   templateUrl: './make-a-claim-progress-bar.component.html',
 })
-export class MakeAClaimProgressBarComponent {}
+export class MakeAClaimProgressBarComponent {
+  @Input() stepIndex: number;
+  public steps = ['Select qualification', 'Add learners', 'Upload certificate', 'Review and submit'];
+}

--- a/src/app/features/wdf/wdf-claims/wdf-claims-routing.module.ts
+++ b/src/app/features/wdf/wdf-claims/wdf-claims-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { HasPermissionsGuard } from '@core/guards/permissions/has-permissions/has-permissions.guard';
 
+import { AddLearnersStartPageComponent } from './add-learners-start-page/add-learners-start-page.component';
 import { GrantLetterSentComponent } from './wdf-grant-letter/grant-leter-sent/grant-letter-sent.component';
 import { WdfGrantLetterComponent } from './wdf-grant-letter/wdf-grant-letter.component';
 
@@ -22,6 +23,20 @@ const routes: Routes = [
         path: 'grant-letter-sent',
         component: GrantLetterSentComponent,
         data: { title: 'WDF Grant Letter sent' },
+      },
+    ],
+  },
+  {
+    path: 'add-learners',
+    canActivate: [HasPermissionsGuard],
+    data: {
+      permissions: ['canManageWdfClaims'],
+    },
+    children: [
+      {
+        path: '',
+        component: AddLearnersStartPageComponent,
+        data: { title: 'Add learners' },
       },
     ],
   },

--- a/src/app/features/wdf/wdf-claims/wdf-claims.module.ts
+++ b/src/app/features/wdf/wdf-claims/wdf-claims.module.ts
@@ -5,12 +5,18 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { SharedModule } from '@shared/shared.module';
 
 import { AddLearnersStartPageComponent } from './add-learners-start-page/add-learners-start-page.component';
+import { MakeAClaimProgressBarComponent } from './make-a-claim-progress-bar/make-a-claim-progress-bar.component';
 import { WdfClaimsRoutingModule } from './wdf-claims-routing.module';
 import { GrantLetterSentComponent } from './wdf-grant-letter/grant-leter-sent/grant-letter-sent.component';
 import { WdfGrantLetterComponent } from './wdf-grant-letter/wdf-grant-letter.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, WdfClaimsRoutingModule],
-  declarations: [WdfGrantLetterComponent, GrantLetterSentComponent, AddLearnersStartPageComponent],
+  declarations: [
+    WdfGrantLetterComponent,
+    GrantLetterSentComponent,
+    AddLearnersStartPageComponent,
+    MakeAClaimProgressBarComponent,
+  ],
 })
 export class WdfClaimsModule {}

--- a/src/app/features/wdf/wdf-claims/wdf-claims.module.ts
+++ b/src/app/features/wdf/wdf-claims/wdf-claims.module.ts
@@ -4,12 +4,13 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { SharedModule } from '@shared/shared.module';
 
+import { AddLearnersStartPageComponent } from './add-learners-start-page/add-learners-start-page.component';
 import { WdfClaimsRoutingModule } from './wdf-claims-routing.module';
 import { GrantLetterSentComponent } from './wdf-grant-letter/grant-leter-sent/grant-letter-sent.component';
 import { WdfGrantLetterComponent } from './wdf-grant-letter/wdf-grant-letter.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, WdfClaimsRoutingModule],
-  declarations: [WdfGrantLetterComponent, GrantLetterSentComponent],
+  declarations: [WdfGrantLetterComponent, GrantLetterSentComponent, AddLearnersStartPageComponent],
 })
 export class WdfClaimsModule {}

--- a/src/assets/images/progress-bar/black-line.svg
+++ b/src/assets/images/progress-bar/black-line.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="3px" height="26px" viewBox="0 0 3 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Black line</title>
+    <g id="Black-line" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Rectangle" fill="#0B0C0C" x="0" y="0" width="3" height="26"></rect>
+    </g>
+</svg>

--- a/src/assets/images/progress-bar/doing.svg
+++ b/src/assets/images/progress-bar/doing.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Progress/Doing</title>
+    <g id="Progress/Doing" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <circle id="Oval" stroke="#0B0C0C" stroke-width="3" fill="#FFFFFF" cx="12" cy="12" r="10.5"></circle>
+    </g>
+</svg>

--- a/src/assets/images/progress-bar/done.svg
+++ b/src/assets/images/progress-bar/done.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Progress/Done</title>
+    <g id="Progress/Done" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <circle id="Oval" stroke="#0B0C0C" stroke-width="3" fill="#0B0C0C" cx="12" cy="12" r="10.5"></circle>
+        <g id="Icon" transform="translate(1.000000, 1.000000)">
+            <polygon id="Path" points="0 0 22 0 22 22 0 22"></polygon>
+            <polygon id="Glyph" stroke="#FFFFFF" fill="#FFFFFF" stroke-linejoin="round" points="8.91659786 14.4104478 5.57568877 11.2761194 4.46205241 12.3208955 8.91659786 16.5 18.4620524 7.54477612 17.348416 6.5"></polygon>
+        </g>
+    </g>
+</svg>

--- a/src/assets/images/progress-bar/grey-line.svg
+++ b/src/assets/images/progress-bar/grey-line.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="3px" height="26px" viewBox="0 0 3 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Grey line</title>
+    <g id="Grey-line" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Rectangle" fill="#BFBEBE" x="0" y="0" width="3" height="26"></rect>
+    </g>
+</svg>

--- a/src/assets/images/progress-bar/to-do.svg
+++ b/src/assets/images/progress-bar/to-do.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Progress/To do</title>
+    <g id="Progress/To-do" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <circle id="Oval" stroke="#BFBEBE" stroke-width="3" fill="#FFFFFF" cx="12" cy="12" r="10.5"></circle>
+    </g>
+</svg>


### PR DESCRIPTION
#### Work done
- Create WDF claims add learners start page
- Create WDF claim progress bar component to be reused across WDF claim pages

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
