### PR TITLE
Move cssr service call up into the get rankings function

### DIFF
--- a/server/routes/establishments/benchmarks/benchmarksService.js
+++ b/server/routes/establishments/benchmarks/benchmarksService.js
@@ -182,9 +182,10 @@ const getComparisonGroupRankings = async function ({
   mainService,
   attributes,
   mainJob,
+  cssr
 }) {
-  const cssr = await models.cssr.getCSSR(establishmentId);
   if (!cssr) return {};
+
   const where = mainJob ? { MainJobRole: mainJob } : {};
   return await benchmarksModel.findAll({
     attributes: ['LocalAuthorityArea', 'MainServiceFK', ...attributes],


### PR DESCRIPTION
#### Work done
- Reduce the number of calls to the cssr service by moving call up into the get rankings route function and out of the individual functions for Pay, Sickness etc.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
