### PR TITLE
Add rankings resolver and set pay rankings data on data area pay

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -18,6 +18,7 @@ import { LoggedInUserResolver } from '@core/resolvers/logged-in-user.resolver';
 import { NotificationsListResolver } from '@core/resolvers/notifications-list.resolver';
 import { PageResolver } from '@core/resolvers/page.resolver';
 import { PrimaryWorkplaceResolver } from '@core/resolvers/primary-workplace.resolver';
+import { RankingsResolver } from '@core/resolvers/rankings.resolver';
 import { WizardResolver } from '@core/resolvers/wizard/wizard.resolver';
 import { WorkersResolver } from '@core/resolvers/workers.resolver';
 import { AdminComponent } from '@features/admin/admin.component';
@@ -141,6 +142,7 @@ const routes: Routes = [
           totalStaffRecords: TotalStaffRecordsResolver,
           cqcStatusCheck: CqcStatusCheckResolver,
           benchmarks: BenchmarksResolver,
+          rankings: RankingsResolver,
         },
         data: { title: 'Dashboard', workerPagination: true },
       },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { LoggedInUserResolver } from '@core/resolvers/logged-in-user.resolver';
 import { NotificationsListResolver } from '@core/resolvers/notifications-list.resolver';
 import { PageResolver } from '@core/resolvers/page.resolver';
 import { PrimaryWorkplaceResolver } from '@core/resolvers/primary-workplace.resolver';
+import { RankingsResolver } from '@core/resolvers/rankings.resolver';
 import { WizardResolver } from '@core/resolvers/wizard/wizard.resolver';
 import { WorkersResolver } from '@core/resolvers/workers.resolver';
 import { AuthInterceptor } from '@core/services/auth-interceptor';
@@ -189,6 +190,7 @@ import { SentryErrorHandler } from './SentryErrorHandler.component';
     TotalStaffRecordsResolver,
     CqcStatusCheckResolver,
     BenchmarksResolver,
+    RankingsResolver,
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/core/model/benchmarks.model.ts
+++ b/src/app/core/model/benchmarks.model.ts
@@ -35,10 +35,15 @@ export interface BenchmarkValue {
 }
 
 export interface RankingsResponse {
-  currentRank: number;
-  maxRank: number;
+  currentRank?: number;
+  maxRank?: number;
   hasValue: boolean;
-  stateMessage: string;
+  stateMessage?: string;
+  allValues?: Array<RankingsValue>;
+}
+export interface RankingsValue {
+  value: number;
+  currentEst: boolean;
 }
 
 export interface CompareGroupsRankingsResponse {
@@ -57,7 +62,9 @@ export interface AllRankingsResponse {
   pay: PayRankingsResponse;
   qualifications: CompareGroupsRankingsResponse;
   sickness: CompareGroupsRankingsResponse;
-  turnoverRate: CompareGroupsRankingsResponse;
+  turnover: CompareGroupsRankingsResponse;
+  vacancy: CompareGroupsRankingsResponse;
+  timeInRole: CompareGroupsRankingsResponse;
 }
 
 export enum Metric {

--- a/src/app/core/resolvers/rankings.resolver.spec.ts
+++ b/src/app/core/resolvers/rankings.resolver.spec.ts
@@ -1,0 +1,50 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { BenchmarksService } from '@core/services/benchmarks.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+
+import { RankingsResolver } from './rankings.resolver';
+
+describe('RankingsResollver', () => {
+  function setup() {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [
+        RankingsResolver,
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
+        },
+      ],
+    });
+
+    const resolver = TestBed.inject(RankingsResolver);
+    const route = TestBed.inject(ActivatedRoute);
+
+    const benchmarksService = TestBed.inject(BenchmarksService);
+    const benchmarksSpy = spyOn(benchmarksService, 'getAllRankingData').and.callThrough();
+
+    return {
+      resolver,
+      route,
+      benchmarksSpy,
+    };
+  }
+
+  it('should create', () => {
+    const { resolver } = setup();
+    expect(resolver).toBeTruthy();
+  });
+
+  it('should call the getAllRankingData function with the workplace uid', async () => {
+    const { resolver, route, benchmarksSpy } = await setup();
+
+    resolver.resolve(route.snapshot);
+
+    const establishmentId = MockEstablishmentService.prototype.establishmentId;
+    expect(benchmarksSpy).toHaveBeenCalledWith(establishmentId);
+  });
+});

--- a/src/app/core/resolvers/rankings.resolver.ts
+++ b/src/app/core/resolvers/rankings.resolver.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { BenchmarksService } from '@core/services/benchmarks.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { of } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Injectable()
+export class RankingsResolver implements Resolve<any> {
+  constructor(private establishmentService: EstablishmentService, private benchmarksService: BenchmarksService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    const workplaceUid = this.establishmentService.establishmentId;
+
+    if (workplaceUid) {
+      return this.benchmarksService.getAllRankingData(workplaceUid).pipe(
+        tap((rankingsData) => {
+          this.benchmarksService.rankingsData = rankingsData;
+        }),
+      );
+    }
+    return of(null);
+  }
+}

--- a/src/app/core/services/benchmarks.service.ts
+++ b/src/app/core/services/benchmarks.service.ts
@@ -15,6 +15,7 @@ import { Observable } from 'rxjs';
 export class BenchmarksService {
   private returnToURL: URLStructure;
   private _benchmarksData$: BenchmarksResponse = null;
+  private _rankingsData$: AllRankingsResponse = null;
   constructor(private http: HttpClient) {}
 
   public get returnTo(): URLStructure {
@@ -31,6 +32,14 @@ export class BenchmarksService {
 
   public set benchmarksData(benchmarksData) {
     this._benchmarksData$ = benchmarksData;
+  }
+
+  public get rankingsData(): AllRankingsResponse {
+    return this._rankingsData$;
+  }
+
+  public set rankingsData(rankingsData) {
+    this._rankingsData$ = rankingsData;
   }
 
   postBenchmarkTabUsage(establishmentId: number) {

--- a/src/app/core/test-utils/MockBenchmarkService.ts
+++ b/src/app/core/test-utils/MockBenchmarkService.ts
@@ -15,10 +15,38 @@ const allRankingsResponseBuilder = build('AllRankingsResponse', {
           maxRank: fake((f) => f.datatype.number({ min: 2, max: 100 })),
           hasValue: true,
           stateMessage: '',
+          allValues: [],
+        },
+      },
+      seniorCareWorkerPay: {
+        groupRankings: {
+          currentRank: fake((f) => f.datatype.number({ min: 1, max: 100 })),
+          maxRank: fake((f) => f.datatype.number({ min: 2, max: 100 })),
+          hasValue: true,
+          stateMessage: '',
+          allValues: [],
+        },
+      },
+      registeredNursePay: {
+        groupRankings: {
+          currentRank: fake((f) => f.datatype.number({ min: 1, max: 100 })),
+          maxRank: fake((f) => f.datatype.number({ min: 2, max: 100 })),
+          hasValue: true,
+          stateMessage: '',
+          allValues: [],
+        },
+      },
+      registeredManagerPay: {
+        groupRankings: {
+          currentRank: fake((f) => f.datatype.number({ min: 1, max: 100 })),
+          maxRank: fake((f) => f.datatype.number({ min: 2, max: 100 })),
+          hasValue: true,
+          stateMessage: '',
+          allValues: [],
         },
       },
     },
-    turnoverRate: {
+    turnover: {
       groupRankings: {
         currentRank: fake((f) => f.datatype.number({ min: 1, max: 100 })),
         maxRank: fake((f) => f.datatype.number({ min: 2, max: 100 })),
@@ -35,6 +63,22 @@ const allRankingsResponseBuilder = build('AllRankingsResponse', {
       },
     },
     qualifications: {
+      groupRankings: {
+        currentRank: fake((f) => f.datatype.number({ min: 1, max: 100 })),
+        maxRank: fake((f) => f.datatype.number({ min: 2, max: 100 })),
+        hasValue: true,
+        stateMessage: '',
+      },
+    },
+    vacancy: {
+      groupRankings: {
+        currentRank: fake((f) => f.datatype.number({ min: 1, max: 100 })),
+        maxRank: fake((f) => f.datatype.number({ min: 2, max: 100 })),
+        hasValue: true,
+        stateMessage: '',
+      },
+    },
+    timeInRole: {
       groupRankings: {
         currentRank: fake((f) => f.datatype.number({ min: 1, max: 100 })),
         maxRank: fake((f) => f.datatype.number({ min: 2, max: 100 })),

--- a/src/app/shared/components/benchmark-metric/ranking-content/ranking-content.component.ts
+++ b/src/app/shared/components/benchmark-metric/ranking-content/ranking-content.component.ts
@@ -2,8 +2,8 @@ import { Component, Input } from '@angular/core';
 import { NoData } from '@core/model/benchmarks.model';
 
 export interface RankingContent {
-  stateMessage: string;
-  currentRank: number;
+  stateMessage?: string;
+  currentRank?: number;
   hasValue: boolean;
   noData: NoData;
   smallText?: boolean;

--- a/src/app/shared/components/benchmarks-tab/rankings/rankings.component.html
+++ b/src/app/shared/components/benchmarks-tab/rankings/rankings.component.html
@@ -51,11 +51,7 @@
   </div>
 </div>
 <p>{{ metricContent['Turnover'].description }}</p>
-<app-gauge
-  *ngIf="rankings.turnoverRate"
-  [maxRank]="turnoverContent.maxRank"
-  [currentRank]="turnoverContent.currentRank"
->
+<app-gauge *ngIf="rankings.turnover" [maxRank]="turnoverContent.maxRank" [currentRank]="turnoverContent.currentRank">
   <ng-container your-rank>
     <app-ranking-content *ngIf="turnoverContent" [content]="turnoverContent"></app-ranking-content>
   </ng-container>

--- a/src/app/shared/components/benchmarks-tab/rankings/rankings.component.spec.ts
+++ b/src/app/shared/components/benchmarks-tab/rankings/rankings.component.spec.ts
@@ -183,7 +183,7 @@ describe('BenchmarksRankingsComponent', () => {
       const rank = parseInt(content.split('Lowest')[0]);
 
       maxRanks.push(fixture.componentInstance.rankings.pay.careWorkerPay.groupRankings.maxRank);
-      maxRanks.push(fixture.componentInstance.rankings.turnoverRate.groupRankings.maxRank);
+      maxRanks.push(fixture.componentInstance.rankings.turnover.groupRankings.maxRank);
       maxRanks.push(fixture.componentInstance.rankings.sickness.groupRankings.maxRank);
       maxRanks.push(fixture.componentInstance.rankings.qualifications.groupRankings.maxRank);
 
@@ -201,7 +201,7 @@ describe('BenchmarksRankingsComponent', () => {
       const rank = parseInt(content);
 
       currentRanks.push(fixture.componentInstance.rankings.pay.careWorkerPay.groupRankings.currentRank);
-      currentRanks.push(fixture.componentInstance.rankings.turnoverRate.groupRankings.currentRank);
+      currentRanks.push(fixture.componentInstance.rankings.turnover.groupRankings.currentRank);
       currentRanks.push(fixture.componentInstance.rankings.sickness.groupRankings.currentRank);
       currentRanks.push(fixture.componentInstance.rankings.qualifications.groupRankings.currentRank);
 

--- a/src/app/shared/components/benchmarks-tab/rankings/rankings.component.ts
+++ b/src/app/shared/components/benchmarks-tab/rankings/rankings.component.ts
@@ -113,7 +113,7 @@ export class BenchmarksRankingsComponent implements OnInit, OnDestroy {
           noData: MetricsContent.Pay.noData,
         };
         this.turnoverContent = {
-          ...this.rankings.turnoverRate.groupRankings,
+          ...this.rankings.turnover.groupRankings,
           smallText: true,
           noData: MetricsContent.Turnover.noData,
         };

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.spec.ts
@@ -18,6 +18,136 @@ describe('DataAreaPayComponent', () => {
       declarations: [BenchmarksSelectViewPanelComponent],
       schemas: [NO_ERRORS_SCHEMA],
       componentProperties: {
+        rankingsData: {
+          pay: {
+            careWorkerPay: {
+              groupRankings: {
+                maxRank: 14,
+                currentRank: 7,
+                hasValue: true,
+                allValues: [],
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+            seniorCareWorkerPay: {
+              groupRankings: {
+                maxRank: 3,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+            registeredNursePay: {
+              groupRankings: {
+                maxRank: 9,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+              goodCqcRankings: {
+                maxRank: 3,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+            },
+            registeredManagerPay: {
+              groupRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+          },
+          turnover: {
+            groupRankings: {
+              maxRank: 54,
+              currentRank: 32,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 2,
+              hasValue: true,
+              allValues: [
+                {
+                  value: -1,
+                  currentEst: false,
+                },
+                {
+                  value: 0.3333333333333333,
+                  currentEst: true,
+                },
+                {
+                  value: 5,
+                  currentEst: false,
+                },
+              ],
+            },
+          },
+          sickness: {
+            groupRankings: {
+              maxRank: 42,
+              currentRank: 11,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 3,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+          qualifications: {
+            groupRankings: {
+              maxRank: 41,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              hasValue: false,
+              stateMessage: 'no-comparison-data',
+            },
+          },
+          vacancy: {
+            groupRankings: {
+              maxRank: 88,
+              currentRank: 21,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+          timeInRole: {
+            groupRankings: {
+              maxRank: 47,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+        },
         data: {
           meta: {
             workplaces: 0,

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
@@ -74,15 +74,15 @@ export class DataAreaPayComponent implements OnChanges {
 
   public setRankings(isGoodAndOutstanding: boolean): void {
     if (isGoodAndOutstanding) {
-      this.careWorkerRankings = this.rankingsData.pay.careWorkerPay.goodCqcRankings;
-      this.seniorCareWorkerRankings = this.rankingsData.pay.seniorCareWorkerPay.goodCqcRankings;
-      this.registeredNurseRankings = this.rankingsData.pay.registeredNursePay.goodCqcRankings;
-      this.registeredManagerRankings = this.rankingsData.pay.registeredManagerPay.goodCqcRankings;
+      this.careWorkerRankings = this.rankingsData?.pay.careWorkerPay.goodCqcRankings;
+      this.seniorCareWorkerRankings = this.rankingsData?.pay.seniorCareWorkerPay.goodCqcRankings;
+      this.registeredNurseRankings = this.rankingsData?.pay.registeredNursePay.goodCqcRankings;
+      this.registeredManagerRankings = this.rankingsData?.pay.registeredManagerPay.goodCqcRankings;
     } else {
-      this.careWorkerRankings = this.rankingsData.pay.careWorkerPay.groupRankings;
-      this.seniorCareWorkerRankings = this.rankingsData.pay.seniorCareWorkerPay.groupRankings;
-      this.registeredNurseRankings = this.rankingsData.pay.registeredNursePay.groupRankings;
-      this.registeredManagerRankings = this.rankingsData.pay.registeredManagerPay.groupRankings;
+      this.careWorkerRankings = this.rankingsData?.pay.careWorkerPay.groupRankings;
+      this.seniorCareWorkerRankings = this.rankingsData?.pay.seniorCareWorkerPay.groupRankings;
+      this.registeredNurseRankings = this.rankingsData?.pay.registeredNursePay.groupRankings;
+      this.registeredManagerRankings = this.rankingsData?.pay.registeredManagerPay.groupRankings;
     }
   }
 

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
@@ -1,5 +1,10 @@
 import { Component, Input, OnChanges } from '@angular/core';
-import { BenchmarksResponse, BenchmarkValue } from '@core/model/benchmarks.model';
+import {
+  AllRankingsResponse,
+  BenchmarksResponse,
+  BenchmarkValue,
+  RankingsResponse,
+} from '@core/model/benchmarks.model';
 import { FormatUtil } from '@core/utils/format-util';
 
 @Component({
@@ -9,6 +14,7 @@ import { FormatUtil } from '@core/utils/format-util';
 })
 export class DataAreaPayComponent implements OnChanges {
   @Input() data: BenchmarksResponse;
+  @Input() rankingsData: AllRankingsResponse;
   @Input() viewBenchmarksComparisonGroups: boolean;
   @Input() showRegisteredNurseSalary: boolean;
   public viewBenchmarksPosition = false;
@@ -20,25 +26,30 @@ export class DataAreaPayComponent implements OnChanges {
   public comparisionGroupSeniorCareWorkerPay: string;
   public comparisionGroupRegisteredNurseSalary: string;
   public comparisionGroupRegisteredManagerSalary: string;
+  public careWorkerRankings: RankingsResponse;
+  public seniorCareWorkerRankings: RankingsResponse;
+  public registeredNurseRankings: RankingsResponse;
+  public registeredManagerRankings: RankingsResponse;
 
   ngOnChanges(): void {
-    this.showWorkplacePayAndSalary();
-    this.showComparisionGroupPayAndSalary();
+    this.setWorkplacePayAndSalary();
+    this.setComparisionGroupPayAndSalary(this.viewBenchmarksComparisonGroups);
+    this.setRankings(this.viewBenchmarksComparisonGroups);
   }
 
   public handleViewBenchmarkPosition(visible: boolean): void {
     this.viewBenchmarksPosition = visible;
   }
 
-  public showWorkplacePayAndSalary(): void {
+  public setWorkplacePayAndSalary(): void {
     this.careWorkerPay = this.formatWorkplacePay(this.data.careWorkerPay.workplaceValue);
     this.seniorCareWorkerPay = this.formatWorkplacePay(this.data.seniorCareWorkerPay.workplaceValue);
     this.registeredNurseSalary = this.formatWorkplaceSalary(this.data.registeredNursePay.workplaceValue);
     this.registeredManagerSalary = this.formatWorkplaceSalary(this.data.registeredManagerPay.workplaceValue);
   }
 
-  public showComparisionGroupPayAndSalary(): void {
-    if (this.viewBenchmarksComparisonGroups) {
+  public setComparisionGroupPayAndSalary(isGoodAndOutstanding: boolean): void {
+    if (isGoodAndOutstanding) {
       this.comparisionGroupCareWorkerPay = this.formatComparisionGroupPay(this.data?.careWorkerPay.goodCqc);
       this.comparisionGroupSeniorCareWorkerPay = this.formatComparisionGroupPay(this.data?.seniorCareWorkerPay.goodCqc);
       this.comparisionGroupRegisteredNurseSalary = this.formatComparisionGroupSalary(
@@ -58,6 +69,20 @@ export class DataAreaPayComponent implements OnChanges {
       this.comparisionGroupRegisteredManagerSalary = this.formatComparisionGroupSalary(
         this.data?.registeredManagerPay.comparisonGroup,
       );
+    }
+  }
+
+  public setRankings(isGoodAndOutstanding: boolean): void {
+    if (isGoodAndOutstanding) {
+      this.careWorkerRankings = this.rankingsData.pay.careWorkerPay.goodCqcRankings;
+      this.seniorCareWorkerRankings = this.rankingsData.pay.seniorCareWorkerPay.goodCqcRankings;
+      this.registeredNurseRankings = this.rankingsData.pay.registeredNursePay.goodCqcRankings;
+      this.registeredManagerRankings = this.rankingsData.pay.registeredManagerPay.goodCqcRankings;
+    } else {
+      this.careWorkerRankings = this.rankingsData.pay.careWorkerPay.groupRankings;
+      this.seniorCareWorkerRankings = this.rankingsData.pay.seniorCareWorkerPay.groupRankings;
+      this.registeredNurseRankings = this.rankingsData.pay.registeredNursePay.groupRankings;
+      this.registeredManagerRankings = this.rankingsData.pay.registeredManagerPay.groupRankings;
     }
   }
 

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -94,6 +94,7 @@
       <ng-template #showPay>
         <app-data-area-pay
           [data]="tilesData"
+          [rankingsData]="rankingsData"
           data-testid="payArea"
           [viewBenchmarksComparisonGroups]="viewBenchmarksComparisonGroups"
           [showRegisteredNurseSalary]="showRegisteredNurseSalary"

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
-import { BenchmarksResponse, MetricsContent } from '@core/model/benchmarks.model';
+import { AllRankingsResponse, BenchmarksResponse, MetricsContent } from '@core/model/benchmarks.model';
 import { Establishment } from '@core/model/establishment.model';
 import { BenchmarksService } from '@core/services/benchmarks.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
@@ -31,6 +31,7 @@ export class DataAreaTabComponent implements OnInit, OnDestroy {
   public downloadRecruitmentBenchmarksText: string;
   public tilesData: BenchmarksResponse;
   public showRegisteredNurseSalary: boolean;
+  public rankingsData: AllRankingsResponse;
 
   constructor(
     private permissionsService: PermissionsService,
@@ -43,6 +44,7 @@ export class DataAreaTabComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.tilesData = this.benchmarksService.benchmarksData;
+    this.rankingsData = this.benchmarksService.rankingsData;
     this.canViewFullBenchmarks = this.permissionsService.can(this.workplace.uid, 'canViewBenchmarks');
     this.breadcrumbService.show(JourneyType.BENCHMARKS_TAB);
     this.setDownloadBenchmarksText();


### PR DESCRIPTION
#### Work done
- Work as part of [1251-data-area-pay-where-you-rank](https://trello.com/c/CpOIZOJT/1251-data-area-pay-where-you-rank)
- Adds the rankings resolver to get all rankings data. 
- Passes the rankings response to the pay data area
- Sets pay data in the pay data area component
- 
#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
