### PR TITLE
Bugfix/training and quals total

### DIFF
--- a/src/app/core/model/trainingAndQualifications.model.ts
+++ b/src/app/core/model/trainingAndQualifications.model.ts
@@ -5,3 +5,11 @@ export interface TrainingAndQualificationRecords {
   qualifications: QualificationsByGroup;
   training: TrainingRecords;
 }
+
+export interface TrainingCounts {
+  totalRecords?: number;
+  totalExpiredTraining?: number;
+  totalExpiringTraining?: number;
+  missingMandatoryTraining?: number;
+  staffMissingMandatoryTraining?: number;
+}

--- a/src/app/core/resolvers/workers.resolver.ts
+++ b/src/app/core/resolvers/workers.resolver.ts
@@ -5,7 +5,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Observable, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { catchError, map, take } from 'rxjs/operators';
 
 @Injectable()
 export class WorkersResolver implements Resolve<any> {
@@ -21,11 +21,37 @@ export class WorkersResolver implements Resolve<any> {
       ? route.paramMap.get('establishmentuid')
       : this.establishmentService.establishmentId;
 
-    const paginationParams = route.data.workerPagination ? { pageIndex: 0, itemsPerPage: 15 } : {};
-
     if (!this.permissionsService.can(workplaceUid, 'canViewListOfWorkers')) return of(null);
 
+    const trainingCounts = {
+      totalRecords: 0,
+      totalExpiredTraining: 0,
+      totalExpiringTraining: 0,
+      missingMandatoryTraining: 0,
+      staffMissingMandatoryTraining: 0,
+    };
+
+    this.workerService
+      .getAllWorkers(workplaceUid)
+      .pipe(take(1))
+      .subscribe((result) => {
+        result.workers.forEach((worker) => {
+          const totalTrainingRecord = worker.trainingCount;
+          trainingCounts.totalRecords += totalTrainingRecord + worker.qualificationCount;
+          trainingCounts.totalExpiredTraining += worker.expiredTrainingCount;
+          trainingCounts.totalExpiringTraining += worker.expiringTrainingCount;
+          trainingCounts.missingMandatoryTraining += worker.missingMandatoryTrainingCount;
+          if (worker.missingMandatoryTrainingCount > 0) trainingCounts.staffMissingMandatoryTraining += 1;
+        });
+      });
+
+    const paginationParams = route.data.workerPagination ? { pageIndex: 0, itemsPerPage: 15 } : {};
+
     return this.workerService.getAllWorkers(workplaceUid, paginationParams).pipe(
+      map((response) => ({
+        ...response,
+        trainingCounts,
+      })),
       catchError(() => {
         this.router.navigate(['/problem-with-the-service']);
         return of(null);

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -33,6 +33,7 @@
           [workplace]="workplace"
           [workers]="workers"
           [workerCount]="workerCount"
+          [trainingCounts]="trainingCounts"
         ></app-training-and-qualifications-tab>
       </app-tab>
 

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -79,7 +79,7 @@ describe('DashboardComponent', () => {
               data: {
                 users: oneUser ? ([EditUser()] as UserDetails[]) : ([EditUser(), EditUser()] as UserDetails[]),
                 articleList: null,
-                workers: { workers: [], workerCount: 0 },
+                workers: { workers: [], workerCount: 0, trainingCounts: {} },
                 totalStaffRecords,
               },
             },

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
+import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
 import { AlertService } from '@core/services/alert.service';
 import { AuthService } from '@core/services/auth.service';
@@ -30,7 +31,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   public canAddUser: boolean;
   public showCQCDetailsBanner = false;
   public workers: Worker[];
-  public trainingCounts = {};
+  public trainingCounts: TrainingCounts;
   public workerCount: number;
   public showSharingPermissionsBanner: boolean;
   private showBanner = false;

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -30,6 +30,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   public canAddUser: boolean;
   public showCQCDetailsBanner = false;
   public workers: Worker[];
+  public trainingCounts = {};
   public workerCount: number;
   public showSharingPermissionsBanner: boolean;
   private showBanner = false;
@@ -67,7 +68,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       if (this.canViewListOfWorkers) {
         this.setWorkersAndTrainingAlert();
       }
-
       this.setShowSecondUserBanner();
     }
 
@@ -85,10 +85,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   private setWorkersAndTrainingAlert(): void {
-    const { workers = [], workerCount = 0 } = this.route.snapshot.data.workers;
+    const { workers = [], workerCount = 0, trainingCounts } = this.route.snapshot.data.workers;
 
     this.workers = workers;
     this.workerCount = workerCount;
+    this.trainingCounts = trainingCounts;
     this.workerService.setWorkers(workers);
     if (workers.length > 0) {
       this.trainingAlert = workers[0].trainingAlert;

--- a/src/app/features/workplace/view-workplace/view-workplace.component.html
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.html
@@ -54,6 +54,7 @@
           [workplace]="workplace"
           [workers]="workers"
           [workerCount]="workerCount"
+          [trainingCounts]="trainingCounts"
         ></app-training-and-qualifications-tab>
       </app-tab>
       <app-tab *ngIf="canViewBenchmarks" [title]="'Benchmarks'">

--- a/src/app/features/workplace/view-workplace/view-workplace.component.spec.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthService } from '@core/services/auth.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
@@ -19,7 +19,9 @@ import { MockNotificationsService } from '@core/test-utils/MockNotificationsServ
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
 import { MockWorkerService } from '@core/test-utils/MockWorkerService';
+import { HomeTabComponent } from '@features/dashboard/home-tab/home-tab.component';
 import { ViewWorkplaceComponent } from '@features/workplace/view-workplace/view-workplace.component';
+import { TabComponent } from '@shared/components/tabs/tab.component';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
@@ -38,7 +40,7 @@ describe('view-workplace', () => {
         ]),
         HttpClientTestingModule,
       ],
-      declarations: [],
+      declarations: [TabComponent, HomeTabComponent],
       providers: [
         {
           provide: WindowRef,
@@ -72,6 +74,17 @@ describe('view-workplace', () => {
         },
         { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
         { provide: WorkerService, useClass: MockWorkerService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                workers: { workers: [], workerCount: 0, trainingCounts: {} },
+              },
+            },
+            queryParams: of({ view: null }),
+          },
+        },
       ],
     });
 

--- a/src/app/features/workplace/view-workplace/view-workplace.component.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.ts
@@ -31,6 +31,7 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
   public trainingAlert: number;
   public showCQCDetailsBanner: boolean = this.establishmentService.checkCQCDetailsBanner;
   public workers: Worker[];
+  public trainingCounts = {};
   public workerCount: number;
   public showSharingPermissionsBanner: boolean;
 
@@ -74,19 +75,7 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
     this.showSharingPermissionsBanner = this.workplace.showSharingPermissionsBanner;
 
     if (this.canViewListOfWorkers) {
-      this.subscriptions.add(
-        this.workerService.getAllWorkers(this.workplace.uid, { pageIndex: 0, itemsPerPage: 15 }).subscribe(
-          ({ workers, workerCount }) => {
-            this.workers = workers;
-            this.workerCount = workerCount;
-            this.workerService.setWorkers(workers);
-            this.trainingAlert = this.getTrainingAlertFlag(workers);
-          },
-          (error) => {
-            console.error(error.error);
-          },
-        ),
-      );
+      this.setWorkersAndTrainingAlert();
     }
 
     this.totalStaffRecords = this.route.snapshot.data.totalStaffRecords;
@@ -114,6 +103,16 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
           this.deleteWorkplace();
         }
       });
+  }
+
+  private setWorkersAndTrainingAlert(): void {
+    const { workers = [], workerCount = 0, trainingCounts } = this.route.snapshot.data.workers;
+
+    this.workers = workers;
+    this.workerCount = workerCount;
+    this.trainingCounts = trainingCounts;
+    this.workerService.setWorkers(workers);
+    this.trainingAlert = this.getTrainingAlertFlag(workers);
   }
 
   private deleteWorkplace(): void {

--- a/src/app/features/workplace/view-workplace/view-workplace.component.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
+import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { URLStructure } from '@core/model/url.model';
 import { Worker } from '@core/model/worker.model';
 import { AlertService } from '@core/services/alert.service';
@@ -31,7 +32,7 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
   public trainingAlert: number;
   public showCQCDetailsBanner: boolean = this.establishmentService.checkCQCDetailsBanner;
   public workers: Worker[];
-  public trainingCounts = {};
+  public trainingCounts: TrainingCounts;
   public workerCount: number;
   public showSharingPermissionsBanner: boolean;
 

--- a/src/app/features/workplace/workplace-routing.module.ts
+++ b/src/app/features/workplace/workplace-routing.module.ts
@@ -9,6 +9,7 @@ import { AllUsersForEstablishmentResolver } from '@core/resolvers/dashboard/all-
 import { TotalStaffRecordsResolver } from '@core/resolvers/dashboard/total-staff-records.resolver';
 import { ExpiresSoonAlertDatesResolver } from '@core/resolvers/expiresSoonAlertDates.resolver';
 import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
+import { WorkersResolver } from '@core/resolvers/workers.resolver';
 import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
 import { CreateUserAccountComponent } from '@features/workplace/create-user-account/create-user-account.component';
 import { SelectMainServiceCqcConfirmComponent } from '@features/workplace/select-main-service/select-main-service-cqc-confirm.component';
@@ -70,9 +71,11 @@ const routes: Routes = [
         data: {
           permissions: ['canViewEstablishment'],
           title: 'View Workplace',
+          workerPagination: true,
         },
         resolve: {
           users: AllUsersForEstablishmentResolver,
+          workers: WorkersResolver,
           totalStaffRecords: TotalStaffRecordsResolver,
         },
       },

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.spec.ts
@@ -45,6 +45,7 @@ describe('TrainingAndQualificationsTabComponent', () => {
       ],
       componentProperties: {
         workplace: establishmentBuilder() as Establishment,
+        trainingCounts: {},
       },
     });
 

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
+import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -16,7 +17,7 @@ export class TrainingAndQualificationsTabComponent implements OnDestroy, OnChang
   @Input() workplace: Establishment;
   @Input() workers: Worker[];
   @Input() workerCount: number;
-  @Input() trainingCounts;
+  @Input() trainingCounts: TrainingCounts;
 
   private subscriptions: Subscription = new Subscription();
 

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
@@ -16,6 +16,7 @@ export class TrainingAndQualificationsTabComponent implements OnDestroy, OnChang
   @Input() workplace: Establishment;
   @Input() workers: Worker[];
   @Input() workerCount: number;
+  @Input() trainingCounts;
 
   private subscriptions: Subscription = new Subscription();
 
@@ -45,10 +46,11 @@ export class TrainingAndQualificationsTabComponent implements OnDestroy, OnChang
     });
     this.getAllTrainingByCategory();
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
+    this.trainingTotals();
   }
 
   public ngOnChanges(changes: SimpleChanges): void {
-    if ('workers' in changes) {
+    if ('workers' in changes || 'trainingCounts' in changes) {
       this.trainingTotals();
     }
   }
@@ -65,24 +67,14 @@ export class TrainingAndQualificationsTabComponent implements OnDestroy, OnChang
   }
 
   private trainingTotals(): void {
-    this.totalRecords = 0;
-    this.totalExpiredTraining = 0;
-    this.totalExpiringTraining = 0;
-    this.missingMandatoryTraining = 0;
-    this.staffMissingMandatoryTraining = 0;
-    if (this.workers) {
-      this.workers.forEach((worker: Worker) => {
-        const totalTrainingRecord = worker.trainingCount;
-        this.totalRecords += totalTrainingRecord + worker.qualificationCount;
-        this.totalExpiredTraining += worker.expiredTrainingCount;
-        this.totalExpiringTraining += worker.expiringTrainingCount;
-        this.missingMandatoryTraining += worker.missingMandatoryTrainingCount;
-        if (worker.missingMandatoryTrainingCount > 0) this.staffMissingMandatoryTraining += 1;
-      });
-    }
+    this.totalRecords = this.trainingCounts.totalRecords;
+    this.totalExpiredTraining = this.trainingCounts.totalExpiredTraining;
+    this.totalExpiringTraining = this.trainingCounts.totalExpiringTraining;
+    this.missingMandatoryTraining = this.trainingCounts.missingMandatoryTraining;
+    this.staffMissingMandatoryTraining = this.trainingCounts.staffMissingMandatoryTraining;
   }
 
-  public handleViewTrainingByCategory(visible: boolean) {
+  public handleViewTrainingByCategory(visible: boolean): void {
     this.viewTrainingByCategory = visible;
   }
 


### PR DESCRIPTION
#### Work done
- add an initial call to the workers resolver to get all workers so that we can get the total training counts
- add training counts input to training and quals tab component
- implement the workers resolver on view workplace component and remove existing call to getAllWorkers from ngOnInit
- pass training count from dashboard and view workplace components
- fix tests failing from the changes

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
