### PR TITLE
1301 benchmarks r and r text changes

### DIFF
--- a/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.html
+++ b/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.html
@@ -1,0 +1,8 @@
+<a
+  class="asc-font-19"
+  data-testid="about-the-data-link"
+  data-html2canvas-ignore
+  [routerLink]="['/workplace', workplaceUid, 'benchmarks', 'about-the-data']"
+  (click)="setReturn()"
+  >About the data</a
+>

--- a/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.spec.ts
@@ -1,0 +1,49 @@
+import { SharedModule } from '@shared/shared.module';
+import { render, within } from '@testing-library/angular';
+import { AboutTheDataLinkComponent } from './about-the-data-link.component';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('AboutTheDataLinkComponent', () => {
+  const setup = async () => {
+    const { fixture, getByText, getByTestId, queryByTestId, queryByText } = await render(AboutTheDataLinkComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
+        },
+      ],
+      schemas: [],
+      componentProperties: {},
+    });
+
+    const component = fixture.componentInstance;
+
+    return {
+      component,
+      fixture,
+      getByText,
+      getByTestId,
+      queryByTestId,
+      queryByText,
+    };
+  };
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should show about the data text', async () => {
+    const { getByTestId } = await setup();
+
+    const link = getByTestId('about-the-data-link');
+
+    expect(link).toBeTruthy();
+    expect(within(link).getByText('About the data')).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.ts
+++ b/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnChanges } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { BenchmarksService } from '@core/services/benchmarks.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -7,7 +7,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
   selector: 'app-about-the-data-link',
   templateUrl: './about-the-data-link.component.html',
 })
-export class AboutTheDataLinkComponent implements OnInit, OnChanges {
+export class AboutTheDataLinkComponent implements OnInit {
   public workplaceUid: string;
 
   constructor(
@@ -18,10 +18,6 @@ export class AboutTheDataLinkComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     this.workplaceUid = this.establishmentService ? this.establishmentService.primaryWorkplace.uid : null;
-  }
-
-  ngOnChanges(): void {
-    //this.workplaceUid = this.establishmentService.primaryWorkplace.uid;
   }
 
   public setReturn(): void {

--- a/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.ts
+++ b/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit, OnChanges } from '@angular/core';
+import { Router } from '@angular/router';
+import { BenchmarksService } from '@core/services/benchmarks.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+
+@Component({
+  selector: 'app-about-the-data-link',
+  templateUrl: './about-the-data-link.component.html',
+})
+export class AboutTheDataLinkComponent implements OnInit, OnChanges {
+  public workplaceUid: string;
+
+  constructor(
+    private establishmentService: EstablishmentService,
+    protected benchmarksService: BenchmarksService,
+    protected router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.workplaceUid = this.establishmentService ? this.establishmentService.primaryWorkplace.uid : null;
+  }
+
+  ngOnChanges(): void {
+    //this.workplaceUid = this.establishmentService.primaryWorkplace.uid;
+  }
+
+  public setReturn(): void {
+    this.benchmarksService.setReturnTo({
+      url: [this.router.url.split('#')[0]],
+      fragment: 'benchmarks',
+    });
+  }
+}

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -53,7 +53,8 @@
             class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2"
             data-testid="no-workplace-turnover-or-percent-data"
           >
-            You've not added the data we need to show <br />where you're positioned (see 'About the data')
+            You've not added the data we need to show <br />where you're positioned (see '<app-about-the-data-link
+            ></app-about-the-data-link>')
           </p>
         </ng-template>
       </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -36,9 +36,27 @@
       </ng-template>
     </ng-container>
     <ng-template #hasComparisonData>
-      <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8" data-testid="no-workplace-data">
-        You've not added any {{ section | lowercase }} data, so we <br />cannot show you where you're positioned.
-      </p>
+      <ng-container *ngIf="isPay; else recrAndRet">
+        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-8" data-testid="no-workplace-pay-data">
+          You've not added any {{ section | lowercase }} data, so we <br />cannot show you where you're positioned.
+        </p>
+      </ng-container>
+      <ng-template #recrAndRet>
+        <ng-container *ngIf="type == 'vacancy'; else turnoverOrPerecent">
+          <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-workplace-vacancy-data">
+            You've not added any vacancies, so we cannot show<br />
+            where you're positioned.
+          </p>
+        </ng-container>
+        <ng-template #turnoverOrPerecent>
+          <p
+            class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2"
+            data-testid="no-workplace-turnover-or-percent-data"
+          >
+            You've not added the data we need to show <br />where you're positioned (see 'About the data')
+          </p>
+        </ng-template>
+      </ng-template>
     </ng-template>
   </ng-template>
   <highcharts-chart class="chart" [Highcharts]="Highcharts" [options]="options"></highcharts-chart>

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.html
@@ -53,8 +53,8 @@
             class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2"
             data-testid="no-workplace-turnover-or-percent-data"
           >
-            You've not added the data we need to show <br />where you're positioned (see '<app-about-the-data-link
-            ></app-about-the-data-link>')
+            You've not added the data we need to show where <br />you're positioned (see '<app-about-the-data-link
+            ></app-about-the-data-link>').
           </p>
         </ng-template>
       </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
@@ -2,14 +2,18 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RankingsResponse } from '@core/model/benchmarks.model';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
-
+import { EstablishmentService } from '@core/services/establishment.service';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { DataAreaBarchartComponent } from './data-area-barchart.component';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('DataAreaBarchartComponent', () => {
   const setup = async () => {
     const { fixture, getByText, getByTestId, queryByTestId, queryByText } = await render(DataAreaBarchartComponent, {
-      imports: [SharedModule],
-      providers: [],
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+      providers: [{ provide: EstablishmentService, useClass: MockEstablishmentService }],
       schemas: [NO_ERRORS_SCHEMA],
       componentProperties: {
         isPay: false,
@@ -127,6 +131,7 @@ describe('DataAreaBarchartComponent', () => {
       component.type = 'timeInRole';
 
       fixture.detectChanges();
+
       expect(queryByTestId('no-workplace-turnover-or-percent-data')).toBeTruthy();
     });
   });

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
@@ -74,7 +74,7 @@ describe('DataAreaBarchartComponent', () => {
     expect(queryByTestId('no-comparison-data')).toBeTruthy();
   });
 
-  fdescribe('no workplace data message', () => {
+  describe('no workplace data message', () => {
     it('should show when no pay workplace data is provided', async () => {
       const { component, queryByTestId, fixture } = await setup();
       component.rankingsData = {

--- a/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-barchart/data-area-barchart.component.spec.ts
@@ -74,16 +74,61 @@ describe('DataAreaBarchartComponent', () => {
     expect(queryByTestId('no-comparison-data')).toBeTruthy();
   });
 
-  it('should show the no workplace data message when no workplace data is provided', async () => {
-    const { component, queryByTestId, fixture } = await setup();
-    component.rankingsData = {
-      stateMessage: 'no-pay-data',
-      hasValue: false,
-      allValues: [{ value: 34, currentEst: false }],
-    } as RankingsResponse;
+  fdescribe('no workplace data message', () => {
+    it('should show when no pay workplace data is provided', async () => {
+      const { component, queryByTestId, fixture } = await setup();
+      component.rankingsData = {
+        stateMessage: 'no-pay-data',
+        hasValue: false,
+        allValues: [{ value: 34, currentEst: false }],
+      } as RankingsResponse;
+      component.isPay = true;
 
-    fixture.detectChanges();
-    expect(queryByTestId('no-workplace-data')).toBeTruthy();
+      fixture.detectChanges();
+      expect(queryByTestId('no-workplace-pay-data')).toBeTruthy();
+    });
+
+    it('should show the when no vacancy workplace data is provided', async () => {
+      const { component, queryByTestId, fixture } = await setup();
+      component.rankingsData = {
+        stateMessage: 'no-vacancies',
+        hasValue: false,
+        allValues: [{ value: 34, currentEst: false }],
+      } as RankingsResponse;
+      component.isPay = false;
+      component.type = 'vacancy';
+
+      fixture.detectChanges();
+      expect(queryByTestId('no-workplace-vacancy-data')).toBeTruthy();
+    });
+
+    it('should show the when no turnover workplace data is provided', async () => {
+      const { component, queryByTestId, fixture } = await setup();
+      component.rankingsData = {
+        stateMessage: 'no-leavers',
+        hasValue: false,
+        allValues: [{ value: 34, currentEst: false }],
+      } as RankingsResponse;
+      component.isPay = false;
+      component.type = 'turnover';
+
+      fixture.detectChanges();
+      expect(queryByTestId('no-workplace-turnover-or-percent-data')).toBeTruthy();
+    });
+
+    it('should show the when no time in role workplace data is provided', async () => {
+      const { component, queryByTestId, fixture } = await setup();
+      component.rankingsData = {
+        stateMessage: 'not-enough-data',
+        hasValue: false,
+        allValues: [{ value: 34, currentEst: false }],
+      } as RankingsResponse;
+      component.isPay = false;
+      component.type = 'timeInRole';
+
+      fixture.detectChanges();
+      expect(queryByTestId('no-workplace-turnover-or-percent-data')).toBeTruthy();
+    });
   });
 
   it('should show the correct summary for time in role', async () => {

--- a/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-pay/data-area-pay.component.html
@@ -117,12 +117,14 @@
           [workplaceRankNumber]="rankings.careWorkerPay.workplacesRankNumber"
           [workplacesNumber]="rankings.careWorkerPay.totalWorkplaces"
           [noWorkplaceData]="rankings.careWorkerPay.noWorkplaceData"
+          [isPay]="true"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="rankings.seniorCareWorkerPay.title"
           [workplaceRankNumber]="rankings.seniorCareWorkerPay.workplacesRankNumber"
           [workplacesNumber]="rankings.seniorCareWorkerPay.totalWorkplaces"
           [noWorkplaceData]="rankings.seniorCareWorkerPay.noWorkplaceData"
+          [isPay]="true"
         ></app-data-area-ranking>
         <app-data-area-ranking
           *ngIf="showRegisteredNurseSalary"
@@ -130,12 +132,14 @@
           [workplaceRankNumber]="rankings.registeredNursePay.workplacesRankNumber"
           [workplacesNumber]="rankings.registeredNursePay.totalWorkplaces"
           [noWorkplaceData]="rankings.registeredNursePay.noWorkplaceData"
+          [isPay]="true"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="rankings.registeredManagerPay.title"
           [workplaceRankNumber]="rankings.registeredManagerPay.workplacesRankNumber"
           [workplacesNumber]="rankings.registeredManagerPay.totalWorkplaces"
           [noWorkplaceData]="rankings.registeredManagerPay.noWorkplaceData"
+          [isPay]="true"
         ></app-data-area-ranking>
       </div>
     </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
@@ -7,10 +7,29 @@
         group of <span class="govuk-!-font-weight-bold">{{ workplacesNumber }} </span> workplaces.
       </p>
     </ng-container>
+
     <ng-template #noRankingData>
-      <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-workplace-data">
-        You've not added any {{ rankingTitle | lowercase }} data, so we <br />cannot show you where you're ranked.
-      </p>
+      <ng-container *ngIf="isPay; else recrAndRet">
+        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-workplace-pay-data">
+          You've not added any {{ rankingTitle | lowercase }} data, so we <br />cannot show you where you're ranked.
+        </p>
+      </ng-container>
+      <ng-template #recrAndRet>
+        <ng-container *ngIf="type == 'vacancy'; else turnoverOrPerecent">
+          <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-testid="no-workplace-vacancy-data">
+            You've not added any vacancies, so we cannot show <br />
+            where you're ranked.
+          </p>
+        </ng-container>
+        <ng-template #turnoverOrPerecent>
+          <p
+            class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2"
+            data-testid="no-workplace-turnover-or-percent-data"
+          >
+            You've not added the data we need to show <br />where you're ranked (see 'About the data')
+          </p>
+        </ng-template>
+      </ng-template>
     </ng-template>
   </ng-container>
   <ng-template #noComparisonData>

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
@@ -26,8 +26,8 @@
             class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2"
             data-testid="no-workplace-turnover-or-percent-data"
           >
-            You've not added the data we need to show <br />where you're ranked (see '<app-about-the-data-link
-            ></app-about-the-data-link>')
+            You've not added the data we need to show where <br />you're ranked (see '<app-about-the-data-link
+            ></app-about-the-data-link>').
           </p>
         </ng-template>
       </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.html
@@ -26,7 +26,8 @@
             class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2"
             data-testid="no-workplace-turnover-or-percent-data"
           >
-            You've not added the data we need to show <br />where you're ranked (see 'About the data')
+            You've not added the data we need to show <br />where you're ranked (see '<app-about-the-data-link
+            ></app-about-the-data-link>')
           </p>
         </ng-template>
       </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
@@ -44,7 +44,7 @@ describe('DataAreaRankingComponent', () => {
     expect(getByTestId('ranking-data')).toBeTruthy();
   });
 
-  fdescribe('no workplace data message', () => {
+  describe('no workplace data message', () => {
     it('should show when no pay workplace data is provided', async () => {
       const { fixture, component, getByTestId } = await setup();
       component.workplaceRankNumber = null;

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.spec.ts
@@ -44,13 +44,49 @@ describe('DataAreaRankingComponent', () => {
     expect(getByTestId('ranking-data')).toBeTruthy();
   });
 
-  it('should show no workplace data message when no workplace data is provided', async () => {
-    const { fixture, component, queryByTestId, getByTestId } = await setup();
-    component.workplaceRankNumber = null;
-    component.workplacesNumber = 10;
-    fixture.detectChanges();
+  fdescribe('no workplace data message', () => {
+    it('should show when no pay workplace data is provided', async () => {
+      const { fixture, component, getByTestId } = await setup();
+      component.workplaceRankNumber = null;
+      component.workplacesNumber = 10;
+      component.isPay = true;
+      fixture.detectChanges();
 
-    expect(getByTestId('no-workplace-data')).toBeTruthy();
+      expect(getByTestId('no-workplace-pay-data')).toBeTruthy();
+    });
+
+    it('should show when no vacancy workplace data is provided', async () => {
+      const { fixture, component, getByTestId } = await setup();
+      component.workplaceRankNumber = null;
+      component.workplacesNumber = 10;
+      component.isPay = false;
+      component.type = 'vacancy';
+      fixture.detectChanges();
+
+      expect(getByTestId('no-workplace-vacancy-data')).toBeTruthy();
+    });
+
+    it('should show when no turnover workplace data is provided', async () => {
+      const { fixture, component, getByTestId } = await setup();
+      component.workplaceRankNumber = null;
+      component.workplacesNumber = 10;
+      component.isPay = false;
+      component.type = 'turnover';
+      fixture.detectChanges();
+
+      expect(getByTestId('no-workplace-turnover-or-percent-data')).toBeTruthy();
+    });
+
+    it('should show when no turnover workplace data is provided', async () => {
+      const { fixture, component, getByTestId } = await setup();
+      component.workplaceRankNumber = null;
+      component.workplacesNumber = 10;
+      component.isPay = false;
+      component.type = 'timeInRole';
+      fixture.detectChanges();
+
+      expect(getByTestId('no-workplace-turnover-or-percent-data')).toBeTruthy();
+    });
   });
 
   it('should show no comparison data message when no comparison data is provided', async () => {

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Establishment } from '@core/model/establishment.model';
 import * as Highcharts from 'highcharts';
 
 import { GaugeOptionsBuilder } from './data-area-ranking-options-builder';
@@ -10,11 +11,15 @@ import { GaugeOptionsBuilder } from './data-area-ranking-options-builder';
 })
 export class DataAreaRankingComponent implements OnInit, OnChanges {
   Highcharts: typeof Highcharts = Highcharts;
+
   @Input() rankingTitle: string;
   @Input() workplaceRankNumber: number;
   @Input() workplacesNumber: number;
   @Input() noWorkplaceData: boolean = false;
+  @Input() isPay: boolean;
+  @Input() type: string;
 
+  public workplace: Establishment;
   public noRankingData: boolean;
   public options: Highcharts.Options;
   public text: string;

--- a/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-ranking/data-area-ranking.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
-import { Establishment } from '@core/model/establishment.model';
 import * as Highcharts from 'highcharts';
 
 import { GaugeOptionsBuilder } from './data-area-ranking-options-builder';
@@ -11,15 +10,13 @@ import { GaugeOptionsBuilder } from './data-area-ranking-options-builder';
 })
 export class DataAreaRankingComponent implements OnInit, OnChanges {
   Highcharts: typeof Highcharts = Highcharts;
-
   @Input() rankingTitle: string;
   @Input() workplaceRankNumber: number;
   @Input() workplacesNumber: number;
-  @Input() noWorkplaceData: boolean = false;
+  @Input() noWorkplaceData = false;
   @Input() isPay: boolean;
   @Input() type: string;
 
-  public workplace: Establishment;
   public noRankingData: boolean;
   public options: Highcharts.Options;
   public text: string;

--- a/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-recruitment-and-retention/data-area-recruitment-and-retention.component.html
@@ -74,18 +74,24 @@
           [workplaceRankNumber]="vacancyCurrentRank"
           [workplacesNumber]="vacancyMaxRank"
           [noWorkplaceData]="vacancyNoWorkplaceData"
+          [isPay]="false"
+          [type]="'vacancy'"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="'Turnover rate'"
           [workplaceRankNumber]="turnoverCurrentRank"
           [workplacesNumber]="turnoverMaxRank"
           [noWorkplaceData]="turnoverNoWorkplaceData"
+          [isPay]="false"
+          [type]="'turnover'"
         ></app-data-area-ranking>
         <app-data-area-ranking
           [rankingTitle]="'Percentage of staff still in their main job role after 12 months'"
           [workplaceRankNumber]="timeInRoleCurrentRank"
           [workplacesNumber]="timeInRoleMaxRank"
           [noWorkplaceData]="timeInRoleNoWorkplaceData"
+          [isPay]="false"
+          [type]="'timeInRole'"
         ></app-data-area-ranking>
       </div>
     </ng-template>

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -26,13 +26,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
-      <a
-        class="asc-font-19"
-        data-html2canvas-ignore
-        [routerLink]="['/workplace', workplace.uid, 'benchmarks', 'about-the-data']"
-        (click)="setReturn()"
-        >About the data</a
-      >
+      <app-about-the-data-link></app-about-the-data-link>
       <div *ngIf="tilesData?.meta.lastUpdated" data-testid="benchmarksLastUpdatedDate" class="govuk-!-margin-top-5">
         <p class="govuk-body">
           The comparison group data was refreshed on {{ tilesData?.meta.lastUpdated | date: 'd MMMM y' }}.

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.spec.ts
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.spec.ts
@@ -15,7 +15,8 @@ import { MockPermissionsService } from '@core/test-utils/MockPermissionsService'
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
-
+import { EstablishmentService } from '@core/services/establishment.service';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { establishmentBuilder } from '../../../../../server/test/factories/models';
 import { BenchmarksSelectViewPanelComponent } from '../benchmarks-select-view-panel/benchmarks-select-view-panel.component';
 import { DataAreaTabComponent } from './data-area-tab.component';
@@ -42,6 +43,10 @@ describe('DataAreaTabComponent', () => {
         {
           provide: BenchmarksService,
           useClass: MockBenchmarksService,
+        },
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
         },
       ],
       declarations: [BenchmarksSelectViewPanelComponent],

--- a/src/app/shared/components/data-area-tab/data-area-tab.component.ts
+++ b/src/app/shared/components/data-area-tab/data-area-tab.component.ts
@@ -82,13 +82,6 @@ export class DataAreaTabComponent implements OnInit, OnDestroy {
     this.downloadRecruitmentBenchmarksText = `Download ${section} benchmarks (PDF, ${fileSize}, 2 pages)`;
   }
 
-  public setReturn(): void {
-    this.benchmarksService.setReturnTo({
-      url: [this.router.url.split('#')[0]],
-      fragment: 'benchmarks',
-    });
-  }
-
   public handleViewBenchmarksByCategory(visible: boolean): void {
     this.viewBenchmarksByCategory = visible;
     this.setDownloadBenchmarksText();

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -10,12 +10,8 @@ import { PageResolver } from '@core/resolvers/page.resolver';
 import { DialogService } from '@core/services/dialog.service';
 import { ArticleListComponent } from '@features/articles/article-list/article-list.component';
 import { NewArticleListComponent } from '@features/articles/new-article-list/new-article-list.component';
-import {
-  MissingMandatoryTrainingComponent,
-} from '@features/training-and-qualifications/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component';
-import {
-  DeleteWorkplaceDialogComponent,
-} from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
+import { MissingMandatoryTrainingComponent } from '@features/training-and-qualifications/new-training-qualifications-record/missing-mandatory-training/missing-mandatory-training.component';
+import { DeleteWorkplaceDialogComponent } from '@features/workplace/delete-workplace-dialog/delete-workplace-dialog.component';
 import { AlertComponent } from '@shared/components/alert/alert.component';
 import { CheckCQCDetailsComponent } from '@shared/components/check-cqc-details/check-cqc-details.component';
 import { NewDashboardHeaderComponent } from '@shared/components/new-dashboard-header/dashboard-header.component';
@@ -34,18 +30,12 @@ import { ChangeDataOwnerDialogComponent } from './components/change-data-owner-d
 import { CharacterCountComponent } from './components/character-count/character-count.component';
 import { DatePickerComponent } from './components/date-picker/date-picker.component';
 import { DetailsComponent } from './components/details/details.component';
-import {
-  ValidationErrorMessageComponent,
-} from './components/drag-and-drop/validation-error-message/validation-error-message.component';
+import { ValidationErrorMessageComponent } from './components/drag-and-drop/validation-error-message/validation-error-message.component';
 import { EligibilityIconComponent } from './components/eligibility-icon/eligibility-icon.component';
 import { ErrorSummaryComponent } from './components/error-summary/error-summary.component';
 import { InsetTextComponent } from './components/inset-text/inset-text.component';
-import {
-  LinkToParentCancelDialogComponent,
-} from './components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
-import {
-  LinkToParentRemoveDialogComponent,
-} from './components/link-to-parent-remove/link-to-parent-remove-dialog.component';
+import { LinkToParentCancelDialogComponent } from './components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
+import { LinkToParentRemoveDialogComponent } from './components/link-to-parent-remove/link-to-parent-remove-dialog.component';
 import { LinkToParentDialogComponent } from './components/link-to-parent/link-to-parent-dialog.component';
 import { LinkWithArrowComponent } from './components/link-with-arrow/link-with-arrow.component';
 import { MessagesComponent } from './components/messages/messages.component';
@@ -55,37 +45,25 @@ import { NewTabsComponent } from './components/new-tabs/new-tabs.component';
 import { WDFTabComponent } from './components/new-wdf-tabs/new-wdf-tab.component';
 import { WDFWorkplaceSummaryComponent } from './components/new-wdf-workplace-summary/wdf-workplace-summary.component';
 import { NewWorkplaceSummaryComponent } from './components/new-workplace-summary/workplace-summary.component';
-import {
-  OwnershipChangeMessageDialogComponent,
-} from './components/ownership-change-message/ownership-change-message-dialog.component';
+import { OwnershipChangeMessageDialogComponent } from './components/ownership-change-message/ownership-change-message-dialog.component';
 import { PageComponent } from './components/page/page.component';
 import { PaginationComponent } from './components/pagination/pagination.component';
 import { PanelComponent } from './components/panel/panel.component';
 import { PhaseBannerComponent } from './components/phase-banner/phase-banner.component';
 import { ProgressBarComponent } from './components/progress-bar/progress-bar.component';
 import { ProgressComponent } from './components/progress/progress.component';
-import {
-  RegistrationSubmitButtonsComponent,
-} from './components/registration-submit-buttons/registration-submit-buttons.component';
+import { RegistrationSubmitButtonsComponent } from './components/registration-submit-buttons/registration-submit-buttons.component';
 import { RejectRequestDialogComponent } from './components/reject-request-dialog/reject-request-dialog.component';
-import {
-  RemoveParentConfirmationComponent,
-} from './components/remove-parent-confirmation/remove-parent-confirmation.component';
+import { RemoveParentConfirmationComponent } from './components/remove-parent-confirmation/remove-parent-confirmation.component';
 import { ReviewCheckboxComponent } from './components/review-checkbox/review-checkbox.component';
 import { SearchInputComponent } from './components/search-input/search-input.component';
-import {
-  SelectWorkplaceDropdownFormComponent,
-} from './components/select-workplace-dropdown-form/select-workplace-dropdown-form.component';
-import {
-  SelectWorkplaceRadioButtonFormComponent,
-} from './components/select-workplace-radio-button-form/select-workplace-radio-button-form.component';
+import { SelectWorkplaceDropdownFormComponent } from './components/select-workplace-dropdown-form/select-workplace-dropdown-form.component';
+import { SelectWorkplaceRadioButtonFormComponent } from './components/select-workplace-radio-button-form/select-workplace-radio-button-form.component';
 import { SetDataPermissionDialogComponent } from './components/set-data-permission/set-data-permission-dialog.component';
 import { BasicRecordComponent } from './components/staff-record-summary/basic-record/basic-record.component';
 import { EmploymentComponent } from './components/staff-record-summary/employment/employment.component';
 import { PersonalDetailsComponent } from './components/staff-record-summary/personal-details/personal-details.component';
-import {
-  QualificationsAndTrainingComponent,
-} from './components/staff-record-summary/qualifications-and-training/qualifications-and-training.component';
+import { QualificationsAndTrainingComponent } from './components/staff-record-summary/qualifications-and-training/qualifications-and-training.component';
 import { StaffRecordSummaryComponent } from './components/staff-record-summary/staff-record-summary.component';
 import { StaffRecordsTabComponent } from './components/staff-records-tab/staff-records-tab.component';
 import { StaffSummaryComponent } from './components/staff-summary/staff-summary.component';
@@ -99,35 +77,21 @@ import { TabComponent } from './components/tabs/tab.component';
 import { TabsComponent } from './components/tabs/tabs.component';
 import { TotalStaffPanelComponent } from './components/total-staff-panel/total-staff-panel.component';
 import { TotalStaffComponent } from './components/total-staff/total-staff.component';
-import {
-  TrainingAndQualificationsCategoriesComponent,
-} from './components/training-and-qualifications-categories/training-and-qualifications-categories.component';
-import {
-  ViewTrainingComponent,
-} from './components/training-and-qualifications-categories/view-trainings/view-trainings.component';
-import {
-  TrainingAndQualificationsSummaryComponent,
-} from './components/training-and-qualifications-summary/training-and-qualifications-summary.component';
-import {
-  TrainingAndQualificationsTabComponent,
-} from './components/training-and-qualifications-tab/training-and-qualifications-tab.component';
+import { TrainingAndQualificationsCategoriesComponent } from './components/training-and-qualifications-categories/training-and-qualifications-categories.component';
+import { ViewTrainingComponent } from './components/training-and-qualifications-categories/view-trainings/view-trainings.component';
+import { TrainingAndQualificationsSummaryComponent } from './components/training-and-qualifications-summary/training-and-qualifications-summary.component';
+import { TrainingAndQualificationsTabComponent } from './components/training-and-qualifications-tab/training-and-qualifications-tab.component';
 import { TrainingInfoPanelComponent } from './components/training-info-panel/training-info-panel.component';
 import { TrainingLinkPanelComponent } from './components/training-link-panel/training-link-panel.component';
-import {
-  TrainingSelectViewPanelComponent,
-} from './components/training-select-view-panel/training-select-view-panel.component';
+import { TrainingSelectViewPanelComponent } from './components/training-select-view-panel/training-select-view-panel.component';
 import { UserAccountsSummaryComponent } from './components/user-accounts-summary/user-accounts-summary.component';
 import { UserFormComponent } from './components/user-form/user-form.component';
 import { UserTableComponent } from './components/users-table/user.table.component';
 import { WdfConfirmationPanelComponent } from './components/wdf-confirmation-panel/wdf-confirmation-panel.component';
 import { WdfFieldConfirmationComponent } from './components/wdf-field-confirmation/wdf-field-confirmation.component';
-import {
-  WdfStaffMismatchMessageComponent,
-} from './components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component';
+import { WdfStaffMismatchMessageComponent } from './components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component';
 import { WdfTabComponent } from './components/wdf-tab/wdf-tab.component';
-import {
-  WorkplaceContinueCancelButtonComponent,
-} from './components/workplace-continue-cancel-button.component/workplace-continue-cancel-button.component';
+import { WorkplaceContinueCancelButtonComponent } from './components/workplace-continue-cancel-button.component/workplace-continue-cancel-button.component';
 import { WorkplaceSubmitButtonComponent } from './components/workplace-submit-button/workplace-submit-button.component';
 import { WorkplaceSummaryComponent } from './components/workplace-summary/workplace-summary.component';
 import { FileValueAccessorDirective } from './form-controls/file-control-value-accessor';
@@ -148,6 +112,7 @@ import { ServiceNamePipe } from './pipes/service-name.pipe';
 import { WorkerDaysPipe } from './pipes/worker-days.pipe';
 import { WorkerPayPipe } from './pipes/worker-pay.pipe';
 import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-bearer.pipe';
+import { AboutTheDataLinkComponent } from './components/data-area-tab/about-the-data-link/about-the-data-link.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, RouterModule, OverlayModule],
@@ -261,6 +226,7 @@ import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-be
     NewDashboardHeaderComponent,
     ServiceNamePipe,
     FormatAmpersandPipe,
+    AboutTheDataLinkComponent,
   ],
   exports: [
     AbsoluteNumberPipe,
@@ -370,6 +336,7 @@ import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-be
     NewDashboardHeaderComponent,
     ServiceNamePipe,
     FormatAmpersandPipe,
+    AboutTheDataLinkComponent,
   ],
   providers: [DialogService, TotalStaffComponent, ArticleListResolver, PageResolver],
 })


### PR DESCRIPTION
#### Work done
- For the ticket [here](https://trello.com/c/PNKtjACC/1301-benchmarks-text-changes)
- Update text on ranking and bar chart when no workplace data is available for vacancy, turnover or time in role
- Create about the data link component

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
