### PR TITLE
Update bar chart component to use rankings data from backend

### DIFF
--- a/server/routes/establishments/benchmarks/rankings/index.js
+++ b/server/routes/establishments/benchmarks/rankings/index.js
@@ -28,6 +28,7 @@ const getPayRanking = async function (establishmentId, mainService, workerId) {
   const annualOrHourly = [CARE_WORKER_ID, SENIOR_CARE_WORKER_ID].includes(workerId) ? 'Hourly' : 'Annually';
   const field = annualOrHourly === 'Hourly' ? 'AverageHourlyRate' : 'AverageAnnualFTE';
   const currentmetricValue = await getPay({ establishmentId, annualOrHourly, mainJob: workerId });
+  console.log({ currentmetricValue });
 
   const groupRankings = await getComparisonGroupAndCalculateRanking(
     establishmentId,
@@ -199,8 +200,13 @@ const getComparisonGroupAndCalculateRanking = async function (
 
   const mappedComparisonGroupRankings = comparisonGroupRankings.map(mapComparisonGroupCallback).filter((a) => a);
   if (mappedComparisonGroupRankings.length === 0) {
+    const values = [];
+    if (!metric.stateMessage) {
+      values.push({ value: metric.value, currentEst: true });
+    }
+
     return {
-      allValues: [{ value: metric.value, currentEst: true }],
+      allValues: values,
       hasValue: false,
       stateMessage: 'no-comparison-data',
     };

--- a/server/routes/establishments/benchmarks/rankings/index.js
+++ b/server/routes/establishments/benchmarks/rankings/index.js
@@ -28,7 +28,6 @@ const getPayRanking = async function (establishmentId, mainService, workerId) {
   const annualOrHourly = [CARE_WORKER_ID, SENIOR_CARE_WORKER_ID].includes(workerId) ? 'Hourly' : 'Annually';
   const field = annualOrHourly === 'Hourly' ? 'AverageHourlyRate' : 'AverageAnnualFTE';
   const currentmetricValue = await getPay({ establishmentId, annualOrHourly, mainJob: workerId });
-  console.log({ currentmetricValue });
 
   const groupRankings = await getComparisonGroupAndCalculateRanking(
     establishmentId,

--- a/server/routes/establishments/benchmarks/rankings/index.js
+++ b/server/routes/establishments/benchmarks/rankings/index.js
@@ -200,14 +200,22 @@ const getComparisonGroupAndCalculateRanking = async function (
   const mappedComparisonGroupRankings = comparisonGroupRankings.map(mapComparisonGroupCallback).filter((a) => a);
   if (mappedComparisonGroupRankings.length === 0) {
     return {
+      allValues: [{ value: metric.value, currentEst: true }],
       hasValue: false,
       stateMessage: 'no-comparison-data',
     };
   }
 
+  const valuesData = mappedComparisonGroupRankings
+    .sort((a, b) => b - a)
+    .map((rank) => {
+      return { value: rank, currentEst: false };
+    });
+
   const maxRank = mappedComparisonGroupRankings.length + 1;
   if (metric.stateMessage) {
     return {
+      allValues: valuesData,
       maxRank,
       hasValue: false,
       ...metric,
@@ -215,9 +223,6 @@ const getComparisonGroupAndCalculateRanking = async function (
   }
 
   const currentRank = await calculateRankingCallback(metric.value, mappedComparisonGroupRankings);
-  const valuesData = mappedComparisonGroupRankings.map((rank) => {
-    return { value: rank, currentEst: false };
-  });
   valuesData.splice(currentRank - 1, 0, { value: metric.value, currentEst: true });
   return {
     maxRank,

--- a/src/app/core/model/benchmarks.model.ts
+++ b/src/app/core/model/benchmarks.model.ts
@@ -72,6 +72,12 @@ export enum Metric {
   'turnover',
   'qualifications',
   'sickness',
+  'vacancy',
+  'timeInRole',
+  'careWorkerPay',
+  'seniorCareWorkerPay',
+  'registeredManagerPay',
+  'registeredNursePay',
 }
 
 export interface NoData {
@@ -83,6 +89,7 @@ export interface NoData {
   'no-pay-data'?: string;
   'no-sickness-data'?: string;
   'no-qualifications-data'?: string;
+  'no-comparison-data'?: string;
 }
 
 export class MetricsContent {

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
@@ -82,6 +82,9 @@ export class DataAreaBarchartOptionsBuilder {
       text: null,
     },
     plotOptions: {
+      column: {
+        maxPointWidth: 100,
+      },
       series: {
         dataLabels: {
           enabled: false,

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
@@ -83,6 +83,9 @@ export class DataAreaBarchartOptionsBuilder {
     },
     plotOptions: {
       series: {
+        dataLabels: {
+          enabled: false,
+        },
         states: {
           hover: {
             enabled: false,
@@ -98,10 +101,31 @@ export class DataAreaBarchartOptionsBuilder {
     type: Metric,
     altDescription: string,
   ): Highcharts.Options {
-    const noData = '';
-    // console.log('***** BUILD CHART OPTIONS *****');
-    console.log(rankingData);
-    // console.log(type);
+    const plotlines = [];
+    const currentEstablishmentValue = rankingData.allValues?.find((obj) => {
+      return obj.currentEst === true;
+    })?.value;
+    if (currentEstablishmentValue) {
+      const value =
+        type === Metric.careWorkerPay || type === Metric.seniorCareWorkerPay
+          ? currentEstablishmentValue / 100
+          : currentEstablishmentValue;
+      plotlines.push({
+        color: 'black',
+        width: 2,
+        value: value,
+        zIndex: 5,
+        label: {
+          text: `<span class="govuk-body govuk-!-font-size-16 govuk-!-font-weight-bold">You, ${this.formatLineLabel(
+            type,
+            value,
+          )}</span>`,
+          align: 'right',
+          x: 100,
+          y: 5,
+        },
+      });
+    }
     const source = {
       chart: {
         // events: {
@@ -114,9 +138,6 @@ export class DataAreaBarchartOptionsBuilder {
             description: altDescription,
           },
           data: this.buildChartData(rankingData, type),
-          // dataLabels: {
-          //   formatter: this.formatDataLabels(type),
-          // },
         },
       ],
       yAxis: {
@@ -124,6 +145,7 @@ export class DataAreaBarchartOptionsBuilder {
           text: this.getYAxisTitle(type),
         },
         formatter: this.formatLabel(),
+        plotLines: plotlines,
       },
     };
 
@@ -185,29 +207,50 @@ export class DataAreaBarchartOptionsBuilder {
     };
   }
 
-  private formatDataLabels(type: Metric): Highcharts.DataLabelsFormatterCallbackFunction {
-    return function () {
-      console.log('***** here *****');
-      console.log(this.y);
-      let value;
-      switch (type) {
-        case (Metric.pay,
-        Metric.careWorkerPay,
-        Metric.seniorCareWorkerPay,
-        Metric.registeredManagerPay,
-        Metric.registeredNursePay):
-          value = FormatUtil.formatMoney(this.y);
-          break;
-        case Metric.sickness:
-          value = this.y + ' days';
-          break;
-        default:
-          value = FormatUtil.formatPercent(this.y);
-      }
-      const size = this.key === 'Your workplace' ? 'govuk-heading-xl' : 'govuk-heading-m';
-      return '<span class="' + size + ' govuk-!-margin-bottom-2">' + value + '</span>';
-    };
+  private formatLineLabel(type: Metric, labelValue: number): string {
+    let value;
+    switch (type) {
+      case Metric.pay:
+      case Metric.careWorkerPay:
+      case Metric.seniorCareWorkerPay:
+        value = '£' + labelValue.toFixed(2);
+        break;
+      case Metric.registeredManagerPay:
+      case Metric.registeredNursePay:
+        value = FormatUtil.formatSalary(labelValue);
+        break;
+      case Metric.sickness:
+        value = labelValue + ' days';
+        break;
+      default:
+        value = FormatUtil.formatPercent(labelValue);
+    }
+    return value;
   }
+
+  // private formatDataLabels(type: Metric): Highcharts.DataLabelsFormatterCallbackFunction {
+  //   return function () {
+  //     let value;
+  //     switch (type) {
+  //       case Metric.pay:
+  //       case Metric.careWorkerPay:
+  //       case Metric.seniorCareWorkerPay:
+  //         value = '£' + this.y.toFixed(2);
+  //         break;
+  //       case Metric.registeredManagerPay:
+  //       case Metric.registeredNursePay:
+  //         value = FormatUtil.formatSalary(this.y);
+  //         break;
+  //       case Metric.sickness:
+  //         value = this.y + ' days';
+  //         break;
+  //       default:
+  //         value = FormatUtil.formatPercent(this.y);
+  //     }
+  //     const size = this.key === 'Your workplace' ? 'govuk-heading-xl' : 'govuk-body-s';
+  //     return '<span class="' + size + '">' + value + '</span>';
+  //   };
+  // }
 
   // private addEmptyStates(noData: string): Highcharts.ChartLoadCallbackFunction {
   //   return function () {

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
@@ -145,7 +145,7 @@ export class DataAreaBarchartOptionsBuilder {
       ],
       yAxis: {
         title: {
-          text: this.getYAxisTitle(type),
+          text: null,
         },
         formatter: this.formatLabel(),
         plotLines: plotlines,
@@ -154,8 +154,12 @@ export class DataAreaBarchartOptionsBuilder {
 
     const options = cloneDeep(this.defaultOptions);
     options.title = {
+      y: 30,
+      x: 0,
       align: 'left',
-      text: `<span class="govuk-!-font-size-16 govuk-!-font-weight-bold" style='font-family:"Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif'>${title}</span>`,
+      text: `<span class="govuk-!-font-size-16 govuk-!-font-weight-bold" style='font-family:"Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif'>${this.getYAxisTitle(
+        type,
+      )}</span>`,
     };
 
     return merge(options, source);

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
@@ -1,0 +1,250 @@
+import { Injectable } from '@angular/core';
+import { Metric, RankingsResponse } from '@core/model/benchmarks.model';
+import { FormatUtil } from '@core/utils/format-util';
+import cloneDeep from 'lodash/cloneDeep';
+import merge from 'lodash/merge';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DataAreaBarchartOptionsBuilder {
+  private defaultOptions: Highcharts.Options = {
+    chart: {
+      type: 'column',
+      marginTop: 75,
+      marginRight: 100,
+      backgroundColor: '#f3f2f1',
+      plotBorderColor: '#d4d5d5',
+      plotBorderWidth: 1,
+    },
+    series: [
+      {
+        accessibility: {
+          enabled: true,
+        },
+        // dataLabels: {
+        //   enabled: true,
+        //   align: 'left',
+        //   padding: 0,
+        //   useHTML: true,
+        //   crop: false,
+        //   overflow: 'allow',
+        // },
+        type: 'column',
+        showInLegend: false,
+        groupPadding: 0,
+        pointPadding: 0.03,
+      },
+    ],
+
+    yAxis: {
+      visible: true,
+      min: 0,
+      title: {
+        useHTML: true,
+        // rotation: 0,
+      },
+      gridLineColor: '#d4d5d5',
+      labels: {
+        useHTML: true,
+        formatter: this.formatLabel(),
+      },
+    },
+    xAxis: {
+      type: 'category',
+      title: {
+        text: this.getXAxisTitle(),
+        useHTML: true,
+      },
+      labels: {
+        enabled: false,
+      },
+    },
+    responsive: {
+      rules: [
+        {
+          condition: {
+            maxWidth: 500,
+          },
+          chartOptions: {
+            xAxis: {},
+          },
+        },
+      ],
+    },
+    tooltip: {
+      enabled: false,
+    },
+    credits: {
+      enabled: false,
+    },
+    title: {
+      text: null,
+    },
+    plotOptions: {
+      series: {
+        states: {
+          hover: {
+            enabled: false,
+          },
+        },
+      },
+    },
+  };
+
+  public buildChartOptions(rankingData: RankingsResponse, type: Metric, altDescription: string): Highcharts.Options {
+    const noData = '';
+    // console.log('***** BUILD CHART OPTIONS *****');
+    console.log(rankingData);
+    // console.log(type);
+    const source = {
+      chart: {
+        // events: {
+        //   load: this.addEmptyStates(noData),
+        // },
+      },
+      series: [
+        {
+          accessibility: {
+            description: altDescription,
+          },
+          data: this.buildChartData(rankingData, type),
+          // dataLabels: {
+          //   formatter: this.formatDataLabels(type),
+          // },
+        },
+      ],
+      yAxis: {
+        title: {
+          text: this.getYAxisTitle(type),
+        },
+        formatter: this.formatLabel(),
+      },
+    };
+
+    const options = cloneDeep(this.defaultOptions);
+    return merge(options, source);
+  }
+
+  private getXAxisTitle(): string {
+    return '<span class="govuk-body govuk-!-font-size-19 govuk-!-font-weight-bold">Workplaces</span>';
+  }
+
+  private getYAxisTitle(type: Metric): string {
+    let axisTitle;
+    switch (type) {
+      case Metric.careWorkerPay:
+      case Metric.seniorCareWorkerPay:
+        axisTitle = 'Hourly pay';
+        break;
+      case Metric.registeredManagerPay:
+      case Metric.registeredNursePay:
+        axisTitle = 'Annual salary';
+        break;
+      case Metric.vacancy:
+        axisTitle = 'Vacancy rate';
+        break;
+      case Metric.turnover:
+        axisTitle = 'Turnover rate';
+        break;
+      case Metric.timeInRole:
+        axisTitle = 'Percentage of staff';
+        break;
+    }
+    return '<span class="govuk-body govuk-!-font-size-19 govuk-!-font-weight-bold">' + axisTitle + '</span>';
+  }
+
+  // public buildEmptyChartOptions(altDescription: string): Highcharts.Options {
+  //   const source = {
+  //     series: [
+  //       {
+  //         accessibility: {
+  //           description: altDescription,
+  //         },
+  //         data: this.buildChartData(null),
+  //       },
+  //     ],
+  //   };
+
+  //   return merge(this.defaultOptions, source);
+  // }
+
+  private formatLabel(): Highcharts.AxisLabelsFormatterCallbackFunction {
+    return function () {
+      return '<span class="govuk-body">£' + this.value + '</span>';
+    };
+  }
+
+  private formatDataLabels(type: Metric): Highcharts.DataLabelsFormatterCallbackFunction {
+    return function () {
+      console.log('***** here *****');
+      console.log(this.y);
+      let value;
+      switch (type) {
+        case (Metric.pay,
+        Metric.careWorkerPay,
+        Metric.seniorCareWorkerPay,
+        Metric.registeredManagerPay,
+        Metric.registeredNursePay):
+          value = FormatUtil.formatMoney(this.y);
+          break;
+        case Metric.sickness:
+          value = this.y + ' days';
+          break;
+        default:
+          value = FormatUtil.formatPercent(this.y);
+      }
+      const size = this.key === 'Your workplace' ? 'govuk-heading-xl' : 'govuk-heading-m';
+      return '<span class="' + size + ' govuk-!-margin-bottom-2">' + value + '</span>';
+    };
+  }
+
+  // private addEmptyStates(noData: string): Highcharts.ChartLoadCallbackFunction {
+  //   return function () {
+  //     const categoryWidth = this.plotWidth / this.xAxis[0].series[0].data.length;
+  //     let width = categoryWidth - 30;
+
+  //     this.series[0].points.forEach((point, index) => {
+  //       if (point.y === null && (index === 0 || index === 1 || this.series[0].points[index - 1]?.y !== null)) {
+  //         let message;
+  //         if (point.name !== 'Your workplace') {
+  //           message = 'We do not have enough data to show this comparison yet.';
+  //           if (this.series[0].points[index + 1]?.y === null && this.series[0].points[index + 2]?.y === null) {
+  //             width = categoryWidth * 3 - 40;
+  //             message = 'We do not have enough data to show these comparisons yet.';
+  //           } else if (this.series[0].points[index + 1]?.y === null) {
+  //             width = categoryWidth * 2 - 40;
+  //             message = 'We do not have enough data to show these comparisons yet.';
+  //           }
+  //         } else {
+  //           message = noData;
+  //         }
+
+  //         const offset = point.x * categoryWidth + width / 2 + 10;
+  //         const text = this.renderer
+  //           .text('<span class="govuk-body no-data">' + message + '</span>', -999, -999, true)
+  //           .css({
+  //             width,
+  //           })
+  //           .add();
+  //         text.attr({
+  //           x: this.plotLeft + offset - text.getBBox().width / 2,
+  //           y: this.plotTop + (this.plotHeight / 3) * 2,
+  //         });
+  //       }
+  //     });
+  //   };
+  // }
+
+  private buildChartData(rankingData: RankingsResponse, type: Metric): any[] {
+    return rankingData.allValues
+      ?.map((workplace) => {
+        const value =
+          type === Metric.careWorkerPay || type === Metric.seniorCareWorkerPay
+            ? workplace.value / 100
+            : workplace.value;
+        return { y: value, color: workplace.currentEst ? '#28a197' : '#6F72AF' };
+      })
+      .reverse();
+  }
+}

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
@@ -92,7 +92,12 @@ export class DataAreaBarchartOptionsBuilder {
     },
   };
 
-  public buildChartOptions(rankingData: RankingsResponse, type: Metric, altDescription: string): Highcharts.Options {
+  public buildChartOptions(
+    title: string,
+    rankingData: RankingsResponse,
+    type: Metric,
+    altDescription: string,
+  ): Highcharts.Options {
     const noData = '';
     // console.log('***** BUILD CHART OPTIONS *****');
     console.log(rankingData);
@@ -123,6 +128,11 @@ export class DataAreaBarchartOptionsBuilder {
     };
 
     const options = cloneDeep(this.defaultOptions);
+    options.title = {
+      align: 'left',
+      text: `<span class="govuk-!-font-size-16 govuk-!-font-weight-bold" style='font-family:"Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif'>${title}</span>`,
+    };
+
     return merge(options, source);
   }
 

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
@@ -118,14 +118,15 @@ export class DataAreaBarchartOptionsBuilder {
         width: 2,
         value: value,
         zIndex: 5,
+        useHTML: true,
         label: {
-          text: `<span class="govuk-body govuk-!-font-size-16 govuk-!-font-weight-bold">You, ${this.formatLineLabel(
+          text: `<span class="govuk-body govuk-!-font-size-16 govuk-!-font-weight-bold">You,<br/><span class="govuk-body govuk-!-font-size-16 govuk-!-font-weight-bold"> ${this.formatLineLabel(
             type,
             value,
           )}</span>`,
-          align: 'right',
-          x: 100,
-          y: 5,
+          align: 'center',
+          x: 246,
+          y: 0,
         },
       });
     }

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-top-4 govuk-!-padding-3 barchart-container">
   <div class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-2">{{ section }}</div>
   <ng-container *ngIf="!rankingsData.stateMessage; else noData">
-    <p class="govuk-body govuk-!-margin-top-2">
+    <p class="govuk-body govuk-!-margin-top-2" data-testid="all-data">
       Your workplace pays more than
       <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces - rank }}</span> others in a comparision group of
       <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces }} </span> workplaces.
@@ -9,12 +9,12 @@
   </ng-container>
   <ng-template #noData>
     <ng-container *ngIf="rankingsData.stateMessage == 'no-comparison-data'; else noWorkplaceData">
-      <p class="govuk-body govuk-!-margin-top-2">
+      <p class="govuk-body govuk-!-margin-top-2" data-testid="no-comparison-data">
         We do not have enough comparison group data to show where you're ranked yet.
       </p>
     </ng-container>
     <ng-template #noWorkplaceData>
-      <p class="govuk-body govuk-!-margin-top-2">
+      <p class="govuk-body govuk-!-margin-top-2" data-testid="no-workplace-data">
         You've not added any {{ section.toLowerCase() }} data, so we cannot show you where you're ranked.
       </p>
     </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -1,14 +1,23 @@
 <div class="govuk-!-margin-top-4 govuk-!-padding-3 barchart-container">
-  <div class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-2">{{ positionedTitle }}</div>
-  <ng-container *ngIf="payMoreThanWorkplacesNumber; else noPositionData">
-  <p class="govuk-body govuk-!-margin-top-2">
-    Your workplace pays more than <span class="govuk-!-font-weight-bold">{{ payMoreThanWorkplacesNumber }}</span> others
-    in a comparision group of <span class="govuk-!-font-weight-bold">{{ workplacesNumber }} </span> workplaces.
-  </p>
-  </ng-container>
-  <ng-template #noPositionData>
+  <div class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-2">{{ section }}</div>
+  <ng-container *ngIf="!rankingsData.stateMessage; else noData">
     <p class="govuk-body govuk-!-margin-top-2">
-      You've not added any {{ positionedTitle }} data, so we cannot show you where you're ranked.
+      Your workplace pays more than
+      <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces - rank }}</span> others in a comparision group of
+      <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces }} </span> workplaces.
     </p>
+  </ng-container>
+  <ng-template #noData>
+    <ng-container *ngIf="rankingsData.stateMessage == 'no-comparison-data'; else noWorkplaceData">
+      <p class="govuk-body govuk-!-margin-top-2">
+        We do not have enough comparison group data to show where you're ranked yet.
+      </p>
+    </ng-container>
+    <ng-template #noWorkplaceData>
+      <p class="govuk-body govuk-!-margin-top-2">
+        You've not added any {{ section.toLowerCase() }} data, so we cannot show you where you're ranked.
+      </p>
+    </ng-template>
   </ng-template>
+  <highcharts-chart class="chart" [Highcharts]="Highcharts" [options]="options"></highcharts-chart>
 </div>

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -3,8 +3,8 @@
   <ng-container *ngIf="!rankingsData.stateMessage; else noData">
     <p class="govuk-body govuk-!-margin-top-2" data-testid="all-data">
       Your workplace pays more than
-      <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces - rank }}</span> others in a comparision group of
-      <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces }} </span> workplaces.
+      <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces - rank }}</span> others in a <br />
+      comparision group of <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces }} </span> workplaces.
     </p>
   </ng-container>
   <ng-template #noData>

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -15,7 +15,7 @@
     </ng-container>
     <ng-template #noWorkplaceData>
       <p class="govuk-body govuk-!-margin-top-2" data-testid="no-workplace-data">
-        You've not added any {{ section.toLowerCase() }} data, so we cannot show you where you're ranked.
+        You've not added any {{ section | lowercase }} data, so we cannot show you where you're ranked.
       </p>
     </ng-template>
   </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
@@ -1,18 +1,65 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { RankingsResponse } from '@core/model/benchmarks.model';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
 
 import { DataAreaBarchartComponent } from './data-area-barchart.component';
 
 describe('DataAreaBarchartComponent', () => {
-  let component: DataAreaBarchartComponent;
-  let fixture: ComponentFixture<DataAreaBarchartComponent>;
+  const setup = async () => {
+    const { fixture, getByText, getByTestId, queryByTestId } = await render(DataAreaBarchartComponent, {
+      imports: [SharedModule],
+      providers: [],
+      schemas: [NO_ERRORS_SCHEMA],
+      componentProperties: {
+        rankingsData: {
+          maxRank: 14,
+          currentRank: 7,
+          hasValue: true,
+          allValues: [],
+        } as RankingsResponse,
+      },
+    });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DataAreaBarchartComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    const component = fixture.componentInstance;
+
+    return {
+      component,
+      fixture,
+      getByText,
+      getByTestId,
+      queryByTestId,
+    };
+  };
 
   it('should create', async () => {
+    const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should show the default message when all data is provided', async () => {
+    const { component, queryByTestId } = await setup();
+
+    expect(queryByTestId('all-data')).toBeTruthy();
+  });
+
+  it('should show the no comparison group message when no comparsion group data is provided', async () => {
+    const { component, queryByTestId } = await setup();
+    (component.rankingsData = {
+      stateMessage: 'no-comparison-data',
+      hasValue: false,
+      allValues: [],
+    } as RankingsResponse),
+      expect(queryByTestId('no-comparison-data')).toBeTruthy();
+  });
+
+  it('should show the no workplace data message when no workplace data is provided', async () => {
+    const { component, queryByTestId } = await setup();
+    (component.rankingsData = {
+      stateMessage: 'no-pay-data',
+      hasValue: false,
+      allValues: [],
+    } as RankingsResponse),
+      expect(queryByTestId('no-workplace-data')).toBeTruthy();
   });
 });

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges } from '@angular/core';
-import { Metric, NoData, RankingsResponse } from '@core/model/benchmarks.model';
+import { Metric, RankingsResponse } from '@core/model/benchmarks.model';
 import * as Highcharts from 'highcharts';
 
 import { DataAreaBarchartOptionsBuilder } from './data-area-barchart-options-builder';
@@ -12,22 +12,24 @@ import { DataAreaBarchartOptionsBuilder } from './data-area-barchart-options-bui
 export class DataAreaBarchartComponent implements OnChanges {
   Highcharts: typeof Highcharts = Highcharts;
 
-  @Input() section: string = '';
+  @Input() section = '';
   @Input() type: string;
   @Input() rankingsData: RankingsResponse = null;
-
   @Input() altDescription = '';
-
   public options: Highcharts.Options;
   public numberOfWorkplaces: number;
   public rank: number;
-  public noData: NoData;
 
   constructor(private builder: DataAreaBarchartOptionsBuilder) {}
 
   ngOnChanges(): void {
     this.numberOfWorkplaces = this.rankingsData.maxRank ? this.rankingsData.maxRank : null;
     this.rank = this.rankingsData.currentRank ? this.rankingsData.currentRank : null;
-    this.options = this.builder.buildChartOptions(this.rankingsData, Metric[this.type], this.altDescription);
+    this.options = this.builder.buildChartOptions(
+      this.section,
+      this.rankingsData,
+      Metric[this.type],
+      this.altDescription,
+    );
   }
 }

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
@@ -21,7 +21,6 @@ export class DataAreaBarchartComponent implements OnChanges {
   public rank: number;
 
   constructor(private builder: DataAreaBarchartOptionsBuilder) {}
-
   ngOnChanges(): void {
     this.numberOfWorkplaces = this.rankingsData.maxRank ? this.rankingsData.maxRank : null;
     this.rank = this.rankingsData.currentRank ? this.rankingsData.currentRank : null;

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
@@ -1,14 +1,33 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
+import { Metric, NoData, RankingsResponse } from '@core/model/benchmarks.model';
+import * as Highcharts from 'highcharts';
+
+import { DataAreaBarchartOptionsBuilder } from './data-area-barchart-options-builder';
 
 @Component({
   selector: 'app-data-area-barchart',
   templateUrl: './data-area-barchart.component.html',
   styleUrls: ['./data-area-barchart.component.scss'],
 })
-export class DataAreaBarchartComponent {
-  @Input() positionedTitle: string;
-  @Input() payMoreThanWorkplacesNumber: number;
-  @Input() workplacesNumber: number;
+export class DataAreaBarchartComponent implements OnChanges {
+  Highcharts: typeof Highcharts = Highcharts;
 
-  public noPositionData: boolean;
+  @Input() section: string = '';
+  @Input() type: string;
+  @Input() rankingsData: RankingsResponse = null;
+
+  @Input() altDescription = '';
+
+  public options: Highcharts.Options;
+  public numberOfWorkplaces: number;
+  public rank: number;
+  public noData: NoData;
+
+  constructor(private builder: DataAreaBarchartOptionsBuilder) {}
+
+  ngOnChanges(): void {
+    this.numberOfWorkplaces = this.rankingsData.maxRank ? this.rankingsData.maxRank : null;
+    this.rank = this.rankingsData.currentRank ? this.rankingsData.currentRank : null;
+    this.options = this.builder.buildChartOptions(this.rankingsData, Metric[this.type], this.altDescription);
+  }
 }

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
@@ -75,13 +75,31 @@
 
     <ng-container *ngIf="viewBenchmarksPosition; else showRankings">
       <div class="govuk-!-margin-top-7" data-testid="barcharts">
-        <ng-container *ngFor="let position of positionData | keyvalue">
-          <app-data-area-barchart
-            [positionedTitle]="position.value.title"
-            [payMoreThanWorkplacesNumber]="position.value.payMoreThanWorkplacesNumber"
-            [workplacesNumber]="position.value.totalWorkplaces"
-          ></app-data-area-barchart>
-        </ng-container>
+        <app-data-area-barchart
+          [section]="'Care worker pay'"
+          [type]="'careWorkerPay'"
+          [rankingsData]="careWorkerRankings"
+          [altDescription]="'Care worker pay barchart'"
+        ></app-data-area-barchart>
+        <app-data-area-barchart
+          [section]="'Senior care worker pay'"
+          [type]="'seniorCareWorkerPay'"
+          [rankingsData]="seniorCareWorkerRankings"
+          [altDesrcripton]="'Senior care worker pay barchart'"
+        ></app-data-area-barchart>
+        <app-data-area-barchart
+          *ngIf="showRegisteredNurseSalary"
+          [section]="'Registered nurse salary'"
+          [type]="'registeredNursePay'"
+          [rankingsData]="registeredNurseRankings"
+          [altDescription]="'Registered nurse salary barchart'"
+        ></app-data-area-barchart>
+        <app-data-area-barchart
+          [section]="'Registered manager salary'"
+          [type]="'registeredManagerPay'"
+          [rankingsData]="registeredManagerRankings"
+          [altDescription]="'Registered manager salary barchart'"
+        ></app-data-area-barchart>
       </div>
     </ng-container>
     <ng-template #showRankings>


### PR DESCRIPTION
#### Work done
- As part of [1257-data-area-pay-where-you're-positioned](https://trello.com/c/VhCu7mXF/1257-data-area-pay-where-youre-positioned)
- Add all values of the current establishment to rankings response when there are no comparison group data.
- Update bar chart component to use the rankings data from the backend.

Bar chart when data is available
![Screenshot 2023-06-20 at 18 54 36](https://github.com/NMDSdevopsServiceAdm/SopraSteria-SFC/assets/47318392/39ce02d4-4c74-4fcd-83e2-b0f33a815d61)

Bar chart when there is no comparison group data
![Screenshot 2023-06-20 at 18 54 47](https://github.com/NMDSdevopsServiceAdm/SopraSteria-SFC/assets/47318392/dcc649f5-efe8-4334-a85f-9d3a187b9663)

Bar chart when there is no workplace data
![Screenshot 2023-06-20 at 18 54 40](https://github.com/NMDSdevopsServiceAdm/SopraSteria-SFC/assets/47318392/3e2af5d8-de0f-47c5-a3b9-3d5afb07a24d)

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
