### PR TITLE
Feat/workplace message6

### DIFF
--- a/src/app/features/new-dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.html
@@ -1,5 +1,6 @@
 <app-new-dashboard-header tab="home"></app-new-dashboard-header>
 <app-summary-section
+  *ngIf="canViewListOfWorkers"
   [workplace]="workplace"
   [workerCount]="workerCount"
   [(navigateToTab)]="navigateToTab"

--- a/src/app/features/new-dashboard/home-tab/home-tab.component.spec.ts
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.spec.ts
@@ -21,7 +21,6 @@ import { NewArticleListComponent } from '@features/articles/new-article-list/new
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
-
 import { of } from 'rxjs';
 
 import { Establishment } from '../../../../mockdata/establishment';
@@ -31,7 +30,7 @@ import { SummarySectionComponent } from './summary-section/summary-section.compo
 
 describe('NewHomeTabComponent', () => {
   const setup = async (checkCqcDetails = false, establishment = Establishment) => {
-    const { fixture, getByText, queryByText, getByTestId } = await render(NewHomeTabComponent, {
+    const { fixture, getByText, queryByText, getByTestId, queryByTestId } = await render(NewHomeTabComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       providers: [
         WindowRef,
@@ -92,6 +91,7 @@ describe('NewHomeTabComponent', () => {
       getByText,
       queryByText,
       getByTestId,
+      queryByTestId,
       alertServiceSpy,
       parentsRequestService,
       tabsServiceSpy,
@@ -463,16 +463,32 @@ describe('NewHomeTabComponent', () => {
 
   describe('summary', () => {
     it('should show summary box', async () => {
-      const { getByTestId } = await setup();
+      const { component, fixture, getByTestId } = await setup();
+
+      component.canViewListOfWorkers = true;
+      fixture.detectChanges();
 
       const summaryBox = getByTestId('summaryBox');
 
       expect(summaryBox).toBeTruthy();
     });
 
+    it('should not show the summary section if the user does not have the correct permissions', async () => {
+      const { component, fixture, queryByTestId } = await setup();
+
+      component.canViewListOfWorkers = false;
+      fixture.detectChanges();
+
+      const summaryBox = queryByTestId('summaryBox');
+      expect(summaryBox).toBeFalsy();
+    });
+
     describe('workplace summary section', () => {
       it('should take you to the workplace tab when clicking the workplace link', async () => {
-        const { getByText, tabsServiceSpy } = await setup();
+        const { component, fixture, getByText, tabsServiceSpy } = await setup();
+
+        component.canViewListOfWorkers = true;
+        fixture.detectChanges();
 
         const workplaceLink = getByText('Workplace');
         fireEvent.click(workplaceLink);
@@ -482,7 +498,10 @@ describe('NewHomeTabComponent', () => {
 
       it('should show a warning link which should navigate to the workplace tab', async () => {
         const establishment = { ...Establishment, showAddWorkplaceDetailsBanner: true };
-        const { getByText, tabsServiceSpy } = await setup(true, establishment);
+        const { component, fixture, getByText, tabsServiceSpy } = await setup(true, establishment);
+
+        component.canViewListOfWorkers = true;
+        fixture.detectChanges();
 
         const link = getByText('Add more details to your workplace');
         fireEvent.click(link);
@@ -494,7 +513,10 @@ describe('NewHomeTabComponent', () => {
 
     describe('staff records summary section', () => {
       it('should show staff records link and take you to the staff records tab', async () => {
-        const { getByText, tabsServiceSpy } = await setup();
+        const { component, fixture, getByText, tabsServiceSpy } = await setup();
+
+        component.canViewListOfWorkers = true;
+        fixture.detectChanges();
 
         const staffRecordsLink = getByText('Staff records');
         fireEvent.click(staffRecordsLink);
@@ -505,7 +527,10 @@ describe('NewHomeTabComponent', () => {
 
     describe('training and qualifications summary section', () => {
       it('should show training and qualifications link that take you the training and qualifications tab', async () => {
-        const { getByText, tabsServiceSpy } = await setup();
+        const { component, fixture, getByText, tabsServiceSpy } = await setup();
+
+        component.canViewListOfWorkers = true;
+        fixture.detectChanges();
 
         const trainingAndQualificationsLink = getByText('Training and qualifications');
         fireEvent.click(trainingAndQualificationsLink);

--- a/src/app/features/new-dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.ts
@@ -36,6 +36,7 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
   public canRunLocalAuthorityReport: boolean;
   public canBulkUpload: boolean;
   public canEditEstablishment: boolean;
+  public canViewListOfWorkers: boolean;
   public user: UserDetails;
   public workplaceSummaryMessage: string;
   public workerCount: number;
@@ -50,8 +51,7 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    const { workerCount } = this.route.snapshot.data.workers;
-    this.workerCount = workerCount;
+    this.workerCount = this.route.snapshot.data.workers?.workerCount;
 
     this.user = this.userService.loggedInUser;
     this.setPermissionLinks();
@@ -88,7 +88,8 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
     const workplaceUid: string = this.workplace ? this.workplace.uid : null;
     this.canEditEstablishment = this.permissionsService.can(workplaceUid, 'canEditEstablishment');
     // this.canAddWorker = this.permissionsService.can(workplaceUid, 'canAddWorker');
-    // this.canViewListOfWorkers = this.permissionsService.can(workplaceUid, 'canViewListOfWorkers');
+    this.canViewListOfWorkers = this.permissionsService.can(workplaceUid, 'canViewListOfWorkers');
+
     this.canBulkUpload = this.permissionsService.can(workplaceUid, 'canBulkUpload');
     this.canViewWorkplaces = this.workplace && this.workplace.isParent;
     this.canViewChangeDataOwner =

--- a/src/app/features/new-dashboard/home-tab/summary-section/summary-section.component.spec.ts
+++ b/src/app/features/new-dashboard/home-tab/summary-section/summary-section.component.spec.ts
@@ -125,6 +125,33 @@ describe('Summary section', () => {
       expect(within(workplaceRow).getByText(`You've not added any vacancy and turnover data`)).toBeTruthy();
       expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
     });
+
+    it('should show a warning saying that no vacancy data has been added if it has not been added, but starters data has been added', async () => {
+      const establishment = { ...Establishment, leavers: null, vacancies: null, starters: 'None' };
+      const { getByTestId } = await setup(false, establishment);
+
+      const workplaceRow = getByTestId('workplace-row');
+      expect(within(workplaceRow).getByText(`You've not added any staff vacancy data`)).toBeTruthy();
+      expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+    });
+
+    it('should show a warning saying that no vacancy data has been added if it has not been added, but leavers data has been added', async () => {
+      const establishment = { ...Establishment, leavers: 'None', vacancies: null, starters: null };
+      const { getByTestId } = await setup(false, establishment);
+
+      const workplaceRow = getByTestId('workplace-row');
+      expect(within(workplaceRow).getByText(`You've not added any staff vacancy data`)).toBeTruthy();
+      expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+    });
+
+    it('should show a warning saying that no vacancy data has been added if it has not been added, but both starters and leavers data has been added', async () => {
+      const establishment = { ...Establishment, leavers: 'None', vacancies: null, starters: `Don't know` };
+      const { getByTestId } = await setup(false, establishment);
+
+      const workplaceRow = getByTestId('workplace-row');
+      expect(within(workplaceRow).getByText(`You've not added any staff vacancy data`)).toBeTruthy();
+      expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+    });
   });
 
   describe('staff record summary section', () => {

--- a/src/app/features/new-dashboard/home-tab/summary-section/summary-section.component.ts
+++ b/src/app/features/new-dashboard/home-tab/summary-section/summary-section.component.ts
@@ -40,7 +40,7 @@ export class SummarySectionComponent implements OnInit {
       this.redFlag = true;
     } else if (numberOfStaff !== this.workerCount && this.afterEightWeeksFromFirstLogin()) {
       this.sections[0].message = 'Staff total does not match staff records added';
-    } else if (!(!!vacancies?.length || !!starters?.length || !!leavers?.length)) {
+    } else if (!vacancies && !leavers && !starters) {
       this.sections[0].message = `You've not added any vacancy and turnover data`;
     } else if (!vacancies && (leavers || starters)) {
       this.sections[0].message = `You've not added any staff vacancy data`;

--- a/src/app/features/new-dashboard/home-tab/summary-section/summary-section.component.ts
+++ b/src/app/features/new-dashboard/home-tab/summary-section/summary-section.component.ts
@@ -42,6 +42,8 @@ export class SummarySectionComponent implements OnInit {
       this.sections[0].message = 'Staff total does not match staff records added';
     } else if (!(!!vacancies?.length || !!starters?.length || !!leavers?.length)) {
       this.sections[0].message = `You've not added any vacancy and turnover data`;
+    } else if (!vacancies && (leavers || starters)) {
+      this.sections[0].message = `You've not added any staff vacancy data`;
     }
   }
 

--- a/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -270,32 +270,51 @@
       <span *ngIf="noVacancyAndTurnoverData" class="govuk-error-message govuk-summary-list__warning-message"
         >You've not added any vacancy and turnover data</span
       >
-      <dl class="govuk-summary-list govuk-summary-list--medium govuk-summary-list--top-border">
-        <div class="govuk-summary-list__row" data-testid="vacancies">
-          <dt class="govuk-summary-list__key">Current staff vacancies</dt>
-          <dd class="govuk-summary-list__value">
-            <app-summary-record-value>
-              <ng-container *ngIf="!workplace.vacancies?.length; else vacancies"> - </ng-container>
-              <ng-template #vacancies>
-                <ng-container *ngIf="isArray(workplace.vacancies)">
-                  <ul class="govuk-list govuk-!-margin-bottom-0">
-                    <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy.total }} {{ vacancy.title }}</li>
-                  </ul>
-                </ng-container>
-                <ng-container *ngIf="!isArray(workplace.vacancies)">{{ workplace.vacancies }} </ng-container>
-              </ng-template>
-            </app-summary-record-value>
-          </dd>
-          <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
-            <app-summary-record-change
-              [explanationText]="' staff vacancies'"
-              [link]="['/workplace', workplace.uid, 'vacancies']"
-              [hasData]="workplace.vacancies?.length"
-              (setReturnClicked)="this.setReturn()"
-            ></app-summary-record-change>
-          </dd>
-        </div>
-
+      <div [class.govuk-summary-list__warning]="noVacancyData" data-testid="vacancies">
+        <dl
+          class="govuk-summary-list govuk-summary-list--medium govuk-summary-list--top-border govuk-!-margin-bottom-0"
+        >
+          <div
+            class="govuk-summary-list__row"
+            [ngClass]="{
+              'govuk-summary-list__row--no-bottom-border': noVacancyData,
+              'govuk-summary-list__row--no-bottom-padding': noVacancyData
+            }"
+            data-testid="vacancies-top-row"
+          >
+            <dt class="govuk-summary-list__key">Current staff vacancies</dt>
+            <dd class="govuk-summary-list__value">
+              <app-summary-record-value>
+                <ng-container *ngIf="!workplace.vacancies?.length; else vacancies"> - </ng-container>
+                <ng-template #vacancies>
+                  <ng-container *ngIf="isArray(workplace.vacancies)">
+                    <ul class="govuk-list govuk-!-margin-bottom-0">
+                      <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy.total }} {{ vacancy.title }}</li>
+                    </ul>
+                  </ng-container>
+                  <ng-container *ngIf="!isArray(workplace.vacancies)">{{ workplace.vacancies }} </ng-container>
+                </ng-template>
+              </app-summary-record-value>
+            </dd>
+            <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
+              <app-summary-record-change
+                [explanationText]="' staff vacancies'"
+                [link]="['/workplace', workplace.uid, 'vacancies']"
+                [hasData]="workplace.vacancies?.length"
+                (setReturnClicked)="this.setReturn()"
+              ></app-summary-record-change>
+            </dd>
+          </div>
+          <div *ngIf="noVacancyData" class="govuk-summary-list__row govuk-summary-list__row--error-warning-message">
+            <dt class="govuk-summary-list__key govuk-error-message govuk-summary-list__warning-message govuk__nowrap">
+              You've not added any staff vacancy data
+            </dt>
+            <dd class="govuk-summary-list__value"></dd>
+            <dd class="govuk-summary-list__actions"></dd>
+          </div>
+        </dl>
+      </div>
+      <dl class="govuk-summary-list govuk-summary-list--medium">
         <div class="govuk-summary-list__row" data-testid="starters">
           <dt class="govuk-summary-list__key">New starters</dt>
           <dd class="govuk-summary-list__value">

--- a/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -883,6 +883,44 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(within(vacanciesRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(vacanciesRow).queryByText('2 Nursing')).toBeTruthy();
       });
+
+      it('should show warning message if there is no vacancy value but there is a starters value', async () => {
+        const { component, fixture, getByText, getByTestId } = await setup();
+
+        component.workplace.vacancies = null;
+        component.workplace.leavers = null;
+        component.workplace.starters = `Don't know`;
+        component.canEditEstablishment = true;
+        component.checkVacancyAndTurnoverData();
+        fixture.detectChanges();
+
+        const vacanciesRow = getByTestId('vacancies');
+
+        expect(getByText(`You've not added any staff vacancy data`)).toBeTruthy();
+        expect(vacanciesRow.getAttribute('class')).toContain('govuk-summary-list__warning');
+        expect(within(vacanciesRow).getByTestId('vacancies-top-row').getAttribute('class')).toContain(
+          'govuk-summary-list__row--no-bottom-border govuk-summary-list__row--no-bottom-padding',
+        );
+      });
+
+      it('should show warning message if there is no vacancy value but there is a leavers value', async () => {
+        const { component, fixture, getByText, getByTestId } = await setup();
+
+        component.workplace.vacancies = null;
+        component.workplace.leavers = 'None';
+        component.workplace.starters = null;
+        component.canEditEstablishment = true;
+        component.checkVacancyAndTurnoverData();
+        fixture.detectChanges();
+
+        const vacanciesRow = getByTestId('vacancies');
+
+        expect(getByText(`You've not added any staff vacancy data`)).toBeTruthy();
+        expect(vacanciesRow.getAttribute('class')).toContain('govuk-summary-list__warning');
+        expect(within(vacanciesRow).getByTestId('vacancies-top-row').getAttribute('class')).toContain(
+          'govuk-summary-list__row--no-bottom-border govuk-summary-list__row--no-bottom-padding',
+        );
+      });
     });
 
     describe('New starters', () => {

--- a/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
+++ b/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
@@ -32,6 +32,7 @@ export class NewWorkplaceSummaryComponent implements OnInit, OnDestroy {
   public hasCapacity: boolean;
   public capacityMessages = [];
   public noVacancyAndTurnoverData: boolean;
+  public noVacancyData: boolean;
   public numberOfStaffError: boolean;
   public numberOfStaffWarning: boolean;
 
@@ -90,6 +91,7 @@ export class NewWorkplaceSummaryComponent implements OnInit, OnDestroy {
   public checkVacancyAndTurnoverData(): void {
     const { vacancies, starters, leavers } = this.workplace;
     this.noVacancyAndTurnoverData = !vacancies && !starters && !leavers;
+    this.noVacancyData = !vacancies && (!!leavers || !!starters);
   }
 
   private getPermissions(): void {

--- a/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
+++ b/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
@@ -88,11 +88,8 @@ export class NewWorkplaceSummaryComponent implements OnInit, OnDestroy {
   }
 
   public checkVacancyAndTurnoverData(): void {
-    this.noVacancyAndTurnoverData = !(
-      !!this.workplace.vacancies?.length ||
-      !!this.workplace.starters?.length ||
-      !!this.workplace.leavers?.length
-    );
+    const { vacancies, starters, leavers } = this.workplace;
+    this.noVacancyAndTurnoverData = !vacancies && !starters && !leavers;
   }
 
   private getPermissions(): void {


### PR DESCRIPTION
#### Work done
- add a warning if there is no vacancy data but there is either starters or leavers data to workplace summary and home tab summary

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
