### PR TITLE
Feat/1240 data area r and r no comparison group data

### DIFF
--- a/src/app/core/utils/format-util.spec.ts
+++ b/src/app/core/utils/format-util.spec.ts
@@ -51,4 +51,12 @@ describe('FormatUtil', () => {
       expect(formatMoney).toEqual('£36,500');
     });
   });
+
+  describe('formatPercent', () => {
+    it('should show as percentage', async () => {
+      expect(FormatUtil.formatPercent(0.04)).toEqual('4%');
+      expect(FormatUtil.formatPercent(0.597609562)).toEqual('60%');
+      expect(FormatUtil.formatPercent(0.5)).toEqual('50%');
+    });
+  });
 });

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -24,7 +24,8 @@
           class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8 govuk-!-padding-bottom-3"
           data-testid="no-comparison-data"
         >
-          We do not have enough comparison group data to show where you're positioned yet.
+          We do not have enough comparison group data to<br />
+          show you where you're positioned yet.
         </p>
       </ng-container>
       <ng-template #noWorkplaceData>
@@ -36,7 +37,8 @@
   </ng-container>
   <ng-template #noComparisonData>
     <p class="govuk-body govuk-!-margin-top-2 govuk-!-padding-bottom-3" data-testid="no-comparison-data">
-      We do not have enough comparison group data to show where you're positioned yet.
+      We do not have enough comparison group data to<br />
+      show you where you're positioned yet.
     </p>
   </ng-template>
   <highcharts-chart class="chart" [Highcharts]="Highcharts" [options]="options"></highcharts-chart>

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.scss
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.scss
@@ -1,6 +1,6 @@
 .barchart-container {
   background-color: #f3f2f1;
-  padding: 15px 15px 0 15px;
+  padding: 10px 15px 0 15px;
 }
 
 .barchart-summary {

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruiment-and-retention.component.ts
@@ -1,5 +1,11 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
-import { AllRankingsResponse, BenchmarksResponse, RankingsResponse } from '@core/model/benchmarks.model';
+import {
+  AllRankingsResponse,
+  BenchmarksResponse,
+  RankingsResponse,
+  BenchmarkValue,
+} from '@core/model/benchmarks.model';
+import { FormatUtil } from '@core/utils/format-util';
 
 @Component({
   selector: 'app-data-area-recruitment-and-retention',
@@ -20,13 +26,33 @@ export class DataAreaRecruitmentAndRetentionComponent implements OnChanges {
   public vacancyCurrentRank;
   public turnoverCurrentRank;
   public timeInRoleCurrentRank;
+  public vacancyComparisionGroup;
+  public turnoverComparisionGroup;
+  public timeInRoleComparisionGroup;
 
   ngOnChanges(): void {
     this.setRankings(this.viewBenchmarksComparisonGroups);
+    this.setComparisonGroupRecruitmentAndRetention(this.viewBenchmarksComparisonGroups);
   }
 
   public handleViewBenchmarkPosition(visible: boolean): void {
     this.viewBenchmarksPosition = visible;
+  }
+
+  public formatComparisionGroup(data: BenchmarkValue): string {
+    return data.hasValue ? FormatUtil.formatPercent(data.value) : 'Not enough data';
+  }
+
+  public setComparisonGroupRecruitmentAndRetention(isGoodAndOutstanding: boolean): void {
+    if (isGoodAndOutstanding) {
+      this.vacancyComparisionGroup = this.formatComparisionGroup(this.data?.vacancyRate.goodCqc);
+      this.turnoverComparisionGroup = this.formatComparisionGroup(this.data?.turnoverRate.goodCqc);
+      this.timeInRoleComparisionGroup = this.formatComparisionGroup(this.data?.timeInRole.goodCqc);
+    } else {
+      this.vacancyComparisionGroup = this.formatComparisionGroup(this.data?.vacancyRate.comparisonGroup);
+      this.turnoverComparisionGroup = this.formatComparisionGroup(this.data?.turnoverRate.comparisonGroup);
+      this.timeInRoleComparisionGroup = this.formatComparisionGroup(this.data?.timeInRole.comparisonGroup);
+    }
   }
 
   public setCurrentRank(rankings: RankingsResponse) {

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
@@ -23,13 +23,9 @@
         <ng-template #noVacancyData>
           <td class="govuk-table__cell workplace-cell">No data added</td>
         </ng-template>
+
         <td class="govuk-table__cell comparison-group-cell">
-          <ng-container *ngIf="viewBenchmarksComparisonGroups; else vacancyTotalComparison">
-            {{ data?.vacancyRate.goodCqc.value * 100 | number: '1.0-0' }}%
-          </ng-container>
-          <ng-template #vacancyTotalComparison>
-            {{ data?.vacancyRate.comparisonGroup.value * 100 | number: '1.0-0' }}%
-          </ng-template>
+          {{ vacancyComparisionGroup }}
         </td>
       </tr>
       <tr class="govuk-table__row" data-testid="turnoverRow">
@@ -43,12 +39,7 @@
           <td class="govuk-table__cell workplace-cell">No data added</td>
         </ng-template>
         <td class="govuk-table__cell comparison-group-cell">
-          <ng-container *ngIf="viewBenchmarksComparisonGroups; else turnoverTotalComparison">
-            {{ data?.turnoverRate.goodCqc.value * 100 | number: '1.0-0' }}%
-          </ng-container>
-          <ng-template #turnoverTotalComparison>
-            {{ data?.turnoverRate.comparisonGroup.value * 100 | number: '1.0-0' }}%
-          </ng-template>
+          {{ turnoverComparisionGroup }}
         </td>
       </tr>
       <tr class="govuk-table__row" data-testid="timeInRoleRow">
@@ -59,12 +50,7 @@
           {{ data?.timeInRole.workplaceValue.value * 100 | number: '1.0-0' }}%
         </td>
         <td class="govuk-table__cell comparison-group-cell">
-          <ng-container *ngIf="viewBenchmarksComparisonGroups; else timeInRoleTotalComparison">
-            {{ data?.timeInRole.goodCqc.value * 100 | number: '1.0-0' }}%
-          </ng-container>
-          <ng-template #timeInRoleTotalComparison>
-            {{ data?.timeInRole.comparisonGroup.value * 100 | number: '1.0-0' }}%
-          </ng-template>
+          {{ timeInRoleComparisionGroup }}
         </td>
       </tr>
     </tbody>

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.spec.ts
@@ -9,6 +9,7 @@ import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
 
 import { DataAreaRecruitmentAndRetentionComponent } from './data-area-recruiment-and-retention.component';
+import { DescElement } from 'canvg';
 
 describe('DataAreaRecruitmentAndRetentionComponent', () => {
   const setup = async (viewBenchmarksComparisonGroups = false) => {
@@ -169,40 +170,254 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render values for the workplace and comparison data', async () => {
-    const { component, getByTestId } = await setup();
+  describe('comparision table', () => {
+    it('should render values for the workplace and comparison data', async () => {
+      const { getByTestId } = await setup();
 
-    console.log(component.data.turnoverRate);
-    const vacancyRow = getByTestId('vacancyRow');
-    const turnoverRow = getByTestId('turnoverRow');
-    const timeInRoleRow = getByTestId('timeInRoleRow');
+      const vacancyRow = getByTestId('vacancyRow');
+      const turnoverRow = getByTestId('turnoverRow');
+      const timeInRoleRow = getByTestId('timeInRoleRow');
 
-    expect(within(vacancyRow).getByText('7%')).toBeTruthy();
-    expect(within(vacancyRow).getByText('6%')).toBeTruthy();
-    expect(within(turnoverRow).getByText('28%')).toBeTruthy();
-    expect(within(turnoverRow).getByText('27%')).toBeTruthy();
-    expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
-    expect(within(timeInRoleRow).getByText('89%')).toBeTruthy();
-  });
+      expect(within(vacancyRow).getByText('7%')).toBeTruthy();
+      expect(within(vacancyRow).getByText('6%')).toBeTruthy();
+      expect(within(turnoverRow).getByText('28%')).toBeTruthy();
+      expect(within(turnoverRow).getByText('27%')).toBeTruthy();
+      expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
+      expect(within(timeInRoleRow).getByText('89%')).toBeTruthy();
+    });
 
-  it('should render the values for the workplace and goodCqc comparison data', async () => {
-    const { getByTestId } = await setup(true);
+    it('should render the values for the workplace and goodCqc comparison data', async () => {
+      const { getByTestId } = await setup(true);
 
-    const vacancyRow = getByTestId('vacancyRow');
-    const turnoverRow = getByTestId('turnoverRow');
-    const timeInRoleRow = getByTestId('timeInRoleRow');
+      const vacancyRow = getByTestId('vacancyRow');
+      const turnoverRow = getByTestId('turnoverRow');
+      const timeInRoleRow = getByTestId('timeInRoleRow');
 
-    expect(within(vacancyRow).getByText('7%')).toBeTruthy();
-    expect(within(vacancyRow).getByText('5%')).toBeTruthy();
-    expect(within(turnoverRow).getByText('28%')).toBeTruthy();
-    expect(within(turnoverRow).getByText('29%')).toBeTruthy();
-    expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
-    expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
-  });
+      expect(within(vacancyRow).getByText('7%')).toBeTruthy();
+      expect(within(vacancyRow).getByText('5%')).toBeTruthy();
+      expect(within(turnoverRow).getByText('28%')).toBeTruthy();
+      expect(within(turnoverRow).getByText('29%')).toBeTruthy();
+      expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
+      expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
+    });
 
-  describe('no data added message', () => {
-    it('should show when the amount of vacancies is not known', async () => {
-      const { component, getByTestId } = await setup(true);
+    describe('"no data added" message', () => {
+      it('should show when the amount of vacancies is not known', async () => {
+        const { component, getByTestId } = await setup(true);
+
+        component.data = {
+          sickness: {
+            workplaceValue: { value: 11, hasValue: true },
+            comparisonGroup: { value: 12, hasValue: true },
+            goodCqc: { value: 15, hasValue: true },
+          },
+          qualifications: {
+            workplaceValue: { value: 0.521, hasValue: true },
+            comparisonGroup: { value: 0.533, hasValue: true },
+            goodCqc: { value: 0.545, hasValue: true },
+          },
+          turnoverRate: {
+            workplaceValue: { value: 0.281, hasValue: true },
+            comparisonGroup: { value: 0.273, hasValue: true },
+            goodCqc: { value: 0.2851, hasValue: true },
+          },
+          vacancyRate: {
+            workplaceValue: { value: 0, hasValue: false, stateMessage: 'no-vacancies' },
+            comparisonGroup: { value: 0.063, hasValue: true },
+            goodCqc: { value: 0.051, hasValue: true },
+          },
+          careWorkerPay: {
+            workplaceValue: { value: 1015, hasValue: true },
+            comparisonGroup: { value: 1013, hasValue: true },
+            goodCqc: { value: 1026, hasValue: true },
+          },
+          seniorCareWorkerPay: {
+            workplaceValue: { value: 1091, hasValue: true },
+            comparisonGroup: { value: 1091, hasValue: true },
+            goodCqc: { value: 1093, hasValue: true },
+          },
+          registeredNursePay: {
+            workplaceValue: { value: 37250, hasValue: true },
+            comparisonGroup: { value: 37200, hasValue: true },
+            goodCqc: { value: 37350, hasValue: true },
+          },
+          registeredManagerPay: {
+            workplaceValue: { value: 36075, hasValue: true },
+            comparisonGroup: { value: 36110, hasValue: true },
+            goodCqc: { value: 36200, hasValue: true },
+          },
+          timeInRole: {
+            workplaceValue: { value: 0.883, hasValue: true },
+            comparisonGroup: { value: 0.887, hasValue: true },
+            goodCqc: { value: 0.895, hasValue: true },
+          },
+          meta: {
+            workplaces: 35,
+            staff: 460,
+            workplacesGoodCqc: 22,
+            staffGoodCqc: 315,
+            localAuthority: 'LA1',
+            lastUpdated: new Date(),
+          },
+        };
+
+        const vacancyRow = getByTestId('vacancyRow');
+        const turnoverRow = getByTestId('turnoverRow');
+        const timeInRoleRow = getByTestId('timeInRoleRow');
+
+        expect(within(vacancyRow).getByText('No data added')).toBeTruthy();
+        expect(within(vacancyRow).getByText('5%')).toBeTruthy();
+        expect(within(turnoverRow).getByText('28%')).toBeTruthy();
+        expect(within(turnoverRow).getByText('29%')).toBeTruthy();
+        expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
+        expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
+      });
+
+      it('should show when there is a mis-match in staff and staff records', async () => {
+        const { component, getByTestId } = await setup(true);
+
+        component.data = {
+          sickness: {
+            workplaceValue: { value: 11, hasValue: true },
+            comparisonGroup: { value: 12, hasValue: true },
+            goodCqc: { value: 15, hasValue: true },
+          },
+          qualifications: {
+            workplaceValue: { value: 0.521, hasValue: true },
+            comparisonGroup: { value: 0.533, hasValue: true },
+            goodCqc: { value: 0.545, hasValue: true },
+          },
+          turnoverRate: {
+            workplaceValue: { value: 0, hasValue: false, stateMessage: 'mismatch-workers' },
+            comparisonGroup: { value: 0.273, hasValue: true },
+            goodCqc: { value: 0.2851, hasValue: true },
+          },
+          vacancyRate: {
+            workplaceValue: { value: 0, hasValue: false, stateMessage: 'mismatch-workers' },
+            comparisonGroup: { value: 0.063, hasValue: true },
+            goodCqc: { value: 0.051, hasValue: true },
+          },
+          careWorkerPay: {
+            workplaceValue: { value: 1015, hasValue: true },
+            comparisonGroup: { value: 1013, hasValue: true },
+            goodCqc: { value: 1026, hasValue: true },
+          },
+          seniorCareWorkerPay: {
+            workplaceValue: { value: 1091, hasValue: true },
+            comparisonGroup: { value: 1091, hasValue: true },
+            goodCqc: { value: 1093, hasValue: true },
+          },
+          registeredNursePay: {
+            workplaceValue: { value: 37250, hasValue: true },
+            comparisonGroup: { value: 37200, hasValue: true },
+            goodCqc: { value: 37350, hasValue: true },
+          },
+          registeredManagerPay: {
+            workplaceValue: { value: 36075, hasValue: true },
+            comparisonGroup: { value: 36110, hasValue: true },
+            goodCqc: { value: 36200, hasValue: true },
+          },
+          timeInRole: {
+            workplaceValue: { value: 0.883, hasValue: true },
+            comparisonGroup: { value: 0.887, hasValue: true },
+            goodCqc: { value: 0.895, hasValue: true },
+          },
+          meta: {
+            workplaces: 35,
+            staff: 460,
+            workplacesGoodCqc: 22,
+            staffGoodCqc: 315,
+            localAuthority: 'LA1',
+            lastUpdated: new Date(),
+          },
+        };
+
+        const vacancyRow = getByTestId('vacancyRow');
+        const turnoverRow = getByTestId('turnoverRow');
+        const timeInRoleRow = getByTestId('timeInRoleRow');
+
+        expect(within(vacancyRow).getByText('No data added')).toBeTruthy();
+        expect(within(vacancyRow).getByText('5%')).toBeTruthy();
+        expect(within(turnoverRow).getByText('No data added')).toBeTruthy();
+        expect(within(turnoverRow).getByText('29%')).toBeTruthy();
+        expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
+        expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
+      });
+
+      it('should show when the amount of leavers is not known', async () => {
+        const { component, getByTestId } = await setup(true);
+
+        component.data = {
+          sickness: {
+            workplaceValue: { value: 11, hasValue: true },
+            comparisonGroup: { value: 12, hasValue: true },
+            goodCqc: { value: 15, hasValue: true },
+          },
+          qualifications: {
+            workplaceValue: { value: 0.521, hasValue: true },
+            comparisonGroup: { value: 0.533, hasValue: true },
+            goodCqc: { value: 0.545, hasValue: true },
+          },
+          turnoverRate: {
+            workplaceValue: { value: 0, hasValue: false, stateMessage: 'no-leavers' },
+            comparisonGroup: { value: 0.273, hasValue: true },
+            goodCqc: { value: 0.2851, hasValue: true },
+          },
+          vacancyRate: {
+            workplaceValue: { value: 0.068, hasValue: true },
+            comparisonGroup: { value: 0.063, hasValue: true },
+            goodCqc: { value: 0.051, hasValue: true },
+          },
+          careWorkerPay: {
+            workplaceValue: { value: 1015, hasValue: true },
+            comparisonGroup: { value: 1013, hasValue: true },
+            goodCqc: { value: 1026, hasValue: true },
+          },
+          seniorCareWorkerPay: {
+            workplaceValue: { value: 1091, hasValue: true },
+            comparisonGroup: { value: 1091, hasValue: true },
+            goodCqc: { value: 1093, hasValue: true },
+          },
+          registeredNursePay: {
+            workplaceValue: { value: 37250, hasValue: true },
+            comparisonGroup: { value: 37200, hasValue: true },
+            goodCqc: { value: 37350, hasValue: true },
+          },
+          registeredManagerPay: {
+            workplaceValue: { value: 36075, hasValue: true },
+            comparisonGroup: { value: 36110, hasValue: true },
+            goodCqc: { value: 36200, hasValue: true },
+          },
+          timeInRole: {
+            workplaceValue: { value: 0.883, hasValue: true },
+            comparisonGroup: { value: 0.887, hasValue: true },
+            goodCqc: { value: 0.895, hasValue: true },
+          },
+          meta: {
+            workplaces: 35,
+            staff: 460,
+            workplacesGoodCqc: 22,
+            staffGoodCqc: 315,
+            localAuthority: 'LA1',
+            lastUpdated: new Date(),
+          },
+        };
+
+        const vacancyRow = getByTestId('vacancyRow');
+        const turnoverRow = getByTestId('turnoverRow');
+        const timeInRoleRow = getByTestId('timeInRoleRow');
+
+        expect(within(vacancyRow).getByText('7%')).toBeTruthy();
+        expect(within(vacancyRow).getByText('5%')).toBeTruthy();
+        expect(within(turnoverRow).getByText('No data added')).toBeTruthy();
+        expect(within(turnoverRow).getByText('29%')).toBeTruthy();
+        expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
+        expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
+      });
+    });
+
+    it('shows "not enough data" message for comparision group', async () => {
+      const { component, getByTestId } = await setup();
 
       component.data = {
         sickness: {
@@ -217,155 +432,13 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
         },
         turnoverRate: {
           workplaceValue: { value: 0.281, hasValue: true },
-          comparisonGroup: { value: 0.273, hasValue: true },
-          goodCqc: { value: 0.2851, hasValue: true },
-        },
-        vacancyRate: {
-          workplaceValue: { value: 0, hasValue: false, stateMessage: 'no-vacancies' },
-          comparisonGroup: { value: 0.063, hasValue: true },
-          goodCqc: { value: 0.051, hasValue: true },
-        },
-        careWorkerPay: {
-          workplaceValue: { value: 1015, hasValue: true },
-          comparisonGroup: { value: 1013, hasValue: true },
-          goodCqc: { value: 1026, hasValue: true },
-        },
-        seniorCareWorkerPay: {
-          workplaceValue: { value: 1091, hasValue: true },
-          comparisonGroup: { value: 1091, hasValue: true },
-          goodCqc: { value: 1093, hasValue: true },
-        },
-        registeredNursePay: {
-          workplaceValue: { value: 37250, hasValue: true },
-          comparisonGroup: { value: 37200, hasValue: true },
-          goodCqc: { value: 37350, hasValue: true },
-        },
-        registeredManagerPay: {
-          workplaceValue: { value: 36075, hasValue: true },
-          comparisonGroup: { value: 36110, hasValue: true },
-          goodCqc: { value: 36200, hasValue: true },
-        },
-        timeInRole: {
-          workplaceValue: { value: 0.883, hasValue: true },
-          comparisonGroup: { value: 0.887, hasValue: true },
-          goodCqc: { value: 0.895, hasValue: true },
-        },
-        meta: {
-          workplaces: 35,
-          staff: 460,
-          workplacesGoodCqc: 22,
-          staffGoodCqc: 315,
-          localAuthority: 'LA1',
-          lastUpdated: new Date(),
-        },
-      };
-
-      const vacancyRow = getByTestId('vacancyRow');
-      const turnoverRow = getByTestId('turnoverRow');
-      const timeInRoleRow = getByTestId('timeInRoleRow');
-
-      expect(within(vacancyRow).getByText('No data added')).toBeTruthy();
-      expect(within(vacancyRow).getByText('5%')).toBeTruthy();
-      expect(within(turnoverRow).getByText('28%')).toBeTruthy();
-      expect(within(turnoverRow).getByText('29%')).toBeTruthy();
-      expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
-      expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
-    });
-
-    it('should show when there is a mis-match in staff and staff records', async () => {
-      const { component, getByTestId } = await setup(true);
-
-      component.data = {
-        sickness: {
-          workplaceValue: { value: 11, hasValue: true },
-          comparisonGroup: { value: 12, hasValue: true },
-          goodCqc: { value: 15, hasValue: true },
-        },
-        qualifications: {
-          workplaceValue: { value: 0.521, hasValue: true },
-          comparisonGroup: { value: 0.533, hasValue: true },
-          goodCqc: { value: 0.545, hasValue: true },
-        },
-        turnoverRate: {
-          workplaceValue: { value: 0, hasValue: false, stateMessage: 'mismatch-workers' },
-          comparisonGroup: { value: 0.273, hasValue: true },
-          goodCqc: { value: 0.2851, hasValue: true },
-        },
-        vacancyRate: {
-          workplaceValue: { value: 0, hasValue: false, stateMessage: 'mismatch-workers' },
-          comparisonGroup: { value: 0.063, hasValue: true },
-          goodCqc: { value: 0.051, hasValue: true },
-        },
-        careWorkerPay: {
-          workplaceValue: { value: 1015, hasValue: true },
-          comparisonGroup: { value: 1013, hasValue: true },
-          goodCqc: { value: 1026, hasValue: true },
-        },
-        seniorCareWorkerPay: {
-          workplaceValue: { value: 1091, hasValue: true },
-          comparisonGroup: { value: 1091, hasValue: true },
-          goodCqc: { value: 1093, hasValue: true },
-        },
-        registeredNursePay: {
-          workplaceValue: { value: 37250, hasValue: true },
-          comparisonGroup: { value: 37200, hasValue: true },
-          goodCqc: { value: 37350, hasValue: true },
-        },
-        registeredManagerPay: {
-          workplaceValue: { value: 36075, hasValue: true },
-          comparisonGroup: { value: 36110, hasValue: true },
-          goodCqc: { value: 36200, hasValue: true },
-        },
-        timeInRole: {
-          workplaceValue: { value: 0.883, hasValue: true },
-          comparisonGroup: { value: 0.887, hasValue: true },
-          goodCqc: { value: 0.895, hasValue: true },
-        },
-        meta: {
-          workplaces: 35,
-          staff: 460,
-          workplacesGoodCqc: 22,
-          staffGoodCqc: 315,
-          localAuthority: 'LA1',
-          lastUpdated: new Date(),
-        },
-      };
-
-      const vacancyRow = getByTestId('vacancyRow');
-      const turnoverRow = getByTestId('turnoverRow');
-      const timeInRoleRow = getByTestId('timeInRoleRow');
-
-      expect(within(vacancyRow).getByText('No data added')).toBeTruthy();
-      expect(within(vacancyRow).getByText('5%')).toBeTruthy();
-      expect(within(turnoverRow).getByText('No data added')).toBeTruthy();
-      expect(within(turnoverRow).getByText('29%')).toBeTruthy();
-      expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
-      expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
-    });
-
-    it('should show when the amount of leavers is not known', async () => {
-      const { component, getByTestId } = await setup(true);
-
-      component.data = {
-        sickness: {
-          workplaceValue: { value: 11, hasValue: true },
-          comparisonGroup: { value: 12, hasValue: true },
-          goodCqc: { value: 15, hasValue: true },
-        },
-        qualifications: {
-          workplaceValue: { value: 0.521, hasValue: true },
-          comparisonGroup: { value: 0.533, hasValue: true },
-          goodCqc: { value: 0.545, hasValue: true },
-        },
-        turnoverRate: {
-          workplaceValue: { value: 0, hasValue: false, stateMessage: 'no-leavers' },
-          comparisonGroup: { value: 0.273, hasValue: true },
-          goodCqc: { value: 0.2851, hasValue: true },
+          comparisonGroup: { value: 0, hasValue: false, stateMessage: 'no-data' },
+          goodCqc: { value: 0, hasValue: false, stateMessage: 'no-data' },
         },
         vacancyRate: {
           workplaceValue: { value: 0.068, hasValue: true },
-          comparisonGroup: { value: 0.063, hasValue: true },
-          goodCqc: { value: 0.051, hasValue: true },
+          comparisonGroup: { value: 0, hasValue: false, stateMessage: 'no-data' },
+          goodCqc: { value: 0, hasValue: false, stateMessage: 'no-data' },
         },
         careWorkerPay: {
           workplaceValue: { value: 1015, hasValue: true },
@@ -389,8 +462,8 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
         },
         timeInRole: {
           workplaceValue: { value: 0.883, hasValue: true },
-          comparisonGroup: { value: 0.887, hasValue: true },
-          goodCqc: { value: 0.895, hasValue: true },
+          comparisonGroup: { value: 0, hasValue: false, stateMessage: 'no-data' },
+          goodCqc: { value: 0, hasValue: false, stateMessage: 'no-data' },
         },
         meta: {
           workplaces: 35,
@@ -401,17 +474,21 @@ describe('DataAreaRecruitmentAndRetentionComponent', () => {
           lastUpdated: new Date(),
         },
       };
+
+      component.ngOnChanges();
+
+      component.viewBenchmarksComparisonGroups = false;
 
       const vacancyRow = getByTestId('vacancyRow');
       const turnoverRow = getByTestId('turnoverRow');
       const timeInRoleRow = getByTestId('timeInRoleRow');
 
       expect(within(vacancyRow).getByText('7%')).toBeTruthy();
-      expect(within(vacancyRow).getByText('5%')).toBeTruthy();
-      expect(within(turnoverRow).getByText('No data added')).toBeTruthy();
-      expect(within(turnoverRow).getByText('29%')).toBeTruthy();
+      expect(within(vacancyRow).getByText('Not enough data')).toBeTruthy();
+      expect(within(turnoverRow).getByText('28%')).toBeTruthy();
+      expect(within(turnoverRow).getByText('Not enough data')).toBeTruthy();
       expect(within(timeInRoleRow).getByText('88%')).toBeTruthy();
-      expect(within(timeInRoleRow).getByText('90%')).toBeTruthy();
+      expect(within(timeInRoleRow).getByText('Not enough data')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
#### Work done
- Work for [ticket](https://trello.com/c/kPhkAxE5/1240-data-area-r-r-no-comparison-group-data)
- Message in comparison table when there's no data
- Adjust padding on bar chart container
- Add test for formatting to percentage

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
