### PR TITLE
Buildspec files are now compatible with running on build and deploy

### DIFF
--- a/buildspec/build.yml
+++ b/buildspec/build.yml
@@ -17,4 +17,3 @@ phases:
 artifacts:
   files:
     - '**/*'
-  base-directory: 'frontend/src'

--- a/buildspec/deploy-backend.yml
+++ b/buildspec/deploy-backend.yml
@@ -6,14 +6,14 @@ phases:
       - echo Logging in to Amazon ECR...
       - aws --version
       - aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin 914197850242.dkr.ecr.eu-west-1.amazonaws.com
-      - REPOSITORY_URI=914197850242.dkr.ecr.eu-west-1.amazonaws.com/sfc-migration-test
+      - REPOSITORY_URI=636146736465.dkr.ecr.eu-west-1.amazonaws.com/sfc-backend-build-images
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - cd backend 
+      - cd backend
       - docker build -t $REPOSITORY_URI:latest .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:

--- a/buildspec/deploy-backend.yml
+++ b/buildspec/deploy-backend.yml
@@ -5,7 +5,7 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - aws --version
-      - aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin 914197850242.dkr.ecr.eu-west-1.amazonaws.com
+      - aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin 636146736465.dkr.ecr.eu-west-1.amazonaws.com
       - REPOSITORY_URI=636146736465.dkr.ecr.eu-west-1.amazonaws.com/sfc-backend-build-images
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}

--- a/buildspec/deploy-frontend.yml
+++ b/buildspec/deploy-frontend.yml
@@ -5,4 +5,4 @@ phases:
     commands:
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - cd frontend/src
-      - aws s3 cp --recursive . s3://sfc-frontend-nonprod/$COMMIT_HASH
+      - aws s3 cp --recursive . s3://sfc-frontend-build-artifacts/$COMMIT_HASH

--- a/buildspec/test-frontend.yml
+++ b/buildspec/test-frontend.yml
@@ -14,5 +14,5 @@ phases:
       - apt-get --assume-yes install ca-certificates fonts-liberation libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
   build:
     commands:
-      - cd frontend && npm ci
+      - cd frontend
       - npm run test-headless; EXITCODE=$?

--- a/buildspec/test-performance.yml
+++ b/buildspec/test-performance.yml
@@ -11,7 +11,7 @@ phases:
       - apt-get -y install google-chrome-stable
   build:
     commands:
-      - cd frontend && npm ci
+      - cd frontend
       - npm install -g @lhci/cli@0.12.x
       - npm run build
       - lhci autorun


### PR DESCRIPTION
#### Work done
- Changed the ecr uri from nonprod to build and deploy 
- Changed the s3 bucket name from nonprod to build and deploy 
- Removed npm ci from test pipelines in favour of using cache
- Removed base directory so we could include all build files from cache

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
