### PR TITLE
Revert Redis and PG environment varibles

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -64,7 +64,7 @@ const config = convict({
     host: {
       doc: 'Database host name/IP',
       format: String,
-      default: 'host.docker.internal',
+      default: 'localhost',
       env: 'DB_HOST',
     },
     database: {
@@ -622,7 +622,7 @@ const config = convict({
     url: {
       doc: 'The URI to redirect users to the Redis',
       format: String,
-      default: 'redis://sfc-redis:6379',
+      default: 'redis://localhost:6379',
       env: 'REDIS_ENDPOINT',
     },
     serviceName: {


### PR DESCRIPTION
#### Work done
- Reverted the environment variables to Redis & Postgresql as it breaks the environment. Will change these back post migration.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
