### PR TITLE
data area to also be viewed on the old dashboard

### DIFF
--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -39,7 +39,20 @@
       </app-tab>
 
       <app-tab *ngIf="workplace" [title]="'Benchmarks'">
-        <app-benchmarks-tab class="asc-benchmarks-tab" [workplace]="workplace"></app-benchmarks-tab>
+        <ng-container *ngIf="newDataAreaFlag && canSeeNewDataArea; else benchmarksTab">
+          <app-data-area-tab
+            [workplace]="workplace"
+            [tilesData]="tilesData"
+            data-testid="data-area-tab"
+          ></app-data-area-tab>
+        </ng-container>
+        <ng-template #benchmarksTab>
+          <app-benchmarks-tab
+            class="asc-benchmarks-tab"
+            [workplace]="workplace"
+            data-testid="benchmarks-tab"
+          ></app-benchmarks-tab>
+        </ng-template>
       </app-tab>
 
       <app-tab *ngIf="workplace && canViewEstablishment && wdfNewDesignFlag" [title]="'WDF'">

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -245,4 +245,44 @@ describe('DashboardComponent', () => {
       });
     });
   });
+  describe('Benchmarks tab', () => {
+    it('should show the benchmarks tab when it is the selected tab, there is a workplace and there is canViewListOfWorkers permissions', async () => {
+      const { getByTestId } = await setup();
+
+      expect(getByTestId('benchmarks-tab')).toBeTruthy();
+    });
+
+    it('should render the new data area page rather than benchmark page when the newDataAreaFlag is true', async () => {
+      const { component, fixture, getByTestId, queryByTestId } = await setup();
+
+      component.canSeeNewDataArea = true;
+      component.newDataAreaFlag = true;
+      fixture.detectChanges();
+
+      expect(getByTestId('data-area-tab')).toBeTruthy();
+      expect(queryByTestId('benchmarks-tab')).toBeFalsy();
+    });
+
+    it('should render the normal benchmarks page when the newDataAreaFlag is false', async () => {
+      const { component, fixture, getByTestId, queryByTestId } = await setup();
+
+      component.canSeeNewDataArea = true;
+      component.newDataAreaFlag = false;
+      fixture.detectChanges();
+
+      expect(getByTestId('benchmarks-tab')).toBeTruthy();
+      expect(queryByTestId('data-area-tab')).toBeFalsy();
+    });
+
+    it('should render the normal benchmarks page when the establishment is non regulated', async () => {
+      const { component, fixture, getByTestId, queryByTestId } = await setup();
+
+      component.canSeeNewDataArea = false;
+      component.newDataAreaFlag = true;
+      fixture.detectChanges();
+
+      expect(getByTestId('benchmarks-tab')).toBeTruthy();
+      expect(queryByTestId('data-area-tab')).toBeFalsy();
+    });
+  });
 });

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -37,6 +37,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private showBanner = false;
   public wdfNewDesignFlag: boolean;
   public tAndQsLastUpdated: string;
+  public newDataAreaFlag: boolean;
+  public canSeeNewDataArea: boolean;
 
   constructor(
     private authService: AuthService,
@@ -58,6 +60,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.showSharingPermissionsBanner = this.workplace.showSharingPermissionsBanner;
     this.workplaceUid = this.workplace ? this.workplace.uid : null;
     this.establishmentService.setInStaffRecruitmentFlow(false);
+    this.newDataAreaFlag = this.featureFlagsService.newBenchmarksDataArea;
+    this.canSeeNewDataArea = [1, 2, 8].includes(this.workplace.mainService.reportingID);
 
     if (this.workplace) {
       this.getPermissions();

--- a/src/app/features/new-dashboard/dashboard/dashboard.component.html
+++ b/src/app/features/new-dashboard/dashboard/dashboard.component.html
@@ -40,6 +40,7 @@
       <app-data-area-tab
         [workplace]="workplace"
         [tilesData]="tilesData"
+        [newDashboard]="true"
         data-testid="data-area-tab"
       ></app-data-area-tab>
     </ng-container>

--- a/src/app/features/new-dashboard/data-area-tab/data-area-tab.component.html
+++ b/src/app/features/new-dashboard/data-area-tab/data-area-tab.component.html
@@ -1,10 +1,12 @@
-<app-new-dashboard-header
-  [tab]="'benchmarks'"
-  [updatedDate]="tilesData?.meta.lastUpdated"
-  data-html2canvas-ignore
-></app-new-dashboard-header>
+<ng-container *ngIf="newDashboard">
+  <app-new-dashboard-header
+    [tab]="'benchmarks'"
+    [updatedDate]="tilesData?.meta.lastUpdated"
+    data-html2canvas-ignore
+  ></app-new-dashboard-header>
+</ng-container>
 
-<div class="govuk-width-container govuk-!-margin-top-7">
+<div [ngClass]="{ 'govuk-width-container': newDashboard, 'govuk-!-margin-top-7': newDashboard }">
   <app-benchmarks-select-view-panel
     [toggleBoolean]="viewBenchmarksByCategory"
     [falseSelectionName]="'Pay'"

--- a/src/app/features/new-dashboard/data-area-tab/data-area-tab.component.ts
+++ b/src/app/features/new-dashboard/data-area-tab/data-area-tab.component.ts
@@ -17,6 +17,7 @@ import { BenchmarksAboutTheDataComponent } from '@shared/components/benchmarks-t
 export class DataAreaTabComponent implements OnInit, OnDestroy {
   @Input() workplace: Establishment;
   @Input() tilesData: BenchmarksResponse;
+  @Input() newDashboard: Boolean;
   @ViewChild('aboutData') private aboutData: BenchmarksAboutTheDataComponent;
 
   public canViewFullBenchmarks: boolean;
@@ -29,7 +30,6 @@ export class DataAreaTabComponent implements OnInit, OnDestroy {
   public viewBenchmarksPosition = false;
   public downloadPayBenchmarksText = 'Download pay benchmarks';
   public downloadRecruitmentBenchmarksText = 'Download recruitment and retention benchmarks';
-
 
   constructor(
     private permissionsService: PermissionsService,

--- a/src/app/shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component.html
+++ b/src/app/shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-!-margin-top-5 govuk-!-margin-bottom-4">
+<div class="govuk-!-margin-bottom-4">
   <ul class="govuk-tabs__list asc-tabs__list" role="tablist">
     <li
       class="govuk-tabs__list-item asc-tabs__list-item"


### PR DESCRIPTION
#### Work done
- Allow establishments that are using the old dashboard to see the data area if they are in the [1,2,8] service club.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
