### PR TITLE
Fix/benchmarks card text

### DIFF
--- a/src/app/core/model/services.model.ts
+++ b/src/app/core/model/services.model.ts
@@ -5,6 +5,7 @@ export interface Service {
   name: string;
   other?: boolean;
   otherName?: string;
+  reportingID?: number;
 }
 
 export interface ServiceGroup {

--- a/src/app/features/new-dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.ts
@@ -38,7 +38,6 @@ export class NewHomeTabComponent implements OnInit, OnDestroy {
 
   private subscriptions: Subscription = new Subscription();
   public benchmarksMessage: string;
-  public benchmarksHeader: string;
   public canViewWorkplaces: boolean;
   public canViewReports: boolean;
   public canViewChangeDataOwner: boolean;

--- a/src/app/features/workplace/select-main-service/select-main-service.component.ts
+++ b/src/app/features/workplace/select-main-service/select-main-service.component.ts
@@ -44,6 +44,7 @@ export class SelectMainServiceComponent extends SelectMainServiceDirective {
       mainService: {
         id: selectedMainService.id,
         name: selectedMainService.name,
+        reportingID: selectedMainService.reportingID,
         ...(selectedMainService.otherName && { other: selectedMainService.otherName }),
       },
     };

--- a/src/app/shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component.scss
+++ b/src/app/shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component.scss
@@ -9,11 +9,16 @@
   }
 
   &__list-item {
-    padding: 10px 70px;
+    padding: 10px 35px;
+    margin-right: 35px;
     background-color: govuk-colour('white');
 
     &--active {
       border-bottom: 8px solid govuk-colour('blue');
+    }
+
+    &:not:first-of-type {
+      margin-left: 35px;
     }
   }
 


### PR DESCRIPTION
#### Work done
- fix for ticket [#1279-centralised solution to change the way main service is viewed on benchmark text](https://trello.com/c/W2NFVpp6/1279-centralised-solution-to-change-the-way-main-service-is-viewed-on-benchmark-text)
- changing main service was giving the wrong text on the benchmarks card when returning to the home screen until refresh
- add the main service reportingID to the update call
- remove some of the blue active border on benchmarks tabs

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
