### PR TITLE
Fix/add mandatory training parent navigations Fix/stop new mandatory training prefill

### DIFF
--- a/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/src/app/core/breadcrumb/journey.workplaces.ts
@@ -11,6 +11,7 @@ enum Path {
   USER_PERMISSIONS = '/workplace/:workerUid/user/:workerUid/permissions',
   CREATE_ACCOUNT = '/workplace/:workplaceUid/user/create',
   TRAINING_AND_QUALIFICATIONS_RECORD = '/workplace/:workplaceUid/training-and-qualifications-record/:workerUid/training',
+  MANDATORY_TRAINING = '/workplace/:workplaceUid/add-and-manage-mandatory-training',
 }
 
 export const myWorkplaceJourney: JourneyRoute = {
@@ -91,6 +92,14 @@ export const allWorkplacesJourney: JourneyRoute = {
             {
               title: 'Training and qualifications',
               path: Path.TRAINING_AND_QUALIFICATIONS_RECORD,
+              referrer: {
+                path: Path.WORKPLACE,
+                fragment: 'training-and-qualifications',
+              },
+            },
+            {
+              title: 'Add and manage mandatory training categories',
+              path: Path.MANDATORY_TRAINING,
               referrer: {
                 path: Path.WORKPLACE,
                 fragment: 'training-and-qualifications',

--- a/src/app/features/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
+++ b/src/app/features/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
@@ -27,7 +27,9 @@ export class AddAndManageMandatoryTrainingComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.breadcrumbService.show(JourneyType.MANDATORY_TRAINING);
+    this.breadcrumbService.show(
+      this.establishmentService.establishment.isParent ? JourneyType.MANDATORY_TRAINING : JourneyType.ALL_WORKPLACES,
+    );
     this.establishment = this.route.parent.snapshot.data.establishment;
     this.subscriptions.add(
       this.trainingService.getAllMandatoryTrainings(this.establishment.uid).subscribe((trainings) => {
@@ -46,7 +48,7 @@ export class AddAndManageMandatoryTrainingComponent implements OnInit {
   public navigateToAddNewMandatoryTraining() {
     this.router.navigate([
       '/workplace',
-      this.establishmentService.primaryWorkplace.uid,
+      this.establishmentService.establishment.uid,
       'add-and-manage-mandatory-training',
       'add-new-mandatory-training',
     ]);

--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.html
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.html
@@ -48,7 +48,7 @@
               *ngIf="renderAsEditMandatoryTraining"
               class="govuk-grid-column-one-quarter govuk-list govuk-!-margin-top-1 govuk-!-padding-left-1"
             >
-              <a href="#" class="govuk__nowrap" [routerLink]="['../', 'delete-mandatory-training-category']"
+              <a class="govuk__nowrap govuk-link" [routerLink]="['../', 'delete-mandatory-training-category']"
                 >Remove this mandatory training category
               </a>
             </div>

--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.spec.ts
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.spec.ts
@@ -424,7 +424,7 @@ describe('AddMandatoryTrainingComponent', () => {
 
       expect(routerSpy).toHaveBeenCalledWith([
         '/workplace',
-        component.primaryWorkplace.uid,
+        component.establishment.uid,
         'add-and-manage-mandatory-training',
       ]);
     });
@@ -437,21 +437,8 @@ describe('AddMandatoryTrainingComponent', () => {
 
       expect(routerSpy).toHaveBeenCalledWith([
         '/workplace',
-        component.primaryWorkplace.uid,
+        component.establishment.uid,
         'add-and-manage-mandatory-training',
-      ]);
-    });
-
-    xit('should navigate to delete-mandatory-training-category when Remove this mandatory training category is clicked', async () => {
-      const { component, routerSpy, getByText } = await setup(true);
-
-      const removeTrainingCategoryButton = getByText('Remove this mandatory training category');
-      fireEvent.click(removeTrainingCategoryButton);
-
-      expect(routerSpy).toHaveBeenCalledWith([
-        '/workplace',
-        component.primaryWorkplace.uid,
-        ' delete-mandatory-training-category',
       ]);
     });
   });

--- a/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
+++ b/src/app/features/add-mandatory-training/add-mandatory-training.component.ts
@@ -244,11 +244,7 @@ export class AddMandatoryTrainingComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.establishmentService.createAndUpdateMandatoryTraining(this.establishment.uid, props).subscribe(
         () => {
-          this.router.navigate([
-            '/workplace',
-            this.establishmentService.primaryWorkplace.uid,
-            'add-and-manage-mandatory-training',
-          ]);
+          this.router.navigate(['/workplace', this.establishment.uid, 'add-and-manage-mandatory-training']);
           this.alertService.addAlert({
             type: 'success',
             message: this.renderAsEditMandatoryTraining


### PR DESCRIPTION
#### Work done
- Fixed navigation when a parent is accessing mandatory training on a child account

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
