### PR TITLE
Feat/remove user header link from wdf new design feature flag

### DIFF
--- a/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/src/app/core/breadcrumb/journey.workplaces.ts
@@ -42,26 +42,28 @@ export const myWorkplaceJourney: JourneyRoute = {
     {
       title: 'Users',
       path: Path.USERS,
-    },
-    {
-      title: 'Add a user',
-      path: Path.CREATE_ACCOUNT,
-    },
-    {
-      title: 'User details',
-      path: Path.USER_ACCOUNT,
-      referrer: {
-        path: Path.DASHBOARD,
-        fragment: 'users',
-      },
       children: [
         {
-          title: 'Permissions',
-          path: Path.USER_PERMISSIONS,
+          title: 'Add a user',
+          path: Path.CREATE_ACCOUNT,
+        },
+        {
+          title: 'User details',
+          path: Path.USER_ACCOUNT,
           referrer: {
             path: Path.DASHBOARD,
-            fragment: 'users',
+            fragment: 'home',
           },
+          children: [
+            {
+              title: 'Permissions',
+              path: Path.USER_PERMISSIONS,
+              referrer: {
+                path: Path.DASHBOARD,
+                fragment: 'home',
+              },
+            },
+          ],
         },
       ],
     },
@@ -111,7 +113,7 @@ export const allWorkplacesJourney: JourneyRoute = {
               path: Path.USER_ACCOUNT,
               referrer: {
                 path: Path.WORKPLACE,
-                fragment: 'users',
+                fragment: 'workplace-users',
               },
               children: [
                 {
@@ -119,7 +121,7 @@ export const allWorkplacesJourney: JourneyRoute = {
                   path: Path.USER_PERMISSIONS,
                   referrer: {
                     path: Path.WORKPLACE,
-                    fragment: 'users',
+                    fragment: 'workplace-users',
                   },
                 },
               ],

--- a/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/src/app/core/breadcrumb/journey.workplaces.ts
@@ -107,6 +107,10 @@ export const allWorkplacesJourney: JourneyRoute = {
             {
               title: 'Add a user',
               path: Path.CREATE_ACCOUNT,
+              referrer: {
+                path: Path.WORKPLACE,
+                fragment: 'workplace-users',
+              },
             },
             {
               title: 'User details',

--- a/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/src/app/core/breadcrumb/journey.workplaces.ts
@@ -50,18 +50,10 @@ export const myWorkplaceJourney: JourneyRoute = {
         {
           title: 'User details',
           path: Path.USER_ACCOUNT,
-          referrer: {
-            path: Path.DASHBOARD,
-            fragment: 'home',
-          },
           children: [
             {
               title: 'Permissions',
               path: Path.USER_PERMISSIONS,
-              referrer: {
-                path: Path.DASHBOARD,
-                fragment: 'home',
-              },
             },
           ],
         },

--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -34,11 +34,7 @@
               >{{ fullname }}</a
             >
           </li>
-          <li
-            *ngIf="!isOnAdminScreen && wdfNewDesignFlag"
-            class="govuk-header__navigation-item"
-            routerLinkActive="active"
-          >
+          <li *ngIf="!isOnAdminScreen" class="govuk-header__navigation-item" routerLinkActive="active">
             <a
               [routerLink]="['/workplace', workplaceId, 'users']"
               class="govuk-header__link"

--- a/src/app/core/components/header/header.component.spec.ts
+++ b/src/app/core/components/header/header.component.spec.ts
@@ -9,9 +9,7 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { UserService } from '@core/services/user.service';
 import { MockAuthService } from '@core/test-utils/MockAuthService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockUserService } from '@core/test-utils/MockUserService';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { render } from '@testing-library/angular';
 
 import { HeaderComponent } from './header.component';
@@ -35,10 +33,6 @@ describe('HeaderComponent', () => {
         {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
-        },
-        {
-          provide: FeatureFlagsService,
-          useClass: MockFeatureFlagsService,
         },
       ],
     });

--- a/src/app/core/components/header/header.component.ts
+++ b/src/app/core/components/header/header.component.ts
@@ -4,7 +4,6 @@ import { AuthService } from '@core/services/auth.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { IdleService } from '@core/services/idle.service';
 import { UserService } from '@core/services/user.service';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -19,21 +18,17 @@ export class HeaderComponent implements OnInit, OnDestroy {
   public user: UserDetails;
   public showDropdown = false;
   public workplaceId: string;
-  public wdfNewDesignFlag: boolean;
 
   constructor(
     private authService: AuthService,
     private idleService: IdleService,
     private userService: UserService,
     private establishmentService: EstablishmentService,
-    private featureFlagsService: FeatureFlagsService,
   ) {}
 
   async ngOnInit(): Promise<void> {
     this.getUser();
     this.onAdminScreen();
-
-    this.wdfNewDesignFlag = await this.featureFlagsService.configCatClient.getValueAsync('wdfNewDesign', false);
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/resolvers/user-account.resolver.ts
+++ b/src/app/core/resolvers/user-account.resolver.ts
@@ -14,7 +14,7 @@ export class UserAccountResolver implements Resolve<any> {
 
     return this.userService.getUserDetails(establishmentUid, userUid).pipe(
       catchError(() => {
-        this.router.navigate(['/workplace', establishmentUid], { fragment: 'users' });
+        this.router.navigate(['/workplace', establishmentUid, 'users']);
         return of(null);
       }),
     );

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -150,6 +150,7 @@ export class AuthService {
     this._isAuthenticated$.next(false);
     this.userService.loggedInUser = null;
     this.userService.resetAgreedUpdatedTermsStatus = null;
+    this.userService.resetReturnUrl;
     this.establishmentService.resetState();
     this.permissionsService.clearPermissions();
     Sentry.configureScope((scope) => {

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -41,12 +41,33 @@ export class UserService {
     this._userDetails$.next(userDetails);
   }
 
-  public updateReturnUrl(returnUrl: URLStructure) {
-    this._returnUrl$.next(returnUrl);
-  }
-
   public getLoggedInUser(): Observable<UserDetails> {
     return this.http.get<UserDetails>(`/api/user/me`).pipe(tap((user) => (this.loggedInUser = user)));
+  }
+
+  public get returnUrl() {
+    if (this._returnUrl$.value != null) {
+      return this.returnUrl$;
+    }
+
+    const localStorageReturnUrl = localStorage.getItem('returnUrl');
+    if (localStorageReturnUrl) {
+      this._returnUrl$.next(JSON.parse(localStorageReturnUrl));
+    } else if (isDevMode()) {
+      if (!this.returnUrl$) {
+        throw new TypeError('No returnUrl in local storage!');
+      }
+    }
+    return this.returnUrl$;
+  }
+
+  public updateReturnUrl(returnUrl: URLStructure) {
+    this._returnUrl$.next(returnUrl);
+    localStorage.setItem('returnUrl', JSON.stringify(returnUrl));
+  }
+
+  public resetReturnUrl() {
+    this._returnUrl$ = null;
   }
 
   // get agreedUpdatedTermsStatus

--- a/src/app/core/test-utils/MockUserService.ts
+++ b/src/app/core/test-utils/MockUserService.ts
@@ -106,6 +106,12 @@ export { subsid1, subsid2, subsid3 };
 export class MockUserService extends UserService {
   private subsidiaries = 2;
   private isAdmin = false;
+
+  public returnUrl$ = of({
+    url: ['/workplace', '12345asdfg', 'users'],
+    fragment: 'workplace-users',
+  });
+
   public userDetails$ = of({
     uid: 'mocked-uid',
     email: 'john@test.com',

--- a/src/app/features/dashboard/dashboard-header/dashboard-header.component.ts
+++ b/src/app/features/dashboard/dashboard-header/dashboard-header.component.ts
@@ -8,9 +8,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { NotificationsService } from '@core/services/notifications/notifications.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
-import {
-  DeleteWorkplaceDialogComponent,
-} from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
+import { DeleteWorkplaceDialogComponent } from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
 import { interval, Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -145,8 +143,7 @@ export class DashboardHeaderComponent implements OnInit, OnDestroy {
 
   private setUserServiceReturnUrl(): void {
     this.userService.updateReturnUrl({
-      url: ['/dashboard'],
-      fragment: 'users',
+      url: ['/workplace', this.workplace.uid, 'users'],
     });
   }
 

--- a/src/app/features/dashboard/dashboard-header/dashboard-header.component.ts
+++ b/src/app/features/dashboard/dashboard-header/dashboard-header.component.ts
@@ -47,7 +47,6 @@ export class DashboardHeaderComponent implements OnInit, OnDestroy {
     }
 
     this.getLastLoggedIn();
-    this.setUserServiceReturnUrl();
     this.setUpNotificationSubscription();
   }
 
@@ -139,12 +138,6 @@ export class DashboardHeaderComponent implements OnInit, OnDestroy {
         );
       }),
     );
-  }
-
-  private setUserServiceReturnUrl(): void {
-    this.userService.updateReturnUrl({
-      url: ['/workplace', this.workplace.uid, 'users'],
-    });
   }
 
   private getLastLoggedIn(): void {

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -44,17 +44,6 @@
       <app-tab *ngIf="workplace && canViewEstablishment && wdfNewDesignFlag" [title]="'WDF'">
         <app-wdf-tab [workplace]="workplace"></app-wdf-tab>
       </app-tab>
-
-      <app-tab
-        *ngIf="workplace && canViewListOfUsers && !wdfNewDesignFlag"
-        [title]="'Users'"
-        [alert]="showSecondUserBanner"
-      >
-        <app-user-accounts-summary
-          [workplace]="workplace"
-          [showSecondUserBanner]="showSecondUserBanner"
-        ></app-user-accounts-summary>
-      </app-tab>
     </app-tabs>
   </div>
 </div>

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -184,14 +184,6 @@ describe('DashboardComponent', () => {
       expect(getByTestId('red-flag')).toBeTruthy();
     });
 
-    describe('Users tab warning', () => {
-      it('should not display an orange flag on the Users tab when more than one user', async () => {
-        const { queryByTestId } = await setup(false);
-
-        expect(queryByTestId('orange-flag')).toBeFalsy();
-      });
-    });
-
     describe('Staff records tab warning', () => {
       it('should not display an orange flag on the Staff records tab when not 0 staff records', async () => {
         const totalStaffRecords = 3;

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -175,20 +175,6 @@ describe('DashboardComponent', () => {
       expect(queryByTestId('tab_benchmarks')).toBeNull();
     });
 
-    it('should display the Users tab', async () => {
-      const { component, fixture, getByText } = await setup();
-
-      const establishment = {
-        ...component.workplace,
-      };
-      establishment.isRegulated = false;
-      component.workplace = establishment;
-      component.wdfNewDesignFlag = false;
-      fixture.detectChanges();
-
-      expect(getByText('Users')).toBeTruthy();
-    });
-
     it('should display a flag on the workplace tab when the sharing permissions banner flag is true', async () => {
       const { component, fixture, getByTestId } = await setup();
 
@@ -203,12 +189,6 @@ describe('DashboardComponent', () => {
         const { queryByTestId } = await setup(false);
 
         expect(queryByTestId('orange-flag')).toBeFalsy();
-      });
-
-      it('should display an orange flag on the Users tab when only one user', async () => {
-        const { queryByTestId } = await setup(true);
-
-        expect(queryByTestId('orange-flag')).toBeTruthy();
       });
     });
 

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -75,7 +75,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     this.showBanner && this.showStaffRecordBanner();
-    this.setUserServiceReturnUrl();
     this.wdfNewDesignFlag = await this.featureFlagsService.configCatClient.getValueAsync('wdfNewDesign', false);
   }
 
@@ -102,13 +101,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private setShowSecondUserBanner(): void {
     const users = this.route.snapshot.data.users ? this.route.snapshot.data.users : [];
     this.showSecondUserBanner = this.canAddUser && users.length === 1;
-  }
-
-  private setUserServiceReturnUrl(): void {
-    this.userService.updateReturnUrl({
-      url: ['/dashboard'],
-      fragment: 'users',
-    });
   }
 
   private setCheckCQCDetailsBannerInEstablishmentService(): void {

--- a/src/app/features/workplace/create-user-account/create-user-account.component.ts
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.ts
@@ -51,7 +51,7 @@ export class CreateUserAccountComponent extends AccountDetailsDirective {
       this.setPermissionsTypeRadios();
     });
     this.subscriptions.add(
-      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
+      this.userService.returnUrl.pipe(take(1)).subscribe((returnUrl) => {
         this.return = returnUrl;
       }),
     );

--- a/src/app/features/workplace/create-user-account/create-user-account.component.ts
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.ts
@@ -112,8 +112,7 @@ export class CreateUserAccountComponent extends AccountDetailsDirective {
 
   get returnTo(): URLStructure {
     return {
-      url: ['/dashboard'],
-      fragment: 'users',
+      url: ['/workplace', this.workplace.uid, 'users'],
     };
   }
 

--- a/src/app/features/workplace/create-user-account/create-user-account.component.ts
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.ts
@@ -111,8 +111,14 @@ export class CreateUserAccountComponent extends AccountDetailsDirective {
   }
 
   get returnTo(): URLStructure {
+    if (this.establishmentService.isOwnWorkplace()) {
+      return {
+        url: ['/workplace', this.workplace.uid, 'users'],
+      };
+    }
     return {
-      url: ['/workplace', this.workplace.uid, 'users'],
+      url: ['/workplace', this.workplace.uid],
+      fragment: 'workplace-users',
     };
   }
 

--- a/src/app/features/workplace/create-user-account/create-user-account.component.ts
+++ b/src/app/features/workplace/create-user-account/create-user-account.component.ts
@@ -13,9 +13,11 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { UserService } from '@core/services/user.service';
 import { getUserPermissionsTypes } from '@core/utils/users-util';
 import { AccountDetailsDirective } from '@shared/directives/user/account-details.directive';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { take } from 'rxjs/internal/operators/take';
 
 @Component({
   selector: 'app-create-account',
@@ -38,6 +40,7 @@ export class CreateUserAccountComponent extends AccountDetailsDirective {
     protected errorSummaryService: ErrorSummaryService,
     protected fb: FormBuilder,
     protected router: Router,
+    private userService: UserService,
   ) {
     super(backService, errorSummaryService, fb, router);
   }
@@ -47,11 +50,27 @@ export class CreateUserAccountComponent extends AccountDetailsDirective {
       this.wdfUserFlag = value;
       this.setPermissionsTypeRadios();
     });
+    this.subscriptions.add(
+      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
+        this.return = returnUrl;
+      }),
+    );
+
     this.workplace = this.route.parent.snapshot.data.establishment;
-    const journey = this.establishmentService.isOwnWorkplace() ? JourneyType.MY_WORKPLACE : JourneyType.ALL_WORKPLACES;
+
+    const journey = this.setBreadcrumbJourney();
     this.breadcrumbService.show(journey);
+
     this.addFormControls();
     this.establishmentUid = this.route.parent.snapshot.params.establishmentuid;
+  }
+
+  public setBreadcrumbJourney() {
+    if (this.return.fragment == null) {
+      return JourneyType.MY_WORKPLACE;
+    } else {
+      return JourneyType.ALL_WORKPLACES;
+    }
   }
 
   private addFormControls(): void {
@@ -111,15 +130,7 @@ export class CreateUserAccountComponent extends AccountDetailsDirective {
   }
 
   get returnTo(): URLStructure {
-    if (this.establishmentService.isOwnWorkplace()) {
-      return {
-        url: ['/workplace', this.workplace.uid, 'users'],
-      };
-    }
-    return {
-      url: ['/workplace', this.workplace.uid],
-      fragment: 'workplace-users',
-    };
+    return this.return;
   }
 
   private setPermissionsTypeRadios(): void {

--- a/src/app/features/workplace/create-user-account/create-user-account.spec.ts
+++ b/src/app/features/workplace/create-user-account/create-user-account.spec.ts
@@ -8,9 +8,11 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { UserService } from '@core/services/user.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockUserService } from '@core/test-utils/MockUserService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
@@ -39,6 +41,10 @@ describe('CreateUserAccountComponent', () => {
         CreateAccountService,
         { provide: BreadcrumbService, useClass: MockBreadcrumbService },
         { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+        {
+          provide: UserService,
+          useClass: MockUserService,
+        },
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/features/workplace/delete-user-account/delete-user-account.component.spec.ts
+++ b/src/app/features/workplace/delete-user-account/delete-user-account.component.spec.ts
@@ -51,14 +51,19 @@ describe('DeleteUserAccountComponent', () => {
     const componentInstance = component.fixture.componentInstance;
     componentInstance.flow = '/workplace/asdfg12345/user/12345asdfg';
 
-    const spy = spyOn(router, 'navigate');
-    spy.and.returnValue(Promise.resolve(true));
+    const routerSpy = spyOn(router, 'navigate');
+    routerSpy.and.returnValue(Promise.resolve(true));
+
+    componentInstance.return = {
+      url: ['/workplace', '12345asdfg', 'users'],
+      fragment: 'workplace-users',
+    };
 
     return {
       component,
       router,
       componentInstance,
-      spy,
+      routerSpy,
     };
   }
 
@@ -84,7 +89,7 @@ describe('DeleteUserAccountComponent', () => {
   });
 
   it('should navigate back to previous page when delete is successful', async () => {
-    const { component, componentInstance, spy } = await setup();
+    const { component, componentInstance, routerSpy } = await setup();
 
     spyOn(componentInstance.userService, 'deleteUser').and.returnValue(of({}));
 
@@ -93,7 +98,9 @@ describe('DeleteUserAccountComponent', () => {
     fireEvent.click(deleteButton);
     component.fixture.detectChanges();
 
-    expect(spy).toHaveBeenCalledWith(['/workplace', '12345asdfg', 'users']);
+    expect(routerSpy).toHaveBeenCalledWith(componentInstance.return.url, {
+      fragment: componentInstance.return.fragment,
+    });
   });
 
   it('should have a success alert when delete is successful', async () => {

--- a/src/app/features/workplace/delete-user-account/delete-user-account.component.spec.ts
+++ b/src/app/features/workplace/delete-user-account/delete-user-account.component.spec.ts
@@ -54,11 +54,6 @@ describe('DeleteUserAccountComponent', () => {
     const routerSpy = spyOn(router, 'navigate');
     routerSpy.and.returnValue(Promise.resolve(true));
 
-    componentInstance.return = {
-      url: ['/workplace', '12345asdfg', 'users'],
-      fragment: 'workplace-users',
-    };
-
     return {
       component,
       router,

--- a/src/app/features/workplace/delete-user-account/delete-user-account.component.spec.ts
+++ b/src/app/features/workplace/delete-user-account/delete-user-account.component.spec.ts
@@ -93,7 +93,7 @@ describe('DeleteUserAccountComponent', () => {
     fireEvent.click(deleteButton);
     component.fixture.detectChanges();
 
-    expect(spy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'users' });
+    expect(spy).toHaveBeenCalledWith(['/workplace', '12345asdfg', 'users']);
   });
 
   it('should have a success alert when delete is successful', async () => {

--- a/src/app/features/workplace/delete-user-account/delete-user-account.component.ts
+++ b/src/app/features/workplace/delete-user-account/delete-user-account.component.ts
@@ -36,7 +36,7 @@ export class DeleteUserAccountComponent implements OnInit, OnDestroy {
     this.setBackLink();
     this.subscriptions.add(
       this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
-        this.return = returnUrl ? returnUrl : { url: ['/workplace', this.establishment.uid, 'users'] };
+        this.return = returnUrl;
       }),
     );
   }
@@ -49,7 +49,7 @@ export class DeleteUserAccountComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.userService.deleteUser(this.establishment.uid, this.user.uid).subscribe(
         () => {
-          this.router.navigate(this.return.url);
+          this.router.navigate(this.return.url, { fragment: this.return.fragment });
           this.successAlert();
         },
         () => {

--- a/src/app/features/workplace/delete-user-account/delete-user-account.component.ts
+++ b/src/app/features/workplace/delete-user-account/delete-user-account.component.ts
@@ -36,7 +36,7 @@ export class DeleteUserAccountComponent implements OnInit, OnDestroy {
     this.setBackLink();
     this.subscriptions.add(
       this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
-        this.return = returnUrl ? returnUrl : { url: ['/dashboard'] };
+        this.return = returnUrl ? returnUrl : { url: ['/workplace', this.establishment.uid, 'users'] };
       }),
     );
   }
@@ -49,7 +49,7 @@ export class DeleteUserAccountComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.userService.deleteUser(this.establishment.uid, this.user.uid).subscribe(
         () => {
-          this.router.navigate(this.return.url, { fragment: 'users' });
+          this.router.navigate(this.return.url);
           this.successAlert();
         },
         () => {

--- a/src/app/features/workplace/delete-user-account/delete-user-account.component.ts
+++ b/src/app/features/workplace/delete-user-account/delete-user-account.component.ts
@@ -35,7 +35,7 @@ export class DeleteUserAccountComponent implements OnInit, OnDestroy {
     this.establishment = this.route.parent.snapshot.data.establishment;
     this.setBackLink();
     this.subscriptions.add(
-      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
+      this.userService.returnUrl.pipe(take(1)).subscribe((returnUrl) => {
         this.return = returnUrl;
       }),
     );

--- a/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
+++ b/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
@@ -58,9 +58,9 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
       url:
         this.route.snapshot.data.primaryWorkplace &&
         this.workplace.uid === this.route.snapshot.data.primaryWorkplace.uid
-          ? ['/dashboard']
+          ? ['/workplace', this.workplace.uid, 'users']
           : ['/workplace', this.workplace.uid],
-      fragment: 'users',
+      fragment: 'workplace-users',
     };
   }
 
@@ -115,9 +115,7 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.userService.updateUserDetails(this.workplace.uid, this.user.uid, { ...this.user, ...props }).subscribe(
         (data) => {
-          this.router.navigate(['/workplace', this.workplace.uid, 'user', this.user.uid], {
-            fragment: 'users',
-          });
+          this.router.navigate(['/workplace', this.workplace.uid, 'user', this.user.uid]);
           if (data.isPrimary) {
             name = this.user.fullname;
           }

--- a/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
+++ b/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
@@ -60,7 +60,7 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
     this.setupServerErrorsMap();
 
     this.subscriptions.add(
-      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
+      this.userService.returnUrl.pipe(take(1)).subscribe((returnUrl) => {
         this.return = returnUrl;
       }),
     );

--- a/src/app/features/workplace/user-account-saved/user-account-saved.component.html
+++ b/src/app/features/workplace/user-account-saved/user-account-saved.component.html
@@ -6,7 +6,7 @@
       as a user.
     </p>
     <div class="govuk-button-group">
-      <a role="button" draggable="false" class="govuk-button" [routerLink]="(returnUrl$ | async)?.url"> View users </a>
+      <a role="button" draggable="false" class="govuk-button" [routerLink]="return.url"> View users </a>
     </div>
   </div>
 </div>

--- a/src/app/features/workplace/user-account-saved/user-account-saved.component.html
+++ b/src/app/features/workplace/user-account-saved/user-account-saved.component.html
@@ -6,15 +6,7 @@
       as a user.
     </p>
     <div class="govuk-button-group">
-      <a
-        role="button"
-        draggable="false"
-        class="govuk-button"
-        [routerLink]="(returnUrl$ | async)?.url"
-        [fragment]="'users'"
-      >
-        View users
-      </a>
+      <a role="button" draggable="false" class="govuk-button" [routerLink]="(returnUrl$ | async)?.url"> View users </a>
     </div>
   </div>
 </div>

--- a/src/app/features/workplace/user-account-saved/user-account-saved.component.html
+++ b/src/app/features/workplace/user-account-saved/user-account-saved.component.html
@@ -6,7 +6,9 @@
       as a user.
     </p>
     <div class="govuk-button-group">
-      <a role="button" draggable="false" class="govuk-button" [routerLink]="return.url"> View users </a>
+      <a role="button" draggable="false" class="govuk-button" [routerLink]="return.url" [fragment]="return.fragment">
+        View users
+      </a>
     </div>
   </div>
 </div>

--- a/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
+++ b/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
@@ -5,7 +5,7 @@ import { URLStructure } from '@core/model/url.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
-import { Observable, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 @Component({
@@ -22,14 +22,14 @@ export class UserAccountSavedComponent implements OnInit {
     private establishmentService: EstablishmentService,
   ) {}
 
-  public returnUrl$: Observable<URLStructure>;
+  // public returnUrl$: Observable<URLStructure>;
   public userDetails: UserDetails = this.route.snapshot.data.user;
   public return: URLStructure;
 
   ngOnInit() {
     this.workplace = this.establishmentService.primaryWorkplace;
     this.subscriptions.add(
-      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
+      this.userService.returnUrl.pipe(take(1)).subscribe((returnUrl) => {
         this.return = returnUrl;
       }),
     );

--- a/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
+++ b/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
@@ -28,10 +28,9 @@ export class UserAccountSavedComponent implements OnInit {
 
   ngOnInit() {
     this.workplace = this.establishmentService.primaryWorkplace;
-
     this.subscriptions.add(
       this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
-        this.return = returnUrl ? returnUrl : { url: ['/workplace', this.workplace.uid, 'users'] };
+        this.return = returnUrl;
       }),
     );
   }

--- a/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
+++ b/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
@@ -1,21 +1,38 @@
 import { Component, OnInit } from '@angular/core';
-import { URLStructure } from '@core/model/url.model';
-import { UserService } from '@core/services/user.service';
-import { Observable } from 'rxjs';
-import { UserDetails } from '@core/model/userDetails.model';
 import { ActivatedRoute } from '@angular/router';
+import { Establishment } from '@core/model/establishment.model';
+import { URLStructure } from '@core/model/url.model';
+import { UserDetails } from '@core/model/userDetails.model';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { UserService } from '@core/services/user.service';
+import { Observable, Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-account-saved',
   templateUrl: './user-account-saved.component.html',
 })
 export class UserAccountSavedComponent implements OnInit {
-  constructor(private userService: UserService, private route: ActivatedRoute) {}
+  private subscriptions: Subscription = new Subscription();
+  public workplace: Establishment;
+
+  constructor(
+    private userService: UserService,
+    private route: ActivatedRoute,
+    private establishmentService: EstablishmentService,
+  ) {}
 
   public returnUrl$: Observable<URLStructure>;
   public userDetails: UserDetails = this.route.snapshot.data.user;
+  public return: URLStructure;
 
   ngOnInit() {
-    this.returnUrl$ = this.userService.returnUrl$;
+    this.workplace = this.establishmentService.primaryWorkplace;
+
+    this.subscriptions.add(
+      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
+        this.return = returnUrl ? returnUrl : { url: ['/workplace', this.workplace.uid, 'users'] };
+      }),
+    );
   }
 }

--- a/src/app/features/workplace/user-account-view/user-account-view.component.html
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.html
@@ -10,8 +10,6 @@
         *ngIf="canResendActivationLink"
         draggable="false"
         role="button"
-        [routerLink]="return.url"
-        [fragment]="return.fragment"
         (click)="resendActivationLink($event)"
       >
         Resend the user set-up email</a

--- a/src/app/features/workplace/user-account-view/user-account-view.component.html
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.html
@@ -11,6 +11,7 @@
         draggable="false"
         role="button"
         (click)="resendActivationLink($event)"
+        href="#"
       >
         Resend the user set-up email</a
       >

--- a/src/app/features/workplace/user-account-view/user-account-view.component.html
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.html
@@ -10,7 +10,8 @@
         *ngIf="canResendActivationLink"
         draggable="false"
         role="button"
-        href="#"
+        [routerLink]="return.url"
+        [fragment]="return.fragment"
         (click)="resendActivationLink($event)"
       >
         Resend the user set-up email</a

--- a/src/app/features/workplace/user-account-view/user-account-view.component.html
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.html
@@ -53,7 +53,5 @@
   </div>
 </div>
 <div class="govuk-button-group">
-  <a role="button" draggable="false" class="govuk-button" [routerLink]="return.url" [fragment]="'users'">
-    View users
-  </a>
+  <a role="button" draggable="false" class="govuk-button" [routerLink]="return.url"> View users </a>
 </div>

--- a/src/app/features/workplace/user-account-view/user-account-view.component.html
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.html
@@ -53,5 +53,7 @@
   </div>
 </div>
 <div class="govuk-button-group">
-  <a role="button" draggable="false" class="govuk-button" [routerLink]="return.url"> View users </a>
+  <a role="button" draggable="false" class="govuk-button" [routerLink]="return.url" [fragment]="return.fragment">
+    View users
+  </a>
 </div>

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -88,6 +88,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.userService.resendActivationLink(this.user.uid).subscribe(
         () => {
+          this.router.navigate(this.return.url, { fragment: this.return.fragment });
           this.alertService.addAlert({
             type: 'success',
             message: 'The user set-up email has been sent again.',

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -51,7 +51,12 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    const journey = this.establishmentService.isOwnWorkplace() ? JourneyType.MY_WORKPLACE : JourneyType.ALL_WORKPLACES;
+    this.subscriptions.add(
+      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
+        this.return = returnUrl;
+      }),
+    );
+    const journey = this.setBreadcrumbJourney();
     this.breadcrumbService.show(journey);
 
     this.subscriptions.add(
@@ -64,18 +69,18 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
           this.setPermissions();
         }),
     );
-
-    this.setUserServiceReturnUrl();
-
-    this.subscriptions.add(
-      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
-        this.return = returnUrl;
-      }),
-    );
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
+  }
+
+  public setBreadcrumbJourney() {
+    if (this.return.fragment == null) {
+      return JourneyType.MY_WORKPLACE;
+    } else {
+      return JourneyType.ALL_WORKPLACES;
+    }
   }
 
   public resendActivationLink(event: Event): void {
@@ -151,18 +156,5 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
         return user.status === 'Active' && user.role === Roles.Edit;
       }).length > 1
     );
-  }
-
-  private setUserServiceReturnUrl(): void {
-    if (this.establishmentService.isOwnWorkplace()) {
-      this.userService.updateReturnUrl({
-        url: ['/workplace', this.establishment.uid, 'users'],
-      });
-      return;
-    }
-    this.userService.updateReturnUrl({
-      url: ['/workplace', this.establishment.uid],
-      fragment: 'workplace-users',
-    });
   }
 }

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -83,7 +83,6 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.userService.resendActivationLink(this.user.uid).subscribe(
         () => {
-          this.router.navigate(this.return.url);
           this.alertService.addAlert({
             type: 'success',
             message: 'The user set-up email has been sent again.',

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -65,9 +65,11 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
         }),
     );
 
+    this.setUserServiceReturnUrl();
+
     this.subscriptions.add(
       this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
-        this.return = returnUrl ? returnUrl : { url: ['/workplace', this.establishment.uid, 'users'] };
+        this.return = returnUrl;
       }),
     );
   }
@@ -150,5 +152,18 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
         return user.status === 'Active' && user.role === Roles.Edit;
       }).length > 1
     );
+  }
+
+  private setUserServiceReturnUrl(): void {
+    if (this.establishmentService.isOwnWorkplace()) {
+      this.userService.updateReturnUrl({
+        url: ['/workplace', this.establishment.uid, 'users'],
+      });
+      return;
+    }
+    this.userService.updateReturnUrl({
+      url: ['/workplace', this.establishment.uid],
+      fragment: 'workplace-users',
+    });
   }
 }

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -52,7 +52,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.subscriptions.add(
-      this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
+      this.userService.returnUrl.pipe(take(1)).subscribe((returnUrl) => {
         this.return = returnUrl;
       }),
     );

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -67,7 +67,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
 
     this.subscriptions.add(
       this.userService.returnUrl$.pipe(take(1)).subscribe((returnUrl) => {
-        this.return = returnUrl ? returnUrl : { url: ['/workplace', this.establishment.uid] };
+        this.return = returnUrl ? returnUrl : { url: ['/workplace', this.establishment.uid, 'users'] };
       }),
     );
   }

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -81,7 +81,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.userService.resendActivationLink(this.user.uid).subscribe(
         () => {
-          this.router.navigate(this.return.url, { fragment: 'users' });
+          this.router.navigate(this.return.url);
           this.alertService.addAlert({
             type: 'success',
             message: 'The user set-up email has been sent again.',

--- a/src/app/features/workplace/users/users.component.ts
+++ b/src/app/features/workplace/users/users.component.ts
@@ -6,6 +6,7 @@ import { Roles } from '@core/model/roles.enum';
 import { UserDetails, UserPermissionsType, UserStatus } from '@core/model/userDetails.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { UserService } from '@core/services/user.service';
 import { getUserPermissionsTypes } from '@core/utils/users-util';
 import { orderBy } from 'lodash';
 
@@ -25,6 +26,7 @@ export class UsersComponent implements OnInit {
     private route: ActivatedRoute,
     private permissionsService: PermissionsService,
     private breadcrumbService: BreadcrumbService,
+    private userService: UserService,
   ) {}
 
   ngOnInit(): void {
@@ -41,6 +43,8 @@ export class UsersComponent implements OnInit {
       ['status', 'isPrimary', 'role', (user: UserDetails) => (user.fullname ? user.fullname.toLowerCase() : 'a')],
       ['desc', 'desc', 'asc', 'asc'],
     );
+
+    this.setUserServiceReturnUrl();
     this.setShowSecondUserBanner();
   }
 
@@ -68,5 +72,11 @@ export class UsersComponent implements OnInit {
     const editUsers = users.filter((user) => user.role === Roles.Edit);
     const readOnlyUsers = users.filter((user) => user.role === Roles.Read);
     return editUsers.length < 3 || readOnlyUsers.length < readOnlyLimit;
+  }
+
+  private setUserServiceReturnUrl(): void {
+    this.userService.updateReturnUrl({
+      url: ['/workplace', this.workplace.uid, 'users'],
+    });
   }
 }

--- a/src/app/features/workplace/view-workplace/view-workplace.component.html
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.html
@@ -60,7 +60,7 @@
       <app-tab *ngIf="canViewBenchmarks" [title]="'Benchmarks'">
         <app-benchmarks-tab class="asc-benchmarks-tab" [workplace]="workplace"></app-benchmarks-tab>
       </app-tab>
-      <app-tab *ngIf="canViewListOfUsers" [title]="'Users'" [alert]="false">
+      <app-tab *ngIf="canViewListOfUsers" [title]="'Workplace users'" [alert]="false">
         <app-user-accounts-summary [workplace]="workplace" [showSecondUserBanner]="false"></app-user-accounts-summary>
       </app-tab>
     </app-tabs>

--- a/src/app/features/workplace/view-workplace/view-workplace.component.spec.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.spec.ts
@@ -156,7 +156,7 @@ describe('view-workplace', () => {
       component.workplace = establishment;
       fixture.detectChanges();
 
-      expect(getByText('Users')).toBeTruthy();
+      expect(getByText('Workplace users')).toBeTruthy();
     });
 
     it('should display a flag on the workplace tab when the sharing permisson banner is true', async () => {

--- a/src/app/features/workplace/view-workplace/view-workplace.component.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.ts
@@ -88,7 +88,7 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
     };
 
     this.userService.updateReturnUrl({
-      url: ['/workplace', this.workplace.uid],
+      url: ['/workplace', this.workplace.uid, 'users'],
     });
   }
 

--- a/src/app/features/workplace/view-workplace/view-workplace.component.ts
+++ b/src/app/features/workplace/view-workplace/view-workplace.component.ts
@@ -86,10 +86,6 @@ export class ViewWorkplaceComponent implements OnInit, OnDestroy {
       url: ['/workplace', this.workplace.uid],
       fragment: 'workplace',
     };
-
-    this.userService.updateReturnUrl({
-      url: ['/workplace', this.workplace.uid, 'users'],
-    });
   }
 
   public onDeleteWorkplace(event: Event): void {


### PR DESCRIPTION
#### Work done
- Removed user tab from parent accounts and stand-alone accounts
- Removed Users header link from being behind wdf feature flag
- Re-worked user page urls/navigation so they no longer point to the dashboard users tab
- Updated breadcrumbs as necessary

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
