### PR TITLE
create new pipe for changing service name and for replacing an ampers…

### DIFF
--- a/src/app/features/new-dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.html
@@ -18,13 +18,18 @@
               (click)="navigateToTab($event, 'benchmarks')"
               class="govuk-link--no-visited-state govuk-!-font-size-19 govuk-!-font-weight-bold"
               href="#"
-              >{{ benchmarksHeader }}</a
             >
+              <ng-container *ngIf="bigThreeServices && hasBenchmarkComparisonData; else notBigThreeServices">
+                See how your pay, recruitment and retention compares against other workplaces</ng-container
+              >
+              <ng-template #notBigThreeServices> See how you compare against other workplaces</ng-template>
+            </a>
             <p class="govuk-!-margin-top-5">
               {{ benchmarksMessage }}
-            </p></app-card
-          >
+            </p>
+          </app-card>
         </div>
+
         <div class="govuk-grid-column-one-half">
           <app-card [image]="'/assets/images/benefits-bundle.svg'">
             <a

--- a/src/app/features/new-dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.ts
@@ -15,6 +15,7 @@ import { BecomeAParentCancelDialogComponent } from '@shared/components/become-a-
 import { BecomeAParentDialogComponent } from '@shared/components/become-a-parent/become-a-parent-dialog.component';
 import { LinkToParentCancelDialogComponent } from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
 import { LinkToParentDialogComponent } from '@shared/components/link-to-parent/link-to-parent-dialog.component';
+import { ServiceNamePipe } from '@shared/pipes/service-name.pipe';
 import { Subscription } from 'rxjs';
 import { isAdminRole } from 'server/utils/adminUtils';
 
@@ -29,6 +30,7 @@ window.dataLayer = window.dataLayer || {};
 @Component({
   selector: 'app-new-home-tab',
   templateUrl: './home-tab.component.html',
+  providers: [ServiceNamePipe],
 })
 export class NewHomeTabComponent implements OnInit, OnDestroy {
   @Input() workplace: Establishment;
@@ -67,6 +69,7 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
     private tabsService: TabsService,
     private route: ActivatedRoute,
     @Inject(WindowToken) private window: Window,
+    private serviceNamePipe: ServiceNamePipe,
   ) {}
 
   ngOnInit(): void {
@@ -129,8 +132,8 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
       this.benchmarksHeader = 'See how you compare against other workplaces';
       this.benchmarksMessage = `Benchmarks can show how you're doing when it comes to pay, recruitment and retention.`;
     } else {
-      if ([1, 2, 8].filter((x) => x === this.workplace.mainService.reportingID).length > 0) {
-        const benchmarksCareType = this.workplace.mainService.name;
+      if ([1, 2, 8].includes(this.workplace.mainService.reportingID)) {
+        const benchmarksCareType = this.serviceNamePipe.transform(this.workplace.mainService.name);
         this.benchmarksHeader = 'See how your pay, recruitment and retention compares against other workplaces';
         this.benchmarksMessage = `There are ${
           this.meta?.workplaces ? this.meta.workplaces : 0

--- a/src/app/features/new-dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.ts
@@ -11,13 +11,9 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { TabsService } from '@core/services/tabs.service';
 import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
-import {
-  BecomeAParentCancelDialogComponent,
-} from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
+import { BecomeAParentCancelDialogComponent } from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
 import { BecomeAParentDialogComponent } from '@shared/components/become-a-parent/become-a-parent-dialog.component';
-import {
-  LinkToParentCancelDialogComponent,
-} from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
+import { LinkToParentCancelDialogComponent } from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
 import { LinkToParentDialogComponent } from '@shared/components/link-to-parent/link-to-parent-dialog.component';
 import { ServiceNamePipe } from '@shared/pipes/service-name.pipe';
 import { Subscription } from 'rxjs';
@@ -133,7 +129,7 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
   private setBenchmarksCard(): void {
     if (this.hasBenchmarkComparisonData) {
       const serviceName = this.serviceNamePipe.transform(this.workplace.mainService.name);
-      const localAuthority = this.meta?.localAuthority.replace('&', 'and');
+      const localAuthority = this.meta?.localAuthority.replace(/&/g, 'and');
       const noOfWorkplacesText =
         this.meta.workplaces === 1
           ? `There is ${this.meta.workplaces} workplace`

--- a/src/app/features/new-dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.ts
@@ -11,9 +11,13 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { TabsService } from '@core/services/tabs.service';
 import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
-import { BecomeAParentCancelDialogComponent } from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
+import {
+  BecomeAParentCancelDialogComponent,
+} from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
 import { BecomeAParentDialogComponent } from '@shared/components/become-a-parent/become-a-parent-dialog.component';
-import { LinkToParentCancelDialogComponent } from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
+import {
+  LinkToParentCancelDialogComponent,
+} from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
 import { LinkToParentDialogComponent } from '@shared/components/link-to-parent/link-to-parent-dialog.component';
 import { ServiceNamePipe } from '@shared/pipes/service-name.pipe';
 import { Subscription } from 'rxjs';
@@ -38,7 +42,6 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
 
   private subscriptions: Subscription = new Subscription();
   public benchmarksMessage: string;
-  public benchmarksHeader: string;
   public canViewWorkplaces: boolean;
   public canViewReports: boolean;
   public canViewChangeDataOwner: boolean;
@@ -60,6 +63,8 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
   public workerCount: number;
   public workersNotCompleted: Worker[];
   public addWorkplaceDetailsBanner: boolean;
+  public bigThreeServices: boolean;
+  public hasBenchmarkComparisonData: boolean;
 
   constructor(
     private userService: UserService,
@@ -119,35 +124,28 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
       });
     }
 
+    this.bigThreeServices = [1, 2, 8].includes(this.workplace.mainService.reportingID);
+    this.hasBenchmarkComparisonData = !!this.meta?.staff && !!this.meta?.workplaces;
     this.setBenchmarksCard();
     this.subscriptions.add();
   }
 
   private setBenchmarksCard(): void {
-    const comparisonDataAvailable = this.meta?.staff && this.meta?.workplaces;
-
-    const localAuthority = this.meta?.localAuthority.replace('&', 'and');
-
-    if (!comparisonDataAvailable) {
-      this.benchmarksHeader = 'See how you compare against other workplaces';
-      this.benchmarksMessage = `Benchmarks can show how you're doing when it comes to pay, recruitment and retention.`;
+    if (this.hasBenchmarkComparisonData) {
+      const serviceName = this.serviceNamePipe.transform(this.workplace.mainService.name);
+      const localAuthority = this.meta?.localAuthority.replace('&', 'and');
+      const noOfWorkplacesText =
+        this.meta.workplaces === 1
+          ? `There is ${this.meta.workplaces} workplace`
+          : `There are ${this.meta.workplaces} workplaces`;
+      const serviceText = this.bigThreeServices ? `${serviceName.toLowerCase()}` : 'adult social care';
+      this.benchmarksMessage = `${noOfWorkplacesText} providing ${serviceText} in ${localAuthority}.`;
     } else {
-      if ([1, 2, 8].includes(this.workplace.mainService.reportingID)) {
-        const benchmarksCareType = this.serviceNamePipe.transform(this.workplace.mainService.name);
-        this.benchmarksHeader = 'See how your pay, recruitment and retention compares against other workplaces';
-        this.benchmarksMessage = `There are ${
-          this.meta?.workplaces ? this.meta.workplaces : 0
-        } workplaces providing ${benchmarksCareType.toLowerCase()} in ${localAuthority}.`;
-      } else if (!this.workplace.isRegulated) {
-        this.benchmarksHeader = 'See how you compare against other workplaces';
-        this.benchmarksMessage = `There are ${
-          this.meta?.workplaces ? this.meta.workplaces : 0
-        } workplaces providing adult social care in ${localAuthority}.`;
-      }
+      this.benchmarksMessage = `Benchmarks can show how you're doing when it comes to pay, recruitment and retention.`;
     }
   }
 
-  ngOnChanges(changes) {
+  ngOnChanges() {
     this.setBenchmarksCard();
   }
 

--- a/src/app/shared/components/benchmarks-select-comparison-group/benchmarks-select-comparison-group.component.html
+++ b/src/app/shared/components/benchmarks-select-comparison-group/benchmarks-select-comparison-group.component.html
@@ -14,7 +14,7 @@
           (change)="handleViewChange($event)"
         />
         <label class="govuk-label govuk-radios__label" for="comparison-groups">
-          {{ mainServiceName }} providers in {{ localAuthorityLocation }}
+          {{ mainServiceName | serviceName }} providers in {{ localAuthorityLocation | formatAmpersand }}
         </label>
       </div>
       <div class="govuk-radios__item">
@@ -29,7 +29,7 @@
           (change)="handleViewChange($event)"
         />
         <label class="govuk-label govuk-radios__label" for="comparison-groups-good-and-outstanding">
-          Good and outstading CQC providers in {{ localAuthorityLocation }}
+          Good and outstading CQC providers in {{ localAuthorityLocation | formatAmpersand }}
         </label>
       </div>
     </div>

--- a/src/app/shared/components/benchmarks-select-comparison-group/benchmarks-select-comparison-group.component.spec.ts
+++ b/src/app/shared/components/benchmarks-select-comparison-group/benchmarks-select-comparison-group.component.spec.ts
@@ -1,3 +1,4 @@
+import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { spy } from 'sinon';
 
@@ -5,8 +6,8 @@ import { BenchmarksSelectComparisonGroupsComponent } from './benchmarks-select-c
 
 describe('BenchmarksSelectComparisonGroupsComponent', () => {
   async function setup() {
-    const { fixture, getByText, getByTestId } = await render(BenchmarksSelectComparisonGroupsComponent, {
-      imports: [],
+    const { fixture, getByTestId } = await render(BenchmarksSelectComparisonGroupsComponent, {
+      imports: [SharedModule],
       declarations: [],
       providers: [],
       componentProperties: {
@@ -25,7 +26,6 @@ describe('BenchmarksSelectComparisonGroupsComponent', () => {
     return {
       component,
       fixture,
-      getByText,
       getByTestId,
       toggleViewSpy,
     };
@@ -37,7 +37,7 @@ describe('BenchmarksSelectComparisonGroupsComponent', () => {
   });
 
   it('should show the main service input as checked when viewBenchmarksComparisonGroups is false', async () => {
-    const { getByText, getByTestId } = await setup();
+    const { getByTestId } = await setup();
 
     const mainServiceInput = getByTestId('main-service-input');
     const goodAndOutstandingInput = getByTestId('good-and-outstanding-input');
@@ -47,7 +47,7 @@ describe('BenchmarksSelectComparisonGroupsComponent', () => {
   });
 
   it('should show the good and outstand input as checked when viewByTrainingCategory is true', async () => {
-    const { component, getByText, getByTestId } = await setup();
+    const { component, getByTestId } = await setup();
 
     component.viewBenchmarksComparisonGroups = true;
     const mainServiceInput = getByTestId('main-service-input');

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -50,20 +50,25 @@
 
     <div class="govuk-grid-column-two-thirds">
       <ng-container *ngIf="viewBenchmarksComparisonGroups; else nonGoodCqcComparisonGroup">
-        <h3 class="govuk-heading-m">Good and outstanding CQC providers in {{ tilesData?.meta.localAuthority }}</h3>
+        <h3 class="govuk-heading-m">
+          Good and outstanding CQC providers in {{ tilesData?.meta.localAuthority | formatAmpersand }}
+        </h3>
         <p class="govuk-body">
           Your selected comparison group is a maximum
           <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.staffGoodCqc | number }}</span>
           staff from
           <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.workplacesGoodCqc | number }}</span>
           workplaces using ASC-WDS, rated as good or outstanding CQC providers and providing
-          <span class="govuk-body govuk-!-font-weight-bold">{{ workplace.mainService.name.toLowerCase() }}</span>
-          in {{ tilesData?.meta.localAuthority }}.
+          <span class="govuk-body govuk-!-font-weight-bold">{{
+            workplace.mainService.name | serviceName | lowercase
+          }}</span>
+          in {{ tilesData?.meta.localAuthority | formatAmpersand }}.
         </p>
       </ng-container>
       <ng-template #nonGoodCqcComparisonGroup>
         <h3 class="govuk-heading-m">
-          {{ workplace.mainService.name }} providers in {{ tilesData?.meta.localAuthority }}
+          {{ workplace.mainService.name | serviceName }} providers in
+          {{ tilesData?.meta.localAuthority | formatAmpersand }}
         </h3>
         <p class="govuk-body">
           Your selected comparison group is a maximum
@@ -71,8 +76,10 @@
           staff from
           <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.workplaces | number }}</span>
           workplaces using ASC-WDS and providing
-          <span class="govuk-body govuk-!-font-weight-bold">{{ workplace.mainService.name.toLowerCase() }}</span>
-          in {{ tilesData?.meta.localAuthority }}.
+          <span class="govuk-body govuk-!-font-weight-bold">{{
+            workplace.mainService.name | serviceName | lowercase
+          }}</span>
+          in {{ tilesData?.meta.localAuthority | formatAmpersand }}.
         </p>
       </ng-template>
 

--- a/src/app/shared/pipes/dont-know.pipe.spec.ts
+++ b/src/app/shared/pipes/dont-know.pipe.spec.ts
@@ -5,4 +5,14 @@ describe('DontKnowPipe', () => {
     const pipe = new DontKnowPipe();
     expect(pipe).toBeTruthy();
   });
+
+  it(`format Don't know correctly`, () => {
+    const pipe = new DontKnowPipe();
+    expect(pipe.transform(`Don't know`)).toEqual('I do not know');
+  });
+
+  it(`returns the value if it isn't Don't know`, () => {
+    const pipe = new DontKnowPipe();
+    expect(pipe.transform('somevalue')).toEqual('somevalue');
+  });
 });

--- a/src/app/shared/pipes/format-ampersand.pipe.spec.ts
+++ b/src/app/shared/pipes/format-ampersand.pipe.spec.ts
@@ -1,0 +1,18 @@
+import { FormatAmpersandPipe } from './format-ampersand.pipe';
+
+describe('FormatAmpersandPipe', () => {
+  it('creates an instance', () => {
+    const pipe = new FormatAmpersandPipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it('formats a string with and ampersand in it correctly', () => {
+    const pipe = new FormatAmpersandPipe();
+    expect(pipe.transform('L & A')).toEqual('L and A');
+  });
+
+  it('returns the original string if there is not an ampersand in it', () => {
+    const pipe = new FormatAmpersandPipe();
+    expect(pipe.transform('L and A')).toEqual('L and A');
+  });
+});

--- a/src/app/shared/pipes/format-ampersand.pipe.ts
+++ b/src/app/shared/pipes/format-ampersand.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'formatAmpersand',
+})
+export class FormatAmpersandPipe implements PipeTransform {
+  transform(value: string) {
+    return value.replace('&', 'and');
+  }
+}

--- a/src/app/shared/pipes/format-ampersand.pipe.ts
+++ b/src/app/shared/pipes/format-ampersand.pipe.ts
@@ -5,6 +5,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class FormatAmpersandPipe implements PipeTransform {
   transform(value: string) {
-    return value.replace('&', 'and');
+    return value.replace(/&/g, 'and');
   }
 }

--- a/src/app/shared/pipes/service-name.pipe.spec.ts
+++ b/src/app/shared/pipes/service-name.pipe.spec.ts
@@ -1,0 +1,28 @@
+import { ServiceNamePipe } from './service-name.pipe';
+
+describe('ServiceNamePipe', () => {
+  it('creates an instance', () => {
+    const pipe = new ServiceNamePipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it('formats domiciliary care services correctly', () => {
+    const pipe = new ServiceNamePipe();
+    expect(pipe.transform('Domiciliary care services')).toEqual('Domiciliary care');
+  });
+
+  it('formats care home services with nursing correctly', () => {
+    const pipe = new ServiceNamePipe();
+    expect(pipe.transform('Care Home Services With Nursing')).toEqual('Care home with nursing');
+  });
+
+  it('formats care home services without nursing correctly', () => {
+    const pipe = new ServiceNamePipe();
+    expect(pipe.transform('Care Home Services without Nursing')).toEqual('Care home without nursing');
+  });
+
+  it('does not format any other service and just returns it', () => {
+    const pipe = new ServiceNamePipe();
+    expect(pipe.transform('ANOTHER SERVICE')).toEqual('ANOTHER SERVICE');
+  });
+});

--- a/src/app/shared/pipes/service-name.pipe.spec.ts
+++ b/src/app/shared/pipes/service-name.pipe.spec.ts
@@ -13,12 +13,12 @@ describe('ServiceNamePipe', () => {
 
   it('formats care home services with nursing correctly', () => {
     const pipe = new ServiceNamePipe();
-    expect(pipe.transform('Care Home Services With Nursing')).toEqual('Care home with nursing');
+    expect(pipe.transform('Care Home Services With Nursing')).toEqual('Care homes with nursing');
   });
 
   it('formats care home services without nursing correctly', () => {
     const pipe = new ServiceNamePipe();
-    expect(pipe.transform('Care Home Services without Nursing')).toEqual('Care home without nursing');
+    expect(pipe.transform('Care Home Services without Nursing')).toEqual('Care homes without nursing');
   });
 
   it('does not format any other service and just returns it', () => {

--- a/src/app/shared/pipes/service-name.pipe.ts
+++ b/src/app/shared/pipes/service-name.pipe.ts
@@ -9,9 +9,9 @@ export class ServiceNamePipe implements PipeTransform {
       case 'domiciliary care services':
         return 'Domiciliary care';
       case 'care home services with nursing':
-        return 'Care home with nursing';
+        return 'Care homes with nursing';
       case 'care home services without nursing':
-        return 'Care home without nursing';
+        return 'Care homes without nursing';
     }
     return value;
   }

--- a/src/app/shared/pipes/service-name.pipe.ts
+++ b/src/app/shared/pipes/service-name.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'serviceName',
+})
+export class ServiceNamePipe implements PipeTransform {
+  transform(value: string) {
+    switch (value.toLowerCase()) {
+      case 'domiciliary care services':
+        return 'Domiciliary care';
+      case 'care home services with nursing':
+        return 'Care home with nursing';
+      case 'care home services without nursing':
+        return 'Care home without nursing';
+    }
+    return value;
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -10,8 +10,12 @@ import { PageResolver } from '@core/resolvers/page.resolver';
 import { DialogService } from '@core/services/dialog.service';
 import { ArticleListComponent } from '@features/articles/article-list/article-list.component';
 import { NewArticleListComponent } from '@features/articles/new-article-list/new-article-list.component';
-import { MissingMandatoryTrainingComponent } from '@features/training-and-qualifications/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component';
-import { DeleteWorkplaceDialogComponent } from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
+import {
+  MissingMandatoryTrainingComponent,
+} from '@features/training-and-qualifications/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component';
+import {
+  DeleteWorkplaceDialogComponent,
+} from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
 import { AlertComponent } from '@shared/components/alert/alert.component';
 import { CheckCQCDetailsComponent } from '@shared/components/check-cqc-details/check-cqc-details.component';
 import { NewDashboardHeaderComponent } from '@shared/components/new-dashboard-header/dashboard-header.component';
@@ -30,12 +34,18 @@ import { ChangeDataOwnerDialogComponent } from './components/change-data-owner-d
 import { CharacterCountComponent } from './components/character-count/character-count.component';
 import { DatePickerComponent } from './components/date-picker/date-picker.component';
 import { DetailsComponent } from './components/details/details.component';
-import { ValidationErrorMessageComponent } from './components/drag-and-drop/validation-error-message/validation-error-message.component';
+import {
+  ValidationErrorMessageComponent,
+} from './components/drag-and-drop/validation-error-message/validation-error-message.component';
 import { EligibilityIconComponent } from './components/eligibility-icon/eligibility-icon.component';
 import { ErrorSummaryComponent } from './components/error-summary/error-summary.component';
 import { InsetTextComponent } from './components/inset-text/inset-text.component';
-import { LinkToParentCancelDialogComponent } from './components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
-import { LinkToParentRemoveDialogComponent } from './components/link-to-parent-remove/link-to-parent-remove-dialog.component';
+import {
+  LinkToParentCancelDialogComponent,
+} from './components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
+import {
+  LinkToParentRemoveDialogComponent,
+} from './components/link-to-parent-remove/link-to-parent-remove-dialog.component';
 import { LinkToParentDialogComponent } from './components/link-to-parent/link-to-parent-dialog.component';
 import { LinkWithArrowComponent } from './components/link-with-arrow/link-with-arrow.component';
 import { MessagesComponent } from './components/messages/messages.component';
@@ -45,25 +55,37 @@ import { NewTabsComponent } from './components/new-tabs/new-tabs.component';
 import { WDFTabComponent } from './components/new-wdf-tabs/new-wdf-tab.component';
 import { WDFWorkplaceSummaryComponent } from './components/new-wdf-workplace-summary/wdf-workplace-summary.component';
 import { NewWorkplaceSummaryComponent } from './components/new-workplace-summary/workplace-summary.component';
-import { OwnershipChangeMessageDialogComponent } from './components/ownership-change-message/ownership-change-message-dialog.component';
+import {
+  OwnershipChangeMessageDialogComponent,
+} from './components/ownership-change-message/ownership-change-message-dialog.component';
 import { PageComponent } from './components/page/page.component';
 import { PaginationComponent } from './components/pagination/pagination.component';
 import { PanelComponent } from './components/panel/panel.component';
 import { PhaseBannerComponent } from './components/phase-banner/phase-banner.component';
 import { ProgressBarComponent } from './components/progress-bar/progress-bar.component';
 import { ProgressComponent } from './components/progress/progress.component';
-import { RegistrationSubmitButtonsComponent } from './components/registration-submit-buttons/registration-submit-buttons.component';
+import {
+  RegistrationSubmitButtonsComponent,
+} from './components/registration-submit-buttons/registration-submit-buttons.component';
 import { RejectRequestDialogComponent } from './components/reject-request-dialog/reject-request-dialog.component';
-import { RemoveParentConfirmationComponent } from './components/remove-parent-confirmation/remove-parent-confirmation.component';
+import {
+  RemoveParentConfirmationComponent,
+} from './components/remove-parent-confirmation/remove-parent-confirmation.component';
 import { ReviewCheckboxComponent } from './components/review-checkbox/review-checkbox.component';
 import { SearchInputComponent } from './components/search-input/search-input.component';
-import { SelectWorkplaceDropdownFormComponent } from './components/select-workplace-dropdown-form/select-workplace-dropdown-form.component';
-import { SelectWorkplaceRadioButtonFormComponent } from './components/select-workplace-radio-button-form/select-workplace-radio-button-form.component';
+import {
+  SelectWorkplaceDropdownFormComponent,
+} from './components/select-workplace-dropdown-form/select-workplace-dropdown-form.component';
+import {
+  SelectWorkplaceRadioButtonFormComponent,
+} from './components/select-workplace-radio-button-form/select-workplace-radio-button-form.component';
 import { SetDataPermissionDialogComponent } from './components/set-data-permission/set-data-permission-dialog.component';
 import { BasicRecordComponent } from './components/staff-record-summary/basic-record/basic-record.component';
 import { EmploymentComponent } from './components/staff-record-summary/employment/employment.component';
 import { PersonalDetailsComponent } from './components/staff-record-summary/personal-details/personal-details.component';
-import { QualificationsAndTrainingComponent } from './components/staff-record-summary/qualifications-and-training/qualifications-and-training.component';
+import {
+  QualificationsAndTrainingComponent,
+} from './components/staff-record-summary/qualifications-and-training/qualifications-and-training.component';
 import { StaffRecordSummaryComponent } from './components/staff-record-summary/staff-record-summary.component';
 import { StaffRecordsTabComponent } from './components/staff-records-tab/staff-records-tab.component';
 import { StaffSummaryComponent } from './components/staff-summary/staff-summary.component';
@@ -77,21 +99,35 @@ import { TabComponent } from './components/tabs/tab.component';
 import { TabsComponent } from './components/tabs/tabs.component';
 import { TotalStaffPanelComponent } from './components/total-staff-panel/total-staff-panel.component';
 import { TotalStaffComponent } from './components/total-staff/total-staff.component';
-import { TrainingAndQualificationsCategoriesComponent } from './components/training-and-qualifications-categories/training-and-qualifications-categories.component';
-import { ViewTrainingComponent } from './components/training-and-qualifications-categories/view-trainings/view-trainings.component';
-import { TrainingAndQualificationsSummaryComponent } from './components/training-and-qualifications-summary/training-and-qualifications-summary.component';
-import { TrainingAndQualificationsTabComponent } from './components/training-and-qualifications-tab/training-and-qualifications-tab.component';
+import {
+  TrainingAndQualificationsCategoriesComponent,
+} from './components/training-and-qualifications-categories/training-and-qualifications-categories.component';
+import {
+  ViewTrainingComponent,
+} from './components/training-and-qualifications-categories/view-trainings/view-trainings.component';
+import {
+  TrainingAndQualificationsSummaryComponent,
+} from './components/training-and-qualifications-summary/training-and-qualifications-summary.component';
+import {
+  TrainingAndQualificationsTabComponent,
+} from './components/training-and-qualifications-tab/training-and-qualifications-tab.component';
 import { TrainingInfoPanelComponent } from './components/training-info-panel/training-info-panel.component';
 import { TrainingLinkPanelComponent } from './components/training-link-panel/training-link-panel.component';
-import { TrainingSelectViewPanelComponent } from './components/training-select-view-panel/training-select-view-panel.component';
+import {
+  TrainingSelectViewPanelComponent,
+} from './components/training-select-view-panel/training-select-view-panel.component';
 import { UserAccountsSummaryComponent } from './components/user-accounts-summary/user-accounts-summary.component';
 import { UserFormComponent } from './components/user-form/user-form.component';
 import { UserTableComponent } from './components/users-table/user.table.component';
 import { WdfConfirmationPanelComponent } from './components/wdf-confirmation-panel/wdf-confirmation-panel.component';
 import { WdfFieldConfirmationComponent } from './components/wdf-field-confirmation/wdf-field-confirmation.component';
-import { WdfStaffMismatchMessageComponent } from './components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component';
+import {
+  WdfStaffMismatchMessageComponent,
+} from './components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component';
 import { WdfTabComponent } from './components/wdf-tab/wdf-tab.component';
-import { WorkplaceContinueCancelButtonComponent } from './components/workplace-continue-cancel-button.component/workplace-continue-cancel-button.component';
+import {
+  WorkplaceContinueCancelButtonComponent,
+} from './components/workplace-continue-cancel-button.component/workplace-continue-cancel-button.component';
 import { WorkplaceSubmitButtonComponent } from './components/workplace-submit-button/workplace-submit-button.component';
 import { WorkplaceSummaryComponent } from './components/workplace-summary/workplace-summary.component';
 import { FileValueAccessorDirective } from './form-controls/file-control-value-accessor';
@@ -100,6 +136,7 @@ import { ClosedEndedAnswerPipe } from './pipes/closed-ended-answer.pipe';
 import { DataViewPermissionsPipe } from './pipes/data-view-permissions.pipe';
 import { DontKnowPipe } from './pipes/dont-know.pipe';
 import { FirstErrorPipe } from './pipes/first-error.pipe';
+import { FormatAmpersandPipe } from './pipes/format-ampersand.pipe';
 import { LongDatePipe } from './pipes/long-date.pipe';
 import { NumericAnswerPipe } from './pipes/numeric-answer.pipe';
 import { NursingCategoriesTextPipe } from './pipes/nursing-categories-text.pipe';
@@ -107,6 +144,7 @@ import { NursingSpecialismsTextPipe } from './pipes/nursing-specialisms-text.pip
 import { OpenEndedAnswerPipe } from './pipes/open-ended-answer.pipe';
 import { OrderOtherPipe } from './pipes/order-other.pipe';
 import { SelectRecordTypePipe } from './pipes/select-record-type.pipe';
+import { ServiceNamePipe } from './pipes/service-name.pipe';
 import { WorkerDaysPipe } from './pipes/worker-days.pipe';
 import { WorkerPayPipe } from './pipes/worker-pay.pipe';
 import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-bearer.pipe';
@@ -221,6 +259,8 @@ import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-be
     WDFTabComponent,
     WDFWorkplaceSummaryComponent,
     NewDashboardHeaderComponent,
+    ServiceNamePipe,
+    FormatAmpersandPipe,
   ],
   exports: [
     AbsoluteNumberPipe,
@@ -328,6 +368,8 @@ import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-be
     WDFTabComponent,
     WDFWorkplaceSummaryComponent,
     NewDashboardHeaderComponent,
+    ServiceNamePipe,
+    FormatAmpersandPipe,
   ],
   providers: [DialogService, TotalStaffComponent, ArticleListResolver, PageResolver],
 })


### PR DESCRIPTION
…and with a text and. Add pipes to the benchmarks page

#### Work done
- work as part of [1279-centralised solution to change the way main service is viewed on benchmark text](https://trello.com/c/W2NFVpp6/1279-centralised-solution-to-change-the-way-main-service-is-viewed-on-benchmark-text)
- Create a pipe to convert format certain main service names
- Add pipe to benchmarks data area tab components
- Create a pipe to change an ampersand to a text and
- Add pipe to benchmarks data area tab components for local authorities names
- Update the way the benchmarks text is created for the benchmarks card in the home tab

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
