### PR TITLE
Fix/read only sign out

### DIFF
--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -208,6 +208,8 @@ const buildRequest = (req, claim, referencedEstablishment) => {
 };
 
 const checkAuthorisation = async (req, res, next, roleCheck, token, Token_Secret) => {
+  console.log('******************** check authorisation *******************');
+  console.log(roleCheck);
   const claim = jwt.verify(token, Token_Secret);
   const establishmentIdIsUID = isEstablishmentIdUID(req);
   const establishmentMatchesClaim = reqMatchClaimEstablishment(establishmentIdIsUID, req, claim);
@@ -385,8 +387,6 @@ const isAdminManager = (req, res, next) => {
     // var dec = getverify(token, Token_Secret);
 
     jwt.verify(token, Token_Secret, function (err, claim) {
-      console.log('****** is Admin Manager ******');
-      console.log(claim);
       if (err || claim.aud !== config.get('jwt.aud.login') || claim.iss !== thisIss) {
         return res.status(403).send('Invalid Token');
       } else {
@@ -474,3 +474,5 @@ exports.isAdminManager = isAdminManager;
 exports.isAuthorisedRegistrationApproval = isAuthorisedRegistrationApproval;
 exports.isAdminOrOnDemandReporting = isAdminOrOnDemandReporting;
 exports.authorisedEstablishmentPermissionCheck = authorisedEstablishmentPermissionCheck;
+exports.isReadOnlyTryingToNotGET = isReadOnlyTryingToNotGET;
+exports.parentNoWriteAccess = parentNoWriteAccess;

--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -208,8 +208,6 @@ const buildRequest = (req, claim, referencedEstablishment) => {
 };
 
 const checkAuthorisation = async (req, res, next, roleCheck, token, Token_Secret) => {
-  console.log('******************** check authorisation *******************');
-  console.log(roleCheck);
   const claim = jwt.verify(token, Token_Secret);
   const establishmentIdIsUID = isEstablishmentIdUID(req);
   const establishmentMatchesClaim = reqMatchClaimEstablishment(establishmentIdIsUID, req, claim);

--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -91,7 +91,8 @@ const establishmentIDorUIDIsInvalid = (claim) => isEstablishmentIDNaN(claim) || 
 
 const isEstablishmentIdUID = (req) => uuidV4Regex.test(req.params.id);
 
-const isReadOnlyTryingToNotGET = (roleCheck, req, claim) => roleCheck && req.method !== 'GET' && claim.role == 'Read';
+const isReadOnlyTryingToNotGET = (roleCheck, req, claim) =>
+  roleCheck && req.method !== 'GET' && claim.role == 'Read' && req.path !== '/benchmarks/usage';
 
 const subsidaryEstablishmentClaimMismatch = (establishmentMatchesClaim, claim) =>
   !establishmentMatchesClaim && !claim.isParent;

--- a/server/utils/security/isAuthenticated.js
+++ b/server/utils/security/isAuthenticated.js
@@ -153,7 +153,8 @@ const handleExceptions = (req, res, claim, establishmentMatchesClaim, roleCheck)
   }
 };
 
-const parentNoWriteAccess = (req) => req.method !== 'GET' && req.path.split('/')[1] !== 'ownershipChange';
+const parentNoWriteAccess = (req) =>
+  req.method !== 'GET' && req.path.split('/')[1] !== 'ownershipChange' && req.path !== '/benchmarks/usage';
 
 const noDataPermissions = (referencedEstablishment) => referencedEstablishment.dataPermissions === null;
 


### PR DESCRIPTION
#### Work done
- add check to allow read only users and establishments to post to the benchmarks usage endpoint when clicking on the benchmarks tab

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
