### PR TITLE
Adjust css for longer workplace names

### DIFF
--- a/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
+++ b/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
@@ -7,7 +7,7 @@
           data-testid="column-one"
         >
           <ng-container *ngIf="tab === 'home'; else otherTab">
-            <h1 data-testid="workplaceName" class="govuk-heading-l govuk-!-margin-bottom-0">
+            <h1 data-testid="workplaceName" class="govuk-heading-l govuk-!-margin-bottom-0 home-workplace-name">
               {{ workplace?.name }}
             </h1>
 

--- a/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
+++ b/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
@@ -7,21 +7,9 @@
           data-testid="column-one"
         >
           <ng-container *ngIf="tab === 'home'; else otherTab">
-            <h1 data-testid="workplaceName" class="govuk-heading-l govuk-!-margin-bottom-0 home-workplace-name">
+            <h1 data-testid="workplaceName" class="govuk-heading-l govuk-!-margin-bottom-0">
               {{ workplace?.name }}
             </h1>
-
-            <div *ngIf="workplace && canDeleteEstablishment && subsidiaryCount < 1 && workplace.ustatus != 'PENDING'">
-              <button
-                class="govuk-button govuk-button--link govuk__flex govuk__align-items-center govuk-!-padding-left-0"
-                (click)="onDeleteWorkplace($event)"
-              >
-                <img src="/assets/images/bin.svg" alt="" />
-                <span class="govuk-!-margin-left-1">
-                  Delete <span class="govuk-visually-hidden">{{ workplace.name }}</span> Workplace
-                </span>
-              </button>
-            </div>
           </ng-container>
           <ng-template #otherTab>
             <h1 class="govuk-heading-l govuk-!-margin-bottom-0">
@@ -51,6 +39,20 @@
           <ng-container [ngSwitch]="tab">
             <ng-container *ngSwitchCase="'home'">
               <div class="govuk-util__float-right" *ngIf="tab === 'home'" data-testid="contact-info">
+                <div
+                  *ngIf="workplace && canDeleteEstablishment && subsidiaryCount < 1 && workplace.ustatus != 'PENDING'"
+                >
+                  <button
+                    class="govuk-button govuk-button--link govuk__flex govuk__align-items-center govuk-!-padding-left-0"
+                    (click)="onDeleteWorkplace($event)"
+                  >
+                    <img src="/assets/images/bin.svg" alt="" />
+                    <span class="govuk-!-margin-left-1">
+                      Delete <span class="govuk-visually-hidden">{{ workplace.name }}</span> Workplace
+                    </span>
+                  </button>
+                </div>
+
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-0">Contact Skills for Care</h2>
                 <p class="govuk-!-font-size-16 govuk-!-margin-top-2 govuk-!-margin-bottom-0">
                   <span class="govuk-!-margin-right-2">0113 241 0969</span> |

--- a/src/app/shared/components/new-dashboard-header/dashboard-header.component.scss
+++ b/src/app/shared/components/new-dashboard-header/dashboard-header.component.scss
@@ -2,12 +2,18 @@
 
 .asc-dashboard-header {
   background-color: govuk-colour('light-grey');
-  height: 165px;
+  min-height: 165px;
+  height: 185px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
 
   &__full-height {
-    height: 215px;
+    min-height: 215px;
+    height: 235px;
   }
+}
+
+.home-workplace-name {
+  width: 103%;
 }

--- a/src/app/shared/components/new-dashboard-header/dashboard-header.component.scss
+++ b/src/app/shared/components/new-dashboard-header/dashboard-header.component.scss
@@ -2,18 +2,12 @@
 
 .asc-dashboard-header {
   background-color: govuk-colour('light-grey');
-  min-height: 165px;
-  height: 185px;
+  height: 165px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
 
   &__full-height {
-    min-height: 215px;
-    height: 235px;
+    height: 215px;
   }
-}
-
-.home-workplace-name {
-  width: 103%;
 }


### PR DESCRIPTION
#### Work done
- Issue showing longer workplace names as stated [here](https://trello.com/c/Nd44r5na/1302-51543-full-workplace-name-not-showing)
- Move delete workplace button on admin view
![Admin home with button moved small](https://github.com/NMDSdevopsServiceAdm/SopraSteria-SFC/assets/17614754/7d0786e7-3c8d-4c68-b32a-d2f6be0db3b8)



#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
