### PR TITLE
fix: Flaky Benchmarks Viewed Test

### DIFF
--- a/server/test/unit/routes/establishments/benchmarks/usage.spec.js
+++ b/server/test/unit/routes/establishments/benchmarks/usage.spec.js
@@ -10,7 +10,7 @@ describe('usage', () => {
   let benchmarksUsageStub;
 
   beforeEach(() => {
-    benchmarksUsageStub = sinon.stub(models.benchmarksViewed, 'create');
+    benchmarksUsageStub = sinon.stub(models.benchmarksViewed, 'create').returns(null);
     request = {
       method: 'POST',
       url: '/api/establishment/85b2a783-ff2d-4c83-adba-c25378afa19c/benchmarks/usage',
@@ -25,14 +25,22 @@ describe('usage', () => {
   it('should return 200 when a benchmark usage has been successfully logged', async () => {
     const req = httpMocks.createRequest(request);
     const res = httpMocks.createResponse();
-    const viewedTime = moment();
 
     await benchmarksUsage.postBenchmarkTabUsage(req, res);
 
     expect(res.statusCode).to.deep.equal(200);
-    benchmarksUsageStub.should.have.been.calledWith({
-      EstablishmentID: request.establishmentId,
-      ViewedTime: viewedTime,
-    });
+  });
+
+  it('should call create on benchmarksViewed model with current time and establishment id from request', async () => {
+    const req = httpMocks.createRequest(request);
+    const res = httpMocks.createResponse();
+    const viewedTime = moment();
+
+    await benchmarksUsage.postBenchmarkTabUsage(req, res);
+
+    const createParams = benchmarksUsageStub.getCall(0).args[0];
+
+    expect(createParams.ViewedTime).to.deep.equal(viewedTime);
+    expect(createParams.EstablishmentID).to.deep.equal(request.establishmentId);
   });
 });


### PR DESCRIPTION
#### Work done
- Changed test to use getCall and deep equal comparison (it looks like it was failing because of the object comparison of the moment date)

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
