### PR TITLE
Fix/stop new mandatory training prefill

### DIFF
--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.html
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.html
@@ -58,10 +58,20 @@
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-form-group govuk-!-margin-bottom-1">
+        <div
+          class="govuk-form-group govuk-!-margin-bottom-1"
+          [class.govuk-form-group--error]="submitted && form.get('allOrSelectedJobRoles').invalid"
+        >
           <legend class="govuk-fieldset__legend">
             <span class="govuk-label"> Which job roles need this training? </span>
           </legend>
+          <span *ngIf="submitted" class="govuk-error-message">
+            <ng-container *ngIf="submitted && form.get('allOrSelectedJobRoles').invalid">
+              <label id="allOrSelectedJobRoles-error" for="allOrSelectedJobRoles-0"
+                >Select which job roles need this training</label
+              >
+            </ng-container>
+          </span>
           <div class="govuk-radios govuk-radios--inline">
             <div class="govuk-radios__item" *ngFor="let option of allOrSelectedJobRoleOptions; let i = index">
               <input

--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.spec.ts
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.spec.ts
@@ -224,7 +224,7 @@ describe('AddMandatoryTrainingComponent', () => {
       expect(queryByText('Job role 1', { exact: true })).toBeFalsy();
     });
 
-    it('Should display a job role selection when All job roles is selected', async () => {
+    it('Should display a job role selection when All job roles is not selected selected', async () => {
       const { component, fixture, getByLabelText, queryByText } = await setup();
 
       const mandatoryTrainigCategorySelect = getByLabelText('Training category', { exact: false });
@@ -276,6 +276,25 @@ describe('AddMandatoryTrainingComponent', () => {
         expect(createAndUpdateMandatoryTrainingSpy).not.toHaveBeenCalled();
         expect(component.form.invalid).toBeTruthy();
         expect(getAllByText('Select the training category you want to be mandatory').length).toEqual(2);
+      });
+    });
+
+    describe('allOrSelectedJobRoles', async () => {
+      it('Should display a Select which job roles need this training error message if the form is submitted without a job role radio button selected', async () => {
+        const { createAndUpdateMandatoryTrainingSpy, component, fixture, getByLabelText, getByText, getAllByText } =
+          await setup();
+
+        const mandatoryTrainigCategorySelect = getByLabelText('Training category', { exact: false });
+        fireEvent.change(mandatoryTrainigCategorySelect, { target: { value: 1 } });
+
+        fixture.detectChanges();
+
+        const submitButton = getByText('Save and return');
+        fireEvent.click(submitButton);
+
+        expect(createAndUpdateMandatoryTrainingSpy).not.toHaveBeenCalled();
+        expect(component.form.invalid).toBeTruthy();
+        expect(getAllByText('Select which job roles need this training').length).toEqual(2);
       });
     });
 

--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
@@ -126,10 +126,10 @@ export class AddMandatoryTrainingComponent implements OnInit, OnDestroy {
     );
   }
 
-  private setUpForm(trainingId = null, vType = mandatoryTrainingJobOption.all): void {
+  private setUpForm(trainingId = null): void {
     this.form = this.formBuilder.group({
       trainingCategory: [trainingId, [Validators.required]],
-      allOrSelectedJobRoles: [vType],
+      allOrSelectedJobRoles: [null, [Validators.required]],
       selectedJobRoles: this.formBuilder.array([]),
     });
   }
@@ -160,6 +160,15 @@ export class AddMandatoryTrainingComponent implements OnInit, OnDestroy {
           {
             name: 'required',
             message: 'Select the training category you want to be mandatory',
+          },
+        ],
+      },
+      {
+        item: 'allOrSelectedJobRoles',
+        type: [
+          {
+            name: 'required',
+            message: 'Select which job roles need this training',
           },
         ],
       },


### PR DESCRIPTION
#### Work done
- Updated radio buttons to have error handling and stop prefilling when a new mandatory training is being added

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
