### PR TITLE
Feat/track benchmark tab usage backend

### DIFF
--- a/migrations/20220511145442-createBenchmarkTabUsageTable.js
+++ b/migrations/20220511145442-createBenchmarkTabUsageTable.js
@@ -23,7 +23,7 @@ module.exports = {
         },
         ViewedTime: {
           type: Sequelize.DataTypes.DATE,
-          allowNull: true,
+          allowNull: false,
         },
       },
       { schema: 'cqc' },

--- a/migrations/20220511145442-createBenchmarkTabUsageTable.js
+++ b/migrations/20220511145442-createBenchmarkTabUsageTable.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable(
+      'BenchmarksViewed',
+      {
+        ID: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          autoIncrement: true,
+        },
+        EstablishmentID: {
+          type: Sequelize.DataTypes.INTEGER,
+          allowNull: false,
+          references: {
+            model: {
+              tableName: 'Establishment',
+              schema: 'cqc',
+            },
+            key: 'EstablishmentID',
+          },
+        },
+        ViewedTime: {
+          type: Sequelize.DataTypes.DATE,
+          allowNull: true,
+        },
+      },
+      { schema: 'cqc' },
+    );
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.dropTable({
+      tableName: 'BenchmarksViewed',
+      schema: 'cqc',
+    });
+  },
+};

--- a/server/models/benchmarksViewed.js
+++ b/server/models/benchmarksViewed.js
@@ -1,0 +1,38 @@
+module.exports = function (sequelize, DataTypes) {
+  const BenchmarksViewed = sequelize.define(
+    'benchmarksViewed',
+    {
+      ID: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      EstablishmentID: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+      },
+      ViewedTime: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        primaryKey: true,
+      },
+    },
+    {
+      tableName: 'BenchmarksViewed',
+      schema: 'cqc',
+      createdAt: false,
+      updatedAt: false,
+    },
+  );
+
+  BenchmarksViewed.associate = (models) => {
+    BenchmarksViewed.belongsTo(models.establishment, {
+      foreignKey: 'EstablishmentID',
+      targetKey: 'id',
+      as: 'benchmarkEstablishment',
+    });
+  };
+
+  return BenchmarksViewed;
+};

--- a/server/routes/establishments/benchmarks/index.js
+++ b/server/routes/establishments/benchmarks/index.js
@@ -3,6 +3,7 @@ const router = express.Router({ mergeParams: true });
 const models = require('../../../models');
 const clonedeep = require('lodash.clonedeep');
 const rankings = require('./rankings');
+const usage = require('./usage');
 const { getPay, getQualifications, getSickness, getTurnover } = require('./benchmarksService');
 
 const { hasPermission } = require('../../../utils/security/hasPermission');
@@ -110,6 +111,7 @@ router.use('/', hasPermission('canViewBenchmarks'));
 router.route('/').get(viewBenchmarks);
 
 router.use('/rankings', rankings);
+router.use('/usage', usage);
 
 module.exports = router;
 module.exports.pay = pay;

--- a/server/routes/establishments/benchmarks/usage/index.js
+++ b/server/routes/establishments/benchmarks/usage/index.js
@@ -19,3 +19,4 @@ const postBenchmarkTabUsage = async (req, res) => {
 router.route('/').post(postBenchmarkTabUsage);
 
 module.exports = router;
+module.exports.postBenchmarkTabUsage = postBenchmarkTabUsage;

--- a/server/routes/establishments/benchmarks/usage/index.js
+++ b/server/routes/establishments/benchmarks/usage/index.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+const models = require('../../../../models');
+const moment = require('moment');
+
+const postBenchmarkTabUsage = async (req, res) => {
+  const viewedTime = moment();
+  try {
+    await models.benchmarksViewed.create({
+      EstablishmentID: req.establishmentId,
+      ViewedTime: viewedTime,
+    });
+    res.status(200).send();
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({});
+  }
+};
+router.route('/').post(postBenchmarkTabUsage);
+
+module.exports = router;

--- a/server/test/unit/routes/establishments/benchmarks/usage.spec.js
+++ b/server/test/unit/routes/establishments/benchmarks/usage.spec.js
@@ -1,0 +1,38 @@
+const models = require('../../../../../models');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const benchmarksUsage = require('../../../../../routes/establishments/benchmarks/usage');
+const httpMocks = require('node-mocks-http');
+const moment = require('moment');
+
+describe('usage', () => {
+  let request;
+  let benchmarksUsageStub;
+
+  beforeEach(() => {
+    benchmarksUsageStub = sinon.stub(models.benchmarksViewed, 'create');
+    request = {
+      method: 'POST',
+      url: '/api/establishment/85b2a783-ff2d-4c83-adba-c25378afa19c/benchmarks/usage',
+      establishmentId: 1234,
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return 200 when a benchmark usage has been successfully logged', async () => {
+    const req = httpMocks.createRequest(request);
+    const res = httpMocks.createResponse();
+    const viewedTime = moment();
+
+    await benchmarksUsage.postBenchmarkTabUsage(req, res);
+
+    expect(res.statusCode).to.deep.equal(200);
+    benchmarksUsageStub.should.have.been.calledWith({
+      EstablishmentID: request.establishmentId,
+      ViewedTime: viewedTime,
+    });
+  });
+});

--- a/src/app/core/services/benchmarks.service.ts
+++ b/src/app/core/services/benchmarks.service.ts
@@ -35,4 +35,8 @@ export class BenchmarksService {
   getAllRankingData(establishmentId: string): Observable<AllRankingsResponse> {
     return this.http.get<AllRankingsResponse>(`/api/establishment/${establishmentId}/benchmarks/rankings`);
   }
+
+  logBenchmarkTabUsage(establishmentId: string): Observable<any> {
+    return this.http.get<any>(`/api/establishment/${establishmentId}/benchmarks/rankings/logbenchmarks`);
+  }
 }

--- a/src/app/core/services/benchmarks.service.ts
+++ b/src/app/core/services/benchmarks.service.ts
@@ -20,6 +20,10 @@ export class BenchmarksService {
     this.returnToURL = returnTo;
   }
 
+  postBenchmarkTabUsage(establishmentId: string) {
+    return this.http.post<any>(`/api/establishment/${establishmentId}/benchmarks/usage`, null);
+  }
+
   getTileData(establishmentId: string, tilesNeeded: string[]): Observable<BenchmarksResponse> {
     let param = '';
     if (tilesNeeded.length) {
@@ -34,9 +38,5 @@ export class BenchmarksService {
 
   getAllRankingData(establishmentId: string): Observable<AllRankingsResponse> {
     return this.http.get<AllRankingsResponse>(`/api/establishment/${establishmentId}/benchmarks/rankings`);
-  }
-
-  logBenchmarkTabUsage(establishmentId: string): Observable<any> {
-    return this.http.get<any>(`/api/establishment/${establishmentId}/benchmarks/rankings/logbenchmarks`);
   }
 }

--- a/src/app/core/test-utils/MockBenchmarkService.ts
+++ b/src/app/core/test-utils/MockBenchmarkService.ts
@@ -106,4 +106,8 @@ export class MockBenchmarksService extends BenchmarksService {
   public getAllRankingData(establishmentUid): Observable<AllRankingsResponse> {
     return of(allRankingsData);
   }
+
+  public postBenchmarkTabUsage(establishmentUid: string) {
+    return of(null);
+  }
 }

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <app-tabs (selectedTabClick)="logBenchmarkTabUsage($event)">
+    <app-tabs (selectedTabClick)="tabClickEvent($event)">
       <app-tab [title]="'Home'">
         <app-home-tab [workplace]="workplace" [workerCount]="workerCount"></app-home-tab>
       </app-tab>

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <app-tabs>
+    <app-tabs (selectedTabClick)="logBenchmarkTabUsage($event)">
       <app-tab [title]="'Home'">
         <app-home-tab [workplace]="workplace" [workerCount]="workerCount"></app-home-tab>
       </app-tab>

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -263,6 +263,25 @@ describe('DashboardComponent', () => {
         fireEvent.click(benchmarksTab);
         expect(benchmarkUsageSpy).toHaveBeenCalled();
       });
+
+      it('should not call postBenchmarkTabUsage when the other dashboard tabs are clicked', async () => {
+        const { getByTestId, component, fixture, benchmarkUsageSpy } = await setup();
+
+        component.canViewBenchmarks = true;
+        fixture.detectChanges();
+
+        const homeTab = getByTestId('tab_home');
+        const workplaceTab = getByTestId('tab_workplace');
+        const staffRecordsTab = getByTestId('tab_staff-records');
+        const trainingAndQualificationsTab = getByTestId('tab_training-and-qualifications');
+
+        fireEvent.click(homeTab);
+        fireEvent.click(workplaceTab);
+        fireEvent.click(staffRecordsTab);
+        fireEvent.click(trainingAndQualificationsTab);
+
+        expect(benchmarkUsageSpy).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -5,12 +5,14 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { UserDetails } from '@core/model/userDetails.model';
 import { AlertService } from '@core/services/alert.service';
+import { BenchmarksService } from '@core/services/benchmarks.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
+import { MockBenchmarksService } from '@core/test-utils/MockBenchmarkService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
@@ -21,7 +23,7 @@ import { HomeTabComponent } from '@features/dashboard/home-tab/home-tab.componen
 import { TabComponent } from '@shared/components/tabs/tab.component';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
 import { of } from 'rxjs';
 
 const MockWindow = {
@@ -69,6 +71,10 @@ describe('DashboardComponent', () => {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
         },
+        {
+          provide: BenchmarksService,
+          useClass: MockBenchmarksService,
+        },
         { provide: WindowToken, useValue: MockWindow },
         { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
         { provide: WorkerService, useClass: MockWorkerService },
@@ -98,6 +104,9 @@ describe('DashboardComponent', () => {
     const alertService = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alertService, 'addAlert').and.callThrough();
 
+    const benchmarksService = injector.inject(BenchmarksService) as BenchmarksService;
+    const benchmarkUsageSpy = spyOn(benchmarksService, 'postBenchmarkTabUsage').and.callThrough();
+
     const component = fixture.componentInstance;
     return {
       component,
@@ -108,6 +117,7 @@ describe('DashboardComponent', () => {
       establishmentService,
       router,
       alertSpy,
+      benchmarkUsageSpy,
     };
   }
 
@@ -238,6 +248,20 @@ describe('DashboardComponent', () => {
           type: 'success',
           message: `You've confirmed the details of the staff record you added`,
         });
+      });
+    });
+
+    describe('tabClickEvent', () => {
+      it('should call postBenchmarkTabUsage when benchmarks tab is clicked', async () => {
+        const { getByTestId, component, fixture, benchmarkUsageSpy } = await setup();
+
+        component.canViewBenchmarks = true;
+        fixture.detectChanges();
+
+        const benchmarksTab = getByTestId('tab_benchmarks');
+
+        fireEvent.click(benchmarksTab);
+        expect(benchmarkUsageSpy).toHaveBeenCalled();
       });
     });
   });

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -5,6 +5,7 @@ import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
 import { AlertService } from '@core/services/alert.service';
 import { AuthService } from '@core/services/auth.service';
+import { BenchmarksService } from '@core/services/benchmarks.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
@@ -24,6 +25,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   public canViewListOfWorkers: boolean;
   public totalStaffRecords: number;
   public workplace: Establishment;
+  public establishmentId: string;
   public trainingAlert: number;
   public canViewBenchmarks: boolean;
   public workplaceUid: string | null;
@@ -41,6 +43,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private establishmentService: EstablishmentService,
     private permissionsService: PermissionsService,
+    private benchmarksService: BenchmarksService,
     private userService: UserService,
     private workerService: WorkerService,
     private route: ActivatedRoute,
@@ -53,6 +56,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.authService.isOnAdminScreen = false;
     this.showCQCDetailsBanner = this.establishmentService.checkCQCDetailsBanner;
     this.workplace = this.establishmentService.primaryWorkplace;
+    this.establishmentId = this.establishmentService.establishmentId;
     this.showSharingPermissionsBanner = this.workplace.showSharingPermissionsBanner;
     this.workplaceUid = this.workplace ? this.workplace.uid : null;
 
@@ -135,6 +139,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
       type: 'success',
       message: `You've confirmed the details of the staff record you added`,
     });
+  }
+
+  public logBenchmarkTabUsage($event) {
+    if ($event.tabIndex === 4) {
+      this.benchmarksService.logBenchmarkTabUsage(this.establishmentId);
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -143,11 +143,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   public tabClickEvent($event) {
     if ($event.tabSlug === 'benchmarks') {
-      this.subscriptions.add(
-        this.benchmarksService.postBenchmarkTabUsage(this.establishmentId).subscribe((data) => {
-          console.log(data);
-        }),
-      );
+      this.subscriptions.add(this.benchmarksService.postBenchmarkTabUsage(this.establishmentId).subscribe());
     }
   }
 

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -142,7 +142,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   public tabClickEvent($event) {
-    if ($event.tabIndex === 4) {
+    if ($event.tabSlug === 'benchmarks') {
       this.subscriptions.add(
         this.benchmarksService.postBenchmarkTabUsage(this.establishmentId).subscribe((data) => {
           console.log(data);

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -141,9 +141,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  public logBenchmarkTabUsage($event) {
+  public tabClickEvent($event) {
     if ($event.tabIndex === 4) {
-      this.benchmarksService.logBenchmarkTabUsage(this.establishmentId);
+      this.subscriptions.add(
+        this.benchmarksService.postBenchmarkTabUsage(this.establishmentId).subscribe((data) => {
+          console.log(data);
+        }),
+      );
     }
   }
 

--- a/src/app/shared/components/tabs/tabs.component.ts
+++ b/src/app/shared/components/tabs/tabs.component.ts
@@ -4,7 +4,9 @@ import {
   Component,
   ContentChildren,
   ElementRef,
+  EventEmitter,
   OnDestroy,
+  Output,
   QueryList,
   ViewChild,
 } from '@angular/core';
@@ -19,6 +21,8 @@ import { TabComponent } from './tab.component';
   templateUrl: './tabs.component.html',
 })
 export class TabsComponent implements AfterContentInit, OnDestroy {
+  @Output() selectedTabClick = new EventEmitter();
+
   private currentTab: number;
   private subscriptions: Subscription = new Subscription();
   @ContentChildren(TabComponent) tabs: QueryList<TabComponent>;
@@ -97,6 +101,8 @@ export class TabsComponent implements AfterContentInit, OnDestroy {
 
     this.unselectTabs();
     tab.active = true;
+
+    this.selectedTabClick.emit({ tabIndex: this.currentTab });
 
     const path = hasCurrentTab ? this.location.path().split('?')[0] : this.location.path();
     this.location.replaceState(`${path}#${tab.slug}`);

--- a/src/app/shared/components/tabs/tabs.component.ts
+++ b/src/app/shared/components/tabs/tabs.component.ts
@@ -102,7 +102,7 @@ export class TabsComponent implements AfterContentInit, OnDestroy {
     this.unselectTabs();
     tab.active = true;
 
-    this.selectedTabClick.emit({ tabIndex: this.currentTab });
+    this.selectedTabClick.emit({ tabSlug: tab.slug });
 
     const path = hasCurrentTab ? this.location.path().split('?')[0] : this.location.path();
     this.location.replaceState(`${path}#${tab.slug}`);


### PR DESCRIPTION
#### Work done
- Created an event emit if a dashboard tab is clicked
- Created a migration and model for the new BenchmarksViewed table
- Created a endpoint to call backend which will log benchmark tab usage

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
