### PR TITLE
Fix/inactive workplaces query

### DIFF
--- a/server/models/email-campaigns/inactive-workplaces/getInactiveWorkplacesForDeletion.js
+++ b/server/models/email-campaigns/inactive-workplaces/getInactiveWorkplacesForDeletion.js
@@ -30,19 +30,21 @@ const getInactiveWorkplacesForDeletion = async () => {
   WHERE
   	e."LastLogin" <= :twentyFourLastMonths
 	  AND e."LastUpdated" <= :twentyFourLastMonths
-  	AND ("IsParent" = false OR
-	NOT EXISTS(
-		SELECT
-		  "EstablishmentID"
-	  FROM
-		  cqc."EstablishmentLastActivity" s
-	  WHERE
-		  e."EstablishmentID" = s."ParentID"
-		  AND s."LastLogin" > :twentyFourLastMonths
-		  AND s."LastUpdated" > :twentyFourLastMonths
-	  )
+    AND NOT EXISTS
+    (
+       SELECT s."EstablishmentID" AS EstablishmentID
+          FROM cqc."EstablishmentLastActivity" s
+          WHERE  s."IsParent" = true AND EXISTS
+          (
+            SELECT c."EstablishmentID"
+             FROM cqc."EstablishmentLastActivity" c
+              WHERE s."EstablishmentID" = c."ParentID"
+              AND c."LastLogin" > :twentyFourLastMonths
+              AND c."LastUpdated" > :twentyFourLastMonths
+              AND c."IsParent"= false
+           ) AND s."EstablishmentID"  =  e."EstablishmentID"
+   )
 
-  )
       `,
     {
       type: models.sequelize.QueryTypes.SELECT,

--- a/server/models/email-campaigns/inactive-workplaces/getInactiveWorkplacesForDeletion.js
+++ b/server/models/email-campaigns/inactive-workplaces/getInactiveWorkplacesForDeletion.js
@@ -41,6 +41,7 @@ const getInactiveWorkplacesForDeletion = async () => {
 		  AND s."LastLogin" > :twentyFourLastMonths
 		  AND s."LastUpdated" > :twentyFourLastMonths
 	  )
+
   )
       `,
     {

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -2033,18 +2033,21 @@ module.exports = function (sequelize, DataTypes) {
     WHERE
       e."LastLogin" <= :twentyFourLastMonths
       AND e."LastUpdated" <= :twentyFourLastMonths
-      AND ("IsParent" = false OR
-    NOT EXISTS(
-      SELECT
-        "EstablishmentID"
-      FROM
-        cqc."EstablishmentLastActivity" s
-      WHERE
-        e."EstablishmentID" = s."ParentID"
-        AND s."LastLogin" > :twentyFourLastMonths
-        AND s."LastUpdated" > :twentyFourLastMonths
-      )
-    )
+      AND NOT EXISTS
+      (
+         SELECT s."EstablishmentID" AS EstablishmentID
+            FROM cqc."EstablishmentLastActivity" s
+            WHERE  s."IsParent" = true AND EXISTS
+          (
+             SELECT c."EstablishmentID"
+              FROM cqc."EstablishmentLastActivity" c
+                WHERE s."EstablishmentID" = c."ParentID"
+                 AND c."LastLogin" > :twentyFourLastMonths
+                 AND c."LastUpdated" > :twentyFourLastMonths
+              AND c."IsParent"= false
+            ) AND s."EstablishmentID"  =  e."EstablishmentID"
+     )
+
     and e."EstablishmentID" IN(:establishmentIds)
         `,
       {

--- a/src/app/features/workers/nursing-category/nursing-category.component.spec.ts
+++ b/src/app/features/workers/nursing-category/nursing-category.component.spec.ts
@@ -63,7 +63,6 @@ describe('NursingCategoryComponent', () => {
       const { getByText } = await setup();
 
       expect(getByText('Save and return')).toBeTruthy();
-      expect(getByText('Cancel')).toBeTruthy();
     });
   });
 });

--- a/src/app/features/workers/nursing-category/nursing-category.component.spec.ts
+++ b/src/app/features/workers/nursing-category/nursing-category.component.spec.ts
@@ -63,6 +63,7 @@ describe('NursingCategoryComponent', () => {
       const { getByText } = await setup();
 
       expect(getByText('Save and return')).toBeTruthy();
+      expect(getByText('Cancel')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
#### Work done
- Rewrite the archive inactive workplaces query so when a parent workplace has an active child it shouldn’t be deleted.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
