### PR TITLE
Bug fix - Set newHomePage flag on application start

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -51,10 +51,10 @@ export class AppComponent implements OnInit {
     });
 
     this.angulartics2GoogleTagManager.startTracking();
-    this.featureFlagsService.start();
   }
 
   async ngOnInit(): Promise<void> {
+    await this.featureFlagsService.start();
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe((nav: NavigationEnd) => {
       this.isAdminSection = nav.url.includes('sfcadmin');
       this.dashboardView = nav.url.includes('dashboard') || nav.url === '/';
@@ -85,6 +85,7 @@ export class AppComponent implements OnInit {
       }
     });
 
+    await this.featureFlagsService.configCatClient.forceRefreshAsync();
     this.newHomeDesignFlag = await this.featureFlagsService.configCatClient.getValueAsync('homePageNewDesign', false);
     this.featureFlagsService.newHomeDesignFlag = this.newHomeDesignFlag;
   }

--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -48,7 +48,7 @@
                 data-testid="singleUserNotification"
             /></a>
           </li>
-          <li *ngIf="newHomeDesignFlag && !isOnAdminScreen && standAloneAccount" class="govuk-header__navigation-item">
+          <li *ngIf="!isOnAdminScreen && standAloneAccount" class="govuk-header__navigation-item">
             <a class="govuk-header__link" [routerLink]="['/notifications']">Notifications</a>
             <img
               src="/assets/images/flag-orange.svg"

--- a/src/app/core/components/header/header.component.spec.ts
+++ b/src/app/core/components/header/header.component.spec.ts
@@ -12,10 +12,8 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { UserService } from '@core/services/user.service';
 import { MockAuthService } from '@core/test-utils/MockAuthService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockNotificationsService } from '@core/test-utils/MockNotificationsService';
 import { EditUser, MockUserService } from '@core/test-utils/MockUserService';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { render } from '@testing-library/angular';
 import { of } from 'rxjs';
 
@@ -41,10 +39,6 @@ describe('HeaderComponent', () => {
         {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
-        },
-        {
-          provide: FeatureFlagsService,
-          useClass: MockFeatureFlagsService,
         },
         {
           provide: NotificationsService,
@@ -181,30 +175,6 @@ describe('HeaderComponent', () => {
   });
 
   describe('notifications link', () => {
-    it('should show the notifications link when logged in, in a stand alone account and the feature flag is on', async () => {
-      const { component, fixture, getByText } = await setup(false, 0, true);
-
-      component.newHomeDesignFlag = true;
-      fixture.detectChanges();
-
-      expect(getByText('Notifications')).toBeTruthy();
-    });
-
-    it('should not show the notifications link when logged in, the feature flag is not on but not in a stand alone account ', async () => {
-      const { component, fixture, queryByText } = await setup(false, 0, true, false);
-
-      component.newHomeDesignFlag = true;
-      fixture.detectChanges();
-
-      expect(queryByText('Notifications')).toBeFalsy();
-    });
-
-    it('should not show the notifications link when logged in, in a stand alone account but the feature flag is not on', async () => {
-      const { queryByText } = await setup(false, 0, true);
-
-      expect(queryByText('Notifications')).toBeFalsy();
-    });
-
     it('should not show the notifications link when logged in, in a stand alone account but not on admin screen', async () => {
       const { component, fixture, queryByText } = await setup(false, 0, true);
 

--- a/src/app/core/components/header/header.component.ts
+++ b/src/app/core/components/header/header.component.ts
@@ -5,7 +5,6 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { IdleService } from '@core/services/idle.service';
 import { NotificationsService } from '@core/services/notifications/notifications.service';
 import { UserService } from '@core/services/user.service';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { interval, Subscription } from 'rxjs';
 
 @Component({
@@ -30,7 +29,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private userService: UserService,
     private establishmentService: EstablishmentService,
     private notificationsService: NotificationsService,
-    private featureFlagsService: FeatureFlagsService,
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -38,8 +36,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     this.setupUserSubscription();
     this.onAdminScreen();
     this.workplaceId && this.getUsers();
-    this.newHomeDesignFlag = await this.featureFlagsService.configCatClient.getValueAsync('homePageNewDesign', false);
-    this.newHomeDesignFlag && this.setUpNotificationSubscription();
+    this.standAloneAccount && this.setUpNotificationSubscription();
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/test-utils/MockFeatureFlagService.ts
+++ b/src/app/core/test-utils/MockFeatureFlagService.ts
@@ -33,5 +33,5 @@ export class MockFeatureFlagsService extends FeatureFlagsService {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public start(): void {}
+  public async start(): Promise<void> {}
 }

--- a/src/app/features/new-dashboard/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/new-dashboard/dashboard/dashboard.component.spec.ts
@@ -155,5 +155,28 @@ describe('NewDashboardComponent', () => {
 
       expect(getByTestId('benchmarks-tab')).toBeTruthy();
     });
+<<<<<<< Updated upstream
+=======
+
+    it('should render the new data area page rather than benchmark page when the newDataAreaFlag is true', async () => {
+      const { component, fixture, getByTestId, queryByTestId } = await setup('benchmarks');
+
+      component.newDataAreaFlag = true;
+      fixture.detectChanges();
+
+      expect(getByTestId('data-area-tab')).toBeTruthy();
+      expect(queryByTestId('benchmarks-tab')).toBeFalsy();
+    });
+
+    it('should render the normal benchmarks page when the newDataAreaFlag is false', async () => {
+      const { component, fixture, getByTestId, queryByTestId } = await setup('benchmarks');
+
+      component.newDataAreaFlag = false;
+      fixture.detectChanges();
+
+      expect(getByTestId('benchmarks-tab')).toBeTruthy();
+      expect(queryByTestId('data-area-tab')).toBeFalsy();
+    });
+>>>>>>> Stashed changes
   });
 });

--- a/src/app/shared/services/feature-flags.service.ts
+++ b/src/app/shared/services/feature-flags.service.ts
@@ -9,11 +9,11 @@ export class FeatureFlagsService {
 
   constructor() {}
 
-  start(): void {
+  async start(): Promise<void> {
     if (environment.environmentName === 'other') {
       this.configCatClient = mockConfigCatClient;
     } else {
-      this.configCatClient = configcat.createClientWithManualPoll(environment.configCatKey, {});
+      this.configCatClient = await configcat.createClientWithManualPoll(environment.configCatKey, {});
     }
   }
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,7 +8,7 @@ export const environment = {
   tracesSampleRate: 0,
   configCatKey: 'Ag_ZCDm6FkSAA5-xhxheOA/KeZCUBHikUSw7OXsthDzLQ',
   cmsUri: 'https://sfccmstest.cloudapps.digital',
-  dev: true
+  dev: true,
 };
 
 /*


### PR DESCRIPTION
#### Work done
- Moved configCat start into application init with an await async
- Called RefreshAsync before getting the newHomepage flag in application init

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
