### PR TITLE
Add get address to create account postcode lookup

### DIFF
--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -809,7 +809,7 @@ module.exports = function (sequelize, DataTypes) {
 
   Establishment.addHook('afterUpdate', (record) => {
     const postcode = record.dataValues.PostCode;
-    if (postcode) sequelize.models.postcodes.firstOrCreate(postcode); // TODO RETURN?
+    if (postcode) sequelize.models.postcodes.firstOrCreate(postcode);
   });
 
   Establishment.associate = (models) => {

--- a/server/models/establishment.js
+++ b/server/models/establishment.js
@@ -809,7 +809,7 @@ module.exports = function (sequelize, DataTypes) {
 
   Establishment.addHook('afterUpdate', (record) => {
     const postcode = record.dataValues.PostCode;
-    if (postcode) sequelize.models.postcodes.firstOrCreate(postcode);
+    if (postcode) sequelize.models.postcodes.firstOrCreate(postcode); // TODO RETURN?
   });
 
   Establishment.associate = (models) => {

--- a/server/routes/postcodes.js
+++ b/server/routes/postcodes.js
@@ -46,7 +46,7 @@ const createAddressObjectFromGetAddressesAPIResults = (data, postcode) => {
     addressLine3: filteredAddressInfo[2] ? filteredAddressInfo[2] : '',
     townCity: data.town_or_city,
     county: data.county,
-    postalCode: postcode, // Does not return from getAddress
+    postalCode: postcode,
   };
 };
 
@@ -75,6 +75,14 @@ const getAddressesWithPostcode = async (req, res) => {
 
     if (postcodeData.length === 0) {
       const addressAPIResults = await getAddressAPI.getPostcodeData(req.params.postcode);
+
+      if (addressAPIResults == null) {
+        res.status(404);
+        return res.send({
+          success: 0,
+          message: 'No Response From getAddressAPI',
+        });
+      }
       postcodeData = transformGetAddressAPIResults(addressAPIResults);
 
       if (postcodeData.length === 0) {

--- a/server/test/unit/routes/establishments/updateSingleEstablishmentField.spec.js
+++ b/server/test/unit/routes/establishments/updateSingleEstablishmentField.spec.js
@@ -4,8 +4,15 @@ const sinon = require('sinon');
 const models = require('../../../../models');
 
 const { updateEstablishment } = require('../../../../routes/establishments/updateSingleEstablishmentField');
+const getAddressAPI = require('../../../../utils/getAddressAPI');
 
 describe('server/routes/establishments/updateSingleEstablishmentField', () => {
+  beforeEach(() => {
+    sinon.stub(getAddressAPI, 'getPostcodeData').callsFake(async () => {
+      return null;
+    });
+  });
+
   afterEach(async () => {
     sinon.restore();
   });

--- a/server/test/unit/routes/postcodes.spec.js
+++ b/server/test/unit/routes/postcodes.spec.js
@@ -3,8 +3,15 @@ const sinon = require('sinon');
 const postcodes = require('../../../routes/postcodes');
 const models = require('../../../models');
 const httpMocks = require('node-mocks-http');
+const getAddressAPI = require('../../../utils/getAddressAPI');
 
 describe('postcodes', () => {
+  beforeEach(() => {
+    sinon.stub(getAddressAPI, 'getPostcodeData').callsFake(async () => {
+      return null;
+    });
+  });
+
   afterEach(() => {
     sinon.restore();
   });


### PR DESCRIPTION
#### Work done
- Add getAddressAPI all if postcode not found on create
- Add transformer for response
- Stub tests to not communicate with getAddress
- Handle no responses from getAddressAPI

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
