### PR TITLE
1247 data area pay comparison table

### DIFF
--- a/src/app/core/utils/format-util.spec.ts
+++ b/src/app/core/utils/format-util.spec.ts
@@ -24,4 +24,31 @@ describe('FormatUtil', () => {
       expect(formatSingleDigit).toEqual('09');
     });
   });
+
+  describe('formatMoney', () => {
+    it('should show decimals for number with less than 4 digits', async () => {
+      const formatMoney = FormatUtil.formatMoney(899);
+
+      expect(formatMoney).toEqual('£8.99');
+    });
+
+    it('should format longer decimal pay data correctly', () => {
+      const paydata = FormatUtil.formatMoney(512.345);
+      expect(paydata).toBe('£5.12');
+    });
+
+    it('should show decimals for number with less than 4 digits', async () => {
+      const formatMoney = FormatUtil.formatMoney(0);
+
+      expect(formatMoney).toEqual('£0.00');
+    });
+  });
+
+  describe('formatSalary', () => {
+    it('should show comma for number with more than 4 digits', async () => {
+      const formatMoney = FormatUtil.formatSalary(36500);
+
+      expect(formatMoney).toEqual('£36,500');
+    });
+  });
 });

--- a/src/app/core/utils/format-util.ts
+++ b/src/app/core/utils/format-util.ts
@@ -6,6 +6,10 @@ export class FormatUtil {
     return '£' + (Number(data) / 100).toFixed(2);
   }
 
+  public static formatSalary(data) {
+    return '£' + Number(data).toLocaleString('en');
+  }
+
   public static formatSingleDigit(value: number): string {
     return String(value < 10 ? `0${value}` : value);
   }

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
@@ -19,27 +19,33 @@
         <th scope="row" class="govuk-table__header commparision-row-header govuk-!-font-weight-regular">
           Care worker pay
         </th>
-        <td class="govuk-table__cell workplace-cell">£10.26 (hourly)</td>
-        <td class="govuk-table__cell comparision-group-cell">£9.75 (hourly)</td>
+        <td class="govuk-table__cell workplace-cell">{{ careWorkerPay }}</td>
+        <td class="govuk-table__cell comparision-group-cell">{{ comparisionGroupCareWorkerPay }}</td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header commparision-row-header govuk-!-font-weight-regular">
           Senior care worker pay
         </th>
-        <td class="govuk-table__cell workplace-cell">£11.05 (hourly)</td>
-        <td class="govuk-table__cell comparision-group-cell">£11.50 (hourly)</td>
+        <td class="govuk-table__cell workplace-cell">{{ seniorCareWorkerPay }}</td>
+        <td class="govuk-table__cell comparision-group-cell">
+          {{ comparisionGroupSeniorCareWorkerPay }}
+        </td>
       </tr>
-      <tr class="govuk-table__row">
+      <tr class="govuk-table__row" *ngIf="showRegisteredNurseSalary" data-testid="register-nurse-comparision">
         <th scope="row" class="govuk-table__header commparision-row-header govuk-!-font-weight-regular">
           Registered nurse salary
         </th>
-        <td class="govuk-table__cell workplace-cell">£34,130 (annually)</td>
-        <td class="govuk-table__cell comparision-group-cell">£34,100 (annually)</td>
+        <td class="govuk-table__cell workplace-cell">{{ registeredNurseSalary }}</td>
+        <td class="govuk-table__cell comparision-group-cell">
+          {{ comparisionGroupRegisteredNurseSalary }}
+        </td>
       </tr>
       <tr class="govuk-table__row last-row">
         <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Registered manager salary</th>
-        <td class="govuk-table__cell workplace-cell">£35,637 (annually)</td>
-        <td class="govuk-table__cell comparision-group-cell">£36,185 (annually)</td>
+        <td class="govuk-table__cell workplace-cell">{{ registeredManagerSalary }}</td>
+        <td class="govuk-table__cell comparision-group-cell">
+          {{ comparisionGroupRegisteredManagerSalary }}
+        </td>
       </tr>
     </tbody>
   </table>

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.spec.ts
@@ -3,22 +3,94 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import {
-  BenchmarksSelectViewPanelComponent,
-} from '@shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component';
+import { FormatUtil } from '@core/utils/format-util';
+import { BenchmarksSelectViewPanelComponent } from '@shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
 import { DataAreaPayComponent } from './data-area-pay.component';
 
-describe('DataAreaTabComponent', () => {
+fdescribe('DataAreaPayComponent', () => {
   const setup = async () => {
     const { fixture, getByText, getByTestId, queryByTestId } = await render(DataAreaPayComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [],
       declarations: [BenchmarksSelectViewPanelComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      componentProperties: {},
+      componentProperties: {
+        data: {
+          meta: {
+            workplaces: 0,
+            staff: 0,
+            localAuthority: 'Oxfordshire',
+          },
+          careWorkerPay: {
+            workplaceValue: {
+              value: 0,
+              hasValue: false,
+            },
+            comparisonGroup: {
+              value: 0,
+              hasValue: false,
+              stateMessage: 'no-data',
+            },
+            goodCqc: {
+              value: 0,
+              hasValue: false,
+              stateMessage: 'no-data',
+            },
+          },
+          seniorCareWorkerPay: {
+            workplaceValue: {
+              value: 0,
+              hasValue: false,
+            },
+            comparisonGroup: {
+              value: 0,
+              hasValue: false,
+              stateMessage: 'no-data',
+            },
+            goodCqc: {
+              value: 0,
+              hasValue: false,
+              stateMessage: 'no-data',
+            },
+          },
+          registeredNursePay: {
+            workplaceValue: {
+              value: 0,
+              hasValue: false,
+              stateMessage: 'no-pay-data',
+            },
+            comparisonGroup: {
+              value: 0,
+              hasValue: false,
+              stateMessage: 'no-data',
+            },
+            goodCqc: {
+              value: 0,
+              hasValue: false,
+              stateMessage: 'no-data',
+            },
+          },
+          registeredManagerPay: {
+            workplaceValue: {
+              value: 0,
+              hasValue: false,
+            },
+            comparisonGroup: {
+              value: 0,
+              hasValue: false,
+              stateMessage: 'no-data',
+            },
+            goodCqc: {
+              value: 0,
+              hasValue: false,
+              stateMessage: 'no-data',
+            },
+          },
+        },
+      },
     });
 
     const component = fixture.componentInstance;
@@ -74,5 +146,450 @@ describe('DataAreaTabComponent', () => {
 
     expect(component.viewBenchmarksPosition).toEqual(true);
     expect(getByTestId('barcharts')).toBeTruthy();
+  });
+
+  it('should show registered nurse salary in comparision group table', async () => {
+    const { component, fixture, getByTestId } = await setup();
+
+    component.showRegisteredNurseSalary = true;
+    fixture.detectChanges();
+
+    expect(getByTestId('register-nurse-comparision')).toBeTruthy();
+  });
+
+  it('should not show registered nurse salary in comparision group table', async () => {
+    const { component, fixture, queryByTestId } = await setup();
+
+    component.showRegisteredNurseSalary = false;
+    fixture.detectChanges();
+
+    expect(queryByTestId('register-nurse-comparision')).toBeFalsy();
+  });
+
+  describe('pay data', async () => {
+    it('should set all pay data when there is workplace pay data', async () => {
+      const { component, fixture, queryByTestId } = await setup();
+
+      const payDataForWorkplace = {
+        meta: {
+          workplaces: 0,
+          staff: 0,
+          localAuthority: 'Oxfordshire',
+        },
+        careWorkerPay: {
+          workplaceValue: {
+            value: 889,
+            hasValue: true,
+          },
+          comparisonGroup: {
+            value: 900,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 1000,
+            hasValue: true,
+          },
+        },
+        seniorCareWorkerPay: {
+          workplaceValue: {
+            value: 979,
+            hasValue: true,
+          },
+          comparisonGroup: {
+            value: 780,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 800,
+            hasValue: true,
+          },
+        },
+        registeredNursePay: {
+          workplaceValue: {
+            value: 26000,
+            hasValue: true,
+          },
+          comparisonGroup: {
+            value: 27500,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 30000,
+            hasValue: true,
+          },
+        },
+        registeredManagerPay: {
+          workplaceValue: {
+            value: 30000,
+            hasValue: true,
+          },
+          comparisonGroup: {
+            value: 29000,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 30000,
+            hasValue: true,
+          },
+        },
+      };
+
+      component.data = payDataForWorkplace;
+      component.ngOnChanges();
+
+      expect(component.careWorkerPay).toEqual(
+        FormatUtil.formatMoney(payDataForWorkplace.careWorkerPay.workplaceValue.value) + ' (hourly)',
+      );
+      expect(component.seniorCareWorkerPay).toEqual(
+        FormatUtil.formatMoney(payDataForWorkplace.seniorCareWorkerPay.workplaceValue.value) + ' (hourly)',
+      );
+      expect(component.registeredNurseSalary).toEqual(
+        FormatUtil.formatSalary(payDataForWorkplace.registeredNursePay.workplaceValue.value) + ' (annually)',
+      );
+      expect(component.registeredManagerSalary).toEqual(
+        FormatUtil.formatSalary(payDataForWorkplace.registeredManagerPay.workplaceValue.value) + ' (annually)',
+      );
+    });
+
+    it('should set "no data added" when there is no workplace pay data', async () => {
+      const { component, fixture, queryByTestId } = await setup();
+
+      const payDataWithoutWorkplaceData = {
+        meta: {
+          workplaces: 0,
+          staff: 0,
+          localAuthority: 'Oxfordshire',
+        },
+        careWorkerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 900,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 1000,
+            hasValue: true,
+          },
+        },
+        seniorCareWorkerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 780,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 800,
+            hasValue: true,
+          },
+        },
+        registeredNursePay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 27500,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 30000,
+            hasValue: true,
+          },
+        },
+        registeredManagerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 29000,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 30000,
+            hasValue: true,
+          },
+        },
+      };
+
+      component.data = payDataWithoutWorkplaceData;
+      component.ngOnChanges();
+
+      expect(component.careWorkerPay).toEqual('No data added');
+      expect(component.seniorCareWorkerPay).toEqual('No data added');
+      expect(component.registeredNurseSalary).toEqual('No data added');
+      expect(component.registeredManagerSalary).toEqual('No data added');
+    });
+  });
+
+  describe('comparison group data', async () => {
+    it('should be set when there is group data and the group select toggle is not set', async () => {
+      const { component, fixture, queryByTestId } = await setup();
+      const payDataForWorkplaceWithComparisonGroups = {
+        meta: {
+          workplaces: 0,
+          staff: 0,
+          localAuthority: 'Oxfordshire',
+        },
+        careWorkerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 900,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 1000,
+            hasValue: true,
+          },
+        },
+        seniorCareWorkerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 780,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 800,
+            hasValue: true,
+          },
+        },
+        registeredNursePay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 27500,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 30000,
+            hasValue: true,
+          },
+        },
+        registeredManagerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 29000,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 30000,
+            hasValue: true,
+          },
+        },
+      };
+      component.viewBenchmarksComparisonGroups = false;
+      component.data = payDataForWorkplaceWithComparisonGroups;
+      component.ngOnChanges();
+
+      expect(component.comparisionGroupCareWorkerPay).toEqual(
+        FormatUtil.formatMoney(payDataForWorkplaceWithComparisonGroups.careWorkerPay.comparisonGroup.value) +
+          ' (hourly)',
+      );
+      expect(component.comparisionGroupSeniorCareWorkerPay).toEqual(
+        FormatUtil.formatMoney(payDataForWorkplaceWithComparisonGroups.seniorCareWorkerPay.comparisonGroup.value) +
+          ' (hourly)',
+      );
+      expect(component.comparisionGroupRegisteredNurseSalary).toEqual(
+        FormatUtil.formatSalary(payDataForWorkplaceWithComparisonGroups.registeredNursePay.comparisonGroup.value) +
+          ' (annually)',
+      );
+      expect(component.comparisionGroupRegisteredManagerSalary).toEqual(
+        FormatUtil.formatSalary(payDataForWorkplaceWithComparisonGroups.registeredManagerPay.comparisonGroup.value) +
+          ' (annually)',
+      );
+    });
+
+    it('should be set with good and outstanding when there is group data and the group select toggle is set', async () => {
+      const { component, fixture, queryByTestId } = await setup();
+      const payDataForWorkplaceWithComparisonGroups = {
+        meta: {
+          workplaces: 0,
+          staff: 0,
+          localAuthority: 'Oxfordshire',
+        },
+        careWorkerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 900,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 1000,
+            hasValue: true,
+          },
+        },
+        seniorCareWorkerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 780,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 800,
+            hasValue: true,
+          },
+        },
+        registeredNursePay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 27500,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 30000,
+            hasValue: true,
+          },
+        },
+        registeredManagerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 29000,
+            hasValue: true,
+          },
+          goodCqc: {
+            value: 30000,
+            hasValue: true,
+          },
+        },
+      };
+      component.viewBenchmarksComparisonGroups = true;
+      component.data = payDataForWorkplaceWithComparisonGroups;
+      component.ngOnChanges();
+
+      expect(component.comparisionGroupCareWorkerPay).toEqual(
+        FormatUtil.formatMoney(payDataForWorkplaceWithComparisonGroups.careWorkerPay.goodCqc.value) + ' (hourly)',
+      );
+      expect(component.comparisionGroupSeniorCareWorkerPay).toEqual(
+        FormatUtil.formatMoney(payDataForWorkplaceWithComparisonGroups.seniorCareWorkerPay.goodCqc.value) + ' (hourly)',
+      );
+      expect(component.comparisionGroupRegisteredNurseSalary).toEqual(
+        FormatUtil.formatSalary(payDataForWorkplaceWithComparisonGroups.registeredNursePay.goodCqc.value) +
+          ' (annually)',
+      );
+      expect(component.comparisionGroupRegisteredManagerSalary).toEqual(
+        FormatUtil.formatSalary(payDataForWorkplaceWithComparisonGroups.registeredManagerPay.goodCqc.value) +
+          ' (annually)',
+      );
+    });
+
+    it('should be set to "Not enough data" when comparison group data is not available', async () => {
+      const { component, fixture, queryByTestId } = await setup();
+      const payDataWithoutComparisonData = {
+        meta: {
+          workplaces: 0,
+          staff: 0,
+          localAuthority: 'Oxfordshire',
+        },
+        careWorkerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 0,
+            hasValue: false,
+            stateMessage: 'no-data',
+          },
+          goodCqc: {
+            value: 0,
+            hasValue: false,
+            stateMessage: 'no-data',
+          },
+        },
+        seniorCareWorkerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 0,
+            hasValue: false,
+            stateMessage: 'no-data',
+          },
+          goodCqc: {
+            value: 0,
+            hasValue: false,
+            stateMessage: 'no-data',
+          },
+        },
+        registeredNursePay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+            stateMessage: 'no-pay-data',
+          },
+          comparisonGroup: {
+            value: 0,
+            hasValue: false,
+            stateMessage: 'no-data',
+          },
+          goodCqc: {
+            value: 0,
+            hasValue: false,
+            stateMessage: 'no-data',
+          },
+        },
+        registeredManagerPay: {
+          workplaceValue: {
+            value: 0,
+            hasValue: false,
+          },
+          comparisonGroup: {
+            value: 0,
+            hasValue: false,
+            stateMessage: 'no-data',
+          },
+          goodCqc: {
+            value: 0,
+            hasValue: false,
+            stateMessage: 'no-data',
+          },
+        },
+      };
+      component.viewBenchmarksComparisonGroups = true;
+      component.data = payDataWithoutComparisonData;
+      component.ngOnChanges();
+
+      expect(component.comparisionGroupCareWorkerPay).toEqual('Not enough data');
+      expect(component.comparisionGroupSeniorCareWorkerPay).toEqual('Not enough data');
+      expect(component.comparisionGroupRegisteredNurseSalary).toEqual('Not enough data');
+      expect(component.comparisionGroupRegisteredManagerSalary).toEqual('Not enough data');
+
+      component.viewBenchmarksComparisonGroups = false;
+      component.ngOnChanges();
+      expect(component.comparisionGroupCareWorkerPay).toEqual('Not enough data');
+      expect(component.comparisionGroupSeniorCareWorkerPay).toEqual('Not enough data');
+      expect(component.comparisionGroupRegisteredNurseSalary).toEqual('Not enough data');
+      expect(component.comparisionGroupRegisteredManagerSalary).toEqual('Not enough data');
+    });
   });
 });

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
@@ -8,6 +8,7 @@ import { BenchmarksResponse } from '@core/model/benchmarks.model';
 })
 export class DataAreaPayComponent {
   @Input() data: BenchmarksResponse;
+  @Input() viewBenchmarksComparisonGroups: boolean;
   public viewBenchmarksPosition = false;
 
   public handleViewBenchmarkPosition(visible: boolean): void {

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
@@ -1,17 +1,70 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { BenchmarksResponse } from '@core/model/benchmarks.model';
+import { FormatUtil } from '@core/utils/format-util';
 
 @Component({
   selector: 'app-data-area-pay',
   templateUrl: './data-area-pay.component.html',
   styleUrls: ['../data-area-tab.component.scss'],
 })
-export class DataAreaPayComponent {
+export class DataAreaPayComponent implements OnChanges {
   @Input() data: BenchmarksResponse;
   @Input() viewBenchmarksComparisonGroups: boolean;
+  @Input() showRegisteredNurseSalary: boolean;
   public viewBenchmarksPosition = false;
+  public careWorkerPay: string;
+  public seniorCareWorkerPay: string;
+  public registeredNurseSalary: string;
+  public registeredManagerSalary: string;
+  public comparisionGroupCareWorkerPay: string;
+  public comparisionGroupSeniorCareWorkerPay: string;
+  public comparisionGroupRegisteredNurseSalary: string;
+  public comparisionGroupRegisteredManagerSalary: string;
+  public formatMoney = FormatUtil.formatMoney;
+  public formatSalary = FormatUtil.formatSalary;
+
+  ngOnChanges(): void {
+    this.showWorkplacePayAndSalary();
+    this.showComparisionGroupPayAndSalary();
+  }
 
   public handleViewBenchmarkPosition(visible: boolean): void {
     this.viewBenchmarksPosition = visible;
+  }
+  public showWorkplacePayAndSalary(): void {
+    this.careWorkerPay = `${this.formatMoney(this.data?.careWorkerPay.workplaceValue.value)} (hourly)`;
+    this.seniorCareWorkerPay = `${this.formatMoney(this.data?.seniorCareWorkerPay.workplaceValue.value)} (hourly)`;
+    this.registeredNurseSalary = `${this.formatMoney(this.data?.registeredNursePay.workplaceValue.value)} (annually)`;
+    this.registeredManagerSalary = `${this.formatMoney(
+      this.data?.registeredManagerPay.workplaceValue.value,
+    )} (annually)`;
+  }
+
+  public showComparisionGroupPayAndSalary(): void {
+    if (this.viewBenchmarksComparisonGroups) {
+      this.comparisionGroupCareWorkerPay = `${this.formatMoney(this.data?.careWorkerPay.goodCqc.value)} (hourly)`;
+      this.comparisionGroupSeniorCareWorkerPay = `${this.formatMoney(
+        this.data?.seniorCareWorkerPay.goodCqc.value,
+      )} (hourly)`;
+      this.comparisionGroupRegisteredNurseSalary = `${this.formatSalary(
+        this.data?.registeredNursePay.goodCqc.value,
+      )} (annually)`;
+      this.comparisionGroupRegisteredManagerSalary = `${this.formatSalary(
+        this.data?.registeredManagerPay.goodCqc.value,
+      )} (annually)`;
+    } else {
+      this.comparisionGroupCareWorkerPay = `${this.formatMoney(
+        this.data?.careWorkerPay.comparisonGroup.value,
+      )} (hourly)`;
+      this.comparisionGroupSeniorCareWorkerPay = `${this.formatMoney(
+        this.data?.seniorCareWorkerPay.comparisonGroup.value,
+      )} (hourly)`;
+      this.comparisionGroupRegisteredNurseSalary = `${this.formatSalary(
+        this.data?.registeredNursePay.comparisonGroup.value,
+      )} (annually)`;
+      this.comparisionGroupRegisteredManagerSalary = `${this.formatSalary(
+        this.data?.registeredManagerPay.comparisonGroup.value,
+      )} (annually)`;
+    }
   }
 }

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
@@ -31,6 +31,7 @@ export class DataAreaPayComponent implements OnChanges {
   public handleViewBenchmarkPosition(visible: boolean): void {
     this.viewBenchmarksPosition = visible;
   }
+
   public showWorkplacePayAndSalary(): void {
     this.careWorkerPay = this.data.careWorkerPay.workplaceValue.hasValue
       ? `${this.formatMoney(this.data?.careWorkerPay.workplaceValue.value)} (hourly)`
@@ -39,38 +40,40 @@ export class DataAreaPayComponent implements OnChanges {
       ? `${this.formatMoney(this.data?.seniorCareWorkerPay.workplaceValue.value)} (hourly)`
       : 'No data added';
     this.registeredNurseSalary = this.data.registeredNursePay.workplaceValue.hasValue
-      ? `${this.formatMoney(this.data?.registeredNursePay.workplaceValue.value)} (annually)`
+      ? `${this.formatSalary(this.data?.registeredNursePay.workplaceValue.value)} (annually)`
       : 'No data added';
     this.registeredManagerSalary = this.data.registeredManagerPay.workplaceValue.hasValue
-      ? `${this.formatMoney(this.data?.registeredManagerPay.workplaceValue.value)} (annually)`
+      ? `${this.formatSalary(this.data?.registeredManagerPay.workplaceValue.value)} (annually)`
       : 'No data added';
   }
 
   public showComparisionGroupPayAndSalary(): void {
     if (this.viewBenchmarksComparisonGroups) {
-      this.comparisionGroupCareWorkerPay = `${this.formatMoney(this.data?.careWorkerPay.goodCqc.value)} (hourly)`;
-      this.comparisionGroupSeniorCareWorkerPay = `${this.formatMoney(
-        this.data?.seniorCareWorkerPay.goodCqc.value,
-      )} (hourly)`;
-      this.comparisionGroupRegisteredNurseSalary = `${this.formatSalary(
-        this.data?.registeredNursePay.goodCqc.value,
-      )} (annually)`;
-      this.comparisionGroupRegisteredManagerSalary = `${this.formatSalary(
-        this.data?.registeredManagerPay.goodCqc.value,
-      )} (annually)`;
+      this.comparisionGroupCareWorkerPay = this.data?.careWorkerPay.goodCqc.hasValue
+        ? `${this.formatMoney(this.data?.careWorkerPay.goodCqc.value)} (hourly)`
+        : 'Not enough data';
+      this.comparisionGroupSeniorCareWorkerPay = this.data?.seniorCareWorkerPay.goodCqc.hasValue
+        ? `${this.formatMoney(this.data?.seniorCareWorkerPay.goodCqc.value)} (hourly)`
+        : 'Not enough data';
+      this.comparisionGroupRegisteredNurseSalary = this.data?.registeredNursePay.goodCqc.hasValue
+        ? `${this.formatSalary(this.data?.registeredNursePay.goodCqc.value)} (annually)`
+        : 'Not enough data';
+      this.comparisionGroupRegisteredManagerSalary = this.data?.registeredManagerPay.goodCqc.hasValue
+        ? `${this.formatSalary(this.data?.registeredManagerPay.goodCqc.value)} (annually)`
+        : 'Not enough data';
     } else {
-      this.comparisionGroupCareWorkerPay = `${this.formatMoney(
-        this.data?.careWorkerPay.comparisonGroup.value,
-      )} (hourly)`;
-      this.comparisionGroupSeniorCareWorkerPay = `${this.formatMoney(
-        this.data?.seniorCareWorkerPay.comparisonGroup.value,
-      )} (hourly)`;
-      this.comparisionGroupRegisteredNurseSalary = `${this.formatSalary(
-        this.data?.registeredNursePay.comparisonGroup.value,
-      )} (annually)`;
-      this.comparisionGroupRegisteredManagerSalary = `${this.formatSalary(
-        this.data?.registeredManagerPay.comparisonGroup.value,
-      )} (annually)`;
+      this.comparisionGroupCareWorkerPay = this.data?.careWorkerPay.comparisonGroup.hasValue
+        ? `${this.formatMoney(this.data?.careWorkerPay.comparisonGroup.value)} (hourly)`
+        : 'Not enough data';
+      this.comparisionGroupSeniorCareWorkerPay = this.data?.seniorCareWorkerPay.comparisonGroup.hasValue
+        ? `${this.formatMoney(this.data?.seniorCareWorkerPay.comparisonGroup.value)} (hourly)`
+        : 'Not enough data';
+      this.comparisionGroupRegisteredNurseSalary = this.data?.registeredNursePay.comparisonGroup.hasValue
+        ? `${this.formatSalary(this.data?.registeredNursePay.comparisonGroup.value)} (annually)`
+        : 'Not enough data';
+      this.comparisionGroupRegisteredManagerSalary = this.data?.registeredManagerPay.comparisonGroup.hasValue
+        ? `${this.formatSalary(this.data?.registeredManagerPay.comparisonGroup.value)} (annually)`
+        : 'Not enough data';
     }
   }
 }

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
@@ -32,12 +32,18 @@ export class DataAreaPayComponent implements OnChanges {
     this.viewBenchmarksPosition = visible;
   }
   public showWorkplacePayAndSalary(): void {
-    this.careWorkerPay = `${this.formatMoney(this.data?.careWorkerPay.workplaceValue.value)} (hourly)`;
-    this.seniorCareWorkerPay = `${this.formatMoney(this.data?.seniorCareWorkerPay.workplaceValue.value)} (hourly)`;
-    this.registeredNurseSalary = `${this.formatMoney(this.data?.registeredNursePay.workplaceValue.value)} (annually)`;
-    this.registeredManagerSalary = `${this.formatMoney(
-      this.data?.registeredManagerPay.workplaceValue.value,
-    )} (annually)`;
+    this.careWorkerPay = this.data.careWorkerPay.workplaceValue.hasValue
+      ? `${this.formatMoney(this.data?.careWorkerPay.workplaceValue.value)} (hourly)`
+      : 'No data added';
+    this.seniorCareWorkerPay = this.data.seniorCareWorkerPay.workplaceValue.hasValue
+      ? `${this.formatMoney(this.data?.seniorCareWorkerPay.workplaceValue.value)} (hourly)`
+      : 'No data added';
+    this.registeredNurseSalary = this.data.registeredNursePay.workplaceValue.hasValue
+      ? `${this.formatMoney(this.data?.registeredNursePay.workplaceValue.value)} (annually)`
+      : 'No data added';
+    this.registeredManagerSalary = this.data.registeredManagerPay.workplaceValue.hasValue
+      ? `${this.formatMoney(this.data?.registeredManagerPay.workplaceValue.value)} (annually)`
+      : 'No data added';
   }
 
   public showComparisionGroupPayAndSalary(): void {

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -90,7 +90,11 @@
         ></app-data-area-recruitment-and-retention>
       </ng-container>
       <ng-template #showPay>
-        <app-data-area-pay [data]="tilesData" data-testid="payArea"></app-data-area-pay>
+        <app-data-area-pay
+          [data]="tilesData"
+          data-testid="payArea"
+          [viewBenchmarksComparisonGroups]="viewBenchmarksComparisonGroups"
+        ></app-data-area-pay>
       </ng-template>
 
       <div class="govuk-!-margin-top-7">

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -94,6 +94,7 @@
           [data]="tilesData"
           data-testid="payArea"
           [viewBenchmarksComparisonGroups]="viewBenchmarksComparisonGroups"
+          [showRegisteredNurseSalary]="showRegisteredNurseSalary"
         ></app-data-area-pay>
       </ng-template>
 

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.ts
@@ -30,6 +30,7 @@ export class DataAreaTabComponent implements OnInit, OnDestroy {
   public viewBenchmarksPosition = false;
   public downloadRecruitmentBenchmarksText: string;
   public tilesData: BenchmarksResponse;
+  public showRegisteredNurseSalary: boolean;
 
   constructor(
     private permissionsService: PermissionsService,
@@ -45,6 +46,7 @@ export class DataAreaTabComponent implements OnInit, OnDestroy {
     this.canViewFullBenchmarks = this.permissionsService.can(this.workplace.uid, 'canViewBenchmarks');
     this.breadcrumbService.show(JourneyType.BENCHMARKS_TAB);
     this.setDownloadBenchmarksText();
+    this.showRegisteredNurseSalary = this.workplace.mainService.reportingID === 1 ? true : false;
   }
 
   public async downloadAsPDF() {


### PR DESCRIPTION
#### Work done
- As part of work for [247-data-area-comparison-groups-table-pay](https://trello.com/c/I7vusOqI/1247-data-area-comparison-groups-table-pay)
- Add pay table to data area pay component. 
- Set the pay and salary string from benchmark data

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
