### PR TITLE
Fix/log benchmarks usage for child workplaces

### DIFF
--- a/src/app/core/services/benchmarks.service.ts
+++ b/src/app/core/services/benchmarks.service.ts
@@ -20,7 +20,7 @@ export class BenchmarksService {
     this.returnToURL = returnTo;
   }
 
-  postBenchmarkTabUsage(establishmentId: string) {
+  postBenchmarkTabUsage(establishmentId: number) {
     return this.http.post<any>(`/api/establishment/${establishmentId}/benchmarks/usage`, null);
   }
 

--- a/src/app/core/test-utils/MockBenchmarkService.ts
+++ b/src/app/core/test-utils/MockBenchmarkService.ts
@@ -107,7 +107,7 @@ export class MockBenchmarksService extends BenchmarksService {
     return of(allRankingsData);
   }
 
-  public postBenchmarkTabUsage(establishmentUid: string) {
+  public postBenchmarkTabUsage(establishmentUid: number) {
     return of(null);
   }
 }

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -25,7 +25,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   public canViewListOfWorkers: boolean;
   public totalStaffRecords: number;
   public workplace: Establishment;
-  public establishmentId: string;
   public trainingAlert: number;
   public canViewBenchmarks: boolean;
   public workplaceUid: string | null;
@@ -56,7 +55,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.authService.isOnAdminScreen = false;
     this.showCQCDetailsBanner = this.establishmentService.checkCQCDetailsBanner;
     this.workplace = this.establishmentService.primaryWorkplace;
-    this.establishmentId = this.establishmentService.establishmentId;
     this.showSharingPermissionsBanner = this.workplace.showSharingPermissionsBanner;
     this.workplaceUid = this.workplace ? this.workplace.uid : null;
 
@@ -143,7 +141,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   public tabClickEvent($event) {
     if ($event.tabSlug === 'benchmarks') {
-      this.subscriptions.add(this.benchmarksService.postBenchmarkTabUsage(this.establishmentId).subscribe());
+      this.subscriptions.add(this.benchmarksService.postBenchmarkTabUsage(this.workplace.id).subscribe());
     }
   }
 

--- a/src/app/features/workplace/view-workplace/view-workplace.component.html
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.html
@@ -25,7 +25,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <app-tabs>
+    <app-tabs (selectedTabClick)="tabClickEvent($event)">
       <app-tab
         [title]="'Workplace'"
         [redAlert]="workplace?.employerType && (showCQCDetailsBanner || showSharingPermissionsBanner)"

--- a/src/app/features/workplace/view-workplace/view-workplace.component.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.ts
@@ -6,6 +6,7 @@ import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { URLStructure } from '@core/model/url.model';
 import { Worker } from '@core/model/worker.model';
 import { AlertService } from '@core/services/alert.service';
+import { BenchmarksService } from '@core/services/benchmarks.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -41,6 +42,7 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
     private breadcrumbService: BreadcrumbService,
     private dialogService: DialogService,
     private establishmentService: EstablishmentService,
+    private benchmarksService: BenchmarksService,
     private permissionsService: PermissionsService,
     private router: Router,
     private userService: UserService,
@@ -53,7 +55,6 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
     this.breadcrumbService.show(JourneyType.ALL_WORKPLACES);
     this.primaryEstablishment = this.establishmentService.primaryWorkplace;
     this.workplace = this.establishmentService.establishment;
-
     this.canViewBenchmarks = this.permissionsService.can(this.workplace.uid, 'canViewBenchmarks');
     this.canViewListOfUsers = this.permissionsService.can(this.workplace.uid, 'canViewListOfUsers');
     this.canViewListOfWorkers = this.permissionsService.can(this.workplace.uid, 'canViewListOfWorkers');
@@ -167,6 +168,12 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
       }
     } else {
       return 0;
+    }
+  }
+
+  public tabClickEvent($event) {
+    if ($event.tabSlug === 'benchmarks') {
+      this.subscriptions.add(this.benchmarksService.postBenchmarkTabUsage(this.workplace.id).subscribe());
     }
   }
 


### PR DESCRIPTION
#### Work done
- Added logBenchmark functionality to child workplaces
- Changed typing of postBenchmarkTabUsage

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
