### PR TITLE
Feat/remove frontend dependency on backend

### DIFF
--- a/src/app/core/guards/permissions/check-permissions/check-permissions.guard.ts
+++ b/src/app/core/guards/permissions/check-permissions/check-permissions.guard.ts
@@ -4,8 +4,7 @@ import { PermissionType } from '@core/model/permissions.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
-
-import { isAdminRole } from '../../../../../../server/utils/adminUtils';
+import { isAdminRole } from '@core/utils/check-role-util';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/core/model/job.model.ts
+++ b/src/app/core/model/job.model.ts
@@ -10,6 +10,7 @@ export interface GetJobsResponse {
 
 export interface JobRole {
   jobId: number;
+  jobRoleName?: string;
   title?: string;
   other?: string;
 }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -3,13 +3,13 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { JwtHelperService } from '@auth0/angular-jwt';
 import { UserToken } from '@core/model/auth.model';
+import { isAdminRole } from '@core/utils/check-role-util';
 import * as Sentry from '@sentry/browser';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import isNull from 'lodash/isNull';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, filter, tap } from 'rxjs/operators';
 
-import { isAdminRole } from '../../../../server/utils/adminUtils';
 import { EstablishmentService } from './establishment.service';
 import { PermissionsService } from './permissions/permissions.service';
 import { UserService } from './user.service';

--- a/src/app/core/test-utils/MockEstablishmentService.ts
+++ b/src/app/core/test-utils/MockEstablishmentService.ts
@@ -5,6 +5,7 @@ import { GetChildWorkplacesResponse } from '@core/model/my-workplaces.model';
 import { ServiceGroup } from '@core/model/services.model';
 import { URLStructure } from '@core/model/url.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { build, fake, perBuild, sequence } from '@jackfranklin/test-data-bot';
 import { Observable, of } from 'rxjs';
 
 import { subsid1, subsid2, subsid3 } from './MockUserService';
@@ -15,6 +16,81 @@ interface EmployerTypeRequest {
     other?: string;
   };
 }
+
+export const establishmentBuilder = build('Establishment', {
+  fields: {
+    id: sequence(),
+    uid: fake((f) => f.datatype.uuid()),
+    name: fake((f) => f.lorem.sentence()),
+    address: fake((f) => f.address.streetAddress()),
+    postcode: fake((f) => f.address.zipCode('??# #??')),
+    isRegulated: perBuild(() => false),
+    nmdsId: fake((f) => f.lorem.word()),
+    created: new Date(),
+    updated: new Date(),
+    updatedBy: fake((f) => f.name.firstName()),
+    isParent: perBuild(() => false),
+    parentId: null,
+    mainService: {
+      id: 16,
+      name: fake((f) => f.lorem.sentence()),
+    },
+    employerType: {
+      value: fake((f) => f.company.companyName()),
+    },
+    numberOfStaff: 3,
+    totalWorkers: 4,
+    otherServices: { value: 'Yes', services: [{ category: 'Adult community care', services: [] }] },
+    serviceUsers: [],
+    capacities: [],
+    shareWith: { cqc: null, localAuthorities: null },
+    localAuthorities: [],
+    primaryAuthority: undefined,
+    vacancies: undefined,
+    totalVacancies: 0,
+    starters: undefined,
+    totalStarters: 0,
+    leavers: undefined,
+    totalLeavers: 0,
+    dataOwner: undefined,
+    dataPermissions: undefined,
+    dataOwnershipRequested: fake((f) => f.name.firstName()),
+    moneySpentOnAdvertisingInTheLastFourWeeks: fake((f) => f.finance.amount(1, 10000, 2)),
+    peopleInterviewedInTheLastFourWeeks: fake((f) => f.datatype.number(1000)),
+    doNewStartersRepeatMandatoryTrainingFromPreviousEmployment: 'Yes, always',
+    wouldYouAcceptCareCertificatesFromPreviousEmployment: 'No, never',
+    careWorkersCashLoyaltyForFirstTwoYears: fake((f) => f.finance.amount(1, 10000, 2)),
+    sickPay: 'Yes',
+    careWorkersLeaveDaysPerYear: fake((f) => f.datatype.number(1000)),
+    wdf: null,
+  },
+});
+
+export const establishmentWithShareWith = (shareWith) => {
+  return establishmentBuilder({
+    overrides: {
+      shareWith,
+      otherService: { value: 'Yes', services: [{ category: 'Adult community care', services: [] }] },
+    },
+  });
+};
+
+export const establishmentWithWdfBuilder = () => {
+  return establishmentBuilder({
+    overrides: {
+      wdf: {
+        mainService: { isEligible: false, updatedSinceEffectiveDate: true },
+        starters: { isEligible: false, updatedSinceEffectiveDate: true },
+        leavers: { isEligible: false, updatedSinceEffectiveDate: true },
+        vacancies: { isEligible: false, updatedSinceEffectiveDate: true },
+        capacities: { isEligible: false, updatedSinceEffectiveDate: true },
+        serviceUsers: { isEligible: false, updatedSinceEffectiveDate: true },
+        numberOfStaff: { isEligible: false, updatedSinceEffectiveDate: true },
+        employerType: { isEligible: false, updatedSinceEffectiveDate: true },
+      },
+    },
+  });
+};
 
 @Injectable()
 export class MockEstablishmentService extends EstablishmentService {

--- a/src/app/core/test-utils/MockWorkerService.ts
+++ b/src/app/core/test-utils/MockWorkerService.ts
@@ -16,6 +16,7 @@ export const workerBuilder = build('Worker', {
     nameOrId: fake((f) => f.name.findName()),
     mainJob: {
       id: sequence(),
+      jobRoleName: fake((f) => f.lorem.sentence()),
       title: fake((f) => f.lorem.sentence()),
       other: null,
     },
@@ -42,6 +43,9 @@ export const workerBuilder = build('Worker', {
     },
     nurseSpecialism: null,
     wdfEligible: perBuild(() => false),
+    wdf: {
+      isEligible: perBuild(() => false),
+    },
     trainingCount: 0,
     expiredTrainingCount: 0,
     expiringTrainingCount: 0,
@@ -50,7 +54,6 @@ export const workerBuilder = build('Worker', {
     longTermAbsence: null,
     completed: perBuild(() => false),
     created: new Date('2020-03-31'),
-
     ethnicity: {
       ethnicityId: 1,
       ethnicity: 'white ethnicity 1',
@@ -129,6 +132,30 @@ export const longTermAbsentWorker = workerBuilder({
     longTermAbsence: 'Illness',
   },
 });
+
+export const workerWithWdf = () => {
+  return workerBuilder({
+    overrides: {
+      wdfEligible: perBuild(() => true),
+      wdf: {
+        isEligible: true,
+        mainJobStartDate: { isEligible: true, updatedSinceEffectiveDate: true },
+        daysSick: { isEligible: true, updatedSinceEffectiveDate: true },
+        zeroHoursContract: { isEligible: true, updatedSinceEffectiveDate: true },
+        weeklyHoursContracted: { isEligible: true, updatedSinceEffectiveDate: true },
+        weeklyHoursAverage: { isEligible: true, updatedSinceEffectiveDate: true },
+        annualHourlyPay: { isEligible: true, updatedSinceEffectiveDate: true },
+        mainJob: { isEligible: true, updatedSinceEffectiveDate: true },
+        contract: { isEligible: true, updatedSinceEffectiveDate: true },
+        socialCareQualification: { isEligible: true, updatedSinceEffectiveDate: true },
+        qualificationInSocialCare: { isEligible: true, updatedSinceEffectiveDate: true },
+        careCertificate: { isEligible: true, updatedSinceEffectiveDate: true },
+        otherQualification: { isEligible: true, updatedSinceEffectiveDate: true },
+        highestQualification: { isEligible: true, updatedSinceEffectiveDate: true },
+      },
+    },
+  });
+};
 
 export const AllWorkers = [
   {

--- a/src/app/core/utils/check-role-util.spec.ts
+++ b/src/app/core/utils/check-role-util.spec.ts
@@ -1,0 +1,20 @@
+import { isAdminRole } from './check-role-util';
+
+fdescribe('check-role-util', () => {
+  describe('isAdminRole', () => {
+    it('should return true if the role is an Admin', () => {
+      const isAdmin = isAdminRole('Admin');
+      expect(isAdmin).toBeTruthy();
+    });
+
+    it('should return true if the role is an AdminManager', () => {
+      const isAdmin = isAdminRole('AdminManager');
+      expect(isAdmin).toBeTruthy();
+    });
+
+    it('should return false if the role is not Admin or AdminManager', () => {
+      const isAdmin = isAdminRole('Edit');
+      expect(isAdmin).toBeFalsy();
+    });
+  });
+});

--- a/src/app/core/utils/check-role-util.spec.ts
+++ b/src/app/core/utils/check-role-util.spec.ts
@@ -1,6 +1,6 @@
 import { isAdminRole } from './check-role-util';
 
-fdescribe('check-role-util', () => {
+describe('check-role-util', () => {
   describe('isAdminRole', () => {
     it('should return true if the role is an Admin', () => {
       const isAdmin = isAdminRole('Admin');

--- a/src/app/core/utils/check-role-util.ts
+++ b/src/app/core/utils/check-role-util.ts
@@ -1,0 +1,6 @@
+import { Roles } from '@core/model/roles.enum';
+
+export const isAdminRole = (role: string): boolean => {
+  const adminRoles = [Roles.Admin.toString(), Roles.AdminManager.toString()];
+  return adminRoles.includes(role);
+};

--- a/src/app/features/bulk-upload/bulk-upload-page/bulk-upload-page.component.ts
+++ b/src/app/features/bulk-upload/bulk-upload-page/bulk-upload-page.component.ts
@@ -7,8 +7,8 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { BulkUploadService, BulkUploadServiceV2 } from '@core/services/bulk-upload.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { isAdminRole } from '@core/utils/check-role-util';
 
-import { isAdminRole } from '../../../../../server/utils/adminUtils';
 import { AdminSkipService } from '../admin-skip.service';
 
 @Component({

--- a/src/app/features/dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/dashboard/home-tab/home-tab.component.ts
@@ -14,6 +14,7 @@ import { ReportService } from '@core/services/report.service';
 import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { WorkerService } from '@core/services/worker.service';
+import { isAdminRole } from '@core/utils/check-role-util';
 import { BecomeAParentCancelDialogComponent } from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
 import { BecomeAParentDialogComponent } from '@shared/components/become-a-parent/become-a-parent-dialog.component';
 import { CancelDataOwnerDialogComponent } from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
@@ -27,7 +28,6 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import saveAs from 'file-saver';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { isAdminRole } from 'server/utils/adminUtils';
 
 declare global {
   interface Window {

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -8,9 +8,8 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { IdleService } from '@core/services/idle.service';
 import { UserService } from '@core/services/user.service';
+import { isAdminRole } from '@core/utils/check-role-util';
 import { Subscription } from 'rxjs';
-
-import { isAdminRole } from '../../../../server/utils/adminUtils';
 
 @Component({
   selector: 'app-login',

--- a/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
+++ b/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
@@ -5,28 +6,28 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
+import { Roles } from '@core/model/roles.enum';
+import { AuthService } from '@core/services/auth.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { PdfService } from '@core/services/pdf.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { UserService } from '@core/services/user.service';
+import { WindowToken } from '@core/services/window';
+import { WindowRef } from '@core/services/window.ref';
+import { MockAuthService } from '@core/test-utils/MockAuthService';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { MockUserService } from '@core/test-utils/MockUserService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { NewBenchmarksTabComponent } from './benchmarks-tab.component';
 import { NewComparisonGroupHeaderComponent } from './comparison-group-header/comparison-group-header.component';
-import { WindowRef } from '@core/services/window.ref';
-import { UserService } from '@core/services/user.service';
-import { MockUserService } from '@core/test-utils/MockUserService';
-import { HttpClient } from '@angular/common/http';
-import { AuthService } from '@core/services/auth.service';
-import { MockAuthService } from '@core/test-utils/MockAuthService';
-import { EstablishmentService } from '@core/services/establishment.service';
-import { WindowToken } from '@core/services/window';
-import { Roles } from '@core/model/roles.enum';
+
 const MockWindow = {
   dataLayer: {
     push: () => {

--- a/src/app/features/new-dashboard/home-tab/home-tab.component.ts
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.ts
@@ -11,13 +11,13 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { TabsService } from '@core/services/tabs.service';
 import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
+import { isAdminRole } from '@core/utils/check-role-util';
 import { BecomeAParentCancelDialogComponent } from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
 import { BecomeAParentDialogComponent } from '@shared/components/become-a-parent/become-a-parent-dialog.component';
 import { LinkToParentCancelDialogComponent } from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
 import { LinkToParentDialogComponent } from '@shared/components/link-to-parent/link-to-parent-dialog.component';
 import { ServiceNamePipe } from '@shared/pipes/service-name.pipe';
 import { Subscription } from 'rxjs';
-import { isAdminRole } from 'server/utils/adminUtils';
 
 declare global {
   interface Window {

--- a/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.spec.ts
+++ b/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.spec.ts
@@ -4,21 +4,22 @@ import { getTestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
+import { Worker } from '@core/model/worker.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
-
-import { establishmentBuilder, workerBuilder } from '../../../../../../server/test/factories/models';
 
 import { StaffBasicRecord } from './staff-basic-record.component';
 
 describe('StaffBasicRecord', () => {
   async function setup() {
     const establishment = establishmentBuilder() as Establishment;
-    const workers = [workerBuilder(), workerBuilder(), workerBuilder()];
+    const workers = [workerBuilder(), workerBuilder(), workerBuilder()] as Worker[];
 
     const component = await render(StaffBasicRecord, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],

--- a/src/app/features/new-dashboard/staff-tab/staff-tab.component.spec.ts
+++ b/src/app/features/new-dashboard/staff-tab/staff-tab.component.spec.ts
@@ -17,6 +17,7 @@ import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
 import { MockAuthService } from '@core/test-utils/MockAuthService';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
@@ -25,7 +26,6 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { NewDashboardHeaderComponent } from '../../../shared/components/new-dashboard-header/dashboard-header.component';
 import { NewStaffTabComponent } from './staff-tab.component';
 

--- a/src/app/features/new-dashboard/training-tab/training-tab.component.spec.ts
+++ b/src/app/features/new-dashboard/training-tab/training-tab.component.spec.ts
@@ -13,6 +13,7 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { TabsService } from '@core/services/tabs.service';
 import { WindowRef } from '@core/services/window.ref';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { workerBuilder } from '@core/test-utils/MockWorkerService';
@@ -20,7 +21,6 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { NewTrainingTabComponent } from './training-tab.component';
 
 describe('NewTrainingTabComponent', () => {

--- a/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -6,12 +6,12 @@ import { Establishment } from '@core/model/establishment.model';
 import { AlertService } from '@core/services/alert.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockWorkerService, qualificationRecord, trainingRecord } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { of } from 'rxjs';
 
-import { establishmentBuilder } from '../../../../../../server/test/factories/models';
 import { WorkersModule } from '../../../workers/workers.module';
 import { DeleteRecordComponent } from './delete-record.component';
 

--- a/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -11,14 +11,13 @@ import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
 import { MockActivatedRoute } from '@core/test-utils/MockActivatedRoute';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockWorkerService, qualificationsByGroup } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { of } from 'rxjs';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { WorkersModule } from '../../workers/workers.module';
 import { NewTrainingAndQualificationsRecordComponent } from './new-training-and-qualifications-record.component';
 

--- a/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
@@ -2,17 +2,17 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Worker } from '@core/model/worker.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkerService } from '@core/services/worker.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { MockWorkerService } from '@core/test-utils/MockWorkerService';
+import { MockWorkerService, workerBuilder, workerWithWdf } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 import { Observable } from 'rxjs';
 
-import { workerBuilder, workerBuilderWithWdf } from '../../../../../../server/test/factories/models';
 import { WdfModule } from '../wdf.module';
 import { WdfStaffRecordComponent } from './wdf-staff-record.component';
 
@@ -58,8 +58,8 @@ describe('WdfStaffRecordComponent', () => {
     const expectedStatusMessage = 'Update this staff record to save yourself time next year';
     const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
-    component.worker = workerBuilder();
-    component.updatedWorker = workerBuilder();
+    component.worker = workerBuilder() as Worker;
+    component.updatedWorker = workerBuilder() as Worker;
     component.exitUrl = { url: [] };
     component.overallWdfEligibility = true;
     component.workerList = ['1', '2', '3', '4'];
@@ -75,8 +75,8 @@ describe('WdfStaffRecordComponent', () => {
     const expectedStatusMessage = 'This record does not meet the WDF 2021 to 2022 requirements';
     const redCrossVisuallyHiddenMessage = 'Red cross';
 
-    component.worker = workerBuilder();
-    component.updatedWorker = workerBuilder();
+    component.worker = workerBuilder() as Worker;
+    component.updatedWorker = workerBuilder() as Worker;
 
     component.exitUrl = { url: [] };
     component.overallWdfEligibility = false;
@@ -98,8 +98,8 @@ describe('WdfStaffRecordComponent', () => {
     const orangeFlagStatusMessage = 'Update this staff record to save yourself time next year';
     const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
 
-    component.worker = workerBuilderWithWdf();
-    component.updatedWorker = workerBuilderWithWdf();
+    component.worker = workerWithWdf() as Worker;
+    component.updatedWorker = workerWithWdf() as Worker;
 
     component.exitUrl = { url: [] };
     component.overallWdfEligibility = true;

--- a/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
@@ -4,17 +4,18 @@ import { BrowserModule } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
+import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { ReportService } from '@core/services/report.service';
 import { UserService } from '@core/services/user.service';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockReportService } from '@core/test-utils/MockReportService';
+import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
-import { establishmentBuilder, workerBuilder } from '../../../../../../server/test/factories/models';
 import { WdfModule } from '../wdf.module';
 import { WdfStaffSummaryComponent } from './wdf-staff-summary.component';
 
@@ -33,7 +34,7 @@ describe('WdfStaffSummaryComponent', () => {
       ],
       componentProperties: {
         workplace: establishmentBuilder() as Establishment,
-        workers: [workerBuilder(), workerBuilder(), workerBuilder()],
+        workers: [workerBuilder(), workerBuilder(), workerBuilder()] as Worker[],
       },
     });
     const component = fixture.componentInstance;

--- a/src/app/features/workers/long-term-absence/long-term-absence.component.spec.ts
+++ b/src/app/features/workers/long-term-absence/long-term-absence.component.spec.ts
@@ -5,12 +5,12 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { WorkerService } from '@core/services/worker.service';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockWorkerServiceWithUpdateWorker, workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import sinon from 'sinon';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { WorkersModule } from '../workers.module';
 import { LongTermAbsenceComponent } from './long-term-absence.component';
 

--- a/src/app/features/workers/staff-details/staff-details.component.spec.ts
+++ b/src/app/features/workers/staff-details/staff-details.component.spec.ts
@@ -2,11 +2,12 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
-import { UntypedFormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Contracts } from '@core/model/contracts.enum';
 import { Roles } from '@core/model/roles.enum';
+import { Worker } from '@core/model/worker.model';
 import { AlertService } from '@core/services/alert.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { JobService } from '@core/services/job.service';
@@ -17,13 +18,12 @@ import { WorkerService } from '@core/services/worker.service';
 import { MockJobService } from '@core/test-utils/MockJobService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
-import { MockWorkerServiceWithUpdateWorker } from '@core/test-utils/MockWorkerService';
+import { MockWorkerServiceWithUpdateWorker, workerBuilder } from '@core/test-utils/MockWorkerService';
 import { ProgressBarComponent } from '@shared/components/progress-bar/progress-bar.component';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
-import { workerBuilder } from '../../../../../server/test/factories/models';
 import { StaffDetailsComponent } from './staff-details.component';
 
 describe('StaffDetailsComponent', () => {
@@ -283,7 +283,7 @@ describe('StaffDetailsComponent', () => {
 
       const createWorkerSpy = spyOn(workerService, 'createWorker').and.callThrough();
       spyOn(workerService, 'setState').and.callFake(() => {
-        component.worker = workerBuilder();
+        component.worker = workerBuilder() as Worker;
         component.worker.nameOrId = 'Someone';
         component.worker.contract = 'Temporary' as Contracts;
         component.worker.mainJob = { jobId: 1 };
@@ -324,7 +324,7 @@ describe('StaffDetailsComponent', () => {
 
       spyOn(workerService, 'createWorker').and.callThrough();
       spyOn(workerService, 'setState').and.callFake(() => {
-        component.worker = workerBuilder();
+        component.worker = workerBuilder() as Worker;
         component.worker.nameOrId = 'Someone';
         component.worker.contract = 'Temporary' as Contracts;
         component.worker.mainJob = { jobId: 1 };
@@ -354,7 +354,7 @@ describe('StaffDetailsComponent', () => {
 
       spyOn(workerService, 'createWorker').and.callThrough();
       spyOn(workerService, 'setState').and.callFake(() => {
-        component.worker = workerBuilder();
+        component.worker = workerBuilder() as Worker;
         component.worker.nameOrId = 'Someone';
         component.worker.contract = 'Temporary' as Contracts;
         component.worker.mainJob = { jobId: 1 };

--- a/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -11,6 +11,7 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockWorkerServiceWithUpdateWorker } from '@core/test-utils/MockWorkerService';
@@ -18,7 +19,6 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { WorkersModule } from '../workers.module';
 import { StaffRecordComponent } from './staff-record.component';
 

--- a/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -12,10 +12,9 @@ import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
+import { isAdminRole } from '@core/utils/check-role-util';
 import { Subscription } from 'rxjs';
 import { take, withLatestFrom } from 'rxjs/operators';
-
-import { isAdminRole } from '../../../../../server/utils/adminUtils';
 
 @Component({
   selector: 'app-user-account-view',

--- a/src/app/features/workplace/users/users.component.spec.ts
+++ b/src/app/features/workplace/users/users.component.spec.ts
@@ -8,12 +8,12 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { EditUser, ReadUser } from '@core/test-utils/MockUserService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { UsersComponent } from './users.component';
 
 describe('UsersComponent', () => {

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.ts
@@ -151,6 +151,5 @@ export class DataAreaPayComponent {
         noWorkplaceData: this.hasWorkplaceData(this.registeredManagerRankings),
       },
     };
-    console.log(this.rankings);
   }
 }

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.spec.ts
@@ -10,13 +10,13 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { WindowRef } from '@core/services/window.ref';
 import { MockBenchmarksService } from '@core/test-utils/MockBenchmarkService';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { BenchmarksSelectViewPanelComponent } from '../benchmarks-select-view-panel/benchmarks-select-view-panel.component';
 import { DataAreaTabComponent } from './data-area-tab.component';
 
@@ -100,7 +100,7 @@ describe('DataAreaTabComponent', () => {
   });
 
   it('should check the pay benchmarks data to see if there is comparison data', async () => {
-    const { component, fixture, getByTestId, queryByTestId } = await setup();
+    const { component } = await setup();
     const noCompData = {
       value: 0,
       stateMessage: 'no-data',

--- a/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
+++ b/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
@@ -10,7 +10,11 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
 import { MockCqcStatusChangeService } from '@core/test-utils/MockCqcStatusChangeService';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import {
+  establishmentWithShareWith,
+  establishmentWithWdfBuilder,
+  MockEstablishmentService,
+} from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockWorkerService } from '@core/test-utils/MockWorkerService';
 import { WdfModule } from '@features/wdf/wdf-data-change/wdf.module';
@@ -18,7 +22,6 @@ import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 import dayjs from 'dayjs';
 
-import { establishmentWithShareWith, establishmentWithWdfBuilder } from '../../../../../server/test/factories/models';
 import { WDFWorkplaceSummaryComponent } from './wdf-workplace-summary.component';
 
 describe('WDFWorkplaceSummaryComponent', () => {

--- a/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -4,18 +4,18 @@ import { TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
 import { CqcStatusChangeService } from '@core/services/cqc-status-change.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TabsService } from '@core/services/tabs.service';
 import { UserService } from '@core/services/user.service';
 import { MockCqcStatusChangeService } from '@core/test-utils/MockCqcStatusChangeService';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { establishmentWithShareWith, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
 
-import { establishmentWithShareWith } from '../../../../../server/test/factories/models';
 import { NewWorkplaceSummaryComponent } from './workplace-summary.component';
 
 describe('NewWorkplaceSummaryComponent', () => {
@@ -38,7 +38,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         },
       ],
       componentProperties: {
-        workplace: establishmentWithShareWith(shareWith),
+        workplace: establishmentWithShareWith(shareWith) as Establishment,
       },
     });
 
@@ -278,6 +278,7 @@ describe('NewWorkplaceSummaryComponent', () => {
 
         component.canEditEstablishment = true;
         component.workplace.numberOfStaff = null;
+        component.numberOfStaffError = true;
 
         fixture.detectChanges();
 
@@ -365,7 +366,7 @@ describe('NewWorkplaceSummaryComponent', () => {
 
         component.canEditEstablishment = true;
         component.typeOfEmployer = '';
-
+        component.workplace.employerType = null;
         fixture.detectChanges();
 
         const employerTypeRow = within(document.body).queryByTestId('employerType');

--- a/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
+++ b/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
@@ -3,13 +3,15 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
+import { Worker } from '@core/model/worker.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { workerWithWdf } from '@core/test-utils/MockWorkerService';
 import { SummaryRecordChangeComponent } from '@shared/components/summary-record-change/summary-record-change.component';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
-import { establishmentBuilder, workerBuilderWithWdf } from '../../../../../../server/test/factories/models';
 import { BasicRecordComponent } from './basic-record.component';
 
 describe('BasicRecordComponent', () => {
@@ -28,7 +30,7 @@ describe('BasicRecordComponent', () => {
         canEditWorker: true,
         mandatoryDetailsPage,
         workplace: establishmentBuilder() as Establishment,
-        worker: workerBuilderWithWdf(),
+        worker: workerWithWdf() as Worker,
       },
     });
 

--- a/src/app/shared/components/staff-record-summary/employment/employment.component.html
+++ b/src/app/shared/components/staff-record-summary/employment/employment.component.html
@@ -17,7 +17,7 @@
           worker.wdf?.mainJobStartDate.isEligible === 'Yes' &&
           !worker.wdf?.mainJobStartDate.updatedSinceEffectiveDate
         "
-        [changeLink]="getRoutePath('main-job-start-date',wdfView)"
+        [changeLink]="getRoutePath('main-job-start-date', wdfView)"
         (fieldConfirmation)="this.confirmField('mainJobStartDate')"
         (setReturnClicked)="this.setReturn()"
         [workerUid]="worker.uid"
@@ -155,7 +155,7 @@
           worker.wdf?.daysSick.isEligible === 'Yes' &&
           !worker.wdf?.daysSick.updatedSinceEffectiveDate
         "
-        [changeLink]="getRoutePath('days-of-sickness',wdfView)"
+        [changeLink]="getRoutePath('days-of-sickness', wdfView)"
         (fieldConfirmation)="this.confirmField('daysSick')"
         (setReturnClicked)="this.setReturn()"
         [workerUid]="worker.uid"
@@ -191,7 +191,7 @@
           worker.wdf?.zeroHoursContract.isEligible === 'Yes' &&
           !worker.wdf?.zeroHoursContract.updatedSinceEffectiveDate
         "
-        [changeLink]="getRoutePath('contract-with-zero-hours',wdfView)"
+        [changeLink]="getRoutePath('contract-with-zero-hours', wdfView)"
         (fieldConfirmation)="this.confirmField('zeroHoursContract')"
         (setReturnClicked)="this.setReturn()"
         [workerUid]="worker.uid"
@@ -235,7 +235,7 @@
           worker.wdf?.weeklyHoursAverage.isEligible === 'Yes' &&
           !worker.wdf?.weeklyHoursAverage.updatedSinceEffectiveDate
         "
-        [changeLink]="getRoutePath('average-weekly-hours',wdfView)"
+        [changeLink]="getRoutePath('average-weekly-hours', wdfView)"
         (fieldConfirmation)="this.confirmField('weeklyHoursAverage')"
         (setReturnClicked)="this.setReturn()"
         [workerUid]="worker.uid"
@@ -284,7 +284,7 @@
           worker.wdf?.weeklyHoursContracted.isEligible === 'Yes' &&
           !worker.wdf?.weeklyHoursContracted.updatedSinceEffectiveDate
         "
-        [changeLink]="getRoutePath('weekly-contracted-hours',wdfView)"
+        [changeLink]="getRoutePath('weekly-contracted-hours', wdfView)"
         (fieldConfirmation)="this.confirmField('weeklyHoursContracted')"
         (setReturnClicked)="this.setReturn()"
         [workerUid]="worker.uid"
@@ -330,7 +330,7 @@
           worker.wdf?.annualHourlyPay.isEligible === 'Yes' &&
           !worker.wdf?.annualHourlyPay.updatedSinceEffectiveDate
         "
-        [changeLink]="getRoutePath('salary',wdfView)"
+        [changeLink]="getRoutePath('salary', wdfView)"
         (fieldConfirmation)="this.confirmField('annualHourlyPay')"
         (setReturnClicked)="this.setReturn()"
         [workerUid]="worker.uid"

--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
@@ -337,10 +337,10 @@ describe('StaffRecordSummaryComponent', () => {
     component.worker.wdf.weeklyHoursContracted.updatedSinceEffectiveDate = false;
     component.worker.weeklyHoursContracted = { value: 'Yes', hours: 30 };
     component.worker.contract = Contracts.Permanent;
+    component.worker.zeroHoursContract = 'No';
 
     fixture.detectChanges();
 
-    expect(true).toBeTruthy();
     expect(getByText('Is this still correct?')).toBeTruthy();
     expect(getByText('Yes, it is')).toBeTruthy();
     expect(getByText('No, change it')).toBeTruthy();
@@ -356,6 +356,7 @@ describe('StaffRecordSummaryComponent', () => {
     component.worker.wdf.weeklyHoursContracted.updatedSinceEffectiveDate = false;
     component.worker.weeklyHoursContracted = { value: 'Yes', hours: 30 };
     component.worker.contract = Contracts.Permanent;
+    component.worker.zeroHoursContract = 'No';
 
     fixture.detectChanges();
 

--- a/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
+++ b/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
@@ -7,19 +7,19 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Contracts } from '@core/model/contracts.enum';
 import { Establishment } from '@core/model/establishment.model';
 import { Eligibility } from '@core/model/wdf.model';
-import { WorkerDays, WorkerEditResponse } from '@core/model/worker.model';
+import { Worker, WorkerDays, WorkerEditResponse } from '@core/model/worker.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { WdfConfirmFieldsService } from '@core/services/wdf/wdf-confirm-fields.service';
 import { WorkerService } from '@core/services/worker.service';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { MockWorkerService } from '@core/test-utils/MockWorkerService';
+import { MockWorkerService, workerWithWdf } from '@core/test-utils/MockWorkerService';
 import { WdfModule } from '@features/wdf/wdf-data-change/wdf.module';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 import { of } from 'rxjs';
 
-import { establishmentBuilder, workerBuilderWithWdf } from '../../../../../server/test/factories/models';
 import { StaffRecordSummaryComponent } from './staff-record-summary.component';
 
 describe('StaffRecordSummaryComponent', () => {
@@ -41,7 +41,7 @@ describe('StaffRecordSummaryComponent', () => {
       componentProperties: {
         wdfView: true,
         workplace: establishmentBuilder() as Establishment,
-        worker: workerBuilderWithWdf(),
+        worker: workerWithWdf() as Worker,
       },
     });
 
@@ -340,6 +340,7 @@ describe('StaffRecordSummaryComponent', () => {
 
     fixture.detectChanges();
 
+    expect(true).toBeTruthy();
     expect(getByText('Is this still correct?')).toBeTruthy();
     expect(getByText('Yes, it is')).toBeTruthy();
     expect(getByText('No, change it')).toBeTruthy();

--- a/src/app/shared/components/staff-records-tab/staff-records-tab.component.spec.ts
+++ b/src/app/shared/components/staff-records-tab/staff-records-tab.component.spec.ts
@@ -9,13 +9,12 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { UserService } from '@core/services/user.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockWorkerService } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { StaffRecordsTabComponent } from './staff-records-tab.component';
 
 describe('StaffRecordsTab', () => {

--- a/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
+++ b/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
@@ -4,17 +4,19 @@ import { getTestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
+import { Worker } from '@core/model/worker.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { of } from 'rxjs';
 import sinon from 'sinon';
 
-import { establishmentBuilder, workerBuilder } from '../../../../../server/test/factories/models';
 import { PaginationComponent } from '../pagination/pagination.component';
 import { TablePaginationWrapperComponent } from '../table-pagination-wrapper/table-pagination-wrapper.component';
 import { StaffSummaryComponent } from './staff-summary.component';
@@ -22,7 +24,7 @@ import { StaffSummaryComponent } from './staff-summary.component';
 describe('StaffSummaryComponent', () => {
   async function setup(isWdf = false, qsParamGetMock = sinon.fake()) {
     const establishment = establishmentBuilder() as Establishment;
-    const workers = [workerBuilder(), workerBuilder(), workerBuilder()];
+    const workers = [workerBuilder(), workerBuilder(), workerBuilder()] as Worker[];
 
     const component = await render(StaffSummaryComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],

--- a/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.spec.ts
+++ b/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.spec.ts
@@ -2,12 +2,12 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { WdfStaffMismatchMessageComponent } from './wdf-staff-mismatch-message.component';
 
 describe('WdfStaffMismatchMessageComponent', () => {
@@ -29,7 +29,7 @@ describe('WdfStaffMismatchMessageComponent', () => {
             },
           },
         ],
-        componentProperties: { workplace: establishmentBuilder(), workerCount: 1 },
+        componentProperties: { workplace: establishmentBuilder() as Establishment, workerCount: 1 },
       },
     );
 

--- a/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
+++ b/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
@@ -3,12 +3,12 @@ import { BrowserModule } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
 import { ReportService } from '@core/services/report.service';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockReportService } from '@core/test-utils/MockReportService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 import dayjs from 'dayjs';
 
-import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { WdfTabComponent } from './wdf-tab.component';
 
 describe('WdfTabComponent', () => {

--- a/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -10,7 +10,11 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
 import { MockCqcStatusChangeService } from '@core/test-utils/MockCqcStatusChangeService';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import {
+  establishmentWithShareWith,
+  establishmentWithWdfBuilder,
+  MockEstablishmentService,
+} from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockWorkerService } from '@core/test-utils/MockWorkerService';
 import { WdfModule } from '@features/wdf/wdf-data-change/wdf.module';
@@ -18,7 +22,6 @@ import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 import dayjs from 'dayjs';
 
-import { establishmentWithShareWith, establishmentWithWdfBuilder } from '../../../../../server/test/factories/models';
 import { WorkplaceSummaryComponent } from './workplace-summary.component';
 
 describe('WorkplaceSummaryComponent', () => {


### PR DESCRIPTION
#### Work done
- remove the use of backend utility functions and test models in the frontend to allow the codebase to be split into frontend and backend

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
