### PR TITLE
Move position of cssr and workerId params to avoid mistakes when calling

### DIFF
--- a/server/routes/establishments/benchmarks/index.js
+++ b/server/routes/establishments/benchmarks/index.js
@@ -91,8 +91,8 @@ const payBenchmarks = async (establishmentId, mainService, workerId, cssr) => {
     mainService,
     'benchmarksPayByLAAndService',
     ['AverageHourlyRate', 'AverageAnnualFTE', 'MainJobRole', 'BaseWorkers'],
-    workerId,
     cssr,
+    workerId,
   );
 
   const annualOrHourly = [CARE_WORKER_ID, SENIOR_CARE_WORKER_ID].includes(workerId) ? 'Hourly' : 'Annually';
@@ -186,7 +186,7 @@ const timeInRoleBenchmarks = async (establishmentId, mainService, cssr) => {
   return await timeInRole({ establishmentId }, comparisonGroups);
 };
 
-const getComparisonGroups = async (mainService, benchmarksModel, attributes, workerId, cssr) => {
+const getComparisonGroups = async (mainService, benchmarksModel, attributes, cssr, workerId) => {
   const comparisonGroup = await benchmarksService.getComparisonData(
     models[benchmarksModel],
     mainService,


### PR DESCRIPTION
#### Work done
- Bug fix where Recruitment and retention benchmark data was not being returned from backend route. 
- Issue was cssr param being passed as worker Id by mistake. 
- Reordered params to avoid this in future as only workId can be undefined which is handled within the function. 


###TODO
 **Once this PR is merged this bug fix should also be merged back into the staging/test branch.** 

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
