### PR TITLE
Spike/hide location id for cqc regulated when head offices main service

### DIFF
--- a/server/routes/cqcStatusCheck/index.js
+++ b/server/routes/cqcStatusCheck/index.js
@@ -50,6 +50,7 @@ function checkMainServiceMatch(mainService, cqcServices) {
   if (!mainService || !cqcServices) return true;
 
   const cqcMainService = convertMainServiceToCQC(mainService);
+  if (!cqcMainService) return true;
 
   return cqcServices.some((service) => cqcMainService.cqc.includes(service.name));
 }

--- a/server/routes/cqcStatusCheck/index.js
+++ b/server/routes/cqcStatusCheck/index.js
@@ -50,7 +50,7 @@ function checkMainServiceMatch(mainService, cqcServices) {
   if (!mainService || !cqcServices) return true;
 
   const cqcMainService = convertMainServiceToCQC(mainService);
-  if (!cqcMainService) return true;
+  if (!cqcMainService) return false;
 
   return cqcServices.some((service) => cqcMainService.cqc.includes(service.name));
 }

--- a/server/routes/cqcStatusCheck/index.js
+++ b/server/routes/cqcStatusCheck/index.js
@@ -22,7 +22,7 @@ const cqcStatusCheck = async (req, res) => {
   } catch (error) {
     console.error('CQC API Error: ', error);
     // If the CQC API responds with a 404, we treat that as an unregistered workplace
-    if (error.response.status === 404) {
+    if (error.response && error.response.status === 404) {
       result.cqcStatusMatch = false;
     } else {
       result.cqcStatusMatch = true;

--- a/server/test/unit/routes/cqcStatusCheck/index.spec.js
+++ b/server/test/unit/routes/cqcStatusCheck/index.spec.js
@@ -254,6 +254,60 @@ describe('server/routes/establishments/cqcStatus', async () => {
 
       expect(res._getData()).to.deep.equal(expectedResult);
     });
+
+    it('should return a false flag if a 404 error is thrown in getWorkplaceCQCData', async () => {
+      const request = {
+        method: 'GET',
+        url: `/api/cqcStatusCheck/${registeredLocationId}`,
+        params: {
+          locationID: registeredLocationId,
+        },
+        query: {
+          postcode: 'WA5 6BL',
+        },
+      };
+
+      sinon.restore();
+      sinon.stub(CQCDataAPI, 'getWorkplaceCQCData').throws({ response: { status: 404 } });
+
+      const expectedResult = {
+        cqcStatusMatch: false,
+      };
+
+      const req = httpMocks.createRequest(request);
+      const res = httpMocks.createResponse();
+
+      await cqcStatusCheck(req, res);
+
+      expect(res._getData()).to.deep.equal(expectedResult);
+    });
+
+    it('should return a true flag if an unexpected error is thrown', async () => {
+      const request = {
+        method: 'GET',
+        url: `/api/cqcStatusCheck/${registeredLocationId}`,
+        params: {
+          locationID: registeredLocationId,
+        },
+        query: {
+          postcode: 'WA5 6BL',
+        },
+      };
+
+      sinon.restore();
+      sinon.stub(CQCDataAPI, 'getWorkplaceCQCData').throws();
+
+      const expectedResult = {
+        cqcStatusMatch: true,
+      };
+
+      const req = httpMocks.createRequest(request);
+      const res = httpMocks.createResponse();
+
+      await cqcStatusCheck(req, res);
+
+      expect(res._getData()).to.deep.equal(expectedResult);
+    });
   });
 
   // This is a little odd but since we are relying on a third party, it's useful to check that

--- a/server/test/unit/routes/cqcStatusCheck/index.spec.js
+++ b/server/test/unit/routes/cqcStatusCheck/index.spec.js
@@ -257,7 +257,7 @@ describe('server/routes/establishments/cqcStatus', async () => {
   });
 
   // This is a little odd but since we are relying on a third party, it's useful to check that
-  // the name's don't change, otherwise the mapping function is redundent.
+  // the names don't change, otherwise the mapping function is redundant.
   describe('mainService check', async () => {
     locationIDs.forEach(async (location) => {
       it(`should find ${location.locationID} and match main service`, async () => {
@@ -265,7 +265,30 @@ describe('server/routes/establishments/cqcStatus', async () => {
 
         const mainServiceCheck = checkMainServiceMatch(location.mainService, workplaceCQCData.gacServiceTypes);
 
-        expect(mainServiceCheck).to.deep.equal(true);
+        expect(mainServiceCheck).to.equal(true);
+      });
+    });
+
+    describe('checkMainServiceMatch()', async () => {
+      it('should return true if no main service mapping found when converting main service to CQC', async () => {
+        const location = { locationID: '1-4413548038', mainService: 'Head office services' };
+        const workplaceCQCData = await CQCDataAPI.getWorkplaceCQCData(location.locationID);
+
+        const mainServiceCheck = checkMainServiceMatch(location.mainService, workplaceCQCData.gacServiceTypes);
+
+        expect(mainServiceCheck).to.equal(true);
+      });
+
+      it('should return true if null passed in as main service', async () => {
+        const mainServiceCheck = checkMainServiceMatch(null, []);
+
+        expect(mainServiceCheck).to.equal(true);
+      });
+
+      it('should return true if null passed in as cqcServices', async () => {
+        const mainServiceCheck = checkMainServiceMatch(locationIDs[0].mainService, null);
+
+        expect(mainServiceCheck).to.equal(true);
       });
     });
   });

--- a/server/test/unit/routes/cqcStatusCheck/index.spec.js
+++ b/server/test/unit/routes/cqcStatusCheck/index.spec.js
@@ -270,13 +270,15 @@ describe('server/routes/establishments/cqcStatus', async () => {
     });
 
     describe('checkMainServiceMatch()', async () => {
-      it('should return true if no main service mapping found when converting main service to CQC', async () => {
+      // For case when provider with Head office services as
+      // main service (which should not have location ID) mistakenly adds a location ID
+      it('should return false if no main service mapping found when converting main service to CQC', async () => {
         const location = { locationID: '1-4413548038', mainService: 'Head office services' };
         const workplaceCQCData = await CQCDataAPI.getWorkplaceCQCData(location.locationID);
 
         const mainServiceCheck = checkMainServiceMatch(location.mainService, workplaceCQCData.gacServiceTypes);
 
-        expect(mainServiceCheck).to.equal(true);
+        expect(mainServiceCheck).to.equal(false);
       });
 
       it('should return true if null passed in as main service', async () => {

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -33,7 +33,10 @@
       ></app-summary-record-change>
     </dd>
   </div>
-  <div class="govuk-summary-list__row" *ngIf="workplace?.isRegulated">
+  <div
+    class="govuk-summary-list__row"
+    *ngIf="workplace?.isRegulated && workplace?.mainService?.name != 'Head office services'"
+  >
     <dt class="govuk-summary-list__key">CQC location ID</dt>
     <dd class="govuk-summary-list__value">
       {{ workplace.locationId }}

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -33,10 +33,7 @@
       ></app-summary-record-change>
     </dd>
   </div>
-  <div
-    class="govuk-summary-list__row"
-    *ngIf="workplace?.isRegulated && workplace?.mainService?.name != 'Head office services'"
-  >
+  <div class="govuk-summary-list__row" *ngIf="workplace?.isRegulated">
     <dt class="govuk-summary-list__key">CQC location ID</dt>
     <dd class="govuk-summary-list__value">
       {{ workplace.locationId }}

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -189,6 +189,48 @@ describe('WorkplaceSummaryComponent', async () => {
     });
   });
 
+  describe('CQC location ID', async () => {
+    it('should not show CQC location ID when workplace is not CQC regulated', async () => {
+      const { component, fixture, queryByText } = await setup();
+
+      component.canEditEstablishment = true;
+      component.workplace.isRegulated = false;
+      fixture.detectChanges();
+
+      expect(queryByText('CQC location ID')).toBeFalsy();
+    });
+
+    it('should not show CQC location ID when workplace is CQC regulated but has Head office services as main service', async () => {
+      const { component, fixture, queryByText } = await setup();
+
+      component.canEditEstablishment = true;
+      component.workplace.isRegulated = true;
+      component.workplace.mainService = {
+        id: 16,
+        name: 'Head office services',
+      };
+
+      fixture.detectChanges();
+
+      expect(queryByText('CQC location ID')).toBeFalsy();
+    });
+
+    it('should show CQC location ID when workplace is CQC regulated and does not have Head office services as main service', async () => {
+      const { component, fixture, queryByText } = await setup();
+
+      component.canEditEstablishment = true;
+      component.workplace.isRegulated = true;
+      component.workplace.mainService = {
+        id: 12,
+        name: 'Shared lives',
+      };
+
+      fixture.detectChanges();
+
+      expect(queryByText('CQC location ID')).toBeTruthy();
+    });
+  });
+
   describe('Staff records banner', async () => {
     it('should show banner if you have more staff records', async () => {
       const { component, fixture } = await setup();

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -200,31 +200,11 @@ describe('WorkplaceSummaryComponent', async () => {
       expect(queryByText('CQC location ID')).toBeFalsy();
     });
 
-    it('should not show CQC location ID when workplace is CQC regulated but has Head office services as main service', async () => {
+    it('should show CQC location ID when workplace is CQC regulated', async () => {
       const { component, fixture, queryByText } = await setup();
 
       component.canEditEstablishment = true;
       component.workplace.isRegulated = true;
-      component.workplace.mainService = {
-        id: 16,
-        name: 'Head office services',
-      };
-
-      fixture.detectChanges();
-
-      expect(queryByText('CQC location ID')).toBeFalsy();
-    });
-
-    it('should show CQC location ID when workplace is CQC regulated and does not have Head office services as main service', async () => {
-      const { component, fixture, queryByText } = await setup();
-
-      component.canEditEstablishment = true;
-      component.workplace.isRegulated = true;
-      component.workplace.mainService = {
-        id: 12,
-        name: 'Shared lives',
-      };
-
       fixture.detectChanges();
 
       expect(queryByText('CQC location ID')).toBeTruthy();


### PR DESCRIPTION
#### Work done
- Added check for cqc mapping existing in checkMainServiceMatch in cqcStatusCheck index file

#### Note
- Stops issue where workplaces who had Head office services as their main service and had entered a location ID were getting logged out due to an error being thrown in this 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
