### PR TITLE
fix benchmarks not retrieving the correct due to using main service i…

### DIFF
--- a/server/routes/establishments/benchmarks/index.js
+++ b/server/routes/establishments/benchmarks/index.js
@@ -249,10 +249,10 @@ const getMetaData = async (establishmentId, mainService) => {
 const viewBenchmarks = async (req, res) => {
   try {
     const establishmentId = req.establishmentId;
-    const { MainServiceFKValue } = await models.establishment.findbyId(establishmentId);
+    const { mainService } = await models.establishment.findbyId(establishmentId);
 
-    const mainService = [1, 2, 8].includes(MainServiceFKValue) ? MainServiceFKValue : 0;
-    const benchmarksData = await getBenchmarksData(establishmentId, mainService);
+    const mainServiceID = [1, 2, 8].includes(mainService.reportingID) ? mainService.reportingID : 0;
+    const benchmarksData = await getBenchmarksData(establishmentId, mainServiceID);
 
     return res.status(200).json(benchmarksData);
   } catch (err) {

--- a/server/test/unit/routes/establishments/benchmarks/index.spec.js
+++ b/server/test/unit/routes/establishments/benchmarks/index.spec.js
@@ -761,7 +761,7 @@ describe('/benchmarks', () => {
     });
 
     it('should return 200 and the data when successfully getting the benchmarks data', async () => {
-      sinon.stub(models.establishment, 'findbyId').returns({ MainServiceFKValue: 8 });
+      sinon.stub(models.establishment, 'findbyId').returns({ mainService: { reportingID: 8 } });
       sinon
         .stub(benchmarksService, 'getPay')
         .onFirstCall()


### PR DESCRIPTION
…d instead of main service reporting id

#### Work done
- change main service passed in view benchmarks function to use the main service reporting id

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
