### PR TITLE
1244 comparison box r and r

### DIFF
--- a/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -48,27 +48,29 @@
     </div>
     <div class="govuk-grid-column-two-thirds">
       <ng-container *ngIf="!viewBenchmarksComparisonGroups">
-        <h3 class="govuk-heading-m">{{ workplace.mainService.name }} providers in (local authority)</h3>
+        <h3 class="govuk-heading-m">
+          {{ workplace.mainService.name }} providers in {{ tilesData.meta.localAuthority }}
+        </h3>
         <p class="govuk-body">
           Your selected comparison group is a maximum
-          <span class="govuk-body govuk-!-font-weight-bold">(Staff number)</span>
+          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData.meta.staff }}</span>
           staff from
-          <span class="govuk-body govuk-!-font-weight-bold">(workplaces number)</span>
+          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData.meta.workplaces }}</span>
           workplaces using ASC-WDS and providing
           <span class="govuk-body govuk-!-font-weight-bold">{{ workplace.mainService.name.toLowerCase() }}</span>
-          in (local authority).
+          in {{ tilesData.meta.localAuthority }}.
         </p>
       </ng-container>
       <ng-container *ngIf="viewBenchmarksComparisonGroups">
-        <h3 class="govuk-heading-m">Good and outstanding CQC providers in (local authority)</h3>
+        <h3 class="govuk-heading-m">Good and outstanding CQC providers in {{ tilesData.meta.localAuthority }}</h3>
         <p class="govuk-body">
           Your selected comparison group is a maximum
-          <span class="govuk-body govuk-!-font-weight-bold">(Staff number)</span>
+          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData.meta.staffGoodCqc }}</span>
           staff from
-          <span class="govuk-body govuk-!-font-weight-bold">(workplaces number)</span>
+          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData.meta.workplacesGoodCqc }}</span>
           workplaces using ASC-WDS, rated as good or outstanding CQC providers and and providing
           <span class="govuk-body govuk-!-font-weight-bold">{{ workplace.mainService.name.toLowerCase() }}</span>
-          in (local authority).
+          in {{ tilesData.meta.localAuthority }}.
         </p>
       </ng-container>
       <ng-container *ngIf="!viewBenchmarksByCategory">

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -42,35 +42,35 @@
         [viewBenchmarksComparisonGroups]="viewBenchmarksComparisonGroups"
         (handleViewToggle)="handleViewComparisonGroups($event)"
         [mainServiceName]="workplace.mainService.name"
-        [localAuthorityLocation]="tilesData.meta.localAuthority"
+        [localAuthorityLocation]="tilesData?.meta.localAuthority"
       >
       </app-benchmarks-select-comparison-group>
     </div>
     <div class="govuk-grid-column-two-thirds">
       <ng-container *ngIf="!viewBenchmarksComparisonGroups">
         <h3 class="govuk-heading-m">
-          {{ workplace.mainService.name }} providers in {{ tilesData.meta.localAuthority }}
+          {{ workplace.mainService.name }} providers in {{ tilesData?.meta.localAuthority }}
         </h3>
         <p class="govuk-body">
           Your selected comparison group is a maximum
-          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData.meta.staff }}</span>
+          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.staff }}</span>
           staff from
-          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData.meta.workplaces }}</span>
+          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.workplaces }}</span>
           workplaces using ASC-WDS and providing
           <span class="govuk-body govuk-!-font-weight-bold">{{ workplace.mainService.name.toLowerCase() }}</span>
-          in {{ tilesData.meta.localAuthority }}.
+          in {{ tilesData?.meta.localAuthority }}.
         </p>
       </ng-container>
       <ng-container *ngIf="viewBenchmarksComparisonGroups">
-        <h3 class="govuk-heading-m">Good and outstanding CQC providers in {{ tilesData.meta.localAuthority }}</h3>
+        <h3 class="govuk-heading-m">Good and outstanding CQC providers in {{ tilesData?.meta.localAuthority }}</h3>
         <p class="govuk-body">
           Your selected comparison group is a maximum
-          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData.meta.staffGoodCqc }}</span>
+          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.staffGoodCqc }}</span>
           staff from
-          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData.meta.workplacesGoodCqc }}</span>
+          <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.workplacesGoodCqc }}</span>
           workplaces using ASC-WDS, rated as good or outstanding CQC providers and and providing
           <span class="govuk-body govuk-!-font-weight-bold">{{ workplace.mainService.name.toLowerCase() }}</span>
-          in {{ tilesData.meta.localAuthority }}.
+          in {{ tilesData?.meta.localAuthority }}.
         </p>
       </ng-container>
       <ng-container *ngIf="!viewBenchmarksByCategory">

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -42,7 +42,7 @@
         [viewBenchmarksComparisonGroups]="viewBenchmarksComparisonGroups"
         (handleViewToggle)="handleViewComparisonGroups($event)"
         [mainServiceName]="workplace.mainService.name"
-        [localAuthorityLocation]=""
+        [localAuthorityLocation]="tilesData.meta.localAuthority"
       >
       </app-benchmarks-select-comparison-group>
     </div>

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.ts
@@ -43,6 +43,7 @@ export class DataAreaTabComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.tilesData = this.benchmarksService.benchmarksData;
+    console.log(this.tilesData);
     this.canViewFullBenchmarks = this.permissionsService.can(this.workplace.uid, 'canViewBenchmarks');
     this.breadcrumbService.show(JourneyType.BENCHMARKS_TAB);
     this.setDownloadBenchmarksText();

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.ts
@@ -17,7 +17,7 @@ import { DataAreaAboutTheDataComponent } from './about-the-data/about-the-data.c
 })
 export class DataAreaTabComponent implements OnInit, OnDestroy {
   @Input() workplace: Establishment;
-  @Input() newDashboard: Boolean;
+  @Input() newDashboard: boolean;
   @ViewChild('aboutData') private aboutData: DataAreaAboutTheDataComponent;
 
   public canViewFullBenchmarks: boolean;
@@ -43,7 +43,6 @@ export class DataAreaTabComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.tilesData = this.benchmarksService.benchmarksData;
-    console.log(this.tilesData);
     this.canViewFullBenchmarks = this.permissionsService.can(this.workplace.uid, 'canViewBenchmarks');
     this.breadcrumbService.show(JourneyType.BENCHMARKS_TAB);
     this.setDownloadBenchmarksText();


### PR DESCRIPTION
#### Work done
- As part of [1244-data-area-r-r-comparison-box](https://trello.com/c/Henb9YIy/1244-data-area-r-r-comparison-box)
- Add local authority and comparison group data to select box and dynamic text at the top of data area page

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
