### PR TITLE
1276 data area not enough data added for workplace and comparator group

### DIFF
--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart-options-builder.ts
@@ -143,7 +143,8 @@ export class DataAreaBarchartOptionsBuilder {
           accessibility: {
             description: altDescription,
           },
-          data: this.buildChartData(rankingData, type),
+          data: null,
+          opacity: 100,
         },
       ],
       yAxis: {
@@ -158,6 +159,12 @@ export class DataAreaBarchartOptionsBuilder {
         plotLines: plotlines,
       },
     };
+    if (rankingData.allValues?.length == 0) {
+      source.series[0].data = [{ y: 20000 }];
+      source.series[0].opacity = 0;
+    } else {
+      source.series[0].data = this.buildChartData(rankingData, type);
+    }
 
     const options = cloneDeep(this.defaultOptions);
     options.title = {
@@ -200,21 +207,6 @@ export class DataAreaBarchartOptionsBuilder {
     return '<span class="govuk-body govuk-!-font-size-19 govuk-!-font-weight-bold">' + axisTitle + '</span>';
   }
 
-  // public buildEmptyChartOptions(altDescription: string): Highcharts.Options {
-  //   const source = {
-  //     series: [
-  //       {
-  //         accessibility: {
-  //           description: altDescription,
-  //         },
-  //         data: this.buildChartData(null),
-  //       },
-  //     ],
-  //   };
-
-  //   return merge(this.defaultOptions, source);
-  // }
-
   private formatLabel(type: Metric): Highcharts.AxisLabelsFormatterCallbackFunction {
     return function () {
       //return '<span class="govuk-body">£' + this.value + '</span>';
@@ -253,67 +245,6 @@ export class DataAreaBarchartOptionsBuilder {
     }
     return value;
   }
-
-  // private formatDataLabels(type: Metric): Highcharts.DataLabelsFormatterCallbackFunction {
-  //   return function () {
-  //     let value;
-  //     switch (type) {
-  //       case Metric.pay:
-  //       case Metric.careWorkerPay:
-  //       case Metric.seniorCareWorkerPay:
-  //         value = '£' + this.y.toFixed(2);
-  //         break;
-  //       case Metric.registeredManagerPay:
-  //       case Metric.registeredNursePay:
-  //         value = FormatUtil.formatSalary(this.y);
-  //         break;
-  //       case Metric.sickness:
-  //         value = this.y + ' days';
-  //         break;
-  //       default:
-  //         value = FormatUtil.formatPercent(this.y);
-  //     }
-  //     const size = this.key === 'Your workplace' ? 'govuk-heading-xl' : 'govuk-body-s';
-  //     return '<span class="' + size + '">' + value + '</span>';
-  //   };
-  // }
-
-  // private addEmptyStates(noData: string): Highcharts.ChartLoadCallbackFunction {
-  //   return function () {
-  //     const categoryWidth = this.plotWidth / this.xAxis[0].series[0].data.length;
-  //     let width = categoryWidth - 30;
-
-  //     this.series[0].points.forEach((point, index) => {
-  //       if (point.y === null && (index === 0 || index === 1 || this.series[0].points[index - 1]?.y !== null)) {
-  //         let message;
-  //         if (point.name !== 'Your workplace') {
-  //           message = 'We do not have enough data to show this comparison yet.';
-  //           if (this.series[0].points[index + 1]?.y === null && this.series[0].points[index + 2]?.y === null) {
-  //             width = categoryWidth * 3 - 40;
-  //             message = 'We do not have enough data to show these comparisons yet.';
-  //           } else if (this.series[0].points[index + 1]?.y === null) {
-  //             width = categoryWidth * 2 - 40;
-  //             message = 'We do not have enough data to show these comparisons yet.';
-  //           }
-  //         } else {
-  //           message = noData;
-  //         }
-
-  //         const offset = point.x * categoryWidth + width / 2 + 10;
-  //         const text = this.renderer
-  //           .text('<span class="govuk-body no-data">' + message + '</span>', -999, -999, true)
-  //           .css({
-  //             width,
-  //           })
-  //           .add();
-  //         text.attr({
-  //           x: this.plotLeft + offset - text.getBBox().width / 2,
-  //           y: this.plotTop + (this.plotHeight / 3) * 2,
-  //         });
-  //       }
-  //     });
-  //   };
-  // }
 
   private buildChartData(rankingData: RankingsResponse, type: Metric): any[] {
     return rankingData.allValues

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -19,7 +19,7 @@
 
   <ng-template #noData>
     <ng-container *ngIf="rankingsData.stateMessage == 'no-comparison-data'; else hasComparisonData">
-      <ng-container *ngIf="!noWorkplaceData; else noWorkplaceAndComparisonData">
+      <ng-container *ngIf="noWorkplaceData == false; else noWorkplaceAndComparisonData">
         <p
           class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8 govuk-!-padding-bottom-3"
           data-testid="no-comparison-data"

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -1,25 +1,25 @@
 <div class="govuk-!-margin-top-4 barchart-container">
   <div class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-2">{{ section }}</div>
-  <ng-container *ngIf="numberOfWorkplaces; else noComparisonData">
-    <ng-container *ngIf="!rankingsData.stateMessage; else noData">
-      <ng-container *ngIf="isPay; else recruitmentAndRetention">
-        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8" data-testid="all-pay-data">
-          Your workplace pays more than
-          <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces - rank }}</span> others in a comparision group of
-          <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces }} </span> workplaces.
-        </p>
-      </ng-container>
-      <ng-template #recruitmentAndRetention>
-        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8" data-testid="all-recruitment-data">
-          Your workplace has a higher {{ sectionInSummary | lowercase }} than
-          <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces - rank }}</span> others in a comparision group of
-          <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces }} </span> workplaces.
-        </p>
-      </ng-template>
+  <ng-container *ngIf="!rankingsData.stateMessage; else noData">
+    <ng-container *ngIf="isPay; else recruitmentAndRetention">
+      <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8" data-testid="all-pay-data">
+        Your workplace pays more than
+        <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces - rank }}</span> others in a comparision group of
+        <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces }} </span> workplaces.
+      </p>
     </ng-container>
+    <ng-template #recruitmentAndRetention>
+      <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8" data-testid="all-recruitment-data">
+        Your workplace has a higher {{ sectionInSummary | lowercase }} than
+        <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces - rank }}</span> others in a comparision group of
+        <span class="govuk-!-font-weight-bold">{{ numberOfWorkplaces }} </span> workplaces.
+      </p>
+    </ng-template>
+  </ng-container>
 
-    <ng-template #noData>
-      <ng-container *ngIf="rankingsData.stateMessage == 'no-comparison-data'; else noWorkplaceData">
+  <ng-template #noData>
+    <ng-container *ngIf="rankingsData.stateMessage == 'no-comparison-data'; else hasComparisonData">
+      <ng-container *ngIf="!noWorkplaceData; else noWorkplaceAndComparisonData">
         <p
           class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8 govuk-!-padding-bottom-3"
           data-testid="no-comparison-data"
@@ -27,17 +27,18 @@
           We do not have enough comparison group data to show where you're positioned yet.
         </p>
       </ng-container>
-      <ng-template #noWorkplaceData>
-        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8" data-testid="no-workplace-data">
-          You've not added any {{ section | lowercase }} data, so we cannot show you where you're positioned.
+      <ng-template #noWorkplaceAndComparisonData>
+        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8" data-testid="no-workplace-or-comparison-data">
+          We do not have enough workplace and comparison group <br />
+          data to show where you're positioned yet.
         </p>
       </ng-template>
+    </ng-container>
+    <ng-template #hasComparisonData>
+      <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8" data-testid="no-workplace-data">
+        You've not added any {{ section | lowercase }} data, so we cannot show you where you're positioned.
+      </p>
     </ng-template>
-  </ng-container>
-  <ng-template #noComparisonData>
-    <p class="govuk-body govuk-!-margin-top-2 govuk-!-padding-bottom-3" data-testid="no-comparison-data">
-      We do not have enough comparison group data to show where you're positioned yet.
-    </p>
   </ng-template>
   <highcharts-chart class="chart" [Highcharts]="Highcharts" [options]="options"></highcharts-chart>
 </div>

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
@@ -52,9 +52,10 @@ describe('DataAreaBarchartComponent', () => {
     });
 
     it('should show retention message if isPay is false', async () => {
-      const { component, queryByTestId } = await setup();
+      const { component, queryByTestId, fixture } = await setup();
 
       component.isPay = false;
+      fixture.detectChanges();
 
       expect(queryByTestId('all-recruitment-data')).toBeTruthy();
       expect(queryByTestId('all-pay-data')).toBeFalsy();
@@ -62,23 +63,27 @@ describe('DataAreaBarchartComponent', () => {
   });
 
   it('should show the no comparison group message when no comparsion group data is provided', async () => {
-    const { component, queryByTestId } = await setup();
-    (component.rankingsData = {
+    const { component, queryByTestId, fixture } = await setup();
+    component.rankingsData = {
       stateMessage: 'no-comparison-data',
       hasValue: false,
-      allValues: [],
-    } as RankingsResponse),
-      expect(queryByTestId('no-comparison-data')).toBeTruthy();
+      allValues: [{ value: 1, currentEst: true }],
+    } as RankingsResponse;
+
+    component.ngOnChanges();
+    expect(queryByTestId('no-comparison-data')).toBeTruthy();
   });
 
   it('should show the no workplace data message when no workplace data is provided', async () => {
-    const { component, queryByTestId } = await setup();
-    (component.rankingsData = {
+    const { component, queryByTestId, fixture } = await setup();
+    component.rankingsData = {
       stateMessage: 'no-pay-data',
       hasValue: false,
-      allValues: [],
-    } as RankingsResponse),
-      expect(queryByTestId('no-workplace-data')).toBeTruthy();
+      allValues: [{ value: 34, currentEst: false }],
+    } as RankingsResponse;
+
+    fixture.detectChanges();
+    expect(queryByTestId('no-workplace-data')).toBeTruthy();
   });
 
   it('should show the correct summary for time in role', async () => {
@@ -105,14 +110,19 @@ describe('DataAreaBarchartComponent', () => {
     expect(component.sectionInSummary).toEqual('vacancy rate');
   });
 
-  it('should show the no comparison data message when no comparison data is provided', async () => {
-    const { component, queryByTestId } = await setup();
-    (component.rankingsData = {
+  it('should show the no comparison and workplace data message when no comparison or workplace data is provided', async () => {
+    const { component, queryByTestId, fixture } = await setup();
+    component.rankingsData = {
       stateMessage: 'no-comparison-data',
       maxRank: undefined,
       hasValue: false,
       allValues: [],
-    } as RankingsResponse),
-      expect(queryByTestId('no-comparison-data')).toBeTruthy();
+    } as RankingsResponse;
+    component.noWorkplaceData = true;
+
+    fixture.detectChanges();
+    component.ngOnChanges();
+
+    expect(queryByTestId('no-workplace-or-comparison-data')).toBeTruthy();
   });
 });

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
@@ -17,18 +17,17 @@ export class DataAreaBarchartComponent implements OnChanges, OnInit {
   @Input() rankingsData: RankingsResponse = null;
   @Input() altDescription = '';
   @Input() isPay: boolean;
+  @Input() noWorkplaceData: boolean = false;
   public options: Highcharts.Options;
   public numberOfWorkplaces: number;
   public rank: number;
   public sectionInSummary: string;
-  public noWorkplaceData: boolean;
 
   constructor(private builder: DataAreaBarchartOptionsBuilder) {}
 
   ngOnInit(): void {}
 
   ngOnChanges(): void {
-    this.noWorkplaceData = this.rankingsData.allValues?.length == 0;
     this.formatSection(this.type);
     this.numberOfWorkplaces = this.rankingsData.maxRank ? this.rankingsData.maxRank : null;
     this.rank = this.rankingsData.currentRank ? this.rankingsData.currentRank : null;

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.ts
@@ -21,14 +21,14 @@ export class DataAreaBarchartComponent implements OnChanges, OnInit {
   public numberOfWorkplaces: number;
   public rank: number;
   public sectionInSummary: string;
-  public noPositionData: boolean;
-  public noComparisonData: boolean;
+  public noWorkplaceData: boolean;
 
   constructor(private builder: DataAreaBarchartOptionsBuilder) {}
 
   ngOnInit(): void {}
 
   ngOnChanges(): void {
+    this.noWorkplaceData = this.rankingsData.allValues?.length == 0;
     this.formatSection(this.type);
     this.numberOfWorkplaces = this.rankingsData.maxRank ? this.rankingsData.maxRank : null;
     this.rank = this.rankingsData.currentRank ? this.rankingsData.currentRank : null;

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
@@ -112,22 +112,26 @@
           [rankingTitle]="rankings.careWorkerPay.title"
           [workplaceRankNumber]="rankings.careWorkerPay.workplacesRankNumber"
           [workplacesNumber]="rankings.careWorkerPay.totalWorkplaces"
+          [noWorkplaceData]="rankings.careWorkerPay.noWorkplaceData"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="rankings.seniorCareWorkerPay.title"
           [workplaceRankNumber]="rankings.seniorCareWorkerPay.workplacesRankNumber"
           [workplacesNumber]="rankings.seniorCareWorkerPay.totalWorkplaces"
+          [noWorkplaceData]="rankings.seniorCareWorkerPay.noWorkplaceData"
         ></app-data-area-ranking>
         <app-data-area-ranking
           *ngIf="showRegisteredNurseSalary"
           [rankingTitle]="rankings.registeredNursePay.title"
           [workplaceRankNumber]="rankings.registeredNursePay.workplacesRankNumber"
           [workplacesNumber]="rankings.registeredNursePay.totalWorkplaces"
+          [noWorkplaceData]="rankings.registeredNursePay.noWorkplaceData"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="rankings.registeredManagerPay.title"
           [workplaceRankNumber]="rankings.registeredManagerPay.workplacesRankNumber"
           [workplacesNumber]="rankings.registeredManagerPay.totalWorkplaces"
+          [noWorkplaceData]="rankings.registeredManagerPay.noWorkplaceData"
         ></app-data-area-ranking>
       </div>
     </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
@@ -81,6 +81,7 @@
           [rankingsData]="careWorkerRankings"
           [altDescription]="'Care worker pay barchart'"
           [isPay]="true"
+          [noWorkplaceData]="rankings.careWorkerPay.noWorkplaceData"
         ></app-data-area-barchart>
         <app-data-area-barchart
           [section]="'Senior care worker pay'"
@@ -88,6 +89,7 @@
           [rankingsData]="seniorCareWorkerRankings"
           [altDesrcripton]="'Senior care worker pay barchart'"
           [isPay]="true"
+          [noWorkplaceData]="rankings.seniorCareWorkerPay.noWorkplaceData"
         ></app-data-area-barchart>
         <app-data-area-barchart
           *ngIf="showRegisteredNurseSalary"
@@ -96,12 +98,14 @@
           [rankingsData]="registeredNurseRankings"
           [altDescription]="'Registered nurse salary barchart'"
           [isPay]="true"
+          [noWorkplaceData]="rankings.registeredNursePay.noWorkplaceData"
         ></app-data-area-barchart>
         <app-data-area-barchart
           [section]="'Registered manager salary'"
           [type]="'registeredManagerPay'"
           [rankingsData]="registeredManagerRankings"
           [isPay]="true"
+          [noWorkplaceData]="rankings.registeredManagerPay.noWorkplaceData"
           [altDescription]="'Registered manager salary barchart'"
         ></app-data-area-barchart>
       </div>

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.spec.ts
@@ -602,21 +602,25 @@ describe('DataAreaPayComponent', () => {
         title: 'Care worker pay',
         workplacesRankNumber: rankings.pay.careWorkerPay.groupRankings.currentRank,
         totalWorkplaces: rankings.pay.careWorkerPay.groupRankings.maxRank,
+        noWorkplaceData: false,
       });
       expect(component.rankings.seniorCareWorkerPay).toEqual({
         title: 'Senior care worker pay',
         workplacesRankNumber: rankings.pay.seniorCareWorkerPay.groupRankings.currentRank,
         totalWorkplaces: rankings.pay.seniorCareWorkerPay.groupRankings.maxRank,
+        noWorkplaceData: false,
       });
       expect(component.rankings.registeredNursePay).toEqual({
         title: 'Registered nurse salary',
         workplacesRankNumber: rankings.pay.registeredNursePay.groupRankings.currentRank,
         totalWorkplaces: rankings.pay.registeredNursePay.groupRankings.maxRank,
+        noWorkplaceData: false,
       });
       expect(component.rankings.registeredManagerPay).toEqual({
         title: 'Registered manager salary',
         workplacesRankNumber: rankings.pay.registeredManagerPay.groupRankings.currentRank,
         totalWorkplaces: rankings.pay.registeredManagerPay.groupRankings.maxRank,
+        noWorkplaceData: false,
       });
 
       component.viewBenchmarksComparisonGroups = true;
@@ -626,21 +630,25 @@ describe('DataAreaPayComponent', () => {
         title: 'Care worker pay',
         workplacesRankNumber: rankings.pay.careWorkerPay.goodCqcRankings.currentRank,
         totalWorkplaces: rankings.pay.careWorkerPay.goodCqcRankings.maxRank,
+        noWorkplaceData: false,
       });
       expect(component.rankings.seniorCareWorkerPay).toEqual({
         title: 'Senior care worker pay',
         workplacesRankNumber: rankings.pay.seniorCareWorkerPay.goodCqcRankings.currentRank,
         totalWorkplaces: rankings.pay.seniorCareWorkerPay.goodCqcRankings.maxRank,
+        noWorkplaceData: false,
       });
       expect(component.rankings.registeredNursePay).toEqual({
         title: 'Registered nurse salary',
         workplacesRankNumber: rankings.pay.registeredNursePay.goodCqcRankings.currentRank,
         totalWorkplaces: rankings.pay.registeredNursePay.goodCqcRankings.maxRank,
+        noWorkplaceData: false,
       });
       expect(component.rankings.registeredManagerPay).toEqual({
         title: 'Registered manager salary',
         workplacesRankNumber: rankings.pay.registeredManagerPay.goodCqcRankings.currentRank,
         totalWorkplaces: rankings.pay.registeredManagerPay.goodCqcRankings.maxRank,
+        noWorkplaceData: false,
       });
     });
 

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
@@ -39,7 +39,6 @@ export class DataAreaPayComponent {
     this.setComparisonGroupPayAndSalary(this.viewBenchmarksComparisonGroups);
     this.setRankings(this.viewBenchmarksComparisonGroups);
     this.initialiseRankings();
-    this.initialisePositions();
   }
 
   public handleViewBenchmarkPosition(visible: boolean): void {
@@ -121,29 +120,8 @@ export class DataAreaPayComponent {
     return undefined;
   }
 
-  public initialisePositions(): void {
-    this.positionData = {
-      careWorkerPay: {
-        title: 'Care worker pay',
-        payMoreThanWorkplacesNumber: this.getRankNumber(this.careWorkerRankings),
-        totalWorkplaces: this.getMaxRank(this.careWorkerRankings),
-      },
-      seniorCareWorkerPay: {
-        title: 'Senior care worker pay',
-        payMoreThanWorkplacesNumber: this.getRankNumber(this.seniorCareWorkerRankings),
-        totalWorkplaces: this.getMaxRank(this.seniorCareWorkerRankings),
-      },
-      registeredNursePay: {
-        title: 'Registered nurse salary',
-        payMoreThanWorkplacesNumber: this.getRankNumber(this.registeredNurseRankings),
-        totalWorkplaces: this.getMaxRank(this.registeredNurseRankings),
-      },
-      registeredManagerPay: {
-        title: 'Registered manager salary',
-        payMoreThanWorkplacesNumber: this.getRankNumber(this.registeredManagerRankings),
-        totalWorkplaces: this.getMaxRank(this.registeredManagerRankings),
-      },
-    };
+  public hasWorkplaceData(rank: RankingsResponse): boolean {
+    return rank.allValues?.length == 0;
   }
 
   public initialiseRankings(): void {
@@ -152,21 +130,25 @@ export class DataAreaPayComponent {
         title: 'Care worker pay',
         workplacesRankNumber: this.getRankNumber(this.careWorkerRankings),
         totalWorkplaces: this.getMaxRank(this.careWorkerRankings),
+        noWorkplaceData: this.hasWorkplaceData(this.careWorkerRankings),
       },
       seniorCareWorkerPay: {
         title: 'Senior care worker pay',
         workplacesRankNumber: this.getRankNumber(this.seniorCareWorkerRankings),
         totalWorkplaces: this.getMaxRank(this.seniorCareWorkerRankings),
+        noWorkplaceData: this.hasWorkplaceData(this.seniorCareWorkerRankings),
       },
       registeredNursePay: {
         title: 'Registered nurse salary',
         workplacesRankNumber: this.getRankNumber(this.registeredNurseRankings),
         totalWorkplaces: this.getMaxRank(this.registeredNurseRankings),
+        noWorkplaceData: this.hasWorkplaceData(this.registeredNurseRankings),
       },
       registeredManagerPay: {
         title: 'Registered manager salary',
         workplacesRankNumber: this.getRankNumber(this.registeredManagerRankings),
         totalWorkplaces: this.getMaxRank(this.registeredManagerRankings),
+        noWorkplaceData: this.hasWorkplaceData(this.registeredManagerRankings),
       },
     };
   }

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
@@ -151,5 +151,6 @@ export class DataAreaPayComponent {
         noWorkplaceData: this.hasWorkplaceData(this.registeredManagerRankings),
       },
     };
+    console.log(this.rankings);
   }
 }

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
@@ -1,21 +1,31 @@
 <div class="govuk-!-margin-top-5 govuk-!-padding-3 govuk-!-padding-bottom-5 ranking-container">
   <div class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-1">{{ rankingTitle }}</div>
   <ng-container *ngIf="workplacesNumber; else noComparisonData">
-  <ng-container *ngIf="workplaceRankNumber; else noRankingData">
-    <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-3" data-testid="ranking-data">
-      Your workplace ranks <span class="govuk-!-font-weight-bold">{{ workplaceRankNumber }}</span> in a comparison group
-      of <span class="govuk-!-font-weight-bold">{{ workplacesNumber }} </span> workplaces.
-    </p>
-  </ng-container>
-  <ng-template #noRankingData>
-    <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-workplace-data">
-      You've not added any {{ rankingTitle | lowercase }} data, so we cannot show you where you're ranked.
-    </p>
-  </ng-template>
+    <ng-container *ngIf="workplaceRankNumber; else noRankingData">
+      <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-3" data-testid="ranking-data">
+        Your workplace ranks <span class="govuk-!-font-weight-bold">{{ workplaceRankNumber }}</span> in a comparison
+        group of <span class="govuk-!-font-weight-bold">{{ workplacesNumber }} </span> workplaces.
+      </p>
+    </ng-container>
+    <ng-template #noRankingData>
+      <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-workplace-data">
+        You've not added any {{ rankingTitle | lowercase }} data, so we cannot show you where you're ranked.
+      </p>
+    </ng-template>
   </ng-container>
   <ng-template #noComparisonData>
-    <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-comparison-data">
-      We do not have enough comparison group data to <br/> show you where you're ranked yet.</p>
+    <ng-container *ngIf="noWorkplaceData == false; else noWorkplaceDataMessage">
+      <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-comparison-data">
+        We do not have enough comparison group data to <br />
+        show you where you're ranked yet.
+      </p>
+    </ng-container>
+    <ng-template #noWorkplaceDataMessage>
+      <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-workplace-or-comparison-data">
+        We do not have enough workplace and comparison group <br />
+        data to show you where you're ranked yet.
+      </p>
+    </ng-template>
   </ng-template>
   <div class="ranking-bar">
     <highcharts-chart class="chart" [Highcharts]="Highcharts" [options]="options"></highcharts-chart>

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
@@ -4,7 +4,7 @@ import { render } from '@testing-library/angular';
 
 import { DataAreaRankingComponent } from './data-area-ranking.component';
 
-describe('DataAreaRankingComponent', () => {
+fdescribe('DataAreaRankingComponent', () => {
   let component: DataAreaRankingComponent;
   let fixture: ComponentFixture<DataAreaRankingComponent>;
 
@@ -57,8 +57,18 @@ describe('DataAreaRankingComponent', () => {
     const { fixture, component, queryByTestId, getByTestId } = await setup();
     component.workplaceRankNumber = null;
     component.workplacesNumber = null;
+    component.noWorkplaceData = false;
     fixture.detectChanges();
 
     expect(getByTestId('no-comparison-data')).toBeTruthy();
+  });
+  it('should show no comparison and workplace data message when no comparison and workplace data is provided', async () => {
+    const { fixture, component, queryByTestId, getByTestId } = await setup();
+    component.workplaceRankNumber = null;
+    component.workplacesNumber = null;
+    component.noWorkplaceData = true;
+    fixture.detectChanges();
+
+    expect(getByTestId('no-workplace-or-comparison-data')).toBeTruthy();
   });
 });

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
@@ -4,7 +4,7 @@ import { render } from '@testing-library/angular';
 
 import { DataAreaRankingComponent } from './data-area-ranking.component';
 
-fdescribe('DataAreaRankingComponent', () => {
+describe('DataAreaRankingComponent', () => {
   let component: DataAreaRankingComponent;
   let fixture: ComponentFixture<DataAreaRankingComponent>;
 

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
@@ -13,6 +13,7 @@ export class DataAreaRankingComponent implements OnInit, OnChanges {
   @Input() rankingTitle: string;
   @Input() workplaceRankNumber: number;
   @Input() workplacesNumber: number;
+  @Input() noWorkplaceData: boolean = false;
 
   public noRankingData: boolean;
   public options: Highcharts.Options;

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
@@ -70,20 +70,17 @@ export class DataAreaRecruitmentAndRetentionComponent implements OnChanges {
   }
 
   public setComparisonTableData(isGoodAndOutstanding: boolean): void {
+    this.vacancyWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.workplaceValue);
+    this.turnoverWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.workplaceValue);
+    this.timeInRoleWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.workplaceValue);
     if (isGoodAndOutstanding) {
       this.vacancyComparisonGroupData = this.formatComparisonGroupTableData(this.data.vacancyRate.goodCqc);
       this.turnoverComparisonGroupData = this.formatComparisonGroupTableData(this.data.turnoverRate.goodCqc);
       this.timeInRoleComparisonGroupData = this.formatComparisonGroupTableData(this.data.timeInRole.goodCqc);
-      this.vacancyWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.goodCqc);
-      this.turnoverWorkplaceData = this.formatWorkplaceTableData(this.data.turnoverRate.goodCqc);
-      this.timeInRoleWorkplaceData = this.formatWorkplaceTableData(this.data.timeInRole.goodCqc);
     } else {
       this.vacancyComparisonGroupData = this.formatComparisonGroupTableData(this.data.vacancyRate.comparisonGroup);
       this.turnoverComparisonGroupData = this.formatComparisonGroupTableData(this.data.turnoverRate.comparisonGroup);
       this.timeInRoleComparisonGroupData = this.formatComparisonGroupTableData(this.data.timeInRole.comparisonGroup);
-      this.vacancyWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.comparisonGroup);
-      this.turnoverWorkplaceData = this.formatWorkplaceTableData(this.data.turnoverRate.comparisonGroup);
-      this.timeInRoleWorkplaceData = this.formatWorkplaceTableData(this.data.timeInRole.comparisonGroup);
     }
   }
 

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
@@ -1,5 +1,11 @@
 import { Component, Input, OnChanges } from '@angular/core';
-import { AllRankingsResponse, BenchmarksResponse, RankingsResponse } from '@core/model/benchmarks.model';
+import {
+  AllRankingsResponse,
+  BenchmarksResponse,
+  BenchmarkValue,
+  RankingsResponse,
+} from '@core/model/benchmarks.model';
+import { FormatUtil } from '@core/utils/format-util';
 
 @Component({
   selector: 'app-data-area-recruitment-and-retention',
@@ -23,9 +29,16 @@ export class DataAreaRecruitmentAndRetentionComponent implements OnChanges {
   public vacancyNoWorkplaceData: boolean;
   public turnoverNoWorkplaceData: boolean;
   public timeInRoleNoWorkplaceData: boolean;
+  public vacancyComparisonGroupData: string;
+  public turnoverComparisonGroupData: string;
+  public timeInRoleComparisonGroupData: string;
+  public vacancyWorkplaceData: string;
+  public turnoverWorkplaceData: string;
+  public timeInRoleWorkplaceData: string;
 
   ngOnChanges(): void {
     this.setRankings(this.viewBenchmarksComparisonGroups);
+    this.setComparisonTableData(this.viewBenchmarksComparisonGroups);
   }
 
   public handleViewBenchmarkPosition(visible: boolean): void {
@@ -46,6 +59,32 @@ export class DataAreaRecruitmentAndRetentionComponent implements OnChanges {
 
   public hasWorkplaceData(rank: RankingsResponse): boolean {
     return rank.allValues?.length == 0;
+  }
+
+  private formatComparisonGroupTableData(data: BenchmarkValue): string {
+    return data.hasValue ? `${FormatUtil.formatPercent(data.value)}` : 'Not enough data';
+  }
+
+  private formatWorkplaceTableData(data: BenchmarkValue): string {
+    return data.hasValue ? `${FormatUtil.formatPercent(data.value)}` : 'No data added';
+  }
+
+  public setComparisonTableData(isGoodAndOutstanding: boolean): void {
+    if (isGoodAndOutstanding) {
+      this.vacancyComparisonGroupData = this.formatComparisonGroupTableData(this.data.vacancyRate.goodCqc);
+      this.turnoverComparisonGroupData = this.formatComparisonGroupTableData(this.data.turnoverRate.goodCqc);
+      this.timeInRoleComparisonGroupData = this.formatComparisonGroupTableData(this.data.timeInRole.goodCqc);
+      this.vacancyWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.goodCqc);
+      this.turnoverWorkplaceData = this.formatWorkplaceTableData(this.data.turnoverRate.goodCqc);
+      this.timeInRoleWorkplaceData = this.formatWorkplaceTableData(this.data.timeInRole.goodCqc);
+    } else {
+      this.vacancyComparisonGroupData = this.formatComparisonGroupTableData(this.data.vacancyRate.comparisonGroup);
+      this.turnoverComparisonGroupData = this.formatComparisonGroupTableData(this.data.turnoverRate.comparisonGroup);
+      this.timeInRoleComparisonGroupData = this.formatComparisonGroupTableData(this.data.timeInRole.comparisonGroup);
+      this.vacancyWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.comparisonGroup);
+      this.turnoverWorkplaceData = this.formatWorkplaceTableData(this.data.turnoverRate.comparisonGroup);
+      this.timeInRoleWorkplaceData = this.formatWorkplaceTableData(this.data.timeInRole.comparisonGroup);
+    }
   }
 
   public setRankings(isGoodAndOutstanding: boolean): void {

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
@@ -71,8 +71,8 @@ export class DataAreaRecruitmentAndRetentionComponent implements OnChanges {
 
   public setComparisonTableData(isGoodAndOutstanding: boolean): void {
     this.vacancyWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.workplaceValue);
-    this.turnoverWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.workplaceValue);
-    this.timeInRoleWorkplaceData = this.formatWorkplaceTableData(this.data.vacancyRate.workplaceValue);
+    this.turnoverWorkplaceData = this.formatWorkplaceTableData(this.data.turnoverRate.workplaceValue);
+    this.timeInRoleWorkplaceData = this.formatWorkplaceTableData(this.data.timeInRole.workplaceValue);
     if (isGoodAndOutstanding) {
       this.vacancyComparisonGroupData = this.formatComparisonGroupTableData(this.data.vacancyRate.goodCqc);
       this.turnoverComparisonGroupData = this.formatComparisonGroupTableData(this.data.turnoverRate.goodCqc);

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { AllRankingsResponse, BenchmarksResponse, RankingsResponse } from '@core/model/benchmarks.model';
 
 @Component({
@@ -20,6 +20,9 @@ export class DataAreaRecruitmentAndRetentionComponent implements OnChanges {
   public vacancyCurrentRank;
   public turnoverCurrentRank;
   public timeInRoleCurrentRank;
+  public vacancyNoWorkplaceData: boolean;
+  public turnoverNoWorkplaceData: boolean;
+  public timeInRoleNoWorkplaceData: boolean;
 
   ngOnChanges(): void {
     this.setRankings(this.viewBenchmarksComparisonGroups);
@@ -41,6 +44,10 @@ export class DataAreaRecruitmentAndRetentionComponent implements OnChanges {
     }
   }
 
+  public hasWorkplaceData(rank: RankingsResponse): boolean {
+    return rank.allValues?.length == 0;
+  }
+
   public setRankings(isGoodAndOutstanding: boolean): void {
     if (isGoodAndOutstanding) {
       this.vacancyRankings = this.rankingsData?.vacancy.goodCqcRankings;
@@ -59,5 +66,9 @@ export class DataAreaRecruitmentAndRetentionComponent implements OnChanges {
     this.vacancyCurrentRank = this.setCurrentRank(this.vacancyRankings);
     this.turnoverCurrentRank = this.setCurrentRank(this.turnoverRankings);
     this.timeInRoleCurrentRank = this.setCurrentRank(this.timeInRoleRankings);
+
+    this.vacancyNoWorkplaceData = this.hasWorkplaceData(this.vacancyRankings);
+    this.turnoverNoWorkplaceData = this.hasWorkplaceData(this.turnoverRankings);
+    this.timeInRoleNoWorkplaceData = this.hasWorkplaceData(this.timeInRoleRankings);
   }
 }

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
@@ -14,47 +14,20 @@
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row first-row" data-testid="vacancyRow">
         <th scope="row" class="govuk-table__header comparison-row-header govuk-!-font-weight-regular">Vacancy rate</th>
-        <td class="govuk-table__cell workplace-cell">
-          {{ data?.vacancyRate.workplaceValue.value * 100 | number: '1.0-0' }}%
-        </td>
-        <td class="govuk-table__cell comparison-group-cell">
-          <ng-container *ngIf="viewBenchmarksComparisonGroups; else vacancyTotalComparison">
-            {{ data?.vacancyRate.goodCqc.value * 100 | number: '1.0-0' }}%
-          </ng-container>
-          <ng-template #vacancyTotalComparison>
-            {{ data?.vacancyRate.comparisonGroup.value * 100 | number: '1.0-0' }}%
-          </ng-template>
-        </td>
+        <td class="govuk-table__cell workplace-cell">{{ vacancyWorkplaceData }}</td>
+        <td class="govuk-table__cell comparison-group-cell">{{ vacancyComparisonGroupData }}</td>
       </tr>
       <tr class="govuk-table__row" data-testid="turnoverRow">
         <th scope="row" class="govuk-table__header comparison-row-header govuk-!-font-weight-regular">Turnover rate</th>
-        <td class="govuk-table__cell workplace-cell">
-          {{ data?.turnoverRate.workplaceValue.value * 100 | number: '1.0-0' }}%
-        </td>
-        <td class="govuk-table__cell comparison-group-cell">
-          <ng-container *ngIf="viewBenchmarksComparisonGroups; else turnoverTotalComparison">
-            {{ data?.turnoverRate.goodCqc.value * 100 | number: '1.0-0' }}%
-          </ng-container>
-          <ng-template #turnoverTotalComparison>
-            {{ data?.turnoverRate.comparisonGroup.value * 100 | number: '1.0-0' }}%
-          </ng-template>
-        </td>
+        <td class="govuk-table__cell workplace-cell">{{ turnoverWorkplaceData }}</td>
+        <td class="govuk-table__cell comparison-group-cell">{{ turnoverComparisonGroupData }}</td>
       </tr>
       <tr class="govuk-table__row" data-testid="timeInRoleRow">
         <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">
           Percentage of staff still in their main job role after 12 months
         </th>
-        <td class="govuk-table__cell workplace-cell">
-          {{ data?.timeInRole.workplaceValue.value * 100 | number: '1.0-0' }}%
-        </td>
-        <td class="govuk-table__cell comparison-group-cell">
-          <ng-container *ngIf="viewBenchmarksComparisonGroups; else timeInRoleTotalComparison">
-            {{ data?.timeInRole.goodCqc.value * 100 | number: '1.0-0' }}%
-          </ng-container>
-          <ng-template #timeInRoleTotalComparison>
-            {{ data?.timeInRole.comparisonGroup.value * 100 | number: '1.0-0' }}%
-          </ng-template>
-        </td>
+        <td class="govuk-table__cell workplace-cell">{{ timeInRoleWorkplaceData }}</td>
+        <td class="govuk-table__cell comparison-group-cell">{{ timeInRoleComparisonGroupData }}</td>
       </tr>
     </tbody>
   </table>

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
@@ -13,9 +13,7 @@
     </thead>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row first-row" data-testid="vacancyRow">
-        <th scope="row" class="govuk-table__header comparison-row-header govuk-!-font-weight-regular">
-          Vacancy rate
-        </th>
+        <th scope="row" class="govuk-table__header comparison-row-header govuk-!-font-weight-regular">Vacancy rate</th>
         <td class="govuk-table__cell workplace-cell">
           {{ data?.vacancyRate.workplaceValue.value * 100 | number: '1.0-0' }}%
         </td>
@@ -29,9 +27,7 @@
         </td>
       </tr>
       <tr class="govuk-table__row" data-testid="turnoverRow">
-        <th scope="row" class="govuk-table__header comparison-row-header govuk-!-font-weight-regular">
-          Turnover rate
-        </th>
+        <th scope="row" class="govuk-table__header comparison-row-header govuk-!-font-weight-regular">Turnover rate</th>
         <td class="govuk-table__cell workplace-cell">
           {{ data?.turnoverRate.workplaceValue.value * 100 | number: '1.0-0' }}%
         </td>
@@ -101,16 +97,19 @@
           [rankingTitle]="'Vacancy rate'"
           [workplaceRankNumber]="vacancyCurrentRank"
           [workplacesNumber]="vacancyMaxRank"
+          [noWorkplaceData]="vacancyNoWorkplaceData"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="'Turnover rate'"
           [workplaceRankNumber]="turnoverCurrentRank"
           [workplacesNumber]="turnoverMaxRank"
+          [noWorkplaceData]="turnoverNoWorkplaceData"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="'Percentage of staff still in their main job role after 12 months'"
           [workplaceRankNumber]="timeInRoleCurrentRank"
           [workplacesNumber]="timeInRoleMaxRank"
+          [noWorkplaceData]="timeInRoleNoWorkplaceData"
         ></app-data-area-ranking>
       </div>
     </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
@@ -47,6 +47,7 @@
           [rankingsData]="vacancyRankings"
           [isPay]="false"
           [altDescription]="'Vacancy rate barchart'"
+          [noWorkplaceData]="vacancyNoWorkplaceData"
         ></app-data-area-barchart>
         <app-data-area-barchart
           [section]="'Turnover rate'"
@@ -54,6 +55,7 @@
           [rankingsData]="turnoverRankings"
           [isPay]="false"
           [altDescription]="'Turnover rate barchart'"
+          [noWorkplaceData]="turnoverNoWorkplaceData"
         ></app-data-area-barchart>
         <app-data-area-barchart
           [section]="'Percentage of staff still in their main job role after 12 months'"
@@ -61,6 +63,7 @@
           [rankingsData]="timeInRoleRankings"
           [isPay]="false"
           [altDescription]="'Time in role rate barchart'"
+          [noWorkplaceData]="timeInRoleNoWorkplaceData"
         ></app-data-area-barchart>
       </div>
     </ng-container>

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
@@ -201,7 +201,7 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
 
   describe('no data added message', () => {
     it('should show when the amount of vacancies is not known', async () => {
-      const { component, getByTestId } = await setup(true);
+      const { component, getByTestId, fixture } = await setup(true);
 
       component.data = {
         sickness: {
@@ -258,6 +258,8 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
           lastUpdated: new Date(),
         },
       };
+      component.ngOnChanges();
+      fixture.detectChanges();
 
       const vacancyRow = getByTestId('vacancyRow');
       const turnoverRow = getByTestId('turnoverRow');
@@ -272,7 +274,7 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
     });
 
     it('should show when there is a mis-match in staff and staff records', async () => {
-      const { component, getByTestId } = await setup(true);
+      const { component, getByTestId, fixture } = await setup(true);
 
       component.data = {
         sickness: {
@@ -330,6 +332,9 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
         },
       };
 
+      component.ngOnChanges();
+      fixture.detectChanges();
+
       const vacancyRow = getByTestId('vacancyRow');
       const turnoverRow = getByTestId('turnoverRow');
       const timeInRoleRow = getByTestId('timeInRoleRow');
@@ -343,7 +348,7 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
     });
 
     it('should show when the amount of leavers is not known', async () => {
-      const { component, getByTestId } = await setup(true);
+      const { component, getByTestId, fixture } = await setup(true);
 
       component.data = {
         sickness: {
@@ -401,6 +406,9 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
         },
       };
 
+      component.ngOnChanges();
+      fixture.detectChanges();
+
       const vacancyRow = getByTestId('vacancyRow');
       const turnoverRow = getByTestId('turnoverRow');
       const timeInRoleRow = getByTestId('timeInRoleRow');
@@ -431,9 +439,9 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
 
         component.viewBenchmarksPosition = false;
         component.viewBenchmarksComparisonGroups = false;
-        fixture.detectChanges();
 
         component.ngOnChanges();
+        fixture.detectChanges();
 
         expect(component.vacancyMaxRank).toEqual(component.rankingsData.vacancy.groupRankings.maxRank);
         expect(component.turnoverMaxRank).toEqual(component.rankingsData.turnover.groupRankings.maxRank);
@@ -449,9 +457,8 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
 
         component.viewBenchmarksPosition = false;
         component.viewBenchmarksComparisonGroups = true;
-        fixture.detectChanges();
-
         component.ngOnChanges();
+        fixture.detectChanges();
 
         expect(component.vacancyMaxRank).toEqual(component.rankingsData.vacancy.goodCqcRankings.maxRank);
         expect(component.turnoverMaxRank).toEqual(component.rankingsData.turnover.goodCqcRankings.maxRank);
@@ -468,6 +475,7 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
     const { component, fixture, getByTestId, queryByTestId } = await setup();
 
     component.viewBenchmarksPosition = true;
+    component.ngOnChanges();
     fixture.detectChanges();
 
     expect(getByTestId('barcharts')).toBeTruthy();

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
@@ -172,7 +172,6 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
   it('should render values for the workplace and comparison data', async () => {
     const { component, getByTestId } = await setup();
 
-    console.log(component.data.turnoverRate);
     const vacancyRow = getByTestId('vacancyRow');
     const turnoverRow = getByTestId('turnoverRow');
     const timeInRoleRow = getByTestId('timeInRoleRow');


### PR DESCRIPTION
#### Work done
- For ticket [1276-data-area-not-enough-data-added-for-workplace-and-comparator-group](https://trello.com/c/7IVEOb38/1276-data-area-not-enough-data-added-for-workplace-and-comparator-group)
- Add no comparison group and workplace message to rankings and bar chart components.
- Add handling in bar charts options to display an empty bar chart when no data is available.


#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
