### PR TITLE
Fix/persistent sort on t and q page

### DIFF
--- a/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.html
+++ b/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.html
@@ -17,7 +17,11 @@
     <div class="govuk-form-group">
       <label class="govuk-label" for="sortBy"> Sort by </label>
       <select class="govuk-select govuk-!-width-full" id="sortBy" name="sortBy" (change)="sortBy($event.target.value)">
-        <option *ngFor="let option of sortOptions | keyvalue" value="{{ option.key }}">
+        <option
+          *ngFor="let option of sortOptions | keyvalue"
+          value="{{ option.key }}"
+          [selected]="option.key === sortBySelected"
+        >
           {{ option.value }}
         </option>
       </select>

--- a/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.ts
+++ b/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.ts
@@ -1,11 +1,11 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-table-pagination-wrapper',
   templateUrl: './table-pagination-wrapper.component.html',
 })
-export class TablePaginationWrapperComponent {
+export class TablePaginationWrapperComponent implements OnInit {
   @Input() totalCount: number;
   @Input() count: number;
   @Input() sortByParamMap: any;
@@ -24,8 +24,13 @@ export class TablePaginationWrapperComponent {
   public currentPageIndex = 0;
   private fragment: string;
   private tab: string;
+  public sortBySelected: string;
 
   constructor(private router: Router) {}
+
+  ngOnInit(): void {
+    this.sortBySelected = Object.keys(this.sortByParamMap).find((key) => this.sortByParamMap[key] === this.sortByValue);
+  }
 
   private checkForFragment(): void {
     if (this.router.url.includes('#')) {

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.html
@@ -24,12 +24,13 @@
           class="govuk-select govuk-!-width-full"
           id="sortByTrainingCategory"
           name="sortByTrainingCategory"
-          [value]="sortByDefault"
+          [value]="sortByValue"
           (change)="orderTrainingCategories($event.target.value)"
         >
           <option
             *ngFor="let sortTrainingAndQualsOption of sortTrainingAndQualsOptions | keyvalue"
             value="{{ sortTrainingAndQualsOption.key }}"
+            [selected]="sortTrainingAndQualsOption.key === sortByValue"
           >
             {{ sortTrainingAndQualsOption.value }}
           </option>

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.spec.ts
@@ -124,16 +124,22 @@ describe('TrainingAndQualificationsCategoriesComponent', () => {
         workplace: establishmentBuilder() as Establishment,
         trainingCategories: trainingCategories,
         totalTraining,
+        sortByValue: '0_expired',
       },
     });
     const component = fixture.componentInstance;
+
+    const emitSpy = spyOn(component.changeTrainingSortBy, 'emit');
+
     return {
       component,
       getByTestId,
       getByLabelText,
       fixture,
+      emitSpy,
     };
   }
+
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
@@ -158,7 +164,7 @@ describe('TrainingAndQualificationsCategoriesComponent', () => {
   });
 
   it('should change list depending on sort', async () => {
-    const { fixture } = await setup();
+    const { fixture, emitSpy } = await setup();
 
     const select: HTMLSelectElement = fixture.debugElement.query(By.css('#sortByTrainingCategory')).nativeElement;
     select.value = select.options[1].value; // Expiring Soon
@@ -171,6 +177,7 @@ describe('TrainingAndQualificationsCategoriesComponent', () => {
     expect(rows[1].innerHTML).toContain('B Category Name');
     expect(rows[2].innerHTML).toContain('C Category Name');
     expect(rows[3].innerHTML).toContain('D Category Name');
+    expect(emitSpy).toHaveBeenCalledWith({ section: 'training-summary', sortByValue: '1_expires_soon' });
 
     select.value = select.options[2].value; //Missing
     select.dispatchEvent(new Event('change'));
@@ -180,6 +187,8 @@ describe('TrainingAndQualificationsCategoriesComponent', () => {
     expect(rows[1].innerHTML).toContain('A Category Name');
     expect(rows[2].innerHTML).toContain('B Category Name');
     expect(rows[3].innerHTML).toContain('C Category Name');
+
+    expect(emitSpy).toHaveBeenCalledWith({ section: 'training-summary', sortByValue: '2_missing' });
   });
 
   it('should show just the mandatory training categories when the checkbox is selected', async () => {

--- a/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
+++ b/src/app/shared/components/training-and-qualifications-categories/training-and-qualifications-categories.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Establishment, SortTrainingAndQualsOptionsCat } from '@core/model/establishment.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { TrainingStatusService } from '@core/services/trainingStatus.service';
@@ -13,11 +13,13 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit, OnD
   @Input() workplace: Establishment;
   @Input() trainingCategories: Array<any>;
   @Input() totalTraining: number;
+  @Input() sortByValue: string;
+
+  @Output() changeTrainingSortBy = new EventEmitter<{ section: string; sortByValue: string }>();
 
   public workerDetails = [];
   public workerDetailsLabel = [];
   public sortTrainingAndQualsOptions;
-  public sortByDefault: string;
   public showMandatoryTraining = false;
   private subscriptions: Subscription = new Subscription();
 
@@ -28,8 +30,8 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit, OnD
 
   ngOnInit(): void {
     this.sortTrainingAndQualsOptions = SortTrainingAndQualsOptionsCat;
-    this.sortByDefault = '0_expired';
-    this.orderTrainingCategories(this.sortByDefault);
+
+    this.orderTrainingCategories(this.sortByValue);
     this.setExpiresSoonAlertDates();
   }
 
@@ -66,6 +68,7 @@ export class TrainingAndQualificationsCategoriesComponent implements OnInit, OnD
         ['desc', 'asc'],
       );
     }
+    this.changeTrainingSortBy.emit({ section: 'training-summary', sortByValue: dropdownValue });
   }
 
   public toggleDetails(id, event): void {

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.spec.ts
@@ -75,6 +75,7 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
           workers: workers as Worker[],
           workerCount: workers.length,
           totalRecords,
+          sortByValue: 'trainingExpired',
         },
       });
 
@@ -84,6 +85,7 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
     const spy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
     const workerService = TestBed.inject(WorkerService) as WorkerService;
     const workerServiceSpy = spyOn(workerService, 'getAllWorkers').and.callThrough();
+    const emitSpy = spyOn(component.changeStaffSortBy, 'emit');
 
     return {
       component,
@@ -97,6 +99,7 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
       spy,
       workerServiceSpy,
       workerService,
+      emitSpy,
     };
   }
 
@@ -118,8 +121,24 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
     expect(queryByTestId('sortBy')).toBeFalsy();
   });
 
+  it('should handle sort by expired', async () => {
+    const { component, getByLabelText, workerServiceSpy, emitSpy } = await setup();
+
+    expect(workerServiceSpy).not.toHaveBeenCalled();
+
+    const select = getByLabelText('Sort by', { exact: false });
+    fireEvent.change(select, { target: { value: '0_expired' } });
+
+    expect(workerServiceSpy).toHaveBeenCalledWith(component.workplace.uid, {
+      sortBy: 'trainingExpired',
+      pageIndex: 0,
+      itemsPerPage: 15,
+    });
+    expect(emitSpy).toHaveBeenCalledOnceWith({ section: 'staff-summary', sortByValue: 'trainingExpired' });
+  });
+
   it('should handle sort by expiring soon', async () => {
-    const { component, getByLabelText, workerServiceSpy } = await setup();
+    const { component, getByLabelText, workerServiceSpy, emitSpy } = await setup();
 
     expect(workerServiceSpy).not.toHaveBeenCalled();
 
@@ -131,10 +150,11 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
       pageIndex: 0,
       itemsPerPage: 15,
     });
+    expect(emitSpy).toHaveBeenCalledOnceWith({ section: 'staff-summary', sortByValue: 'trainingExpiringSoon' });
   });
 
   it('should handle sort by missing', async () => {
-    const { component, getByLabelText, workerServiceSpy } = await setup();
+    const { component, getByLabelText, workerServiceSpy, emitSpy } = await setup();
 
     expect(workerServiceSpy).not.toHaveBeenCalled();
 
@@ -146,6 +166,7 @@ describe('TrainingAndQualificationsSummaryComponent', () => {
       pageIndex: 0,
       itemsPerPage: 15,
     });
+    expect(emitSpy).toHaveBeenCalledOnceWith({ section: 'staff-summary', sortByValue: 'trainingMissing' });
   });
 
   it('should display the "OK" message if training is up to date', async () => {

--- a/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
+++ b/src/app/shared/components/training-and-qualifications-summary/training-and-qualifications-summary.component.ts
@@ -17,12 +17,12 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
   @Input() wdfView = false;
   @Input() showViewByToggle = false;
   @Input() totalRecords: number;
+  @Input() sortByValue: string;
 
-  @Output() viewTrainingByCategory: EventEmitter<boolean> = new EventEmitter();
+  @Output() changeStaffSortBy = new EventEmitter<{ section: string; sortByValue: string }>();
 
   public canViewWorker: boolean;
   public sortTrainingAndQualsOptions: Record<string, string>;
-  public sortByValue: string;
   public paginatedWorkers: Array<Worker>;
   public searchTerm = '';
   public totalWorkerCount: number;
@@ -43,7 +43,6 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
   ngOnInit(): void {
     this.canViewWorker = this.permissionsService.can(this.workplace.uid, 'canViewWorker');
     this.sortTrainingAndQualsOptions = SortTrainingAndQualsOptionsWorker;
-    this.sortByValue = 'trainingExpired';
     this.paginatedWorkers = this.workers;
     this.totalWorkerCount = this.workerCount;
     this.setSearchIfPrevious();
@@ -82,6 +81,7 @@ export class TrainingAndQualificationsSummaryComponent implements OnInit {
       .subscribe(({ workers, workerCount }) => {
         this.paginatedWorkers = workers;
         this.workerCount = workerCount;
+        this.changeStaffSortBy.emit({ section: 'staff-summary', sortByValue: sortByValue });
       });
   }
 

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
@@ -34,6 +34,8 @@
     [workers]="workers"
     [workerCount]="workerCount"
     [totalRecords]="totalRecords"
+    [sortByValue]="staffSortByValue"
+    (changeStaffSortBy)="updateSortByValue($event)"
   ></app-training-and-qualifications-summary>
 
   <app-training-and-qualifications-categories

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.html
@@ -44,6 +44,8 @@
     [workplace]="workplace"
     [trainingCategories]="trainingCategories"
     [totalTraining]="totalTraining"
+    [sortByValue]="trainingSortByValue"
+    (changeTrainingSortBy)="updateSortByValue($event)"
   ></app-training-and-qualifications-categories>
 </ng-container>
 <ng-template #noStaffRecords>

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.spec.ts
@@ -110,16 +110,16 @@ describe('TrainingAndQualificationsTabComponent', () => {
       component.updateSortByValue(properties);
 
       expect(component.staffSortByValue).toEqual('trainingExpiresSoon');
-      expect(component.trainingSortByValue).toEqual('trainingExpired');
+      expect(component.trainingSortByValue).toEqual('0_expired');
     });
 
     it('should update the training sort by value when called with training-summary section', async () => {
       const { component } = await setup();
 
-      const properties = { section: 'training-summary', sortByValue: 'trainingExpiresSoon' };
+      const properties = { section: 'training-summary', sortByValue: '1_expires_soon' };
       component.updateSortByValue(properties);
 
-      expect(component.trainingSortByValue).toEqual('trainingExpiresSoon');
+      expect(component.trainingSortByValue).toEqual('1_expires_soon');
       expect(component.staffSortByValue).toEqual('trainingExpired');
     });
   });

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.spec.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.spec.ts
@@ -102,6 +102,28 @@ describe('TrainingAndQualificationsTabComponent', () => {
     expect(getByTestId('noStaffRecordsWarningBanner')).toBeTruthy();
   });
 
+  describe('updateSortByValue', () => {
+    it('should update the staff sort by value when called with staff-summary section', async () => {
+      const { component } = await setup();
+
+      const properties = { section: 'staff-summary', sortByValue: 'trainingExpiresSoon' };
+      component.updateSortByValue(properties);
+
+      expect(component.staffSortByValue).toEqual('trainingExpiresSoon');
+      expect(component.trainingSortByValue).toEqual('trainingExpired');
+    });
+
+    it('should update the training sort by value when called with training-summary section', async () => {
+      const { component } = await setup();
+
+      const properties = { section: 'training-summary', sortByValue: 'trainingExpiresSoon' };
+      component.updateSortByValue(properties);
+
+      expect(component.trainingSortByValue).toEqual('trainingExpiresSoon');
+      expect(component.staffSortByValue).toEqual('trainingExpired');
+    });
+  });
+
   describe('staff and training views when there are workers', () => {
     it('should render the tab bar to show different views', async () => {
       const { getByText } = await setup();

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
@@ -34,6 +34,8 @@ export class TrainingAndQualificationsTabComponent implements OnDestroy, OnChang
   public totalStaff: number;
   public isShowAllTrainings: boolean;
   public viewTrainingByCategory = false;
+  public staffSortByValue = 'trainingExpired';
+  public trainingSortByValue = 'trainingExpired';
 
   constructor(
     private route: ActivatedRoute,
@@ -98,17 +100,9 @@ export class TrainingAndQualificationsTabComponent implements OnDestroy, OnChang
     this.viewTrainingByCategory = visible;
   }
 
-  public showAllTrainings(): void {
-    this.isShowAllTrainings = true;
-    this.missingMandatoryTraining = 0;
-    this.totalExpiredTraining = 0;
-    this.totalExpiringTraining = 0;
-  }
-
-  public mandatoryTrainingChangedHandler($event): void {
-    this.missingMandatoryTraining = $event;
-    this.totalExpiredTraining = 0;
-    this.totalExpiringTraining = 0;
+  public updateSortByValue(properties: { section: string; sortByValue: string }): void {
+    const { section, sortByValue } = properties;
+    section === 'staff-summary' ? (this.staffSortByValue = sortByValue) : (this.trainingSortByValue = sortByValue);
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
+++ b/src/app/shared/components/training-and-qualifications-tab/training-and-qualifications-tab.component.ts
@@ -35,7 +35,7 @@ export class TrainingAndQualificationsTabComponent implements OnDestroy, OnChang
   public isShowAllTrainings: boolean;
   public viewTrainingByCategory = false;
   public staffSortByValue = 'trainingExpired';
-  public trainingSortByValue = 'trainingExpired';
+  public trainingSortByValue = '0_expired';
 
   constructor(
     private route: ActivatedRoute,


### PR DESCRIPTION
#### Work done
- make sort persistent on t and q page when toggling between staff and training options

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
