### PR TITLE
Update data area component to fix the check for the comparison group …

### DIFF
--- a/src/app/shared/components/data-area-tab/data-area-tab.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.spec.ts
@@ -103,7 +103,7 @@ describe('DataAreaTabComponent', () => {
     const { component, fixture, getByTestId, queryByTestId } = await setup();
     const noCompData = {
       value: 0,
-      stateMessage: 'no-comparison-data',
+      stateMessage: 'no-data',
       hasValue: false,
     };
     component.tilesData.careWorkerPay.comparisonGroup = noCompData;

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.ts
@@ -63,7 +63,7 @@ export class DataAreaTabComponent implements OnInit, OnDestroy {
   }
 
   public checkComparisonDataExists(): void {
-    const noComparisonData = 'no-comparison-data';
+    const noComparisonData = 'no-data';
 
     if (
       this.tilesData?.careWorkerPay.comparisonGroup.stateMessage === noComparisonData &&


### PR DESCRIPTION
#### Work done
- As part of [1246-data-area-pay-no-comparison-group-data](https://trello.com/c/mooc1m1U/1246-data-area-pay-no-comparison-group-data) ticket
- Fix state message check for showing no comparison group box message.
- 
![Screenshot 2023-06-27 at 16 52 47](https://github.com/NMDSdevopsServiceAdm/SopraSteria-SFC/assets/47318392/a27ae013-2ed2-4a1b-8f1c-e09f3a17d2f3)

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
