### PR TITLE
Bugfix/link to parent notifications

### DIFF
--- a/migrations/20230523110431-addRequestorEstIdColumnToNotificationsEstablishment.js
+++ b/migrations/20230523110431-addRequestorEstIdColumnToNotificationsEstablishment.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const table = {
+  tableName: 'NotificationsEstablishment',
+  schema: 'cqc',
+};
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(table, 'requestorEstUID', {
+      type: Sequelize.DataTypes.UUID,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn(table, 'requestorEstUID');
+  },
+};

--- a/server/data/linkToParent.js
+++ b/server/data/linkToParent.js
@@ -145,7 +145,7 @@ exports.getNotificationDetails = async (params) =>
   });
 
 const getSubEstablishmentNameQuery = `
-  select  parent."NameValue" as "subEstablishmentName", sub."ParentEstablishmentID" as parentEstablishmentId,sub."RejectionReason" as rejectionReason, sub."SubEstablishmentID" as subEstablishmentId
+  select parent."NameValue" as "subEstablishmentName", sub."ParentEstablishmentID" as parentEstablishmentId, sub."RejectionReason" as rejectionReason, sub."SubEstablishmentID" as subEstablishmentId, parent."EstablishmentUID" as subEstablishmentUid
   from cqc."LinkToParent" as sub
   JOIN cqc."Establishment" as parent on sub."SubEstablishmentID" =  parent."EstablishmentID"
   where "LinkToParentUID" = :uid `;

--- a/server/data/notifications.js
+++ b/server/data/notifications.js
@@ -68,7 +68,8 @@ const selectOneEstablishmentNotification = `
     "notificationContentUid",
     "created",
     "isViewed",
-    "createdByUserUID"
+    "createdByUserUID",
+    "requestorEstUID"
   FROM cqc."NotificationsEstablishment"
   WHERE "notificationUid" = :notificationUid
   LIMIT :limit
@@ -114,8 +115,8 @@ VALUES (:type, :typeUid, :recipientUserUid, :isViewed, :createdByUserUID);
 const insertEstablishmentNotificationQuery = `
 INSERT INTO
 cqc."NotificationsEstablishment"
-("notificationContentUid", "type", "establishmentUid", "isViewed", "createdByUserUID")
-VALUES (:notificationContentUid, :type, :establishmentUid, :isViewed, :createdByUserUID);
+("notificationContentUid", "type", "establishmentUid", "isViewed", "createdByUserUID", "requestorEstUID")
+VALUES (:notificationContentUid, :type, :establishmentUid, :isViewed, :createdByUserUID, :requestorEstUID);
 `;
 
 const updateNotificationQuery = `
@@ -189,6 +190,7 @@ exports.insertNewEstablishmentNotification = async (params) => {
       isViewed: false,
       createdByUserUID: params.userUid,
       type: params.type,
+      requestorEstUID: params.requestorEstId || null,
     },
     type: db.QueryTypes.INSERT,
   });
@@ -215,6 +217,17 @@ exports.getRequesterName = async (userUID) =>
   db.query(getRequesterNameQuery, {
     replacements: {
       recipientUserUid: userUID,
+    },
+    type: db.QueryTypes.SELECT,
+  });
+
+const getRequestorEstablishmentQuery = `
+    SELECT "NameValue" from cqc."Establishment" WHERE "EstablishmentUID" = :establishmentUid`;
+
+exports.getRequestorEstablishment = async (estUID) =>
+  db.query(getRequestorEstablishmentQuery, {
+    replacements: {
+      establishmentUid: estUID,
     },
     type: db.QueryTypes.SELECT,
   });

--- a/server/routes/establishments/linkToParent.js
+++ b/server/routes/establishments/linkToParent.js
@@ -197,10 +197,10 @@ const actionLinkToParent = async (req, res) => {
               let notificationParams = {
                 type: params.type,
                 notificationContentUid: params.linkToParentUid,
-                recipientUserUid: params.requestingUserUid,
-                senderUid: params.userUid,
+                establishmentUid: req.body.subEstablishmentUid,
+                userUid: params.userUid,
               };
-              await notifications.insertNewUserNotification(notificationParams);
+              await notifications.insertNewEstablishmentNotification(notificationParams);
               const notificationDetailsParams = {
                 notificationContentUid: params.linkToParentUid,
               };

--- a/server/routes/establishments/linkToParent.js
+++ b/server/routes/establishments/linkToParent.js
@@ -1,6 +1,6 @@
 'use strict';
 const express = require('express');
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const Establishment = require('../../models/classes/establishment');
 const uuid = require('uuid');
 const linkSubToParent = require('../../data/linkToParent');
@@ -253,7 +253,10 @@ const delink = async (req, res) => {
               notificationContentUid: params.deLinkToParentUID,
               establishmentUid: params.parentWorkplaceUId,
               userUid: params.userUid,
+              requestorEstId: req.params.id,
             };
+            console.log('****** DELINK TO PARENT ******');
+            console.log(notificationParams);
             await notifications.insertNewEstablishmentNotification(notificationParams);
             let lastDeLinkToParentRequest = await linkSubToParent.getLastDeLinkToParentRequest(params);
             if (lastDeLinkToParentRequest) {

--- a/server/routes/establishments/linkToParent.js
+++ b/server/routes/establishments/linkToParent.js
@@ -255,8 +255,6 @@ const delink = async (req, res) => {
               userUid: params.userUid,
               requestorEstId: req.params.id,
             };
-            console.log('****** DELINK TO PARENT ******');
-            console.log(notificationParams);
             await notifications.insertNewEstablishmentNotification(notificationParams);
             let lastDeLinkToParentRequest = await linkSubToParent.getLastDeLinkToParentRequest(params);
             if (lastDeLinkToParentRequest) {

--- a/server/routes/notification/index.js
+++ b/server/routes/notification/index.js
@@ -91,7 +91,7 @@ const addTypeContent = async (notification) => {
       break;
     }
     case 'DELINKTOPARENT': {
-      let deLinkNotificationDetails = await notifications.getRequesterName(notification.createdByUserUID);
+      const deLinkNotificationDetails = await notifications.getRequestorEstablishment(notification.requestorEstUID);
       if (deLinkNotificationDetails) {
         let deLinkParentDetails = await notifications.getDeLinkParentDetails(notification.notificationContentUid);
         if (deLinkParentDetails) {
@@ -122,7 +122,6 @@ const addTypeContent = async (notification) => {
 const getNotification = async (req, res) => {
   try {
     const notificationData = await getOneNotification(req.params.notificationUid);
-
     await addTypeContent(notificationData.notification);
 
     // this will fetch notification receiver name
@@ -138,6 +137,8 @@ const getNotification = async (req, res) => {
     // return the item
     return res.status(200).send(notificationData.notification);
   } catch (e) {
+    console.log('**** ERROR ****');
+    console.log(e.message);
     return res.status(500).send({
       message: e.message,
     });

--- a/server/routes/notification/index.js
+++ b/server/routes/notification/index.js
@@ -138,8 +138,6 @@ const getNotification = async (req, res) => {
     // return the item
     return res.status(200).send(notificationData.notification);
   } catch (e) {
-    console.log('**** ERROR ****');
-    console.log(e.message);
     return res.status(500).send({
       message: e.message,
     });

--- a/server/routes/notification/index.js
+++ b/server/routes/notification/index.js
@@ -32,6 +32,7 @@ const getNotificationDetails = async (notification) => {
     notificationDetails[0].subEstablishmentId = subEstablishmentName[0].subestablishmentid;
     notificationDetails[0].parentEstablishmentId = subEstablishmentName[0].parentestablishmentid;
     notificationDetails[0].rejectionReason = subEstablishmentName[0].rejectionreason;
+    notificationDetails[0].subEstablishmentUid = subEstablishmentName[0].subestablishmentuid;
   }
   return notificationDetails;
 };

--- a/src/app/core/services/notifications/notifications.service.ts
+++ b/src/app/core/services/notifications/notifications.service.ts
@@ -18,7 +18,6 @@ export class NotificationsService {
 
   public getAllNotifications(establishmentUid, limit?, sort?, page?) {
     const queryParams = [];
-    console.log(limit);
 
     if (limit) queryParams.push(`limit=${limit}`);
     if (sort) queryParams.push(`sort=${sort}`);

--- a/src/app/core/services/switch-workplace.service.ts
+++ b/src/app/core/services/switch-workplace.service.ts
@@ -57,7 +57,9 @@ export class SwitchWorkplaceService {
         .subscribe(
           (workplace) => {
             this.notificationsService.getAllNotifications(workplaceUid).subscribe((notify) => {
-              this.notificationsService.notifications$.next(this.notificationData ? this.notificationData : notify);
+              this.notificationsService.notifications$.next(
+                this.notificationData ? this.notificationData : notify.notifications,
+              );
               this.establishmentService.setState(workplace);
               this.establishmentService.setPrimaryWorkplace(workplace);
               this.establishmentService.establishmentId = workplace.uid;

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
@@ -33,6 +33,8 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
   public notificationRequestedTo: string;
   public requestorName: string;
   public postCode: string;
+  public notificationRequestedFromUid: string;
+
   constructor(
     private route: ActivatedRoute,
     private breadcrumbService: BreadcrumbService,
@@ -51,6 +53,7 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
     this.notificationUid = this.route.snapshot.params.notificationuid;
     this.notificationRequestedTo = this.notification.typeContent.parentEstablishmentName;
     this.notificationRequestedFrom = this.notification.typeContent.subEstablishmentName;
+    this.notificationRequestedFromUid = this.notification.typeContent.subEstablishmentUid;
     this.requestorName = this.notification.typeContent.requestorName;
     this.postCode = this.notification.typeContent.postCode;
     this.isWorkPlaceRequester = this.workplace.name === this.notificationRequestedTo;
@@ -84,6 +87,7 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
         approvalStatus: 'APPROVED',
         subEstablishmentId: this.notification.typeContent.subEstablishmentId || null,
         parentEstablishmentId: this.notification.typeContent.parentEstablishmentId || null,
+        subEstablishmentUid: this.notification.typeContent.subEstablishmentUid || null,
       };
       this.subscriptions.add(
         this.notificationsService
@@ -155,6 +159,7 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
       approvalStatus: 'DENIED',
       subEstablishmentId: this.notification.typeContent.subEstablishmentId || null,
       parentEstablishmentId: this.notification.typeContent.parentEstablishmentId || null,
+      subEstablishmentUid: this.notification.typeContent.subEstablishmentUid || null,
     };
     this.subscriptions.add(
       this.notificationsService


### PR DESCRIPTION
#### Work done
- add migration to add a column to the notification establishment table for the requestor establishment id
- change the link to parent request and approve to use the notification table

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
