### PR TITLE
fix get meta data to handle when no comparison groups

### DIFF
--- a/server/routes/establishments/benchmarks/index.js
+++ b/server/routes/establishments/benchmarks/index.js
@@ -235,24 +235,23 @@ const getMetaData = async (establishmentId, mainService) => {
     await models.benchmarksEstablishmentsAndWorkersGoodOutstanding.getComparisonData(establishmentId, mainService);
 
   return {
-    workplaces: benchmarksComparisonGroup.workplaces ? benchmarksComparisonGroup.workplaces : 0,
-    staff: benchmarksComparisonGroup.staff ? benchmarksComparisonGroup.staff : 0,
-    workplacesGoodCqc: benchmarksComparisonGroupGoodOutstanding.BaseEstablishments
+    workplaces: benchmarksComparisonGroup ? benchmarksComparisonGroup.workplaces : 0,
+    staff: benchmarksComparisonGroup ? benchmarksComparisonGroup.staff : 0,
+    workplacesGoodCqc: benchmarksComparisonGroupGoodOutstanding
       ? benchmarksComparisonGroupGoodOutstanding.BaseEstablishments
       : 0,
-    staffGoodCqc: benchmarksComparisonGroupGoodOutstanding.WorkerCount
-      ? benchmarksComparisonGroupGoodOutstanding.WorkerCount
-      : 0,
+    staffGoodCqc: benchmarksComparisonGroupGoodOutstanding ? benchmarksComparisonGroupGoodOutstanding.WorkerCount : 0,
     lastUpdated: await models.dataImports.benchmarksLastUpdated(),
-    localAuthority: benchmarksComparisonGroup.localAuthority ? benchmarksComparisonGroup.localAuthority : null,
+    localAuthority: benchmarksComparisonGroup ? benchmarksComparisonGroup.localAuthority : null,
   };
 };
 
 const viewBenchmarks = async (req, res) => {
   try {
     const establishmentId = req.establishmentId;
-    const { MainServiceFKValue: mainService } = await models.establishment.findbyId(establishmentId);
+    const { MainServiceFKValue } = await models.establishment.findbyId(establishmentId);
 
+    const mainService = [1, 2, 8].includes(MainServiceFKValue) ? MainServiceFKValue : 0;
     const benchmarksData = await getBenchmarksData(establishmentId, mainService);
 
     return res.status(200).json(benchmarksData);
@@ -274,7 +273,7 @@ module.exports.sickness = sickness;
 module.exports.turnover = turnover;
 module.exports.buildComparisonGroupMetrics = buildComparisonGroupMetrics;
 module.exports.getMetaData = getMetaData;
-module.exports.getBenchmarkData = getBenchmarksData;
+module.exports.getBenchmarksData = getBenchmarksData;
 module.exports.payBenchmarks = payBenchmarks;
 module.exports.turnoverBenchmarks = turnoverBenchmarks;
 module.exports.vacanciesBenchmarks = vacanciesBenchmarks;

--- a/server/test/unit/routes/establishments/benchmarks/index.spec.js
+++ b/server/test/unit/routes/establishments/benchmarks/index.spec.js
@@ -689,8 +689,8 @@ describe('/benchmarks', () => {
     });
 
     it('should return meta data with the last updated but without the staff, workplaces and local authority present if no comparison group', async () => {
-      sinon.stub(models.benchmarksEstablishmentsAndWorkers, 'getComparisonData').returns({});
-      sinon.stub(models.benchmarksEstablishmentsAndWorkersGoodOutstanding, 'getComparisonData').returns({});
+      sinon.stub(models.benchmarksEstablishmentsAndWorkers, 'getComparisonData').returns(null);
+      sinon.stub(models.benchmarksEstablishmentsAndWorkersGoodOutstanding, 'getComparisonData').returns(null);
       const date = new Date();
       sinon.stub(models.dataImports, 'benchmarksLastUpdated').returns(date);
 
@@ -720,7 +720,6 @@ describe('/benchmarks', () => {
       req = httpMocks.createRequest(request);
       res = httpMocks.createResponse();
 
-      sinon.stub(models.establishment, 'findbyId').returns({ MainServiceFKValue: 8 });
       sinon
         .stub(benchmarksService, 'getComparisonData')
         .onFirstCall()
@@ -762,6 +761,7 @@ describe('/benchmarks', () => {
     });
 
     it('should return 200 and the data when successfully getting the benchmarks data', async () => {
+      sinon.stub(models.establishment, 'findbyId').returns({ MainServiceFKValue: 8 });
       sinon
         .stub(benchmarksService, 'getPay')
         .onFirstCall()
@@ -849,6 +849,8 @@ describe('/benchmarks', () => {
     });
 
     it('should return 500 when an error is thrown', async () => {
+      sinon.stub(models.establishment, 'findbyId').returns({ MainServiceFKValue: 8 });
+
       sinon.stub(benchmarksService, 'getPay').throws();
       await viewBenchmarks(req, res);
 


### PR DESCRIPTION
#### Work done
- Fix to get meta data to handle when no comparison groups instead of blowing up.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
