### PR TITLE
Fix/Update rankings component to lowercase text in no data message

### DIFF
--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
@@ -2,13 +2,13 @@
   <div class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-1">{{ rankingTitle }}</div>
   <ng-container *ngIf="workplaceRankNumber; else noRankingData">
     <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-3" data-testid="ranking-data">
-      Your workplace ranks <span class="govuk-!-font-weight-bold">{{ workplaceRankNumber }}</span> in a comparision
-      group of <span class="govuk-!-font-weight-bold">{{ workplacesNumber }} </span> workplaces.
+      Your workplace ranks <span class="govuk-!-font-weight-bold">{{ workplaceRankNumber }}</span> in a comparison group
+      of <span class="govuk-!-font-weight-bold">{{ workplacesNumber }} </span> workplaces.
     </p>
   </ng-container>
   <ng-template #noRankingData>
     <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-workplace-data">
-      You've not added any {{ rankingTitle.toLowerCase() }} data, so we cannot show you where you're ranked.
+      You've not added any {{ rankingTitle | lowercase }} data, so we cannot show you where you're ranked.
     </p>
   </ng-template>
   <div class="ranking-bar">

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
@@ -1,14 +1,14 @@
 <div class="govuk-!-margin-top-5 govuk-!-padding-3 govuk-!-padding-bottom-5 ranking-container">
   <div class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-1">{{ rankingTitle }}</div>
   <ng-container *ngIf="workplaceRankNumber; else noRankingData">
-  <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-3">
-    Your workplace ranks <span class="govuk-!-font-weight-bold">{{ workplaceRankNumber }}</span> in a comparision group
-    of <span class="govuk-!-font-weight-bold">{{ workplacesNumber }} </span> workplaces.
-  </p>
+    <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-3" data-testid="ranking-data">
+      Your workplace ranks <span class="govuk-!-font-weight-bold">{{ workplaceRankNumber }}</span> in a comparision
+      group of <span class="govuk-!-font-weight-bold">{{ workplacesNumber }} </span> workplaces.
+    </p>
   </ng-container>
   <ng-template #noRankingData>
-    <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2">
-      You've not added any {{ rankingTitle }} data, so we cannot show you where you're ranked.
+    <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-workplace-data">
+      You've not added any {{ rankingTitle.toLowerCase() }} data, so we cannot show you where you're ranked.
     </p>
   </ng-template>
   <div class="ranking-bar">

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
@@ -1,4 +1,6 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
+import { render } from '@testing-library/angular';
 
 import { DataAreaRankingComponent } from './data-area-ranking.component';
 
@@ -6,13 +8,48 @@ describe('DataAreaRankingComponent', () => {
   let component: DataAreaRankingComponent;
   let fixture: ComponentFixture<DataAreaRankingComponent>;
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DataAreaRankingComponent);
-    component = fixture.componentInstance;
+  const setup = async () => {
+    const { fixture, getByText, getByTestId, queryByTestId } = await render(DataAreaRankingComponent, {
+      imports: [],
+      providers: [],
+      declarations: [],
+      schemas: [NO_ERRORS_SCHEMA],
+      componentProperties: {
+        rankingTitle: 'Test ranking',
+      },
+    });
     fixture.detectChanges();
-  });
+    component = fixture.componentInstance;
+
+    return {
+      component,
+      fixture,
+      getByText,
+      getByTestId,
+      queryByTestId,
+    };
+  };
 
   it('should create', async () => {
+    const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should show rankings when data is provided', async () => {
+    const { fixture, component, queryByTestId, getByTestId } = await setup();
+    component.workplaceRankNumber = 7;
+    component.workplacesNumber = 10;
+    fixture.detectChanges();
+
+    expect(getByTestId('ranking-data')).toBeTruthy();
+  });
+
+  it('should show no workplace data message when no workplace data is provided', async () => {
+    const { fixture, component, queryByTestId, getByTestId } = await setup();
+    component.workplaceRankNumber = null;
+    component.workplacesNumber = 10;
+    fixture.detectChanges();
+
+    expect(getByTestId('no-workplace-data')).toBeTruthy();
   });
 });


### PR DESCRIPTION
#### Work done
- As part of [253-data-area-pay-missing-job-role-data-at-workplace](https://trello.com/c/m6wlpP66/1253-data-area-pay-missing-job-role-data-at-workplace)
- Update rankings component to lowercase the rankings title when used in the no data message

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
