### PR TITLE
Feat/workplace tab

### DIFF
--- a/src/app/core/services/establishment.service.ts
+++ b/src/app/core/services/establishment.service.ts
@@ -158,8 +158,6 @@ export class EstablishmentService {
     const returnTo = localStorage.getItem('returnTo');
     if (returnTo) {
       this.returnTo$.next(JSON.parse(returnTo));
-    } else if (isDevMode() && !this.returnTo$.value) {
-      throw new TypeError('No returnTo in local storage!');
     }
 
     return this.returnTo$.value;

--- a/src/app/shared/components/new-workplace-summary/new-workplace-summary.component.html
+++ b/src/app/shared/components/new-workplace-summary/new-workplace-summary.component.html
@@ -7,7 +7,7 @@
   }"
 >
   <ng-container *ngIf="!checkAnswersPage">
-    <div class="govuk-summary-list__row">
+    <div class="govuk-summary-list__row" data-testid="workplace-section">
       <dt class="govuk-summary-list__key">
         <div>Workplace name</div>
         <div *ngIf="workplace && workplace.address" class="govuk-!-padding-top-2">Workplace address</div>
@@ -34,7 +34,7 @@
         ></app-summary-record-change>
       </dd>
     </div>
-    <div class="govuk-summary-list__row" *ngIf="workplace?.isRegulated && !checkAnswersPage">
+    <div class="govuk-summary-list__row" *ngIf="workplace?.isRegulated" data-testid="cqcLocationId">
       <dt class="govuk-summary-list__key">CQC location ID</dt>
       <dd class="govuk-summary-list__value">
         {{ workplace.locationId }}
@@ -43,9 +43,17 @@
         <a [routerLink]="['/workplace', workplace.uid, 'regulated-by-cqc']" (click)="setReturn()"> Change </a>
       </dd>
     </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key" [class.asc-no-border]="staffMismatchWarning()">Number of staff</dt>
-      <dd class="govuk-summary-list__value" [class.asc-no-border]="staffMismatchWarning()">
+    <div class="govuk-summary-list__row" data-testid="numberOfStaff">
+      <dt
+        class="govuk-summary-list__key"
+        [class.asc-no-border]="staffMismatchWarning() && convertToDate(workplace.eightWeeksFromFirstLogin) < now"
+      >
+        Number of staff
+      </dt>
+      <dd
+        class="govuk-summary-list__value"
+        [class.asc-no-border]="staffMismatchWarning() && convertToDate(workplace.eightWeeksFromFirstLogin) < now"
+      >
         <app-summary-record-value
           [wdfView]="wdfView"
           [wdfValue]="workplace.wdf?.numberOfStaff"
@@ -75,7 +83,7 @@
       <dd
         *ngIf="canEditEstablishment"
         class="govuk-summary-list__actions"
-        [class.asc-no-border]="staffMismatchWarning()"
+        [class.asc-no-border]="staffMismatchWarning() && convertToDate(workplace.eightWeeksFromFirstLogin) < now"
       >
         <app-summary-record-change
           *ngIf="
@@ -93,7 +101,7 @@
         ></app-summary-record-change>
       </dd>
     </div>
-    <ng-container *ngIf="staffMismatchWarning()">
+    <ng-container *ngIf="staffMismatchWarning() && convertToDate(workplace.eightWeeksFromFirstLogin) < now">
       <div class="govuk-summary-list__row spacer"></div>
       <div class="govuk-summary-list__row asc-warning-banner" data-testid="morerecords">
         <dt class="govuk-summary-list__key">
@@ -114,7 +122,7 @@
         <div></div>
       </div>
     </ng-container>
-    <div class="govuk-summary-list__row" *ngIf="!checkAnswersPage">
+    <div class="govuk-summary-list__row" data-testid="employerType">
       <dt class="govuk-summary-list__key">Employer type</dt>
       <dd class="govuk-summary-list__value">
         <app-summary-record-value
@@ -153,6 +161,7 @@
       *ngIf="!checkAnswersPage"
       class="govuk-summary-list__row"
       [ngClass]="{ 'govuk-panel--light-blue': cqcStatusRequested }"
+      data-testid="mainService"
     >
       <dt class="govuk-summary-list__key" [ngClass]="{ 'govuk-!-padding-left-3': cqcStatusRequested }">Main service</dt>
       <dd class="govuk-summary-list__value" data-testid="main-service-name">

--- a/src/app/shared/components/new-workplace-summary/new-workplace-summary.component.html
+++ b/src/app/shared/components/new-workplace-summary/new-workplace-summary.component.html
@@ -6,68 +6,140 @@
     'asc-summary-list--wide-value': wdfView && showTotalStaffWarning
   }"
 >
-  <div *ngIf="!checkAnswersPage" class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      <div>Workplace name</div>
-      <div *ngIf="workplace && workplace.address" class="govuk-!-padding-top-2">Workplace address</div>
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <div>
-        {{ workplace.name }}
-      </div>
-      <div *ngIf="workplace" class="govuk-!-padding-top-2">
-        <div *ngIf="workplace.address1">{{ workplace.address1 }}</div>
-        <div *ngIf="workplace.address2">{{ workplace.address2 }}</div>
-        <div *ngIf="workplace.address3">{{ workplace.address3 }}</div>
-        <div *ngIf="workplace.town">{{ workplace.town }}</div>
-        <div *ngIf="workplace.county">{{ workplace.county }}</div>
-        <div *ngIf="workplace.postcode">{{ workplace.postcode }}</div>
-      </div>
-    </dd>
-    <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
-      <app-summary-record-change
-        [explanationText]="''"
-        [link]="['/workplace', workplace.uid, 'update-workplace-details']"
-        [hasData]="workplace.name"
-        (setReturnClicked)="this.setReturn()"
-      ></app-summary-record-change>
-    </dd>
-  </div>
-  <div class="govuk-summary-list__row" *ngIf="workplace?.isRegulated && !checkAnswersPage">
-    <dt class="govuk-summary-list__key">CQC location ID</dt>
-    <dd class="govuk-summary-list__value">
-      {{ workplace.locationId }}
-    </dd>
-    <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
-      <a [routerLink]="['/workplace', workplace.uid, 'regulated-by-cqc']" (click)="setReturn()"> Change </a>
-    </dd>
-  </div>
-
-  <div class="govuk-summary-list__row" *ngIf="!checkAnswersPage">
-    <dt class="govuk-summary-list__key">Employer type</dt>
-    <dd class="govuk-summary-list__value">
-      <app-summary-record-value
-        [wdfView]="wdfView"
-        [wdfValue]="workplace.wdf?.employerType"
-        [overallWdfEligibility]="overallWdfEligibility"
+  <ng-container *ngIf="!checkAnswersPage">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <div>Workplace name</div>
+        <div *ngIf="workplace && workplace.address" class="govuk-!-padding-top-2">Workplace address</div>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <div>
+          {{ workplace.name }}
+        </div>
+        <div *ngIf="workplace" class="govuk-!-padding-top-2">
+          <div *ngIf="workplace.address1">{{ workplace.address1 }}</div>
+          <div *ngIf="workplace.address2">{{ workplace.address2 }}</div>
+          <div *ngIf="workplace.address3">{{ workplace.address3 }}</div>
+          <div *ngIf="workplace.town">{{ workplace.town }}</div>
+          <div *ngIf="workplace.county">{{ workplace.county }}</div>
+          <div *ngIf="workplace.postcode">{{ workplace.postcode }}</div>
+        </div>
+      </dd>
+      <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
+        <app-summary-record-change
+          [explanationText]="''"
+          [link]="['/workplace', workplace.uid, 'update-workplace-details']"
+          [hasData]="workplace.name"
+          (setReturnClicked)="this.setReturn()"
+        ></app-summary-record-change>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row" *ngIf="workplace?.isRegulated && !checkAnswersPage">
+      <dt class="govuk-summary-list__key">CQC location ID</dt>
+      <dd class="govuk-summary-list__value">
+        {{ workplace.locationId }}
+      </dd>
+      <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
+        <a [routerLink]="['/workplace', workplace.uid, 'regulated-by-cqc']" (click)="setReturn()"> Change </a>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key" [class.asc-no-border]="staffMismatchWarning()">Number of staff</dt>
+      <dd class="govuk-summary-list__value" [class.asc-no-border]="staffMismatchWarning()">
+        <app-summary-record-value
+          [wdfView]="wdfView"
+          [wdfValue]="workplace.wdf?.numberOfStaff"
+          [overallWdfEligibility]="overallWdfEligibility"
+        >
+          {{ workplace.numberOfStaff | numericAnswer }}
+        </app-summary-record-value>
+        <app-wdf-field-confirmation
+          *ngIf="
+            canEditEstablishment &&
+            wdfView &&
+            workplace.wdf?.numberOfStaff.isEligible === 'Yes' &&
+            !workplace.wdf?.numberOfStaff.updatedSinceEffectiveDate &&
+            workplace.numberOfStaff === workerCount
+          "
+          [changeLink]="getRoutePath('total-staff')"
+          (fieldConfirmation)="this.confirmField('numberOfStaff')"
+          (setReturnClicked)="this.setReturn()"
+        ></app-wdf-field-confirmation>
+        <app-wdf-staff-mismatch-message
+          *ngIf="wdfView && this.showTotalStaffWarning"
+          [workplace]="workplace"
+          [workerCount]="workerCount"
+          [overallWdfEligibility]="overallWdfEligibility"
+        ></app-wdf-staff-mismatch-message>
+      </dd>
+      <dd
+        *ngIf="canEditEstablishment"
+        class="govuk-summary-list__actions"
+        [class.asc-no-border]="staffMismatchWarning()"
       >
-        <ng-container *ngIf="!(workplace.employerType?.other || workplace.employerType?.value); else employertype">
-          -
-        </ng-container>
-        <ng-template #employertype>
-          {{ workplace.employerType?.other ? workplace.employerType.other : workplace.employerType.value }}
-        </ng-template>
-      </app-summary-record-value>
-    </dd>
-    <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
-      <app-summary-record-change
-        [explanationText]="' employer type'"
-        [link]="['/workplace', workplace.uid, 'type-of-employer']"
-        [hasData]="workplace.employerType?.other || workplace.employerType?.value"
-        (setReturnClicked)="this.setReturn()"
-      ></app-summary-record-change>
-    </dd>
-  </div>
+        <app-summary-record-change
+          *ngIf="
+            !(
+              wdfView &&
+              workplace.wdf?.numberOfStaff.isEligible === 'Yes' &&
+              !workplace.wdf?.numberOfStaff.updatedSinceEffectiveDate &&
+              workplace.numberOfStaff === workerCount
+            )
+          "
+          [explanationText]="' total number of staff'"
+          [link]="['/workplace', workplace.uid, 'total-staff']"
+          [hasData]="isNumber(workplace.numberOfStaff)"
+          (setReturnClicked)="this.setReturn()"
+        ></app-summary-record-change>
+      </dd>
+    </div>
+    <ng-container *ngIf="staffMismatchWarning()">
+      <div class="govuk-summary-list__row spacer"></div>
+      <div class="govuk-summary-list__row asc-warning-banner" data-testid="morerecords">
+        <dt class="govuk-summary-list__key">
+          <span class="govuk-visually-hidden">Number of staff warning</span>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p *ngIf="workplace.numberOfStaff > workerCount">You've more staff than staff records</p>
+          <p *ngIf="workplace.numberOfStaff < workerCount">You've more staff records than staff</p>
+          <p *ngIf="workplace.numberOfStaff == null">The number of staff is missing</p>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a *ngIf="workplace.numberOfStaff" href="#" (click)="selectStaffTab($event)">View staff records</a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row spacer">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+    </ng-container>
+    <div class="govuk-summary-list__row" *ngIf="!checkAnswersPage">
+      <dt class="govuk-summary-list__key">Employer type</dt>
+      <dd class="govuk-summary-list__value">
+        <app-summary-record-value
+          [wdfView]="wdfView"
+          [wdfValue]="workplace.wdf?.employerType"
+          [overallWdfEligibility]="overallWdfEligibility"
+        >
+          <ng-container *ngIf="!(workplace.employerType?.other || workplace.employerType?.value); else employertype">
+            -
+          </ng-container>
+          <ng-template #employertype>
+            {{ workplace.employerType?.other ? workplace.employerType.other : workplace.employerType.value }}
+          </ng-template>
+        </app-summary-record-value>
+      </dd>
+      <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
+        <app-summary-record-change
+          [explanationText]="' employer type'"
+          [link]="['/workplace', workplace.uid, 'type-of-employer']"
+          [hasData]="workplace.employerType?.other || workplace.employerType?.value"
+          (setReturnClicked)="this.setReturn()"
+        ></app-summary-record-change>
+      </dd>
+    </div>
+  </ng-container>
 
   <ng-container>
     <div class="govuk-summary-list__row" data-testid="services-section">
@@ -77,7 +149,75 @@
       <dd class="govuk-summary-list__value"></dd>
       <dd class="govuk-summary-list__actions"></dd>
     </div>
-    <div class="govuk-summary-list__row" data-testid="otherServices">
+    <div
+      *ngIf="!checkAnswersPage"
+      class="govuk-summary-list__row"
+      [ngClass]="{ 'govuk-panel--light-blue': cqcStatusRequested }"
+    >
+      <dt class="govuk-summary-list__key" [ngClass]="{ 'govuk-!-padding-left-3': cqcStatusRequested }">Main service</dt>
+      <dd class="govuk-summary-list__value" data-testid="main-service-name">
+        <app-summary-record-value
+          [wdfView]="wdfView"
+          [wdfValue]="workplace.wdf?.mainService"
+          [overallWdfEligibility]="overallWdfEligibility"
+        >
+          {{ cqcStatusRequested ? requestedServiceName : workplace.mainService?.name }}
+          <ng-container
+            *ngIf="
+              (cqcStatusRequested && requestedServiceOtherName) || (workplace.mainService?.other && !cqcStatusRequested)
+            "
+          >
+            - {{ cqcStatusRequested ? requestedServiceOtherName : workplace.mainService?.other }}
+          </ng-container>
+        </app-summary-record-value>
+        <app-wdf-field-confirmation
+          *ngIf="
+            canEditEstablishment &&
+            wdfView &&
+            workplace.wdf?.mainService.isEligible === 'Yes' &&
+            !workplace.wdf?.mainService.updatedSinceEffectiveDate
+          "
+          [changeLink]="getRoutePath('main-service-cqc')"
+          (fieldConfirmation)="this.confirmField('mainService')"
+          (setReturnClicked)="this.setReturn()"
+        >
+        </app-wdf-field-confirmation>
+      </dd>
+      <dd
+        *ngIf="canEditEstablishment"
+        class="govuk-summary-list__actions"
+        [ngClass]="{ 'govuk-!-padding-right-3': cqcStatusRequested }"
+        data-testid="main-service-change-or-pending"
+      >
+        <ng-container
+          *ngIf="
+            !(
+              wdfView &&
+              workplace.wdf?.mainService.isEligible === 'Yes' &&
+              !workplace.wdf?.mainService.updatedSinceEffectiveDate
+            )
+          "
+        >
+          <a
+            *ngIf="!cqcStatusRequested; else cqcPending"
+            [routerLink]="['/workplace', workplace.uid, 'main-service-cqc']"
+            (click)="setReturn()"
+          >
+            <ng-container *ngIf="!workplace.mainService">
+              Provide information
+              <span class="govuk-visually-hidden"> for</span>
+            </ng-container>
+            <ng-container *ngIf="workplace.mainService"> Change </ng-container>
+            <span class="govuk-visually-hidden"> main service</span>
+          </a>
+          <ng-template #cqcPending>
+            <ng-container> Pending </ng-container>
+            <span class="govuk-visually-hidden"> main service</span>
+          </ng-template>
+        </ng-container>
+      </dd>
+    </div>
+    <div *ngIf="!workplace.showAddWorkplaceDetailsBanner" class="govuk-summary-list__row" data-testid="otherServices">
       <dt class="govuk-summary-list__key">Other services</dt>
       <dd class="govuk-summary-list__value">
         <ng-container [ngSwitch]="workplace.otherServices.value">
@@ -104,7 +244,7 @@
       </dd>
     </div>
 
-    <div class="govuk-summary-list__row" data-testid="serviceCapacity">
+    <div *ngIf="!workplace.showAddWorkplaceDetailsBanner" class="govuk-summary-list__row" data-testid="serviceCapacity">
       <dt class="govuk-summary-list__key">Service capacity</dt>
       <dd class="govuk-summary-list__value">
         <app-summary-record-value
@@ -149,7 +289,7 @@
       </dd>
     </div>
 
-    <div class="govuk-summary-list__row" data-testid="serviceUsers">
+    <div *ngIf="!workplace.showAddWorkplaceDetailsBanner" class="govuk-summary-list__row" data-testid="serviceUsers">
       <dt class="govuk-summary-list__key">Service users</dt>
       <dd class="govuk-summary-list__value">
         <app-summary-record-value
@@ -197,7 +337,7 @@
     </div>
   </ng-container>
 
-  <ng-container>
+  <ng-container *ngIf="!workplace.showAddWorkplaceDetailsBanner">
     <div class="govuk-summary-list__row" data-testid="vacancies-and-turnover-section">
       <dt class="govuk-summary-list__key">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5">Vacancies and turnover</h2>
@@ -354,7 +494,7 @@
     </div>
   </ng-container>
 
-  <ng-container>
+  <ng-container *ngIf="!workplace.showAddWorkplaceDetailsBanner">
     <div class="govuk-summary-list__row" data-testid="recruitment-section">
       <dt class="govuk-summary-list__key">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5">Recruitment</h2>
@@ -498,7 +638,7 @@
     </div>
   </ng-container>
 
-  <ng-container>
+  <ng-container *ngIf="!workplace.showAddWorkplaceDetailsBanner">
     <div class="govuk-summary-list__row" data-testid="permissions-section">
       <dt class="govuk-summary-list__key">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5">Permissions</h2>

--- a/src/app/shared/components/new-workplace-summary/new-workplace-summary.component.ts
+++ b/src/app/shared/components/new-workplace-summary/new-workplace-summary.component.ts
@@ -28,6 +28,7 @@ export class NewWorkplaceSummaryComponent implements OnInit, OnDestroy, OnChange
   public confirmedFields: Array<string> = [];
   public showTotalStaffWarning: boolean;
   public checkAnswersPage: boolean;
+  public now: Date = new Date();
   @Output() allFieldsConfirmed: EventEmitter<Event> = new EventEmitter();
 
   @Input() wdfView = false;
@@ -196,6 +197,10 @@ export class NewWorkplaceSummaryComponent implements OnInit, OnDestroy, OnChange
         }
       }),
     );
+  }
+
+  public convertToDate(dateString: string): Date {
+    return new Date(dateString);
   }
 
   public updateEmployerTypeIfNotUpdatedSinceEffectiveDate(): void {

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.html
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.html
@@ -38,11 +38,6 @@
       Start to add more details about your workplace
     </a>
   </app-inset-text>
-  <app-new-workplace-summary [workplace]="workplace" [return]="summaryReturnUrl"> </app-new-workplace-summary>
-  <!-- <app-workplace-summary
-    *ngIf="workplace"
-    [workplace]="workplace"
-    [workerCount]="workerCount"
-    [return]="summaryReturnUrl"
-  ></app-workplace-summary> -->
+  <app-new-workplace-summary [workplace]="workplace" [workerCount]="workerCount" [return]="summaryReturnUrl">
+  </app-new-workplace-summary>
 </ng-container>

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.html
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.html
@@ -32,20 +32,17 @@
   </div>
 </ng-container>
 
-<ng-container *ngIf="updateWorkplaceAlert; then alert; else summary"></ng-container>
-<ng-template #alert>
+<ng-container>
   <app-inset-text *ngIf="updateWorkplaceAlert" color="todo">
     <a [routerLink]="['/workplace', workplace?.uid, 'start']" [state]="{ navigatedFromFragment: 'workplace' }">
       Start to add more details about your workplace
     </a>
   </app-inset-text>
-</ng-template>
-
-<ng-template #summary>
-  <app-workplace-summary
+  <app-new-workplace-summary [workplace]="workplace" [return]="summaryReturnUrl"> </app-new-workplace-summary>
+  <!-- <app-workplace-summary
     *ngIf="workplace"
     [workplace]="workplace"
     [workerCount]="workerCount"
     [return]="summaryReturnUrl"
-  ></app-workplace-summary>
-</ng-template>
+  ></app-workplace-summary> -->
+</ng-container>

--- a/src/app/shared/components/workplace-tab/workplace-tab.component.ts
+++ b/src/app/shared/components/workplace-tab/workplace-tab.component.ts
@@ -35,7 +35,8 @@ export class WorkplaceTabComponent implements OnInit, OnDestroy {
     this.getShowCQCDetailsBanner();
     this.showSharingPermissionsBanner = this.workplace.showSharingPermissionsBanner;
     this.updateWorkplaceAlert =
-      !this.workplace.employerType && this.permissionsService.can(this.workplace.uid, 'canEditEstablishment');
+      this.workplace.showAddWorkplaceDetailsBanner &&
+      this.permissionsService.can(this.workplace.uid, 'canEditEstablishment');
   }
 
   private getShowCQCDetailsBanner(): void {


### PR DESCRIPTION
#### Work done
- add in the workplace address, type of employer, number of staff to the new workplace summary component
- change the workplace tab to show certain parts of the summary when add details hasn't been done
- add tests

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
