### PR TITLE
add text to benchmarks comparison header

### DIFF
--- a/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
+++ b/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
@@ -3,6 +3,7 @@
 <div class="govuk-width-container govuk-!-margin-top-7">
   <div id="benchmarks-tiles">
     <app-new-comparison-group-header
+      [canViewFullContent]="canViewFullBenchmarks"
       [meta]="tilesData?.meta"
       [workplaceID]="workplace.uid"
       (downloadPDF)="downloadAsPDF()"

--- a/src/app/features/new-dashboard/benchmarks-tab/comparison-group-header/comparison-group-header.component.html
+++ b/src/app/features/new-dashboard/benchmarks-tab/comparison-group-header/comparison-group-header.component.html
@@ -3,7 +3,8 @@
     <ng-container *ngIf="meta && meta.staff && meta.workplaces; else noCompGroup">
       <p data-testid="comparison-group-text">
         <b>Your comparison group</b> is {{ meta.staff | number }} staff from {{ meta.workplaces | number }}
-        {{ pluralizeWorkplaces(meta.workplaces) }} providing the same main service as you in your local authority.
+        {{ pluralizeWorkplaces(meta.workplaces) }} using ASC-WDS and providing
+        {{ canViewFullContent ? 'the same main service as you' : 'adult social care' }} in your local authority.
       </p>
     </ng-container>
     <ng-template #noCompGroup>

--- a/src/app/features/new-dashboard/benchmarks-tab/comparison-group-header/comparison-group-header.component.spec.ts
+++ b/src/app/features/new-dashboard/benchmarks-tab/comparison-group-header/comparison-group-header.component.spec.ts
@@ -8,7 +8,7 @@ import { fireEvent, render } from '@testing-library/angular';
 import { NewComparisonGroupHeaderComponent } from './comparison-group-header.component';
 
 describe('NewComparisonGroupHeaderComponent', () => {
-  const setup = async (metaData = {}) => {
+  const setup = async (metaData = {}, canViewFullContent = true) => {
     const meta = metaData ? metaData : null;
     const { fixture, getByText, getByTestId } = await render(NewComparisonGroupHeaderComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
@@ -16,6 +16,7 @@ describe('NewComparisonGroupHeaderComponent', () => {
       componentProperties: {
         meta: meta as Meta,
         workplaceID: 'mock-uid',
+        canViewFullContent,
       },
     });
 
@@ -34,31 +35,55 @@ describe('NewComparisonGroupHeaderComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render the comparison group text if there is a comparison group with the correct test if only one workplace', async () => {
-    const { getByTestId } = await setup({ workplaces: 1, staff: 1 });
+  describe('can view full benchmarks content', () => {
+    it('should render the comparison group text if there is a comparison group with the correct test if only one workplace', async () => {
+      const { getByTestId } = await setup({ workplaces: 1, staff: 1 });
 
-    const componentText = getByTestId('comparison-group-text');
-    expect(componentText.innerHTML).toContain(
-      `<b>Your comparison group</b> is 1 staff from 1 workplace providing the same main service as you in your local authority.`,
-    );
+      const componentText = getByTestId('comparison-group-text');
+      expect(componentText.innerHTML).toContain(
+        `<b>Your comparison group</b> is 1 staff from 1 workplace using ASC-WDS and providing the same main service as you in your local authority.`,
+      );
+    });
+
+    it('should have the right text with correct comma placement', async () => {
+      const { getByTestId } = await setup({ workplaces: 1000, staff: 1000 });
+
+      const componentText = getByTestId('comparison-group-text');
+      expect(componentText.innerHTML).toContain(
+        `<b>Your comparison group</b> is 1,000 staff from 1,000 workplaces using ASC-WDS and providing the same main service as you in your local authority.`,
+      );
+    });
   });
 
-  it('should have the right text with correct comma placement', async () => {
-    const { getByTestId } = await setup({ workplaces: 1000, staff: 1000 });
+  describe('cannot view full benchmarks content', () => {
+    it('should render the comparison group text if there is a comparison group with the correct test if only one workplace', async () => {
+      const { getByTestId } = await setup({ workplaces: 1, staff: 1 }, false);
 
-    const componentText = getByTestId('comparison-group-text');
-    expect(componentText.innerHTML).toContain(
-      `<b>Your comparison group</b> is 1,000 staff from 1,000 workplaces providing the same main service as you in your local authority.`,
-    );
+      const componentText = getByTestId('comparison-group-text');
+      expect(componentText.innerHTML).toContain(
+        `<b>Your comparison group</b> is 1 staff from 1 workplace using ASC-WDS and providing adult social care in your local authority.`,
+      );
+    });
+
+    it('should have the right text with correct comma placement', async () => {
+      const { getByTestId } = await setup({ workplaces: 1000, staff: 1000 }, false);
+
+      const componentText = getByTestId('comparison-group-text');
+      expect(componentText.innerHTML).toContain(
+        `<b>Your comparison group</b> is 1,000 staff from 1,000 workplaces using ASC-WDS and providing adult social care in your local authority.`,
+      );
+    });
   });
 
-  it('should have the right text with no data', async () => {
-    const { getByTestId } = await setup();
+  describe('no comparison group', () => {
+    it('should have the right text with no data', async () => {
+      const { getByTestId } = await setup();
 
-    const componentText = getByTestId('no-comparison-group-text');
-    expect(componentText.innerHTML).toContain(
-      `<b>Your comparison group</b> information is not available at the moment.`,
-    );
+      const componentText = getByTestId('no-comparison-group-text');
+      expect(componentText.innerHTML).toContain(
+        `<b>Your comparison group</b> information is not available at the moment.`,
+      );
+    });
   });
 
   it('should show the about the data link with href', async () => {

--- a/src/app/features/new-dashboard/benchmarks-tab/comparison-group-header/comparison-group-header.component.ts
+++ b/src/app/features/new-dashboard/benchmarks-tab/comparison-group-header/comparison-group-header.component.ts
@@ -10,6 +10,7 @@ import { BenchmarksService } from '@core/services/benchmarks.service';
 export class NewComparisonGroupHeaderComponent {
   @Input() meta: Meta;
   @Input() workplaceID: string;
+  @Input() canViewFullContent: boolean;
 
   @Output() downloadPDF = new EventEmitter();
 

--- a/src/app/shared/components/benchmarks-tab/comparison-group-header/comparison-group-header.component.html
+++ b/src/app/shared/components/benchmarks-tab/comparison-group-header/comparison-group-header.component.html
@@ -1,18 +1,12 @@
 <div class="govuk-grid-column-two-thirds" data-testid="comparison-group-text">
   <p>
     <ng-container *ngIf="meta && meta.staff && meta.workplaces; else noCompGroup">
-      <ng-container *ngIf="canViewFullContent">
-        <b>Your comparison group</b> is {{ meta.staff | number }} staff from {{ meta.workplaces | number }}
-
-        {{ pluralizeWorkplaces(meta.workplaces) }} providing the same main service as you in your local authority.
-        <span *ngIf="meta.lastUpdated">
-          The comparison group data was last updated {{ meta.lastUpdated | date: 'd MMMM yyyy' }}.
-        </span>
-      </ng-container>
-      <ng-container *ngIf="!canViewFullContent">
-        <b>Your comparison group</b> is {{ meta.staff | number }} staff from {{ meta.workplaces | number }} workplaces
-        using ASC-WDS and providing adult social care in your local authority.
-      </ng-container>
+      <b>Your comparison group</b> is {{ meta.staff | number }} staff from {{ meta.workplaces | number }}
+      {{ pluralizeWorkplaces(meta.workplaces) }} using ASC-WDS and providing
+      {{ canViewFullContent ? 'the same main service as you' : 'adult social care' }} in your local authority.
+      <span *ngIf="meta.lastUpdated">
+        The comparison group data was last updated {{ meta.lastUpdated | date: 'd MMMM yyyy' }}.
+      </span>
     </ng-container>
     <ng-template #noCompGroup> <b>Your comparison group</b> information is not available at the moment. </ng-template>
   </p>

--- a/src/app/shared/components/benchmarks-tab/comparison-group-header/comparison-group-header.component.spec.ts
+++ b/src/app/shared/components/benchmarks-tab/comparison-group-header/comparison-group-header.component.spec.ts
@@ -28,50 +28,84 @@ describe('ComparisonGroupHeaderComponent', () => {
     component.meta = { workplaces: 1, staff: 1 };
     expect(component).toBeTruthy();
   });
-  it('should have the right text with only one workplace', async () => {
-    component.canViewFullContent = true;
-    component.meta = { workplaces: 1, staff: 1 };
-    fixture.detectChanges();
-    const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
-    expect(componenttext.innerHTML).toContain(
-      `<b>Your comparison group</b> is 1 staff from 1 workplace providing the same main service as you in your local authority.`,
-    );
+
+  describe('can view full benchmarks content', () => {
+    it('should have the right text with only one workplace', async () => {
+      component.canViewFullContent = true;
+      component.meta = { workplaces: 1, staff: 1 };
+      fixture.detectChanges();
+      const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
+      expect(componenttext.innerHTML).toContain(
+        `<b>Your comparison group</b> is 1 staff from 1 workplace using ASC-WDS and providing the same main service as you in your local authority.`,
+      );
+    });
+
+    it('should have the right text with correct comma placement', async () => {
+      component.canViewFullContent = true;
+      component.meta = { workplaces: 1000, staff: 1000 };
+      fixture.detectChanges();
+      const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
+      expect(componenttext.innerHTML).toContain(
+        `<b>Your comparison group</b> is 1,000 staff from 1,000 workplaces using ASC-WDS and providing the same main service as you in your local authority.`,
+      );
+    });
+
+    it('should have the last updated date if date supplied', () => {
+      component.canViewFullContent = true;
+      component.meta = { workplaces: 1000, staff: 1000, lastUpdated: new Date('2020-11-10T13:20:29.304Z') };
+      fixture.detectChanges();
+      const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
+      expect(componenttext.innerHTML).toContain(`The comparison group data was last updated 10 November 2020`);
+    });
+    it('should not have the last updated date if date not supplied', () => {
+      component.canViewFullContent = true;
+      component.meta = { workplaces: 1000, staff: 1000 };
+      fixture.detectChanges();
+      const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
+      expect(componenttext.innerHTML).not.toContain(`The comparison group data was last updated`);
+    });
   });
-  it('should have the right text with correct comma placement', async () => {
-    component.canViewFullContent = true;
-    component.meta = { workplaces: 1000, staff: 1000 };
-    fixture.detectChanges();
-    const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
-    expect(componenttext.innerHTML).toContain(
-      `<b>Your comparison group</b> is 1,000 staff from 1,000 workplaces providing the same main service as you in your local authority.`,
-    );
+
+  describe('cannot view full benchmarks content', () => {
+    it('should have the right text with only one workplace', async () => {
+      component.meta = { workplaces: 1, staff: 1 };
+      fixture.detectChanges();
+      const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
+      expect(componenttext.innerHTML).toContain(
+        `<b>Your comparison group</b> is 1 staff from 1 workplace using ASC-WDS and providing adult social care in your local authority.`,
+      );
+    });
+
+    it('should have the right text with correct comma placement', async () => {
+      component.meta = { workplaces: 1000, staff: 1000 };
+      fixture.detectChanges();
+      const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
+      expect(componenttext.innerHTML).toContain(
+        `<b>Your comparison group</b> is 1,000 staff from 1,000 workplaces using ASC-WDS and providing adult social care in your local authority.`,
+      );
+    });
+
+    it('should have the last updated date if date supplied', () => {
+      component.meta = { workplaces: 1000, staff: 1000, lastUpdated: new Date('2020-11-10T13:20:29.304Z') };
+      fixture.detectChanges();
+      const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
+      expect(componenttext.innerHTML).toContain(`The comparison group data was last updated 10 November 2020`);
+    });
+    it('should not have the last updated date if date not supplied', () => {
+      component.meta = { workplaces: 1000, staff: 1000 };
+      fixture.detectChanges();
+      const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
+      expect(componenttext.innerHTML).not.toContain(`The comparison group data was last updated`);
+    });
   });
-  it('should have the right text with no data', async () => {
-    fixture.detectChanges();
-    const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
-    expect(componenttext.innerHTML).toContain(
-      `<b>Your comparison group</b> information is not available at the moment.`,
-    );
-  });
-  it('should pluralize workplaces correctly', () => {
-    const number = component.pluralizeWorkplaces(2);
-    expect(number).toBe('workplaces');
-  });
-  it('should singularize workplaces correctly', () => {
-    const number = component.pluralizeWorkplaces(1);
-    expect(number).toBe('workplace');
-  });
-  it('should have the last updated date if date supplied', () => {
-    component.canViewFullContent = true;
-    component.meta = { workplaces: 1000, staff: 1000, lastUpdated: new Date('2020-11-10T13:20:29.304Z') };
-    fixture.detectChanges();
-    const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
-    expect(componenttext.innerHTML).toContain(`The comparison group data was last updated 10 November 2020`);
-  });
-  it('should not have the last updated date if date not supplied', () => {
-    component.meta = { workplaces: 1000, staff: 1000 };
-    fixture.detectChanges();
-    const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
-    expect(componenttext.innerHTML).not.toContain(`The comparison group data was last updated`);
+
+  describe('no comparison group', () => {
+    it('should have the right text with no data', async () => {
+      fixture.detectChanges();
+      const componenttext = fixture.debugElement.query(By.css('p')).nativeElement;
+      expect(componenttext.innerHTML).toContain(
+        `<b>Your comparison group</b> information is not available at the moment.`,
+      );
+    });
   });
 });


### PR DESCRIPTION
#### Work done
- add conditional to text shown on the benchmarks header depending on the viewing permissions

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
