### PR TITLE
Feat/1252 data area r and r where you rank

### DIFF
--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking-options-builder.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking-options-builder.ts
@@ -101,7 +101,8 @@ export class GaugeOptionsBuilder {
     if (!maxRank && !currentRank) {
       maxRank = 10000000;
     }
-    const topMargin = currentRank ? 55 : 0;
+
+    const topMargin = currentRank ? 35 : 15;
     const padding = maxRank / 85;
 
     return this.build(maxRank, currentRank, padding, topMargin);

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking-options-builder.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking-options-builder.ts
@@ -102,7 +102,7 @@ export class GaugeOptionsBuilder {
       maxRank = 10000000;
     }
     const topMargin = currentRank ? 55 : 0;
-    const padding = 1;
+    const padding = maxRank / 85;
 
     return this.build(maxRank, currentRank, padding, topMargin);
   }

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import * as Highcharts from 'highcharts';
 
 import { GaugeOptionsBuilder } from './data-area-ranking-options-builder';
@@ -8,7 +8,7 @@ import { GaugeOptionsBuilder } from './data-area-ranking-options-builder';
   templateUrl: './data-area-ranking.component.html',
   styleUrls: ['./data-area-ranking.component.scss'],
 })
-export class DataAreaRankingComponent implements OnInit {
+export class DataAreaRankingComponent implements OnChanges {
   Highcharts: typeof Highcharts = Highcharts;
   @Input() rankingTitle: string;
   @Input() workplaceRankNumber: number;
@@ -18,7 +18,7 @@ export class DataAreaRankingComponent implements OnInit {
 
   constructor(private builder: GaugeOptionsBuilder) {}
 
-  ngOnInit() {
+  ngOnChanges(): void {
     this.options = this.builder.buildChartOptions(this.workplacesNumber, this.workplaceRankNumber);
   }
 }

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import * as Highcharts from 'highcharts';
 
 import { GaugeOptionsBuilder } from './data-area-ranking-options-builder';
@@ -8,7 +8,7 @@ import { GaugeOptionsBuilder } from './data-area-ranking-options-builder';
   templateUrl: './data-area-ranking.component.html',
   styleUrls: ['./data-area-ranking.component.scss'],
 })
-export class DataAreaRankingComponent implements OnChanges {
+export class DataAreaRankingComponent implements OnInit, OnChanges {
   Highcharts: typeof Highcharts = Highcharts;
   @Input() rankingTitle: string;
   @Input() workplaceRankNumber: number;
@@ -20,8 +20,11 @@ export class DataAreaRankingComponent implements OnChanges {
 
   constructor(private builder: GaugeOptionsBuilder) {}
 
-  ngOnChanges(): void {
+  ngOnInit() {
     this.options = this.builder.buildChartOptions(this.workplacesNumber, this.workplaceRankNumber);
   }
 
+  ngOnChanges(): void {
+    this.options = this.builder.buildChartOptions(this.workplacesNumber, this.workplaceRankNumber);
+  }
 }

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
@@ -1,17 +1,63 @@
-import { Component, Input } from '@angular/core';
-import { BenchmarksResponse } from '@core/model/benchmarks.model';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { AllRankingsResponse, BenchmarksResponse, RankingsResponse } from '@core/model/benchmarks.model';
 
 @Component({
   selector: 'app-data-area-recruitment-and-retention',
   templateUrl: './data-area-recruitment-and-retention.component.html',
   styleUrls: ['../data-area-tab.component.scss'],
 })
-export class DataAreaRecruitmentAndRetentionComponent {
+export class DataAreaRecruitmentAndRetentionComponent implements OnChanges {
   @Input() data: BenchmarksResponse;
+  @Input() rankingsData: AllRankingsResponse;
   @Input() viewBenchmarksComparisonGroups: boolean;
   public viewBenchmarksPosition = false;
+  public vacancyRankings: RankingsResponse;
+  public turnoverRankings: RankingsResponse;
+  public timeInRoleRankings: RankingsResponse;
+  public vacancyMaxRank;
+  public turnoverMaxRank;
+  public timeInRoleMaxRank;
+  public vacancyCurrentRank;
+  public turnoverCurrentRank;
+  public timeInRoleCurrentRank;
+
+  ngOnChanges(): void {
+    this.setRankings(this.viewBenchmarksComparisonGroups);
+  }
 
   public handleViewBenchmarkPosition(visible: boolean): void {
     this.viewBenchmarksPosition = visible;
+  }
+
+  public setCurrentRank(rankings: RankingsResponse) {
+    if (rankings.hasValue) {
+      return rankings.currentRank;
+    }
+  }
+
+  public setMaxRank(rankings: RankingsResponse) {
+    if (rankings.maxRank) {
+      return rankings.maxRank;
+    }
+  }
+
+  public setRankings(isGoodAndOutstanding: boolean): void {
+    if (isGoodAndOutstanding) {
+      this.vacancyRankings = this.rankingsData?.vacancy.goodCqcRankings;
+      this.turnoverRankings = this.rankingsData?.turnover.goodCqcRankings;
+      this.timeInRoleRankings = this.rankingsData?.timeInRole.goodCqcRankings;
+    } else {
+      this.vacancyRankings = this.rankingsData?.vacancy.groupRankings;
+      this.turnoverRankings = this.rankingsData?.turnover.groupRankings;
+      this.timeInRoleRankings = this.rankingsData?.timeInRole.groupRankings;
+    }
+
+    this.vacancyMaxRank = this.setMaxRank(this.vacancyRankings);
+    this.turnoverMaxRank = this.setMaxRank(this.turnoverRankings);
+    this.timeInRoleMaxRank = this.setMaxRank(this.timeInRoleRankings);
+
+    this.vacancyCurrentRank = this.setCurrentRank(this.vacancyRankings);
+    this.turnoverCurrentRank = this.setCurrentRank(this.turnoverRankings);
+    this.timeInRoleCurrentRank = this.setCurrentRank(this.timeInRoleRankings);
   }
 }

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
@@ -93,18 +93,18 @@
       <div class="govuk-!-margin-top-7" data-testid="rankings">
         <app-data-area-ranking
           [rankingTitle]="'Vacancy rate'"
-          [workplaceRankNumber]="18"
-          [workplacesNumber]="72"
+          [workplaceRankNumber]="vacancyCurrentRank"
+          [workplacesNumber]="vacancyMaxRank"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="'Turnover rate'"
-          [workplaceRankNumber]="51"
-          [workplacesNumber]="72"
+          [workplaceRankNumber]="turnoverCurrentRank"
+          [workplacesNumber]="turnoverMaxRank"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="'Percentage of staff still in their main job role after 12 months'"
-          [workplaceRankNumber]="36"
-          [workplacesNumber]="72"
+          [workplaceRankNumber]="timeInRoleCurrentRank"
+          [workplacesNumber]="timeInRoleMaxRank"
         ></app-data-area-ranking>
       </div>
     </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
@@ -200,7 +200,7 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
     expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
   });
 
-  fdescribe('rankings area', async () => {
+  describe('rankings area', async () => {
     it('should show when viewBenchmarksPosition is false', async () => {
       const { component, fixture, getByTestId, queryByTestId } = await setup();
 
@@ -211,307 +211,41 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
       expect(queryByTestId('barcharts')).toBeFalsy();
     });
 
-    describe('comparison grpoup rankings', async () => {
-      it('should set rankings group rankings when there is group data and group toggle is false', async () => {
+    describe('comparison group rankings', async () => {
+      it('should set group rankings when there is group data and group toggle is false', async () => {
         const { component, fixture } = await setup();
 
-        const rankingsDataForComparision = {
-          pay: {
-            careWorkerPay: {
-              groupRankings: {
-                maxRank: 14,
-                currentRank: 7,
-                hasValue: true,
-                allValues: [],
-              },
-              goodCqcRankings: {
-                hasValue: false,
-                stateMessage: 'no-comparison-data',
-              },
-            },
-            seniorCareWorkerPay: {
-              groupRankings: {
-                maxRank: 3,
-                hasValue: false,
-                stateMessage: 'no-pay-data',
-              },
-              goodCqcRankings: {
-                hasValue: false,
-                stateMessage: 'no-comparison-data',
-              },
-            },
-            registeredNursePay: {
-              groupRankings: {
-                maxRank: 9,
-                hasValue: false,
-                stateMessage: 'no-pay-data',
-              },
-              goodCqcRankings: {
-                maxRank: 3,
-                hasValue: false,
-                stateMessage: 'no-pay-data',
-              },
-            },
-            registeredManagerPay: {
-              groupRankings: {
-                hasValue: false,
-                stateMessage: 'no-comparison-data',
-              },
-              goodCqcRankings: {
-                hasValue: false,
-                stateMessage: 'no-comparison-data',
-              },
-            },
-          },
-          turnover: {
-            groupRankings: {
-              maxRank: 54,
-              currentRank: 32,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              maxRank: 3,
-              currentRank: 2,
-              hasValue: true,
-              allValues: [
-                {
-                  value: -1,
-                  currentEst: false,
-                },
-                {
-                  value: 0.3333333333333333,
-                  currentEst: true,
-                },
-                {
-                  value: 5,
-                  currentEst: false,
-                },
-              ],
-            },
-          },
-          sickness: {
-            groupRankings: {
-              maxRank: 42,
-              currentRank: 11,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              maxRank: 3,
-              currentRank: 3,
-              hasValue: true,
-              allValues: [],
-            },
-          },
-          qualifications: {
-            groupRankings: {
-              maxRank: 41,
-              currentRank: 1,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              hasValue: false,
-              stateMessage: 'no-comparison-data',
-            },
-          },
-          vacancy: {
-            groupRankings: {
-              maxRank: 88,
-              currentRank: 21,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              maxRank: 3,
-              currentRank: 1,
-              hasValue: true,
-              allValues: [],
-            },
-          },
-          timeInRole: {
-            groupRankings: {
-              maxRank: 47,
-              currentRank: 2,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              maxRank: 7,
-              currentRank: 2,
-              hasValue: true,
-              allValues: [],
-            },
-          },
-        };
-
+        component.viewBenchmarksPosition = false;
         component.viewBenchmarksComparisonGroups = false;
         fixture.detectChanges();
 
-        component.rankingsData = rankingsDataForComparision;
         component.ngOnChanges();
 
-        expect(component.vacancyMaxRank).toEqual(rankingsDataForComparision.vacancy.groupRankings.maxRank);
-        expect(component.turnoverMaxRank).toEqual(rankingsDataForComparision.turnover.groupRankings.maxRank);
-        expect(component.timeInRoleMaxRank).toEqual(rankingsDataForComparision.timeInRole.groupRankings.maxRank);
+        expect(component.vacancyMaxRank).toEqual(component.rankingsData.vacancy.groupRankings.maxRank);
+        expect(component.turnoverMaxRank).toEqual(component.rankingsData.turnover.groupRankings.maxRank);
+        expect(component.timeInRoleMaxRank).toEqual(component.rankingsData.timeInRole.groupRankings.maxRank);
 
-        expect(component.vacancyCurrentRank).toEqual(rankingsDataForComparision.vacancy.groupRankings.currentRank);
-        expect(component.turnoverCurrentRank).toEqual(rankingsDataForComparision.turnover.groupRankings.currentRank);
-        expect(component.timeInRoleCurrentRank).toEqual(
-          rankingsDataForComparision.timeInRole.groupRankings.currentRank,
-        );
+        expect(component.vacancyCurrentRank).toEqual(component.rankingsData.vacancy.groupRankings.currentRank);
+        expect(component.turnoverCurrentRank).toEqual(component.rankingsData.turnover.groupRankings.currentRank);
+        expect(component.timeInRoleCurrentRank).toEqual(component.rankingsData.timeInRole.groupRankings.currentRank);
       });
 
-      it('should set rankings group rankings when there is group data and group toggle is true', async () => {
+      it('should set good cqc rankings when there is group data and group toggle is true', async () => {
         const { component, fixture } = await setup();
 
-        const rankingsDataForComparision = {
-          pay: {
-            careWorkerPay: {
-              groupRankings: {
-                maxRank: 14,
-                currentRank: 7,
-                hasValue: true,
-                allValues: [],
-              },
-              goodCqcRankings: {
-                hasValue: false,
-                stateMessage: 'no-comparison-data',
-              },
-            },
-            seniorCareWorkerPay: {
-              groupRankings: {
-                maxRank: 3,
-                hasValue: false,
-                stateMessage: 'no-pay-data',
-              },
-              goodCqcRankings: {
-                hasValue: false,
-                stateMessage: 'no-comparison-data',
-              },
-            },
-            registeredNursePay: {
-              groupRankings: {
-                maxRank: 9,
-                hasValue: false,
-                stateMessage: 'no-pay-data',
-              },
-              goodCqcRankings: {
-                maxRank: 3,
-                hasValue: false,
-                stateMessage: 'no-pay-data',
-              },
-            },
-            registeredManagerPay: {
-              groupRankings: {
-                hasValue: false,
-                stateMessage: 'no-comparison-data',
-              },
-              goodCqcRankings: {
-                hasValue: false,
-                stateMessage: 'no-comparison-data',
-              },
-            },
-          },
-          turnover: {
-            groupRankings: {
-              maxRank: 54,
-              currentRank: 32,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              maxRank: 3,
-              currentRank: 2,
-              hasValue: true,
-              allValues: [
-                {
-                  value: -1,
-                  currentEst: false,
-                },
-                {
-                  value: 0.3333333333333333,
-                  currentEst: true,
-                },
-                {
-                  value: 5,
-                  currentEst: false,
-                },
-              ],
-            },
-          },
-          sickness: {
-            groupRankings: {
-              maxRank: 42,
-              currentRank: 11,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              maxRank: 3,
-              currentRank: 3,
-              hasValue: true,
-              allValues: [],
-            },
-          },
-          qualifications: {
-            groupRankings: {
-              maxRank: 41,
-              currentRank: 1,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              hasValue: false,
-              stateMessage: 'no-comparison-data',
-            },
-          },
-          vacancy: {
-            groupRankings: {
-              maxRank: 88,
-              currentRank: 21,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              maxRank: 3,
-              currentRank: 1,
-              hasValue: true,
-              allValues: [],
-            },
-          },
-          timeInRole: {
-            groupRankings: {
-              maxRank: 47,
-              currentRank: 2,
-              hasValue: true,
-              allValues: [],
-            },
-            goodCqcRankings: {
-              maxRank: 7,
-              currentRank: 2,
-              hasValue: true,
-              allValues: [],
-            },
-          },
-        };
-
+        component.viewBenchmarksPosition = false;
         component.viewBenchmarksComparisonGroups = true;
         fixture.detectChanges();
 
-        component.rankingsData = rankingsDataForComparision;
         component.ngOnChanges();
 
-        expect(component.vacancyMaxRank).toEqual(rankingsDataForComparision.vacancy.goodCqcRankings.maxRank);
-        expect(component.turnoverMaxRank).toEqual(rankingsDataForComparision.turnover.goodCqcRankings.maxRank);
-        expect(component.timeInRoleMaxRank).toEqual(rankingsDataForComparision.timeInRole.goodCqcRankings.maxRank);
+        expect(component.vacancyMaxRank).toEqual(component.rankingsData.vacancy.goodCqcRankings.maxRank);
+        expect(component.turnoverMaxRank).toEqual(component.rankingsData.turnover.goodCqcRankings.maxRank);
+        expect(component.timeInRoleMaxRank).toEqual(component.rankingsData.timeInRole.goodCqcRankings.maxRank);
 
-        expect(component.vacancyCurrentRank).toEqual(rankingsDataForComparision.vacancy.goodCqcRankings.currentRank);
-        expect(component.turnoverCurrentRank).toEqual(rankingsDataForComparision.turnover.goodCqcRankings.currentRank);
-        expect(component.timeInRoleCurrentRank).toEqual(
-          rankingsDataForComparision.timeInRole.goodCqcRankings.currentRank,
-        );
+        expect(component.vacancyCurrentRank).toEqual(component.rankingsData.vacancy.goodCqcRankings.currentRank);
+        expect(component.turnoverCurrentRank).toEqual(component.rankingsData.turnover.goodCqcRankings.currentRank);
+        expect(component.timeInRoleCurrentRank).toEqual(component.rankingsData.timeInRole.goodCqcRankings.currentRank);
       });
     });
   });

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
@@ -4,9 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { benchmarksData } from '@core/test-utils/MockBenchmarkService';
-import {
-  BenchmarksSelectViewPanelComponent,
-} from '@shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component';
+import { BenchmarksSelectViewPanelComponent } from '@shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
 
@@ -22,6 +20,136 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
       componentProperties: {
         data: benchmarksData,
         viewBenchmarksComparisonGroups,
+        rankingsData: {
+          pay: {
+            careWorkerPay: {
+              groupRankings: {
+                maxRank: 14,
+                currentRank: 7,
+                hasValue: true,
+                allValues: [],
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+            seniorCareWorkerPay: {
+              groupRankings: {
+                maxRank: 3,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+            registeredNursePay: {
+              groupRankings: {
+                maxRank: 9,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+              goodCqcRankings: {
+                maxRank: 3,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+            },
+            registeredManagerPay: {
+              groupRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+          },
+          turnover: {
+            groupRankings: {
+              maxRank: 54,
+              currentRank: 32,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 2,
+              hasValue: true,
+              allValues: [
+                {
+                  value: -1,
+                  currentEst: false,
+                },
+                {
+                  value: 0.3333333333333333,
+                  currentEst: true,
+                },
+                {
+                  value: 5,
+                  currentEst: false,
+                },
+              ],
+            },
+          },
+          sickness: {
+            groupRankings: {
+              maxRank: 42,
+              currentRank: 11,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 3,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+          qualifications: {
+            groupRankings: {
+              maxRank: 41,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              hasValue: false,
+              stateMessage: 'no-comparison-data',
+            },
+          },
+          vacancy: {
+            groupRankings: {
+              maxRank: 88,
+              currentRank: 21,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+          timeInRole: {
+            groupRankings: {
+              maxRank: 47,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+        },
       },
     });
 
@@ -58,9 +186,8 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
   });
 
   it('should render the values for the workplace and goodCqc comparison data', async () => {
-    const { component, getByTestId } = await setup(true);
+    const { getByTestId } = await setup(true);
 
-    console.log(component.data.turnoverRate);
     const vacancyRow = getByTestId('vacancyRow');
     const turnoverRow = getByTestId('turnoverRow');
     const timeInRoleRow = getByTestId('timeInRoleRow');
@@ -73,14 +200,320 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
     expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
   });
 
-  it('should show the rankings area when viewBenchmarksPosition is false', async () => {
-    const { component, fixture, getByTestId, queryByTestId } = await setup();
+  fdescribe('rankings area', async () => {
+    it('should show when viewBenchmarksPosition is false', async () => {
+      const { component, fixture, getByTestId, queryByTestId } = await setup();
 
-    component.viewBenchmarksPosition = false;
-    fixture.detectChanges();
+      component.viewBenchmarksPosition = false;
+      fixture.detectChanges();
 
-    expect(getByTestId('rankings')).toBeTruthy();
-    expect(queryByTestId('barcharts')).toBeFalsy();
+      expect(getByTestId('rankings')).toBeTruthy();
+      expect(queryByTestId('barcharts')).toBeFalsy();
+    });
+
+    describe('comparison grpoup rankings', async () => {
+      it('should set rankings group rankings when there is group data and group toggle is false', async () => {
+        const { component, fixture } = await setup();
+
+        const rankingsDataForComparision = {
+          pay: {
+            careWorkerPay: {
+              groupRankings: {
+                maxRank: 14,
+                currentRank: 7,
+                hasValue: true,
+                allValues: [],
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+            seniorCareWorkerPay: {
+              groupRankings: {
+                maxRank: 3,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+            registeredNursePay: {
+              groupRankings: {
+                maxRank: 9,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+              goodCqcRankings: {
+                maxRank: 3,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+            },
+            registeredManagerPay: {
+              groupRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+          },
+          turnover: {
+            groupRankings: {
+              maxRank: 54,
+              currentRank: 32,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 2,
+              hasValue: true,
+              allValues: [
+                {
+                  value: -1,
+                  currentEst: false,
+                },
+                {
+                  value: 0.3333333333333333,
+                  currentEst: true,
+                },
+                {
+                  value: 5,
+                  currentEst: false,
+                },
+              ],
+            },
+          },
+          sickness: {
+            groupRankings: {
+              maxRank: 42,
+              currentRank: 11,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 3,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+          qualifications: {
+            groupRankings: {
+              maxRank: 41,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              hasValue: false,
+              stateMessage: 'no-comparison-data',
+            },
+          },
+          vacancy: {
+            groupRankings: {
+              maxRank: 88,
+              currentRank: 21,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+          timeInRole: {
+            groupRankings: {
+              maxRank: 47,
+              currentRank: 2,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 7,
+              currentRank: 2,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+        };
+
+        component.viewBenchmarksComparisonGroups = false;
+        fixture.detectChanges();
+
+        component.rankingsData = rankingsDataForComparision;
+        component.ngOnChanges();
+
+        expect(component.vacancyMaxRank).toEqual(rankingsDataForComparision.vacancy.groupRankings.maxRank);
+        expect(component.turnoverMaxRank).toEqual(rankingsDataForComparision.turnover.groupRankings.maxRank);
+        expect(component.timeInRoleMaxRank).toEqual(rankingsDataForComparision.timeInRole.groupRankings.maxRank);
+
+        expect(component.vacancyCurrentRank).toEqual(rankingsDataForComparision.vacancy.groupRankings.currentRank);
+        expect(component.turnoverCurrentRank).toEqual(rankingsDataForComparision.turnover.groupRankings.currentRank);
+        expect(component.timeInRoleCurrentRank).toEqual(
+          rankingsDataForComparision.timeInRole.groupRankings.currentRank,
+        );
+      });
+
+      it('should set rankings group rankings when there is group data and group toggle is true', async () => {
+        const { component, fixture } = await setup();
+
+        const rankingsDataForComparision = {
+          pay: {
+            careWorkerPay: {
+              groupRankings: {
+                maxRank: 14,
+                currentRank: 7,
+                hasValue: true,
+                allValues: [],
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+            seniorCareWorkerPay: {
+              groupRankings: {
+                maxRank: 3,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+            registeredNursePay: {
+              groupRankings: {
+                maxRank: 9,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+              goodCqcRankings: {
+                maxRank: 3,
+                hasValue: false,
+                stateMessage: 'no-pay-data',
+              },
+            },
+            registeredManagerPay: {
+              groupRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+              goodCqcRankings: {
+                hasValue: false,
+                stateMessage: 'no-comparison-data',
+              },
+            },
+          },
+          turnover: {
+            groupRankings: {
+              maxRank: 54,
+              currentRank: 32,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 2,
+              hasValue: true,
+              allValues: [
+                {
+                  value: -1,
+                  currentEst: false,
+                },
+                {
+                  value: 0.3333333333333333,
+                  currentEst: true,
+                },
+                {
+                  value: 5,
+                  currentEst: false,
+                },
+              ],
+            },
+          },
+          sickness: {
+            groupRankings: {
+              maxRank: 42,
+              currentRank: 11,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 3,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+          qualifications: {
+            groupRankings: {
+              maxRank: 41,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              hasValue: false,
+              stateMessage: 'no-comparison-data',
+            },
+          },
+          vacancy: {
+            groupRankings: {
+              maxRank: 88,
+              currentRank: 21,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 3,
+              currentRank: 1,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+          timeInRole: {
+            groupRankings: {
+              maxRank: 47,
+              currentRank: 2,
+              hasValue: true,
+              allValues: [],
+            },
+            goodCqcRankings: {
+              maxRank: 7,
+              currentRank: 2,
+              hasValue: true,
+              allValues: [],
+            },
+          },
+        };
+
+        component.viewBenchmarksComparisonGroups = true;
+        fixture.detectChanges();
+
+        component.rankingsData = rankingsDataForComparision;
+        component.ngOnChanges();
+
+        expect(component.vacancyMaxRank).toEqual(rankingsDataForComparision.vacancy.goodCqcRankings.maxRank);
+        expect(component.turnoverMaxRank).toEqual(rankingsDataForComparision.turnover.goodCqcRankings.maxRank);
+        expect(component.timeInRoleMaxRank).toEqual(rankingsDataForComparision.timeInRole.goodCqcRankings.maxRank);
+
+        expect(component.vacancyCurrentRank).toEqual(rankingsDataForComparision.vacancy.goodCqcRankings.currentRank);
+        expect(component.turnoverCurrentRank).toEqual(rankingsDataForComparision.turnover.goodCqcRankings.currentRank);
+        expect(component.timeInRoleCurrentRank).toEqual(
+          rankingsDataForComparision.timeInRole.goodCqcRankings.currentRank,
+        );
+      });
+    });
   });
 
   it('should show the barcharts area when viewBenchmarksPosition is true', async () => {

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -94,6 +94,7 @@
       <ng-container *ngIf="viewBenchmarksByCategory; else showPay">
         <app-data-area-recruitment-and-retention
           [data]="tilesData"
+          [rankingsData]="rankingsData"
           [viewBenchmarksComparisonGroups]="viewBenchmarksComparisonGroups"
           data-testid="recruitmentAndRetentionArea"
         ></app-data-area-recruitment-and-retention>


### PR DESCRIPTION
#### Work done
- [Ticket](https://trello.com/c/LpzAkpOf/1252-data-area-r-r-where-you-rank)
- Update recruitment and retention area to use benchmarks data in ranking gauge
- Update tests to include data changing to good and cqc group rankings 
- Update space for bottom line in data area ranking component


#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
