### PR TITLE
Wdf parent status message dynamic year

### DIFF
--- a/src/app/core/test-utils/MockReportService.ts
+++ b/src/app/core/test-utils/MockReportService.ts
@@ -7,6 +7,9 @@ import { Observable, of } from 'rxjs';
 export class MockReportService extends ReportService {
   public getWDFReport(workplaceUid: string): Observable<WDFReport> {
     const d = new Date();
+    //21 July YEAR
+    d.setMonth(6);
+    d.setDate(21);
     d.setHours(0, 0, 0, 0);
     const dateString = d.toISOString();
 

--- a/src/app/core/test-utils/MockReportService.ts
+++ b/src/app/core/test-utils/MockReportService.ts
@@ -6,13 +6,17 @@ import { Observable, of } from 'rxjs';
 @Injectable()
 export class MockReportService extends ReportService {
   public getWDFReport(workplaceUid: string): Observable<WDFReport> {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    const dateString = d.toISOString();
+
     return of({
       establishmentId: 1,
-      timestamp: '2021-04-12T00:00:00.000Z',
-      effectiveFrom: '2021-04-01T00:00:00.000Z',
+      timestamp: dateString,
+      effectiveFrom: dateString,
       wdf: {
         overall: true,
-        overallWdfEligibility: '2021-07-21T00:00:00.000Z',
+        overallWdfEligibility: dateString,
         workplace: true,
         staff: true,
       },

--- a/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.spec.ts
@@ -206,7 +206,7 @@ describe('WdfDataComponent', () => {
     it('should display the correct message and timeframe if meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your data meets the WDF ${year - 1} to ${year} requirements`;
+      const timeframeSentence = `Your data meets the WDF ${year} to ${year + 1} requirements`;
 
       component.isStandalone = true;
       component.wdfEligibilityStatus.overall = true;
@@ -233,7 +233,7 @@ describe('WdfDataComponent', () => {
     it('should display the not meeting message if not meeting WDF requirements overall', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const notMeetingMessage = `Your data does not meet the WDF ${year - 1} to ${year} requirements`;
+      const notMeetingMessage = `Your data does not meet the WDF ${year} to ${year + 1} requirements`;
 
       component.isStandalone = true;
       component.wdfEligibilityStatus.overall = false;
@@ -245,7 +245,7 @@ describe('WdfDataComponent', () => {
     it('should display the correct message and timeframe for parents if meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your data meets the WDF ${year - 1} to ${year} requirements`;
+      const timeframeSentence = `Your data meets the WDF ${year} to ${year + 1} requirements`;
 
       component.isStandalone = false;
       component.wdfEligibilityStatus.overall = true;
@@ -259,9 +259,9 @@ describe('WdfDataComponent', () => {
     it('should display the "keeping data up to date" message for parents if meeting WDF requirements with data changes', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const keepUpToDateMessage = `Your workplace met the WDF ${
-        year - 1
-      } to ${year} requirements, but keeping your data up to date will save you time next year`;
+      const keepUpToDateMessage = `Your workplace met the WDF ${year} to ${
+        year + 1
+      } requirements, but keeping your data up to date will save you time next year`;
 
       component.isStandalone = false;
       component.wdfEligibilityStatus.overall = true;
@@ -275,7 +275,7 @@ describe('WdfDataComponent', () => {
     it('should display the not meeting message for parents if not meeting WDF requirements overall', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const notMeetingMessage = `Your data does not meet the WDF ${year - 1} to ${year} requirements`;
+      const notMeetingMessage = `Your data does not meet the WDF ${year} to ${year + 1} requirements`;
 
       component.isStandalone = false;
       component.wdfEligibilityStatus.overall = false;

--- a/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.spec.ts
@@ -205,7 +205,8 @@ describe('WdfDataComponent', () => {
   describe('WdfDataStatusMessageComponent', async () => {
     it('should display the correct message and timeframe if meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = 'Your data meets the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data meets the WDF ${year - 1} to ${year} requirements`;
 
       component.isStandalone = true;
       component.wdfEligibilityStatus.overall = true;
@@ -231,7 +232,8 @@ describe('WdfDataComponent', () => {
 
     it('should display the not meeting message if not meeting WDF requirements overall', async () => {
       const { component, fixture, getByText } = await setup();
-      const notMeetingMessage = 'Your data does not meet the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const notMeetingMessage = `Your data does not meet the WDF ${year - 1} to ${year} requirements`;
 
       component.isStandalone = true;
       component.wdfEligibilityStatus.overall = false;
@@ -242,7 +244,8 @@ describe('WdfDataComponent', () => {
 
     it('should display the correct message and timeframe for parents if meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = 'Your data meets the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data meets the WDF ${year - 1} to ${year} requirements`;
 
       component.isStandalone = false;
       component.wdfEligibilityStatus.overall = true;
@@ -255,8 +258,10 @@ describe('WdfDataComponent', () => {
 
     it('should display the "keeping data up to date" message for parents if meeting WDF requirements with data changes', async () => {
       const { component, fixture, getByText } = await setup();
-      const keepUpToDateMessage =
-        'Your workplace met the WDF 2021 to 2022 requirements, but keeping your data up to date will save you time next year';
+      const year = new Date().getFullYear();
+      const keepUpToDateMessage = `Your workplace met the WDF ${
+        year - 1
+      } to ${year} requirements, but keeping your data up to date will save you time next year`;
 
       component.isStandalone = false;
       component.wdfEligibilityStatus.overall = true;
@@ -269,7 +274,8 @@ describe('WdfDataComponent', () => {
 
     it('should display the not meeting message for parents if not meeting WDF requirements overall', async () => {
       const { component, fixture, getByText } = await setup();
-      const notMeetingMessage = 'Your data does not meet the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const notMeetingMessage = `Your data does not meet the WDF ${year - 1} to ${year} requirements`;
 
       component.isStandalone = false;
       component.wdfEligibilityStatus.overall = false;

--- a/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
@@ -46,7 +46,8 @@ describe('WdfOverviewComponent', () => {
 
     it('should display the correct timeframe for meeting WDF requirements', async () => {
       const { getByText } = await setup();
-      const timeframeSentence = 'Your data has met the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data has met the WDF ${year - 1} to ${year} requirements`;
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
@@ -69,7 +70,8 @@ describe('WdfOverviewComponent', () => {
   describe('Unhappy path', async () => {
     it('should not display the meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, queryByText } = await setup();
-      const timeframeSentence = 'Your data has met the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data has met the WDF ${year - 1} to ${year} requirements`;
       const requirementsMetMessage = 'Your data met the requirements on 21 July 2021';
 
       component.overallWdfEligibility = false;
@@ -81,14 +83,15 @@ describe('WdfOverviewComponent', () => {
 
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
-      const requirementsNotMetSentence = 'Your data does not meet the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data does not meet the WDF ${year - 1} to ${year} requirements`;
       const viewWdfLink = 'View your WDF data';
       const viewWdfSentence = 'to see where it does not meet the requirements';
 
       component.overallWdfEligibility = false;
       fixture.detectChanges();
 
-      expect(getByText(requirementsNotMetSentence, { exact: false })).toBeTruthy();
+      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
       expect(getByText(viewWdfLink, { exact: false })).toBeTruthy();
       expect(getByText(viewWdfSentence, { exact: false })).toBeTruthy();
     });
@@ -97,7 +100,8 @@ describe('WdfOverviewComponent', () => {
   describe('Parent workplaces happy path', () => {
     it('should display the correct timeframe for parents for meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = 'All of your workplaces have met the WDF 2021 to 2022 data requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `All of your workplaces have met the WDF ${year - 1} to ${year} data requirements`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = true;
@@ -146,7 +150,8 @@ describe('WdfOverviewComponent', () => {
   describe('Parent workplaces unhappy path', () => {
     it('should not display the meeting requirements message when the parent is not eligible', async () => {
       const { component, fixture, queryByText } = await setup();
-      const timeframeSentence = 'All of your workplaces have met the WDF 2021 to 2022 data requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `All of your workplaces have met the WDF ${year - 1} to ${year} data requirements`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = false;
@@ -157,8 +162,10 @@ describe('WdfOverviewComponent', () => {
 
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
-      const requirementsNotMetSentence =
-        "Some of your workplaces' data does not meet the WDF 2021 to 2022 requirements";
+      const year = new Date().getFullYear();
+      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${
+        year - 1
+      } to ${year} requirements`;
       const viewWorkplacesLink = 'View your workplaces';
       const viewWorkplacesSentence = 'to see which have data that does not meet the requirements.';
 

--- a/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
@@ -54,14 +54,16 @@ describe('WdfOverviewComponent', () => {
 
     it('should display the correct date for when the user became eligible', async () => {
       const { getByText } = await setup();
-      const timeframeSentence = 'Your data met the requirements on 21 July 2021';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data met the requirements on 21 July ${year}`;
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
 
     it('should display the correct date for when WDF eligibility is valid until', async () => {
       const { getByText } = await setup();
-      const timeframeSentence = 'and will continue to meet them until 31 March 2022.';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `and will continue to meet them until 31 March ${year+1}.`;
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
@@ -112,11 +114,12 @@ describe('WdfOverviewComponent', () => {
 
     it('should display the correct date for when parent and all subs became eligible', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = "Your workplaces' data met the requirements on 31 July 2021";
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your workplaces' data met the requirements on 31 July ${year}`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = true;
-      component.parentOverallEligibilityDate = dayjs('2021-07-31').format('D MMMM YYYY');
+      component.parentOverallEligibilityDate = dayjs(`${year}-07-31`).format('D MMMM YYYY');
       fixture.detectChanges();
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
@@ -124,7 +127,8 @@ describe('WdfOverviewComponent', () => {
 
     it('should display the correct date for parents for when WDF eligibility is valid until', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = 'and will continue to meet them until 31 March 2022.';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `and will continue to meet them until 31 March ${year+1}.`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = true;

--- a/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
@@ -47,7 +47,7 @@ describe('WdfOverviewComponent', () => {
     it('should display the correct timeframe for meeting WDF requirements', async () => {
       const { getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your data has met the WDF ${year - 1} to ${year} requirements`;
+      const timeframeSentence = `Your data has met the WDF ${year} to ${year + 1} requirements`;
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
@@ -71,7 +71,7 @@ describe('WdfOverviewComponent', () => {
     it('should not display the meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, queryByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your data has met the WDF ${year - 1} to ${year} requirements`;
+      const timeframeSentence = `Your data has met the WDF ${year} to ${year + 1} requirements`;
       const requirementsMetMessage = 'Your data met the requirements on 21 July 2021';
 
       component.overallWdfEligibility = false;
@@ -84,7 +84,7 @@ describe('WdfOverviewComponent', () => {
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your data does not meet the WDF ${year - 1} to ${year} requirements`;
+      const timeframeSentence = `Your data does not meet the WDF ${year} to ${year + 1} requirements`;
       const viewWdfLink = 'View your WDF data';
       const viewWdfSentence = 'to see where it does not meet the requirements';
 
@@ -101,7 +101,7 @@ describe('WdfOverviewComponent', () => {
     it('should display the correct timeframe for parents for meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `All of your workplaces have met the WDF ${year - 1} to ${year} data requirements`;
+      const timeframeSentence = `All of your workplaces have met the WDF ${year} to ${year + 1} data requirements`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = true;
@@ -151,7 +151,7 @@ describe('WdfOverviewComponent', () => {
     it('should not display the meeting requirements message when the parent is not eligible', async () => {
       const { component, fixture, queryByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `All of your workplaces have met the WDF ${year - 1} to ${year} data requirements`;
+      const timeframeSentence = `All of your workplaces have met the WDF ${year} to ${year + 1} data requirements`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = false;
@@ -163,9 +163,9 @@ describe('WdfOverviewComponent', () => {
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${
-        year - 1
-      } to ${year} requirements`;
+      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${year - 1} to ${
+        year + 1
+      } requirements`;
       const viewWorkplacesLink = 'View your workplaces';
       const viewWorkplacesSentence = 'to see which have data that does not meet the requirements.';
 

--- a/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
@@ -163,7 +163,7 @@ describe('WdfOverviewComponent', () => {
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${year - 1} to ${
+      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${year} to ${
         year + 1
       } requirements`;
       const viewWorkplacesLink = 'View your workplaces';

--- a/src/app/features/wdf/wdf-data-change/wdf-parent-status-message/wdf-parent-status-message.component.html
+++ b/src/app/features/wdf/wdf-data-change/wdf-parent-status-message/wdf-parent-status-message.component.html
@@ -4,7 +4,7 @@
     {{ wdfEndDate | date: 'yyyy' }} requirements
   </ng-container>
   <ng-container *ngIf="overallEligibilityStatus && !currentEligibilityStatus">
-    Your workplaces met the {{ wdfStartDate | date: 'yyyy' }} to
+    Your workplaces met the WDF {{ wdfStartDate | date: 'yyyy' }} to
     {{ wdfEndDate | date: 'yyyy' }} requirements, but updating those currently shown as 'not meeting' will save
     you time next year.
   </ng-container>

--- a/src/app/features/wdf/wdf-data-change/wdf-parent-status-message/wdf-parent-status-message.component.html
+++ b/src/app/features/wdf/wdf-data-change/wdf-parent-status-message/wdf-parent-status-message.component.html
@@ -4,7 +4,8 @@
     {{ wdfEndDate | date: 'yyyy' }} requirements
   </ng-container>
   <ng-container *ngIf="overallEligibilityStatus && !currentEligibilityStatus">
-    Your workplaces met the WDF 2021 to 2022 requirements, but updating those currently shown as 'not meeting' will save
+    Your workplaces met the {{ wdfStartDate | date: 'yyyy' }} to
+    {{ wdfEndDate | date: 'yyyy' }} requirements, but updating those currently shown as 'not meeting' will save
     you time next year.
   </ng-container>
   <ng-container *ngIf="overallEligibilityStatus && currentEligibilityStatus">

--- a/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
@@ -73,7 +73,7 @@ describe('WdfStaffRecordComponent', () => {
   it('should display the "not meeting requirements" message and red cross when user does not meet WDF requirements overall and current staff record does not', async () => {
     const { component, fixture, getByText } = await setup();
     const year = new Date().getFullYear();
-    const expectedStatusMessage = `This record does not meet the WDF ${year - 1} to ${year} requirements`;
+    const expectedStatusMessage = `This record does not meet the WDF ${year} to ${year + 1} requirements`;
     const redCrossVisuallyHiddenMessage = 'Red cross';
 
     component.worker = workerBuilder() as Worker;
@@ -94,7 +94,7 @@ describe('WdfStaffRecordComponent', () => {
   it('should not display the "not meeting requirements" or "update staff record" message when worker eligible', async () => {
     const { component, fixture, queryByText } = await setup();
     const year = new Date().getFullYear();
-    const redCrossStatusMessage = `This record does not meet the WDF ${year - 1} to ${year} requirements`;
+    const redCrossStatusMessage = `This record does not meet the WDF ${year} to ${year + 1} requirements`;
     const redCrossVisuallyHiddenMessage = 'Red cross';
 
     const orangeFlagStatusMessage = 'Update this staff record to save yourself time next year';

--- a/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
@@ -72,7 +72,8 @@ describe('WdfStaffRecordComponent', () => {
 
   it('should display the "not meeting requirements" message and red cross when user does not meet WDF requirements overall and current staff record does not', async () => {
     const { component, fixture, getByText } = await setup();
-    const expectedStatusMessage = 'This record does not meet the WDF 2021 to 2022 requirements';
+    const year = new Date().getFullYear();
+    const expectedStatusMessage = `This record does not meet the WDF ${year - 1} to ${year} requirements`;
     const redCrossVisuallyHiddenMessage = 'Red cross';
 
     component.worker = workerBuilder() as Worker;
@@ -92,7 +93,8 @@ describe('WdfStaffRecordComponent', () => {
 
   it('should not display the "not meeting requirements" or "update staff record" message when worker eligible', async () => {
     const { component, fixture, queryByText } = await setup();
-    const redCrossStatusMessage = 'This record does not meet the WDF 2021 to 2022 requirements';
+    const year = new Date().getFullYear();
+    const redCrossStatusMessage = `This record does not meet the WDF ${year - 1} to ${year} requirements`;
     const redCrossVisuallyHiddenMessage = 'Red cross';
 
     const orangeFlagStatusMessage = 'Update this staff record to save yourself time next year';

--- a/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
@@ -81,8 +81,8 @@ describe('WdfStaffRecordComponent', () => {
 
     component.exitUrl = { url: [] };
     component.overallWdfEligibility = false;
-    component.wdfStartDate = '2021-01-01';
-    component.wdfEndDate = '2022-01-01';
+    component.wdfStartDate = `${year}-01-01`;
+    component.wdfEndDate = `${year+1}-01-01`;
     component.workerList = ['1', '2', '3', '4'];
 
     fixture.detectChanges();
@@ -105,8 +105,8 @@ describe('WdfStaffRecordComponent', () => {
 
     component.exitUrl = { url: [] };
     component.overallWdfEligibility = true;
-    component.wdfStartDate = '2021-01-01';
-    component.wdfEndDate = '2022-01-01';
+    component.wdfStartDate = `${year}-01-01`;
+    component.wdfEndDate = `${year+1}-01-01`;
     component.workerList = ['1', '2', '3', '4'];
     fixture.detectChanges();
 

--- a/src/app/features/wdf/wdf-data-change/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
@@ -75,7 +75,8 @@ describe('WdfWorkplacesSummaryComponent', () => {
   describe('WdfParentStatusMessageComponent', async () => {
     it('should display the correct message and timeframe if meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = `All your workplaces' data meets the WDF 2021 to 2022 requirements`;
+      const year = new Date().getFullYear();
+      const timeframeSentence = `All your workplaces' data meets the WDF ${year - 1} to ${year} requirements`;
 
       component.parentOverallEligibilityStatus = true;
       component.parentCurrentEligibilityStatus = true;
@@ -86,7 +87,10 @@ describe('WdfWorkplacesSummaryComponent', () => {
 
     it('should display the correct message if workplaces have met WDF requirements this year but not meeting currently', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = `Your workplaces met the WDF 2021 to 2022 requirements, but updating those currently shown as 'not meeting' will save you time next year.`;
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your workplaces met the WDF ${
+        year - 1
+      } to ${year} requirements, but updating those currently shown as 'not meeting' will save you time next year.`;
 
       component.parentOverallEligibilityStatus = true;
       component.parentCurrentEligibilityStatus = false;
@@ -97,7 +101,10 @@ describe('WdfWorkplacesSummaryComponent', () => {
 
     it('should display the correct message if workplaces have not met WDF requirements this year', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = `Some of your workplaces' data does not meet the WDF 2021 to 2022 requirements`;
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Some of your workplaces' data does not meet the WDF ${
+        year - 1
+      } to ${year} requirements`;
 
       component.parentOverallEligibilityStatus = false;
       component.parentCurrentEligibilityStatus = false;

--- a/src/app/features/wdf/wdf-data-change/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
+++ b/src/app/features/wdf/wdf-data-change/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
@@ -76,7 +76,7 @@ describe('WdfWorkplacesSummaryComponent', () => {
     it('should display the correct message and timeframe if meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `All your workplaces' data meets the WDF ${year - 1} to ${year} requirements`;
+      const timeframeSentence = `All your workplaces' data meets the WDF ${year} to ${year + 1} requirements`;
 
       component.parentOverallEligibilityStatus = true;
       component.parentCurrentEligibilityStatus = true;
@@ -88,9 +88,9 @@ describe('WdfWorkplacesSummaryComponent', () => {
     it('should display the correct message if workplaces have met WDF requirements this year but not meeting currently', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your workplaces met the WDF ${
-        year - 1
-      } to ${year} requirements, but updating those currently shown as 'not meeting' will save you time next year.`;
+      const timeframeSentence = `Your workplaces met the WDF ${year} to ${
+        year + 1
+      } requirements, but updating those currently shown as 'not meeting' will save you time next year.`;
 
       component.parentOverallEligibilityStatus = true;
       component.parentCurrentEligibilityStatus = false;
@@ -102,9 +102,9 @@ describe('WdfWorkplacesSummaryComponent', () => {
     it('should display the correct message if workplaces have not met WDF requirements this year', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Some of your workplaces' data does not meet the WDF ${
-        year - 1
-      } to ${year} requirements`;
+      const timeframeSentence = `Some of your workplaces' data does not meet the WDF ${year} to ${
+        year + 1
+      } requirements`;
 
       component.parentOverallEligibilityStatus = false;
       component.parentCurrentEligibilityStatus = false;

--- a/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
+++ b/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
@@ -35,7 +35,7 @@ describe('WdfTabComponent', () => {
     it('should display the correct timeframe for meeting WDF requirements', async () => {
       const { getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your data has met the WDF ${year - 1} to ${year} requirements`;
+      const timeframeSentence = `Your data has met the WDF ${year} to ${year + 1} requirements`;
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
@@ -59,7 +59,7 @@ describe('WdfTabComponent', () => {
     it('should not display the meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, queryByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your data has met the WDF ${year - 1} to ${year} requirements`;
+      const timeframeSentence = `Your data has met the WDF ${year} to ${year + 1} requirements`;
       const requirementsMetMessage = 'Your data met the requirements on 21 July 2021';
 
       component.overallWdfEligibility = false;
@@ -72,7 +72,7 @@ describe('WdfTabComponent', () => {
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your data has does not meet the WDF ${year - 1} to ${year} requirements`;
+      const timeframeSentence = `Your data has does not meet the WDF ${year} to ${year + 1} requirements`;
       const viewWdfLink = 'View your WDF data';
       const viewWdfSentence = 'to see where it does not meet the requirements';
 
@@ -89,7 +89,7 @@ describe('WdfTabComponent', () => {
     it('should display the correct timeframe for parents for meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `All of your workplaces have met the WDF ${year - 1} to ${year} data requirements`;
+      const timeframeSentence = `All of your workplaces have met the WDF ${year} to ${year + 1} data requirements`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = true;
@@ -139,7 +139,7 @@ describe('WdfTabComponent', () => {
     it('should not display the meeting requirements message when the parent is not eligible', async () => {
       const { component, fixture, queryByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `All of your workplaces have met the WDF ${year - 1} to ${year} data requirements`;
+      const timeframeSentence = `All of your workplaces have met the WDF ${year} to ${year + 1} data requirements`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = false;
@@ -151,9 +151,9 @@ describe('WdfTabComponent', () => {
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${
-        year - 1
-      } to ${year} requirements`;
+      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${year - 1} to ${
+        year + 1
+      } requirements`;
       const viewWorkplacesLink = 'View your workplaces';
       const viewWorkplacesSentence = 'to see which have data that does not meet the requirements.';
 

--- a/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
+++ b/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
@@ -62,7 +62,7 @@ describe('WdfTabComponent', () => {
       const { component, fixture, queryByText } = await setup();
       const year = new Date().getFullYear();
       const timeframeSentence = `Your data has met the WDF ${year} to ${year + 1} requirements`;
-      const requirementsMetMessage = 'Your data met the requirements on 21 July 2021';
+      const requirementsMetMessage = `Your data met the requirements on 21 July ${year}`;
 
       component.overallWdfEligibility = false;
       fixture.detectChanges();
@@ -74,7 +74,7 @@ describe('WdfTabComponent', () => {
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const timeframeSentence = `Your data has does not meet the WDF ${year} to ${year + 1} requirements`;
+      const timeframeSentence = `Your data does not meet the WDF ${year} to ${year + 1} requirements`;
       const viewWdfLink = 'View your WDF data';
       const viewWdfSentence = 'to see where it does not meet the requirements';
 
@@ -102,11 +102,12 @@ describe('WdfTabComponent', () => {
 
     it('should display the correct date for when parent and all subs became eligible', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = `Your workplaces' data met the requirements on 31 July 2021`;
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your workplaces' data met the requirements on 31 July ${year}`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = true;
-      component.parentOverallEligibilityDate = dayjs('2021-07-31').format('D MMMM YYYY');
+      component.parentOverallEligibilityDate = dayjs(`${year}-07-31`).format('D MMMM YYYY');
       fixture.detectChanges();
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
@@ -114,7 +115,8 @@ describe('WdfTabComponent', () => {
 
     it('should display the correct date for parents for when WDF eligibility is valid until', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = 'and will continue to meet them until 31 March 2022.';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `and will continue to meet them until 31 March ${year+1}`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = true;
@@ -172,11 +174,12 @@ describe('WdfTabComponent', () => {
   describe('getParentAndSubs', async () => {
     it('should calculate parentOverallWdfEligibility to be true if all workplaces are eligible', async () => {
       const { component, fixture } = await setup();
+      const year = new Date().getFullYear();
 
       component.isParent = true;
       component.workplaces = [
-        { wdf: { overall: true, overallWdfEligibility: '2021-07-31' } },
-        { wdf: { overall: true, overallWdfEligibility: '2021-05-01' } },
+        { wdf: { overall: true, overallWdfEligibility: `${year}-07-31` } },
+        { wdf: { overall: true, overallWdfEligibility: `${year}-05-01` } },
       ];
 
       component.getParentOverallWdfEligibility();
@@ -187,10 +190,11 @@ describe('WdfTabComponent', () => {
 
     it('should calculate parentOverallWdfEligibility to be false if a workplace is ineligible', async () => {
       const { component, fixture } = await setup();
+      const year = new Date().getFullYear();
 
       component.isParent = true;
       component.workplaces = [
-        { wdf: { overall: true, overallWdfEligibility: '2021-07-31' } },
+        { wdf: { overall: true, overallWdfEligibility: `${year}-07-31` } },
         { wdf: { overall: false, overallWdfEligibility: '' } },
       ];
 
@@ -202,18 +206,19 @@ describe('WdfTabComponent', () => {
 
     it('should correctly calculate parentOverallEligibilityDate if all workplaces are eligible', async () => {
       const { component, fixture } = await setup();
+      const year = new Date().getFullYear();
 
       component.isParent = true;
       component.parentOverallWdfEligibility = true;
       component.workplaces = [
-        { wdf: { overall: true, overallWdfEligibility: '2021-07-31' } },
-        { wdf: { overall: true, overallWdfEligibility: '2021-05-01' } },
+        { wdf: { overall: true, overallWdfEligibility: `${year}-07-31` } },
+        { wdf: { overall: true, overallWdfEligibility: `${year}-05-01` } },
       ];
 
       component.getLastOverallEligibilityDate();
       fixture.detectChanges();
 
-      expect(component.parentOverallEligibilityDate).toEqual('31 July 2021');
+      expect(component.parentOverallEligibilityDate).toEqual(`31 July ${year}`);
     });
   });
 });

--- a/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
+++ b/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
@@ -34,7 +34,8 @@ describe('WdfTabComponent', () => {
 
     it('should display the correct timeframe for meeting WDF requirements', async () => {
       const { getByText } = await setup();
-      const timeframeSentence = 'Your data has met the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data has met the WDF ${year - 1} to ${year} requirements`;
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
@@ -57,7 +58,8 @@ describe('WdfTabComponent', () => {
   describe('Unhappy path', async () => {
     it('should not display the meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, queryByText } = await setup();
-      const timeframeSentence = 'Your data has met the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data has met the WDF ${year - 1} to ${year} requirements`;
       const requirementsMetMessage = 'Your data met the requirements on 21 July 2021';
 
       component.overallWdfEligibility = false;
@@ -69,14 +71,15 @@ describe('WdfTabComponent', () => {
 
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
-      const requirementsNotMetSentence = 'Your data does not meet the WDF 2021 to 2022 requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data has does not meet the WDF ${year - 1} to ${year} requirements`;
       const viewWdfLink = 'View your WDF data';
       const viewWdfSentence = 'to see where it does not meet the requirements';
 
       component.overallWdfEligibility = false;
       fixture.detectChanges();
 
-      expect(getByText(requirementsNotMetSentence, { exact: false })).toBeTruthy();
+      expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
       expect(getByText(viewWdfLink, { exact: false })).toBeTruthy();
       expect(getByText(viewWdfSentence, { exact: false })).toBeTruthy();
     });
@@ -85,7 +88,8 @@ describe('WdfTabComponent', () => {
   describe('Parent workplaces happy path', () => {
     it('should display the correct timeframe for parents for meeting WDF requirements', async () => {
       const { component, fixture, getByText } = await setup();
-      const timeframeSentence = 'All of your workplaces have met the WDF 2021 to 2022 data requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `All of your workplaces have met the WDF ${year - 1} to ${year} data requirements`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = true;
@@ -134,7 +138,8 @@ describe('WdfTabComponent', () => {
   describe('Parent workplaces unhappy path', () => {
     it('should not display the meeting requirements message when the parent is not eligible', async () => {
       const { component, fixture, queryByText } = await setup();
-      const timeframeSentence = 'All of your workplaces have met the WDF 2021 to 2022 data requirements';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `All of your workplaces have met the WDF ${year - 1} to ${year} data requirements`;
 
       component.isParent = true;
       component.parentOverallWdfEligibility = false;
@@ -145,7 +150,10 @@ describe('WdfTabComponent', () => {
 
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
-      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF 2021 to 2022 requirements`;
+      const year = new Date().getFullYear();
+      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${
+        year - 1
+      } to ${year} requirements`;
       const viewWorkplacesLink = 'View your workplaces';
       const viewWorkplacesSentence = 'to see which have data that does not meet the requirements.';
 

--- a/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
+++ b/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
@@ -151,7 +151,7 @@ describe('WdfTabComponent', () => {
     it('should display the not meeting requirements message when the user is not eligible', async () => {
       const { component, fixture, getByText } = await setup();
       const year = new Date().getFullYear();
-      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${year - 1} to ${
+      const requirementsNotMetSentence = `Some of your workplaces' data does not meet the WDF ${year} to ${
         year + 1
       } requirements`;
       const viewWorkplacesLink = 'View your workplaces';

--- a/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
+++ b/src/app/shared/components/wdf-tab/wdf-tab.component.spec.ts
@@ -42,14 +42,16 @@ describe('WdfTabComponent', () => {
 
     it('should display the correct date for when the user became eligible', async () => {
       const { getByText } = await setup();
-      const timeframeSentence = 'Your data met the requirements on 21 July 2021';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `Your data met the requirements on 21 July ${year}`;
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });
 
     it('should display the correct date for when WDF eligibility is valid until', async () => {
       const { getByText } = await setup();
-      const timeframeSentence = 'and will continue to meet them until 31 March 2022.';
+      const year = new Date().getFullYear();
+      const timeframeSentence = `and will continue to meet them until 31 March ${year + 1}.`;
 
       expect(getByText(timeframeSentence, { exact: false })).toBeTruthy();
     });


### PR DESCRIPTION
#### Work done
- Made the parent status message component years dynamic as was hard-coded to 2021
-- wdf-parent-status-message.component.html
- Made all relevant tests have dynamic dates

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
