### PR TITLE
Feat/1311 become a parent pending

### DIFF
--- a/src/app/core/model/alert.model.ts
+++ b/src/app/core/model/alert.model.ts
@@ -1,4 +1,4 @@
 export interface Alert {
-  type: 'success' | 'warning';
+  type: 'success' | 'warning' | 'pending';
   message: string;
 }

--- a/src/app/features/new-dashboard/become-a-parent/become-a-parent.component.html
+++ b/src/app/features/new-dashboard/become-a-parent/become-a-parent.component.html
@@ -4,7 +4,23 @@
       <div class="parentRequestTextContainer">
         <span class="govuk-caption-l">{{ workplace.name }}</span>
         <h1 class="govuk-heading-l">Become a parent and manage other workplaces' data</h1>
-
+      </div>
+    </div>
+  </div>
+  <ng-container *ngIf="isBecomeParentRequestPending && newHomeDesignParentFlag">
+    <div class="govuk-grid-row govuk-!-margin-top-0">
+      <div class="govuk-grid-column-full govuk-!-margin-top-0">
+        <app-alert
+          [isAlertPositionInside]="true"
+          [linkTextForAlert]="'Cancel parent request'"
+          (notifyAlertLinkClicked)="sendCancelToBecomeAParent($event)"
+        ></app-alert>
+      </div>
+    </div>
+  </ng-container>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="parentRequestTextContainer">
         <p>
           When you send a request to become a parent workplace, Skills for Care will review it and then send you a
           notification to tell you whether your request was approved or not.
@@ -23,7 +39,8 @@
             Alternatively, they can just be linked to, to show that they’re part of a group or organisation.
           </p>
           <p>
-            Being a parent workplace can free up resources at your other workplaces. Managers of your other workplaces can concentrate on tasks away from ASC-WDS, while you ensure that their workplaces' data is up to date.
+            Being a parent workplace can free up resources at your other workplaces. Managers of your other workplaces
+            can concentrate on tasks away from ASC-WDS, while you ensure that their workplaces' data is up to date.
           </p></app-details
         >
         <p>
@@ -33,15 +50,23 @@
       </div>
     </div>
   </div>
-  <div class="govuk-grid-row govuk-!-margin-top-6 parentRequestButtonContainer">
-    <div class="govuk-grid-column-one-half">
-      <button type="button" (click)="sendRequestToBecomeAParent()" class="govuk-button">Send parent request</button>
 
-      <a
-        [routerLink]="['/dashboard']"
-        class="govuk-link govuk-list govuk-list--inline govuk-util__float-right govuk-!-margin-top-1"
-        >Cancel</a
-      >
-    </div>
+  <div class="govuk-grid-row govuk-!-margin-top-6 parentRequestButtonContainer">
+    <ng-container *ngIf="isBecomeParentRequestPending == false; else returnToHomeButton">
+      <div class="govuk-grid-column-one-half">
+        <button type="button" (click)="sendRequestToBecomeAParent()" class="govuk-button">Send parent request</button>
+
+        <a
+          [routerLink]="['/dashboard']"
+          class="govuk-link govuk-list govuk-list--inline govuk-util__float-right govuk-!-margin-top-1"
+          >Cancel</a
+        >
+      </div>
+    </ng-container>
+    <ng-template #returnToHomeButton>
+      <div class="govuk-grid-column-one-half">
+        <button type="button" class="govuk-button" (click)="returnToHome()">Return to home</button>
+      </div>
+    </ng-template>
   </div>
 </div>

--- a/src/app/features/new-dashboard/become-a-parent/become-a-parent.component.spec.ts
+++ b/src/app/features/new-dashboard/become-a-parent/become-a-parent.component.spec.ts
@@ -6,13 +6,15 @@ import { ParentRequestsService } from '@core/services/parent-requests.service';
 import { BenchmarksService } from '@core/services/benchmarks.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { MockBenchmarksService } from '@core/test-utils/MockBenchmarkService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
 import { BecomeAParentComponent } from './become-a-parent.component';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { getTestBed } from '@angular/core/testing';
 import { AlertService } from '@core/services/alert.service';
@@ -38,6 +40,10 @@ describe('BecomeAParentComponent', () => {
           useClass: MockEstablishmentService,
         },
         {
+          provide: FeatureFlagsService,
+          useClass: MockFeatureFlagsService,
+        },
+        {
           provide: ActivatedRoute,
           useValue: {
             snapshot: {
@@ -49,6 +55,9 @@ describe('BecomeAParentComponent', () => {
           },
         },
       ],
+      componentProperties: {
+        isBecomeParentRequestPending: false,
+      },
     });
     const component = fixture.componentInstance;
 
@@ -107,14 +116,14 @@ describe('BecomeAParentComponent', () => {
     expect(getByTestId('becomeAParentRevealText')).toBeTruthy();
   });
 
-  it('should show the link with the correct href', async () => {
+  it('should show the contact us link with the correct href', async () => {
     const { getByText } = await setup();
     const link = getByText('Contact us');
     expect(link).toBeTruthy();
     expect(link.getAttribute('href')).toEqual('/contact-us');
   });
 
-  it('should show the parent request button ', async () => {
+  it('should show the parent request button', async () => {
     const { getByText } = await setup();
 
     const parentRequestButton = getByText('Send parent request');
@@ -129,5 +138,34 @@ describe('BecomeAParentComponent', () => {
 
     expect(cancelRequestLink).toBeTruthy();
     expect(cancelRequestLink.getAttribute('href')).toEqual('/dashboard');
+  });
+
+  describe('pending become a parent request', () => {
+    it('should show return to home button with the correct href back to the home tab', async () => {
+      const { component, fixture, getByText } = await setup();
+
+      component.isBecomeParentRequestPending = true;
+
+      fixture.detectChanges();
+
+      const returnToHomeButton = getByText('Return to home');
+
+      expect(returnToHomeButton).toBeTruthy();
+    });
+
+    it('should navigate to the home tab', async () => {
+      const { component, getByText, routerSpy, fixture } = await setup();
+
+      component.isBecomeParentRequestPending = true;
+
+      fixture.detectChanges();
+
+      const returnToHomeButton = getByText('Return to home');
+
+      fireEvent.click(returnToHomeButton);
+
+      fixture.detectChanges();
+      expect(routerSpy).toHaveBeenCalledWith(['/dashboard']);
+    });
   });
 });

--- a/src/app/features/new-dashboard/home-tab/home-tab.component.html
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.html
@@ -89,7 +89,9 @@
           <app-link-with-arrow *ngIf="canBecomeAParent && !linkToParentRequestedStatus && !workplace.isParent">
             <ng-container *ngIf="parentStatusRequested; else requestBecomeAParent">
               <ng-container *ngIf="newHomeDesignParentFlag; else dialogParentRequestPending">
-                <a class="govuk-link" (click)="cancelBecomeAParent($event)" href="#">Become a parent and manage other workplaces' data (request pending)</a>
+                <a class="govuk-link" [routerLink]="['/become-a-parent']"
+                  >Become a parent and manage other workplaces' data (request pending)</a
+                >
               </ng-container>
               <ng-template #dialogParentRequestPending
                 ><a class="govuk-link" (click)="cancelBecomeAParent($event)" href="#"

--- a/src/app/features/new-dashboard/home-tab/home-tab.component.spec.ts
+++ b/src/app/features/new-dashboard/home-tab/home-tab.component.spec.ts
@@ -495,7 +495,7 @@ describe('NewHomeTabComponent', () => {
           expect(becomeAParentlink.getAttribute('href')).toEqual('/become-a-parent');
         });
 
-        it('should show the become a parent pending request link', async () => {
+        it('should show the become a parent pending request link with the correct href', async () => {
           const { component, fixture, getByText, queryByText } = await setup();
 
           component.newHomeDesignParentFlag = true;
@@ -511,6 +511,7 @@ describe('NewHomeTabComponent', () => {
           );
           expect(becomeAParentPendinglink).toBeTruthy();
           expect(queryByText('Link to my parent organisation')).toBeFalsy();
+          expect(becomeAParentPendinglink.getAttribute('href')).toEqual('/become-a-parent');
         });
       });
     });

--- a/src/app/shared/components/alert/alert.component.html
+++ b/src/app/shared/components/alert/alert.component.html
@@ -1,5 +1,30 @@
-<ng-container *ngIf="alert">
+<!-- <ng-container *ngIf="alert">
   <app-inset-text [color]="alert.type" [closable]="true" [removeBottomMargin]="true" (closed)="remove()">
     <span role="status">{{ alert.message }}</span>
   </app-inset-text>
-</ng-container>
+</ng-container> -->
+
+<div>
+  <ng-container *ngIf="alert && alert.type == 'pending'; else top">
+    <ng-container *ngIf="isAlertPositionInside">
+      <app-inset-text
+        [color]="alert.type"
+        [closable]="false"
+        [removeTopMargin]="true"
+        [removeBottomMargin]="false"
+        (closed)="remove()"
+        [linkTextForAlert]="linkTextForAlert"
+        (alertLinkClicked)="alertLinkClicked($event)"
+      >
+        <span role="status">{{ alert.message }}</span>
+      </app-inset-text>
+    </ng-container>
+  </ng-container>
+  <ng-template #top>
+    <ng-container *ngIf="alert">
+      <app-inset-text [color]="alert.type" [closable]="true" [removeBottomMargin]="true" (closed)="remove()">
+        <span role="status">{{ alert.message }}</span>
+      </app-inset-text>
+    </ng-container>
+  </ng-template>
+</div>

--- a/src/app/shared/components/alert/alert.component.spec.ts
+++ b/src/app/shared/components/alert/alert.component.spec.ts
@@ -1,0 +1,25 @@
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+import { AlertService } from '@core/services/alert.service';
+import { WindowRef } from '@core/services/window.ref';
+import { AlertComponent } from './alert.component';
+
+describe('AlertComponent', () => {
+  const setup = async () => {
+    const { fixture } = await render(AlertComponent, {
+      imports: [SharedModule],
+      providers: [AlertService, WindowRef],
+    });
+
+    const component = fixture.componentInstance;
+
+    return {
+      component,
+    };
+  };
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/alert/alert.component.ts
+++ b/src/app/shared/components/alert/alert.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { Alert } from '@core/model/alert.model';
 import { AlertService } from '@core/services/alert.service';
 import { Subscription } from 'rxjs';
@@ -8,6 +8,10 @@ import { Subscription } from 'rxjs';
   templateUrl: './alert.component.html',
 })
 export class AlertComponent implements OnInit, OnDestroy {
+  @Input() isAlertPositionInside: boolean;
+  @Input() linkTextForAlert: string;
+  @Output() notifyAlertLinkClicked = new EventEmitter();
+
   public alert: Alert;
   private subscriptions: Subscription = new Subscription();
 
@@ -24,6 +28,10 @@ export class AlertComponent implements OnInit, OnDestroy {
 
   remove() {
     this.alertService.removeAlert();
+  }
+
+  alertLinkClicked(event) {
+    this.notifyAlertLinkClicked.emit(event);
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/components/inset-text/inset-text.component.html
+++ b/src/app/shared/components/inset-text/inset-text.component.html
@@ -8,4 +8,7 @@
 >
   <ng-content></ng-content>
   <a *ngIf="closable" href="#" (click)="close($event)" class="govuk-util__float-right">Close</a>
+  <a *ngIf="linkTextForAlert" href="#" class="govuk-util__float-right" (click)="alertLinkClick($event)">{{
+    linkTextForAlert
+  }}</a>
 </div>

--- a/src/app/shared/components/inset-text/inset-text.component.spec.ts
+++ b/src/app/shared/components/inset-text/inset-text.component.spec.ts
@@ -1,27 +1,58 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
+import { render } from '@testing-library/angular';
+import { SharedModule } from '@shared/shared.module';
 import { InsetTextComponent } from './inset-text.component';
 
 describe('InsetTextComponent', () => {
-  let component: InsetTextComponent;
-  let fixture: ComponentFixture<InsetTextComponent>;
+  async function setup() {
+    const { getByRole, getByText, getByLabelText, getByTestId, fixture, queryByText } = await render(
+      InsetTextComponent,
+      {
+        imports: [SharedModule],
+        providers: [],
+        componentProperties: {
+          color: 'todo',
+          closable: false,
+        },
+      },
+    );
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [InsetTextComponent],
-      }).compileComponents();
-    }),
-  );
+    const component = fixture.componentInstance;
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(InsetTextComponent);
-    component = fixture.componentInstance;
-    component.color = 'todo';
-    fixture.detectChanges();
+    return {
+      getByRole,
+      getByText,
+      getByLabelText,
+      getByTestId,
+      queryByText,
+      fixture,
+      component,
+    };
+  }
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should show close link', async () => {
+    const { component, getByText, fixture, getByRole } = await setup();
+
+    component.closable = true;
+    fixture.detectChanges();
+
+    expect(getByText('Close')).toBeTruthy();
+    expect(getByRole('link', { name: /close/i })).toBeTruthy();
+  });
+
+  it('should show the link provided', async () => {
+    const { component, getByText, fixture, getByRole } = await setup();
+
+    const linkText = 'Cancel this';
+
+    component.linkTextForAlert = linkText;
+    fixture.detectChanges();
+
+    expect(getByText(linkText)).toBeTruthy();
+    expect(getByRole('link', { name: linkText })).toBeTruthy();
   });
 });

--- a/src/app/shared/components/inset-text/inset-text.component.ts
+++ b/src/app/shared/components/inset-text/inset-text.component.ts
@@ -9,12 +9,19 @@ export class InsetTextComponent {
   @Input() closable = false;
   @Input() removeBottomMargin = false;
   @Input() removeTopMargin = false;
+  @Input() linkTextForAlert: string;
   @Output() closed = new EventEmitter();
+  @Output() alertLinkClicked = new EventEmitter();
 
   constructor() {}
 
   public close(event: Event) {
     event.preventDefault();
     this.closed.emit();
+  }
+
+  alertLinkClick(event: Event) {
+    event.preventDefault();
+    this.alertLinkClicked.emit(event);
   }
 }

--- a/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
+++ b/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
@@ -147,6 +147,7 @@ export class NewHomeTabDirective implements OnInit, OnDestroy {
     this.subscriptions.add();
 
     this.parentRequestAlertMessage = history.state?.parentRequestMessage;
+
     this.sendAlert();
   }
 
@@ -167,7 +168,6 @@ export class NewHomeTabDirective implements OnInit, OnDestroy {
 
   ngOnChanges() {
     this.setBenchmarksCard();
-
   }
 
   public navigateToTab(event: Event, selectedTab: string): void {
@@ -293,16 +293,16 @@ export class NewHomeTabDirective implements OnInit, OnDestroy {
   }
 
   public sendAlert(): void {
-    if(this.parentRequestAlertMessage){
+    if (this.parentRequestAlertMessage) {
       this.alertService.addAlert({
         type: 'success',
-        message: this.parentRequestAlertMessage
+        message: this.parentRequestAlertMessage,
       });
     }
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
-    this.alertService.removeAlert()
+    this.alertService.removeAlert();
   }
 }

--- a/src/assets/scss/components/_inset-text.scss
+++ b/src/assets/scss/components/_inset-text.scss
@@ -13,4 +13,9 @@
     border-color: govuk-colour('orange');
     background-color: rgba(govuk-colour('orange'), 0.12);
   }
+
+  &.pending {
+    border-color: govuk-colour('blue');
+    background-color: rgba(govuk-colour('blue'), 0.15);
+  }
 }


### PR DESCRIPTION
#### Work done
- [Become a parent pending request](https://trello.com/c/CreJ5sR0/1311-become-a-parent-pending)
- Add banner and change the button text, to become a parent when request is pending
- Allowed insert text to take any string for link and function
- Added a new alert type and colour for the banner
- Add logic to not display banner in usual position in dashboard

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
