### PR TITLE
Remove loose matching on customer postcode lookup

### DIFF
--- a/server/models/benchmarks.js
+++ b/server/models/benchmarks.js
@@ -188,7 +188,6 @@ module.exports = function (sequelize, DataTypes) {
         },
       ],
       raw: true,
-      logging: true,
     });
   };
 

--- a/server/models/cssr.js
+++ b/server/models/cssr.js
@@ -86,7 +86,7 @@ module.exports = function (sequelize, DataTypes) {
     }
 
     // Now try and retrieve CSSR based on district
-    return await CSSR.getIdFromPostcodeDistrict(establishments[0].postcode);
+    return await CSSR.getCssrFromPostcodesDistrict(establishments[0].postcode);
   };
 
   CSSR.getCSSRFromPostcode = async (postcode) => {
@@ -98,14 +98,14 @@ module.exports = function (sequelize, DataTypes) {
     }
 
     // Now try and retrieve CSSR based on district
-    return await CSSR.getIdFromPostcodeDistrict(postcode);
+    return await CSSR.getCssrFromPostcodesDistrict(postcode);
   };
 
   // fallback queries getAddressAPI, caches results
   // then use district to match with cssr.LocalAuthority
-  CSSR.getIdFromPostcodeDistrict = async function (postcode) {
+  CSSR.getCssrFromPostcodesDistrict = async function (postcode) {
     // Check for full records in postcodes table or query getAddressAPI and cache
-    const postcodesRecords = sequelize.models.postcodes.firstOrCreate(postcode);
+    const postcodesRecords = await sequelize.models.postcodes.firstOrCreate(postcode);
 
     if (postcodesRecords && postcodesRecords[0].district) {
       const district = postcodesRecords[0].district;

--- a/server/models/pcodedata.js
+++ b/server/models/pcodedata.js
@@ -86,7 +86,7 @@ module.exports = function (sequelize, DataTypes) {
       return cssrRecords;
     }
 
-    while (!cssrRecords && inwardCode.length > 0) {
+    while (inwardCode.length > 0 && (cssrRecords === undefined || cssrRecords.length == 0)) {
       inwardCode = inwardCode.slice(0, -1);
       console.log(`Attempting to match cssr record for postcode like ${outwardCode} ${inwardCode}%`);
       // try loose matching

--- a/server/models/pcodedata.js
+++ b/server/models/pcodedata.js
@@ -67,7 +67,7 @@ module.exports = function (sequelize, DataTypes) {
   pcodedata.getLinkedCssrRecordsFromPostcode = async function (postcode) {
     const cssrRecords = await this.getLinkedCssrRecordsCompleteMatch(postcode);
 
-    if (!cssrRecords || !cssrRecords.length) {
+    if (!cssrRecords || typeof cssrRecords === Object) {
       console.error('Could not obtain CSSR records from postcode non local custodian match');
       // no match so try nearest authority
       // The UK postcode consists of five to seven alphanumeric characters

--- a/server/models/pcodedata.js
+++ b/server/models/pcodedata.js
@@ -67,7 +67,7 @@ module.exports = function (sequelize, DataTypes) {
   pcodedata.getLinkedCssrRecordsFromPostcode = async function (postcode) {
     const cssrRecords = await this.getLinkedCssrRecordsCompleteMatch(postcode);
 
-    if (!cssrRecords || cssrRecords === undefined || cssrRecords.length == 0) {
+    if (!cssrRecords || !cssrRecords.length) {
       console.error('Could not obtain CSSR records from postcode non local custodian match');
       // no match so try nearest authority
       // The UK postcode consists of five to seven alphanumeric characters
@@ -87,7 +87,7 @@ module.exports = function (sequelize, DataTypes) {
       return cssrRecords;
     }
 
-    while (inwardCode.length > 0 && (cssrRecords === undefined || cssrRecords === null || !cssrRecords)) {
+    while (inwardCode.length > 0 && (!cssrRecords || !cssrRecords.length)) {
       inwardCode = inwardCode.slice(0, -1);
       console.log(`Attempting to match cssr record for postcode like ${outwardCode} ${inwardCode}%`);
       // try loose matching

--- a/server/models/pcodedata.js
+++ b/server/models/pcodedata.js
@@ -66,7 +66,8 @@ module.exports = function (sequelize, DataTypes) {
 
   pcodedata.getLinkedCssrRecordsFromPostcode = async function (postcode) {
     const cssrRecords = await this.getLinkedCssrRecordsCompleteMatch(postcode);
-    if (!cssrRecords || cssrRecords.length == 0) {
+
+    if (!cssrRecords || cssrRecords === undefined || cssrRecords.length == 0) {
       console.error('Could not obtain CSSR records from postcode non local custodian match');
       // no match so try nearest authority
       // The UK postcode consists of five to seven alphanumeric characters
@@ -86,7 +87,7 @@ module.exports = function (sequelize, DataTypes) {
       return cssrRecords;
     }
 
-    while (inwardCode.length > 0 && (cssrRecords === undefined || cssrRecords.length == 0)) {
+    while (inwardCode.length > 0 && (cssrRecords === undefined || cssrRecords === null || !cssrRecords)) {
       inwardCode = inwardCode.slice(0, -1);
       console.log(`Attempting to match cssr record for postcode like ${outwardCode} ${inwardCode}%`);
       // try loose matching

--- a/server/models/postcodes.js
+++ b/server/models/postcodes.js
@@ -127,7 +127,7 @@ module.exports = function (sequelize, DataTypes) {
     let allPostcodeResultsFull = true;
 
     // Check for 'empty' records of just postcode, lat, long
-    if (foundPostcodes) {
+    if (!(foundPostcodes === undefined || foundPostcodes.length == 0)) {
       // Now for each foundPostcode need to check for full record
       // if not full then update record with getAddressAPI
       foundPostcodes.forEach(function (foundPostcode) {
@@ -135,12 +135,12 @@ module.exports = function (sequelize, DataTypes) {
           allPostcodeResultsFull = false;
         }
       });
-    }
 
-    // If postcode exists and has a Country indicates it already has
-    // spoken to getAddressAPI
-    if (foundPostcodes && allPostcodeResultsFull) {
-      return foundPostcodes;
+      // If postcode exists and has a Country indicates it already has
+      // spoken to getAddressAPI
+      if (allPostcodeResultsFull) {
+        return foundPostcodes;
+      }
     }
 
     try {

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -1217,7 +1217,6 @@ module.exports = function (sequelize, DataTypes) {
         establishmentFk: establishmentId,
       },
       raw: true,
-      logging: true,
     });
   };
 

--- a/server/routes/postcodes.js
+++ b/server/routes/postcodes.js
@@ -97,12 +97,14 @@ const getAddressesWithPostcode = async (req, res) => {
 
       if (postcodesRecords) {
         // associate cssrID with postcodes(county/district) and cssr(LocalAuthority/CssR)
-        const cssrID = await models.cssr.getIdFromPostcodeDistrict(cleanPostcode);
+        const cssr = await models.cssr.getCssrFromPostcodesDistrict(cleanPostcode);
 
-        // now update the cssrID for all establishments with this postcode
-        let establishments = await models.establishment.updateCssrIdsByPostcode(cleanPostcode, cssrID);
+        if (cssr && cssr.id) {
+          // now update the cssrID for all establishments with this postcode
+          let establishments = await models.establishment.updateCssrIdsByPostcode(cleanPostcode, cssr.id);
 
-        console.log(`Updated ${establishments.length} establishments with cssrId ${cssrID}`);
+          console.log(`Updated ${establishments.length} establishments with cssrId ${cssr.id}`);
+        }
       }
 
       postcodeData = transformGetAddressAPIResults(postcodesRecords);

--- a/server/routes/postcodes.js
+++ b/server/routes/postcodes.js
@@ -69,7 +69,7 @@ const getAddressesWithPostcode = async (req, res) => {
 
     // Now try to get records with matching with Cssr on LAcode
     // This means we can associate a CssrID to the establishment
-    const results = await models.pcodedata.getLinkedCssrRecordsFromPostcode(cleanPostcode);
+    const results = await models.pcodedata.getLinkedCssrRecordsCompleteMatch(cleanPostcode);
 
     // if linked results by lacode then update the
     // establishments CssrIds

--- a/server/routes/reports/localAuthorityReport/user.js
+++ b/server/routes/reports/localAuthorityReport/user.js
@@ -79,7 +79,7 @@ const identifyLocalAuthority = async (postcode) => {
   // and use this to get the Cssr record
   const cssrResult = await models.pcodedata.getLinkedCssrRecordsFromPostcode(postcode);
 
-  if (cssrResult) {
+  if (cssrResult && !(cssrResult === undefined || cssrResult === null)) {
     return cssrResult.cssrRecord.name;
   }
 

--- a/server/test/unit/routes/postcodes.spec.js
+++ b/server/test/unit/routes/postcodes.spec.js
@@ -131,7 +131,7 @@ describe('postcodes', () => {
 
       const foundAddresses = [];
 
-      sinon.stub(models.pcodedata, 'getLinkedCssrRecordsFromPostcode').returns(foundAddresses);
+      sinon.stub(models.pcodedata, 'getLinkedCssrRecordsCompleteMatch').returns(foundAddresses);
       sinon.stub(models.postcodes, 'firstOrCreate').returns(foundAddresses);
 
       const req = httpMocks.createRequest(request);

--- a/server/test/unit/routes/postcodes.spec.js
+++ b/server/test/unit/routes/postcodes.spec.js
@@ -87,7 +87,7 @@ describe('postcodes', () => {
         method: 'GET',
         url: '/api/postcodes',
         params: {
-          postcode: 'SW1 1AA',
+          postcode: 'SW2 1SD',
         },
       };
 
@@ -100,24 +100,7 @@ describe('postcodes', () => {
             building_number: '91',
             street_description: 'DRURY LANE',
             post_town: 'LONDON',
-            postcode: 'SW1 1AA',
-            local_custodian_code: '1000',
-            county: 'GREATER LONDON',
-            rm_organisation_name: '',
-          },
-          cssrRecord: {
-            local_custodian_code: '1000',
-          },
-        },
-        {
-          dataValues: {
-            uprn: '100010824271',
-            sub_building_name: '',
-            building_name: '',
-            building_number: '92',
-            street_description: 'DRURY LANE',
-            post_town: 'LONDON',
-            postcode: 'SW1 1AA',
+            postcode: 'SW2 1SD',
             local_custodian_code: '1000',
             county: 'GREATER LONDON',
             rm_organisation_name: '',
@@ -128,7 +111,7 @@ describe('postcodes', () => {
         },
       ];
 
-      sinon.stub(models.pcodedata, 'getLinkedCssrRecordsFromPostcode').returns(foundAddresses);
+      sinon.stub(models.pcodedata, 'getLinkedCssrRecordsCompleteMatch').returns(foundAddresses);
 
       const req = httpMocks.createRequest(request);
       const res = httpMocks.createResponse();


### PR DESCRIPTION
#### Work done
- Removed loose matching for postcodes lookup
- renamed function
- fixed issue with loose matching
- fixed tests to reflect no loose matching on getAddresesFromPostcode endpoint

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
