### PR TITLE
Feat/1376 notification changes

### DIFF
--- a/server/data/ownership.js
+++ b/server/data/ownership.js
@@ -236,8 +236,10 @@ SELECT
   "createdByUserUID",
   parent."NameValue" as "parentEstablishmentName",
   parent."EstablishmentUID" as "parentEstablishmentUid",
+  parent."PostCode" as "parentPostCode",
   sub."NameValue" as "subEstablishmentName",
   sub."EstablishmentUID" as "subEstablishmentUid",
+  sub."PostCode" as "subPostCode",
   CASE
       WHEN sub."DataOwner" = :parent THEN :workplace
       WHEN sub."DataOwner" = :workplace THEN :parent

--- a/src/app/core/model/notifications.model.ts
+++ b/src/app/core/model/notifications.model.ts
@@ -31,8 +31,8 @@ export interface NotificationTypes {
 
 export enum NotificationType {
   OWNERCHANGE = 'Change data owner',
-  LINKTOPARENTREQUEST = 'Link to parent organisation',
-  LINKTOPARENTAPPROVED = 'Link to parent organisation',
+  LINKTOPARENTREQUEST = 'Link request',
+  LINKTOPARENTAPPROVED = 'Link request: approved',
   LINKTOPARENTREJECTED = 'Link to parent organisation',
   DELINKTOPARENT = 'Remove link to parent organisation',
   BECOMEAPARENT = 'Become a parent organisation',

--- a/src/app/core/model/notifications.model.ts
+++ b/src/app/core/model/notifications.model.ts
@@ -30,10 +30,10 @@ export interface NotificationTypes {
 }
 
 export enum NotificationType {
-  OWNERCHANGE = 'Change data owner',
+  OWNERCHANGE = 'Change data owner request',
   LINKTOPARENTREQUEST = 'Link request',
   LINKTOPARENTAPPROVED = 'Link request: approved',
   LINKTOPARENTREJECTED = 'Link to parent organisation',
   DELINKTOPARENT = 'Remove link to parent organisation',
-  BECOMEAPARENT = 'Become a parent organisation',
+  BECOMEAPARENT = 'Parent request',
 }

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
@@ -37,16 +37,16 @@
             <p>You have approved a request from {{ notificationRequestedFrom }} to link to you.</p>
           </ng-container>
           <ng-template #nonWorkplaceRequester>
-            <p>{{ notificationRequestedTo }}, {{ postCode }} has approved your request to link to them.</p>
+            <p>Your request to link to {{ notificationRequestedTo }}, {{ postCode }} has been approved.</p>
           </ng-template>
-          <p>The following permissions have been set:</p>
+          <h2 class="govuk-!-margin-top-6">Data permissions</h2>
         </div>
         <div *ngSwitchDefault></div>
       </div>
 
       <table class="govuk-table govuk-table__with-action" *ngIf="notification.typeContent.approvalStatus !== 'DENIED'">
         <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
+          <tr class="govuk-table__row" data-testid="tableHeaders">
             <th scope="col" class="govuk-table__header">Workplace</th>
             <th scope="col" class="govuk-table__header">Permissions</th>
           </tr>
@@ -63,7 +63,7 @@
             </ng-container>
             <ng-template #notNone>
               <td class="govuk-table__cell">
-                View {{ notification.typeContent.permissionRequest | dataViewPermissions | lowercase }}
+                {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
               </td>
             </ng-template>
           </tr>
@@ -71,7 +71,7 @@
             <td class="govuk-table__cell">
               {{ notificationRequestedFrom }}
             </td>
-            <td class="govuk-table__cell">Edit workplace and staff records</td>
+            <td class="govuk-table__cell">Workplace and staff records (edit)</td>
           </tr>
         </tbody>
       </table>

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
@@ -36,7 +36,7 @@
             <p>You have approved a request from {{ notificationRequestedFrom }} to link to you.</p>
           </ng-container>
           <ng-template #nonWorkplaceRequester>
-            <p>Your request to link to {{ notificationRequestedTo }}, {{ postCode }} has been approved.</p>
+            <p>Your request to link to {{ notificationRequestedTo }}, {{ postCode }}, has been approved.</p>
           </ng-template>
         </div>
         <div *ngSwitchDefault></div>

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
@@ -42,9 +42,9 @@
         <div *ngSwitchDefault></div>
       </div>
       <div [ngSwitch]="notification.typeContent.approvalStatus">
-        <div *ngSwitchCase="'REQUESTED'"><h2 class="govuk-!-margin-top-7">Data permissions if approved</h2></div>
+        <div *ngSwitchCase="'REQUESTED'"><h2 class="govuk-!-margin-top-6">Data permissions if approved</h2></div>
         <div *ngSwitchCase="'APPROVED'">
-          <h2 class="govuk-!-margin-top-7">Data permissions</h2>
+          <h2 class="govuk-!-margin-top-6">Data permissions</h2>
         </div>
       </div>
       <table class="govuk-table govuk-table__with-action" *ngIf="notification.typeContent.approvalStatus !== 'DENIED'">
@@ -55,27 +55,52 @@
           </tr>
         </thead>
         <tbody class="govuk-tab">
-          <tr class="govuk-table__row govuk-error-table__row--no-border">
-            <td class="govuk-table__cell">
-              {{ notificationRequestedTo }}
-            </td>
-            <ng-container *ngIf="notification.typeContent.permissionRequest === 'None'; else notNone">
+          <ng-container *ngIf="isWorkPlaceRequester; else nonWorkplaceRequester"
+            ><tr class="govuk-table__row govuk-error-table__row--no-border">
               <td class="govuk-table__cell">
-                {{ notification.typeContent.permissionRequest | dataViewPermissions }}
+                {{ notificationRequestedTo }}
               </td>
-            </ng-container>
-            <ng-template #notNone>
+              <ng-container *ngIf="notification.typeContent.permissionRequest === 'None'; else notNone">
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }}
+                </td>
+              </ng-container>
+              <ng-template #notNone>
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
+                </td>
+              </ng-template>
+            </tr>
+            <tr class="govuk-table__row govuk-error-table__row--no-border">
               <td class="govuk-table__cell">
-                {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
+                {{ notificationRequestedFrom }}
               </td>
-            </ng-template>
-          </tr>
-          <tr class="govuk-table__row govuk-error-table__row--no-border">
-            <td class="govuk-table__cell">
-              {{ notificationRequestedFrom }}
-            </td>
-            <td class="govuk-table__cell">Workplace and staff records (edit)</td>
-          </tr>
+              <td class="govuk-table__cell">Workplace and staff records (edit)</td>
+            </tr></ng-container
+          >
+          <ng-template #nonWorkplaceRequester>
+            <tr class="govuk-table__row govuk-error-table__row--no-border">
+              <td class="govuk-table__cell">
+                {{ notificationRequestedFrom }}
+              </td>
+              <td class="govuk-table__cell">Workplace and staff records (edit)</td>
+            </tr>
+            <tr class="govuk-table__row govuk-error-table__row--no-border">
+              <td class="govuk-table__cell">
+                {{ notificationRequestedTo }}
+              </td>
+              <ng-container *ngIf="notification.typeContent.permissionRequest === 'None'; else notNone">
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }}
+                </td>
+              </ng-container>
+              <ng-template #notNone>
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
+                </td>
+              </ng-template>
+            </tr>
+          </ng-template>
         </tbody>
       </table>
     </div>

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
@@ -1,10 +1,9 @@
 <ng-container *ngIf="notification">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds" style="width: 70%">
       <div [ngSwitch]="notification.typeContent.approvalStatus">
         <div *ngSwitchCase="'REQUESTED'">
-          <p>You have a request from {{ notificationRequestedFrom }} to link to you.</p>
-          <p>Approve the request to set the following permissions:</p>
+          <p>{{ notificationRequestedFrom }}, {{ postCode }} want to link to you.</p>
         </div>
         <div *ngSwitchCase="'CANCELLED'">
           <p>You have a request from {{ notificationRequestedFrom }} to link to you.</p>
@@ -39,11 +38,15 @@
           <ng-template #nonWorkplaceRequester>
             <p>Your request to link to {{ notificationRequestedTo }}, {{ postCode }} has been approved.</p>
           </ng-template>
-          <h2 class="govuk-!-margin-top-6">Data permissions</h2>
         </div>
         <div *ngSwitchDefault></div>
       </div>
-
+      <div [ngSwitch]="notification.typeContent.approvalStatus">
+        <div *ngSwitchCase="'REQUESTED'"><h2 class="govuk-!-margin-top-7">Data permissions if approved</h2></div>
+        <div *ngSwitchCase="'APPROVED'">
+          <h2 class="govuk-!-margin-top-7">Data permissions</h2>
+        </div>
+      </div>
       <table class="govuk-table govuk-table__with-action" *ngIf="notification.typeContent.approvalStatus !== 'DENIED'">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row" data-testid="tableHeaders">

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="notification">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" style="width: 70%">
+    <div class="govuk-grid-column-two-thirds notificationTable">
       <div [ngSwitch]="notification.typeContent.approvalStatus">
         <div *ngSwitchCase="'REQUESTED'">
           <p>{{ notificationRequestedFrom }}, {{ postCode }} want to link to you.</p>

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.spec.ts
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.spec.ts
@@ -97,13 +97,13 @@ describe('NotificationLinkToParentComponent', () => {
     expect(permissionsTableHeading).toBeTruthy();
   });
 
-  it('show show the parent and postcode', async () => {
+  it('should show the parent and postcode', async () => {
     const { component, getByText } = await setup();
 
     const parentName = component.notification.typeContent.parentEstablishmentName;
     const parentPostCode = component.notification.typeContent.postCode;
 
-    const parentNameAndPostCodeText = `Your request to link to ${parentName}, ${parentPostCode} has been approved.`;
+    const parentNameAndPostCodeText = `Your request to link to ${parentName}, ${parentPostCode}, has been approved.`;
 
     expect(getByText(parentNameAndPostCodeText)).toBeTruthy();
   });

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.spec.ts
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.spec.ts
@@ -1,0 +1,110 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AlertService } from '@core/services/alert.service';
+import { DialogService } from '@core/services/dialog.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { WindowRef } from '@core/services/window.ref';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { NotificationTypePipe } from '@shared/pipes/notification-type.pipe';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+import { Observable } from 'rxjs';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+
+import { NotificationLinkToParentComponent } from './notification-link-to-parent.component';
+
+describe('NotificationLinkToParentComponent', () => {
+  async function setup(approvalStatus = 'APPROVED', rejectionReason = null, permissionRequest = 'Workplace and Staff') {
+    const notificationData = {
+      notificationUid: 'SOME UID',
+      typeContent: {
+        approvalStatus: approvalStatus,
+        parentEstablishmentId: 137,
+        parentEstablishmentName: 'Test Parent',
+        permissionRequest: permissionRequest,
+        postCode: 'postalcode',
+        rejectionReason: rejectionReason,
+        requestorName: 'Test sub',
+        subEstablishmentId: 312,
+        subEstablishmentName: 'Test sub',
+        subEstablishmentUid: 'subUid',
+        requestedOwnerType: 'Workplace',
+      },
+    };
+    const { fixture, getByText, getByTestId, queryByText, getAllByText, findByText } = await render(
+      NotificationLinkToParentComponent,
+      {
+        imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+        declarations: [NotificationTypePipe],
+        providers: [
+          AlertService,
+          WindowRef,
+          DialogService,
+          {
+            provide: BreadcrumbService,
+            useClass: MockBreadcrumbService,
+          },
+          {
+            provide: EstablishmentService,
+            useClass: MockEstablishmentService,
+          },
+        ],
+        componentProperties: {
+          events: new Observable<string>(),
+          notification: notificationData,
+        },
+      },
+    );
+
+    const component = fixture.componentInstance;
+
+    return {
+      component,
+      fixture,
+      getByText,
+      getByTestId,
+      queryByText,
+      getAllByText,
+      findByText,
+    };
+  }
+
+  it('should render', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should show the sub heading', async () => {
+    const { getByText } = await setup();
+
+    const subHeading = getByText('Data permissions');
+
+    expect(subHeading).toBeTruthy();
+  });
+
+  it('should show the table headers', async () => {
+    const { getByText, getByTestId } = await setup();
+
+    const workplaceTableHeading = getByText('Workplace');
+    const permissionsTableHeading = getByText('Permissions');
+    const tableHeadings = getByTestId('tableHeaders');
+
+    expect(tableHeadings).toBeTruthy();
+    expect(workplaceTableHeading).toBeTruthy();
+    expect(permissionsTableHeading).toBeTruthy();
+  });
+
+  it('show show the parent and postcode', async () => {
+    const { component, getByText } = await setup();
+
+    const parentName = component.notification.typeContent.parentEstablishmentName;
+    const parentPostCode = component.notification.typeContent.postCode;
+
+    const parentNameAndPostCodeText = `Your request to link to ${parentName}, ${parentPostCode} has been approved.`;
+
+    expect(getByText(parentNameAndPostCodeText)).toBeTruthy();
+  });
+});

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
@@ -58,8 +58,6 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
     this.requestorName = this.notification.typeContent.requestorName;
     this.postCode = this.notification.typeContent.postCode;
     this.isWorkPlaceRequester = this.workplace.name === this.notificationRequestedTo;
-
-    console.log(this.notification);
   }
 
   private performAction(action: string) {

--- a/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
+++ b/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
@@ -15,6 +15,7 @@ import { Observable, Subscription } from 'rxjs';
 @Component({
   selector: 'app-notification-link-to-parent',
   templateUrl: './notification-link-to-parent.component.html',
+  styleUrls: ['../notification/notification.component.scss'],
   providers: [DialogService, Overlay],
 })
 export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
@@ -57,6 +58,8 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
     this.requestorName = this.notification.typeContent.requestorName;
     this.postCode = this.notification.typeContent.postCode;
     this.isWorkPlaceRequester = this.workplace.name === this.notificationRequestedTo;
+
+    console.log(this.notification);
   }
 
   private performAction(action: string) {

--- a/src/app/features/notifications/notification-list/notification-list.component.spec.ts
+++ b/src/app/features/notifications/notification-list/notification-list.component.spec.ts
@@ -154,7 +154,7 @@ describe('NotificationListComponent', () => {
 
       const notifcationsTableRows = fixture.nativeElement.querySelectorAll('tr');
       const rowOne = notifcationsTableRows[1];
-      expect(rowOne.cells['1'].innerHTML).toContain('Become a parent organisation');
+      expect(rowOne.cells['1'].innerHTML).toContain('Parent request');
       expect(rowOne.cells['2'].innerHTML).toContain('1 January 2020 at 12:00am');
     });
   });

--- a/src/app/features/notifications/notification-list/notification-list.component.ts
+++ b/src/app/features/notifications/notification-list/notification-list.component.ts
@@ -48,7 +48,6 @@ export class NotificationListComponent implements OnInit {
       .subscribe((notification) => {
         this.notifications = notification.notifications;
         this.totalCount = notification.count;
-        console.log(this.notifications);
       });
   }
 

--- a/src/app/features/notifications/notification-list/notification-list.component.ts
+++ b/src/app/features/notifications/notification-list/notification-list.component.ts
@@ -47,7 +47,8 @@ export class NotificationListComponent implements OnInit {
       )
       .subscribe((notification) => {
         this.notifications = notification.notifications;
-        this.totalCount = notification.count
+        this.totalCount = notification.count;
+        console.log(this.notifications);
       });
   }
 

--- a/src/app/features/notifications/notification-owner-change/notification-owner-change.component.html
+++ b/src/app/features/notifications/notification-owner-change/notification-owner-change.component.html
@@ -80,53 +80,103 @@
         </tr>
       </thead>
       <tbody class="govuk-tab">
-        <ng-container *ngIf="notification.typeContent.approvalStatus !== 'APPROVED'; else approved">
-          <tr class="govuk-table__row govuk-error-table__row--no-border" data-testid="not-approved">
-            <td class="govuk-table__cell">
-              {{ ownerShipRequestedFrom }}
-            </td>
+        <ng-container *ngIf="isWorkPlaceIsRequester; else nonWorkPlaceRequester">
+          <ng-container *ngIf="notification.typeContent.approvalStatus !== 'APPROVED'; else approved">
+            <tr class="govuk-table__row govuk-error-table__row--no-border" data-testid="not-approved">
+              <td class="govuk-table__cell">
+                {{ ownerShipRequestedFrom }}
+              </td>
 
-            <ng-container *ngIf="notification.typeContent.permissionRequest === 'None'; else notNone">
+              <ng-container *ngIf="notification.typeContent.permissionRequest === 'None'; else notNone">
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }}
+                </td>
+              </ng-container>
+              <ng-template #notNone>
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
+                </td>
+              </ng-template>
+            </tr>
+            <tr class="govuk-table__row govuk-error-table__row--no-border" *ngIf="notification">
               <td class="govuk-table__cell">
-                {{ notification.typeContent.permissionRequest | dataViewPermissions }}
+                {{ ownerShipRequestedTo }}
               </td>
-            </ng-container>
-            <ng-template #notNone>
+              <td class="govuk-table__cell">Workplace and staff records (edit)</td>
+            </tr>
+          </ng-container>
+          <ng-template #approved>
+            <tr class="govuk-table__row govuk-error-table__row--no-border" data-testid="approved">
               <td class="govuk-table__cell">
-                {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
+                {{ ownerShipRequestedTo }}
               </td>
-            </ng-template>
-          </tr>
-          <tr class="govuk-table__row govuk-error-table__row--no-border" *ngIf="notification">
-            <td class="govuk-table__cell">
-              {{ ownerShipRequestedTo }}
-            </td>
-            <td class="govuk-table__cell">Workplace and staff records (edit)</td>
-          </tr>
+
+              <ng-container *ngIf="notification.typeContent.permissionRequest === 'None'; else notNone">
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }}
+                </td>
+              </ng-container>
+              <ng-template #notNone>
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
+                </td>
+              </ng-template>
+            </tr>
+            <tr class="govuk-table__row govuk-error-table__row--no-border" *ngIf="notification">
+              <td class="govuk-table__cell">
+                {{ ownerShipRequestedFrom }}
+              </td>
+              <td class="govuk-table__cell">Workplace and staff records (edit)</td>
+            </tr>
+          </ng-template>
         </ng-container>
-        <ng-template #approved>
-          <tr class="govuk-table__row govuk-error-table__row--no-border" data-testid="approved">
-            <td class="govuk-table__cell">
-              {{ ownerShipRequestedTo }}
-            </td>
-
-            <ng-container *ngIf="notification.typeContent.permissionRequest === 'None'; else notNone">
+        <ng-template #nonWorkPlaceRequester>
+          <ng-container *ngIf="notification.typeContent.approvalStatus !== 'APPROVED'; else approved">
+            <tr class="govuk-table__row govuk-error-table__row--no-border" *ngIf="notification">
               <td class="govuk-table__cell">
-                {{ notification.typeContent.permissionRequest | dataViewPermissions }}
+                {{ ownerShipRequestedTo }}
               </td>
-            </ng-container>
-            <ng-template #notNone>
+              <td class="govuk-table__cell">Workplace and staff records (edit)</td>
+            </tr>
+            <tr class="govuk-table__row govuk-error-table__row--no-border" data-testid="not-approved">
               <td class="govuk-table__cell">
-                {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
+                {{ ownerShipRequestedFrom }}
               </td>
-            </ng-template>
-          </tr>
-          <tr class="govuk-table__row govuk-error-table__row--no-border" *ngIf="notification">
-            <td class="govuk-table__cell">
-              {{ ownerShipRequestedFrom }}
-            </td>
-            <td class="govuk-table__cell">Workplace and staff records (edit)</td>
-          </tr>
+              <ng-container *ngIf="notification.typeContent.permissionRequest === 'None'; else notNone">
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }}
+                </td>
+              </ng-container>
+              <ng-template #notNone>
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
+                </td>
+              </ng-template>
+            </tr>
+          </ng-container>
+          <ng-template #approved>
+            <tr class="govuk-table__row govuk-error-table__row--no-border" *ngIf="notification">
+              <td class="govuk-table__cell">
+                {{ ownerShipRequestedFrom }}
+              </td>
+              <td class="govuk-table__cell">Workplace and staff records (edit)</td>
+            </tr>
+            <tr class="govuk-table__row govuk-error-table__row--no-border" data-testid="approved">
+              <td class="govuk-table__cell">
+                {{ ownerShipRequestedTo }}
+              </td>
+              <ng-container *ngIf="notification.typeContent.permissionRequest === 'None'; else notNone">
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }}
+                </td>
+              </ng-container>
+              <ng-template #notNone>
+                <td class="govuk-table__cell">
+                  {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
+                </td>
+              </ng-template>
+            </tr>
+          </ng-template>
         </ng-template>
       </tbody>
     </table>

--- a/src/app/features/notifications/notification-owner-change/notification-owner-change.component.html
+++ b/src/app/features/notifications/notification-owner-change/notification-owner-change.component.html
@@ -1,9 +1,24 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds notificationTable">
     <div [ngSwitch]="notification.typeContent.approvalStatus">
       <div *ngSwitchCase="'REQUESTED'">
-        <p>You have a request to transfer ownership of data to {{ ownerShipRequestedTo }}.</p>
-        <p>Approve the request to set the following permissions:</p>
+        <ng-container
+          *ngIf="
+            isWorkPlaceIsRequester && notification.typeContent.requestedOwnerType === 'Workplace';
+            else nonWorkPlaceRequester
+          "
+        >
+          <p>
+            {{ ownerShipRequestedTo }}, {{ ownerShipRequestedToPostCode }}, have sent you a change data owner request
+            because they want to be able to edit their own workplace details and staff records.
+          </p></ng-container
+        >
+        <ng-template #nonWorkPlaceRequester
+          ><p>
+            {{ ownerShipRequestedTo }}, {{ ownerShipRequestedToPostCode }}, have sent you a change data owner request
+            because they want to be able to edit your workplace details and staff records.
+          </p></ng-template
+        >
       </div>
       <div *ngSwitchCase="'CANCELLED'">
         <p>You have a request to transfer ownership of data to {{ ownerShipRequestedTo }}.</p>
@@ -27,18 +42,32 @@
       </div>
       <div *ngSwitchCase="'APPROVED'">
         <ng-container *ngIf="isWorkPlaceIsRequester; else nonWorkPlaceRequester">
-          <p>You approved the request to transfer ownership of data to {{ ownerShipRequestedFrom }}</p>
+          <p>You approved the request to transfer ownership of data to {{ ownerShipRequestedFrom }}.</p>
         </ng-container>
         <ng-template #nonWorkPlaceRequester>
-          <p>
-            {{ ownerShipRequestedTo }} has approved your request to become the data owner. You're now free to edit
-            workplace and staff data.
-          </p>
+          <ng-container
+            *ngIf="notification.typeContent.requestedOwnerType === 'Parent'; else nonParentRequestedOwnerType"
+            ><p>
+              {{ ownerShipRequestedTo }}, {{ ownerShipRequestedToPostCode }}, approved your change data owner request
+              and you can now edit your own workplace details and staff records.
+            </p></ng-container
+          >
+          <ng-template #nonParentRequestedOwnerType
+            ><p>
+              {{ ownerShipRequestedTo }}, {{ ownerShipRequestedToPostCode }}, approved your change data owner request
+              and you can now edit their workplace details and staff records.
+            </p></ng-template
+          >
         </ng-template>
       </div>
       <div *ngSwitchDefault></div>
     </div>
-
+    <div [ngSwitch]="notification.typeContent.approvalStatus">
+      <div *ngSwitchCase="'REQUESTED'"><h2 class="govuk-!-margin-top-6">Data permissions if approved</h2></div>
+      <div *ngSwitchCase="'APPROVED'">
+        <h2 class="govuk-!-margin-top-6">Data permissions</h2>
+      </div>
+    </div>
     <table
       class="govuk-table govuk-table__with-action"
       *ngIf="notification.typeContent.approvalStatus !== 'DENIED'"
@@ -64,7 +93,7 @@
             </ng-container>
             <ng-template #notNone>
               <td class="govuk-table__cell">
-                View {{ notification.typeContent.permissionRequest | dataViewPermissions | lowercase }}
+                {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
               </td>
             </ng-template>
           </tr>
@@ -72,7 +101,7 @@
             <td class="govuk-table__cell">
               {{ ownerShipRequestedTo }}
             </td>
-            <td class="govuk-table__cell">Edit workplace and staff records</td>
+            <td class="govuk-table__cell">Workplace and staff records (edit)</td>
           </tr>
         </ng-container>
         <ng-template #approved>
@@ -88,7 +117,7 @@
             </ng-container>
             <ng-template #notNone>
               <td class="govuk-table__cell">
-                View {{ notification.typeContent.permissionRequest | dataViewPermissions | lowercase }}
+                {{ notification.typeContent.permissionRequest | dataViewPermissions }} (view only)
               </td>
             </ng-template>
           </tr>
@@ -96,7 +125,7 @@
             <td class="govuk-table__cell">
               {{ ownerShipRequestedFrom }}
             </td>
-            <td class="govuk-table__cell">Edit workplace and staff records</td>
+            <td class="govuk-table__cell">Workplace and staff records (edit)</td>
           </tr>
         </ng-template>
       </tbody>

--- a/src/app/features/notifications/notification-owner-change/notification-owner-change.component.spec.ts
+++ b/src/app/features/notifications/notification-owner-change/notification-owner-change.component.spec.ts
@@ -81,6 +81,8 @@ describe('NotificationOwnerChangeComponent', () => {
       component.workplace.name = component.notification.typeContent.parentEstablishmentName;
       fixture.detectChanges();
 
+      expect(component.ownerShipRequestedToPostCode).toEqual(component.notification.typeContent.subPostCode);
+      expect(component.ownerShipRequestedFromPostCode).toEqual(component.notification.typeContent.parentPostCode);
       expect(
         getByText(
           'Test Workplace, SB2 3JJ, have sent you a change data owner request because they want to be able to edit their own workplace details and staff records.',
@@ -96,6 +98,8 @@ describe('NotificationOwnerChangeComponent', () => {
       component.ngOnInit();
       fixture.detectChanges();
 
+      expect(component.ownerShipRequestedToPostCode).toEqual(component.notification.typeContent.parentPostCode);
+      expect(component.ownerShipRequestedFromPostCode).toEqual(component.notification.typeContent.subPostCode);
       expect(
         getByText(
           'Test Parent, PR1 2EE, have sent you a change data owner request because they want to be able to edit your workplace details and staff records.',

--- a/src/app/features/notifications/notification-owner-change/notification-owner-change.component.spec.ts
+++ b/src/app/features/notifications/notification-owner-change/notification-owner-change.component.spec.ts
@@ -24,12 +24,15 @@ describe('NotificationOwnerChangeComponent', () => {
         requestedOwnerType: 'Workplace',
         parentEstablishmentName: 'Test Parent',
         parentEstablishmentUid: 'parentUid',
-        subEstablishmentName: 'Test sub',
+        parentPostCode: 'PR1 2EE',
+        subEstablishmentName: 'Test Workplace',
         subEstablishmentUid: 'subUid',
+        subPostCode: 'SB2 3JJ',
         approvalStatus,
         ownerChangeRequestUid: 'REQUEST UID',
         rejectionReason,
         permissionRequest,
+        requestorName: 'Test Workplace',
       },
     };
 
@@ -71,16 +74,39 @@ describe('NotificationOwnerChangeComponent', () => {
   });
 
   describe('main message text', () => {
-    it('should render the correct text when the approval status is REQUESTED', async () => {
-      const { getByText } = await setup();
+    it('should render the correct text when the ownership request is from a workplace and the approval status is REQUESTED', async () => {
+      const { getByText, component, fixture } = await setup();
 
-      expect(getByText('You have a request to transfer ownership of data to Test sub.')).toBeTruthy();
+      component.isWorkPlaceIsRequester = true;
+      component.workplace.name = component.notification.typeContent.parentEstablishmentName;
+      fixture.detectChanges();
+
+      expect(
+        getByText(
+          'Test Workplace, SB2 3JJ, have sent you a change data owner request because they want to be able to edit their own workplace details and staff records.',
+        ),
+      ).toBeTruthy();
+    });
+
+    it('should render the correct text when the ownership request is from a parent and the approval status is REQUESTED', async () => {
+      const { getByText, component, fixture } = await setup('REQUESTED');
+
+      component.notification.typeContent.requestedOwnerType = 'Parent';
+
+      component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(
+        getByText(
+          'Test Parent, PR1 2EE, have sent you a change data owner request because they want to be able to edit your workplace details and staff records.',
+        ),
+      ).toBeTruthy();
     });
 
     it('should render the correct text when the approval status is CANCELLED', async () => {
       const { getByText } = await setup('CANCELLED');
 
-      expect(getByText('You have a request to transfer ownership of data to Test sub.')).toBeTruthy();
+      expect(getByText('You have a request to transfer ownership of data to Test Workplace.')).toBeTruthy();
     });
 
     it('should render the correct text when the approval status is DENIED and isWorkplaceIsRequester is true with no reason if not provided', async () => {
@@ -89,7 +115,7 @@ describe('NotificationOwnerChangeComponent', () => {
       component.isWorkPlaceIsRequester = true;
       fixture.detectChanges();
 
-      expect(getByText('You rejected the request to transfer ownership of data to Test sub')).toBeTruthy();
+      expect(getByText('You rejected the request to transfer ownership of data to Test Workplace')).toBeTruthy();
       expect(getByTestId('no-rejection-reason')).toBeTruthy();
       expect(queryByTestId('rejection-reason')).toBeFalsy();
     });
@@ -103,7 +129,7 @@ describe('NotificationOwnerChangeComponent', () => {
       component.isWorkPlaceIsRequester = true;
       fixture.detectChanges();
 
-      expect(getByText('You rejected the request to transfer ownership of data to Test sub')).toBeTruthy();
+      expect(getByText('You rejected the request to transfer ownership of data to Test Workplace')).toBeTruthy();
       expect(getByTestId('rejection-reason')).toBeTruthy();
       expect(queryByTestId('no-rejection-reason')).toBeFalsy();
     });
@@ -124,16 +150,16 @@ describe('NotificationOwnerChangeComponent', () => {
       expect(queryByTestId('no-rejection-reason')).toBeFalsy();
     });
 
-    it('should render the correct test when the approval status is APPROVED and isWorkplaceIsRequestor is true', async () => {
+    it('should render the correct text when the approval status is APPROVED and isWorkplaceIsRequestor is true', async () => {
       const { component, fixture, getByText } = await setup('APPROVED');
 
       component.isWorkPlaceIsRequester = true;
       fixture.detectChanges();
 
-      expect(getByText('You approved the request to transfer ownership of data to Test Parent'));
+      expect(getByText('You approved the request to transfer ownership of data to Test Parent.'));
     });
 
-    it('should render the correct test when the approval status is APPROVED and isWorkplaceIsRequestor is true', async () => {
+    it('should render the correct text when the approval status is APPROVED and isWorkplaceIsRequestor is false', async () => {
       const { component, fixture, getByText } = await setup('APPROVED');
 
       component.isWorkPlaceIsRequester = false;
@@ -141,7 +167,7 @@ describe('NotificationOwnerChangeComponent', () => {
 
       expect(
         getByText(
-          `Test sub has approved your request to become the data owner. You're now free to edit workplace and staff data.`,
+          `Test Workplace, SB2 3JJ, approved your change data owner request and you can now edit their workplace details and staff records.`,
         ),
       );
     });
@@ -187,7 +213,7 @@ describe('NotificationOwnerChangeComponent', () => {
 
         expect(getByTestId('not-approved')).toBeTruthy();
         expect(getByText(ownerShipRequestedFrom)).toBeTruthy();
-        expect(getByText('View workplace and staff records')).toBeTruthy();
+        expect(getByText('Workplace and staff records (view only)')).toBeTruthy();
         expect(getByText(ownerShipRequestedTo)).toBeTruthy();
       });
     });
@@ -225,7 +251,7 @@ describe('NotificationOwnerChangeComponent', () => {
 
         expect(getByTestId('approved')).toBeTruthy();
         expect(getByText(ownerShipRequestedFrom)).toBeTruthy();
-        expect(getByText('View workplace and staff records')).toBeTruthy();
+        expect(getByText('Workplace and staff records (view only)')).toBeTruthy();
         expect(getByText(ownerShipRequestedTo)).toBeTruthy();
       });
     });

--- a/src/app/features/notifications/notification-owner-change/notification-owner-change.component.ts
+++ b/src/app/features/notifications/notification-owner-change/notification-owner-change.component.ts
@@ -16,6 +16,7 @@ const OWNERSHIP_REJECTED = 'OWNERCHANGEREJECTED';
 @Component({
   selector: 'app-notification-owner-change',
   templateUrl: './notification-owner-change.component.html',
+  styleUrls: ['../notification/notification.component.scss'],
   providers: [DialogService, Overlay],
 })
 export class NotificationOwnerChangeComponent implements OnInit, OnDestroy {
@@ -31,6 +32,8 @@ export class NotificationOwnerChangeComponent implements OnInit, OnDestroy {
   public ownerShipRequestedTo: string;
   public isSubWorkplace: boolean;
   private ownerShipRequestedToUid: string;
+  public ownerShipRequestedFromPostCode: string;
+  public ownerShipRequestedToPostCode: string;
 
   constructor(
     private route: ActivatedRoute,
@@ -61,18 +64,24 @@ export class NotificationOwnerChangeComponent implements OnInit, OnDestroy {
       requestedOwnerType,
       subEstablishmentName,
       subEstablishmentUid,
+      subPostCode,
       parentEstablishmentName,
       parentEstablishmentUid,
+      parentPostCode,
     } = this.notification.typeContent;
 
     if (requestedOwnerType === 'Workplace') {
       this.ownerShipRequestedFrom = parentEstablishmentName;
       this.ownerShipRequestedTo = subEstablishmentName;
       this.ownerShipRequestedToUid = subEstablishmentUid;
+      this.ownerShipRequestedFromPostCode = parentPostCode;
+      this.ownerShipRequestedToPostCode = subPostCode;
     } else {
       this.ownerShipRequestedFrom = subEstablishmentName;
       this.ownerShipRequestedTo = parentEstablishmentName;
       this.ownerShipRequestedToUid = parentEstablishmentUid;
+      this.ownerShipRequestedFromPostCode = subPostCode;
+      this.ownerShipRequestedToPostCode = parentPostCode;
     }
   }
 

--- a/src/app/features/notifications/notification/notification.component.html
+++ b/src/app/features/notifications/notification/notification.component.html
@@ -14,8 +14,12 @@
       {{ notification.created | longDate }}
     </p>
     <br />
-    <h2 class="govuk-heading-s govuk-util__inline-block govuk-!-margin-right-2">Subject:</h2>
-    <p class="govuk-util__inline-block">{{ notification?.type | notificationType }}</p>
+    <div data-testid="subject">
+      <h2 class="govuk-heading-s govuk-util__inline-block govuk-!-margin-right-2">Subject:</h2>
+      <p class="govuk-util__inline-block">
+        {{ notification?.type | notificationType }}<span *ngIf="showStatus">: {{ approvalStatus | lowercase }}</span>
+      </p>
+    </div>
   </div>
 </div>
 <ng-container *ngIf="notification">
@@ -46,7 +50,7 @@
   </div>
   <div class="govuk-grid-row" *ngIf="displayActionButtons" data-testid="actionButtons">
     <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-!-margin-top-2">
+      <div class="govuk-!-margin-top-2 notificationButtons">
         <button (click)="approveRequest()" type="submit" class="govuk-button">Approve request</button>
         <span class="govuk-visually-hidden">or</span>
         <button

--- a/src/app/features/notifications/notification/notification.component.html
+++ b/src/app/features/notifications/notification/notification.component.html
@@ -17,7 +17,7 @@
     <div data-testid="subject">
       <h2 class="govuk-heading-s govuk-util__inline-block govuk-!-margin-right-1">Subject:</h2>
       <p class="govuk-util__inline-block">
-        {{ notification?.type | notificationType }}<span *ngIf="showStatus">: {{ approvalStatus | lowercase }}</span>
+        {{ notification?.type | notificationType }}<span *ngIf="showStatus">: {{ approvalStatus }}</span>
       </p>
     </div>
   </div>

--- a/src/app/features/notifications/notification/notification.component.html
+++ b/src/app/features/notifications/notification/notification.component.html
@@ -8,14 +8,14 @@
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" *ngIf="notification">
-    <h2 class="govuk-heading-s govuk-util__inline-block govuk-!-margin-right-2">From:</h2>
+    <h2 class="govuk-heading-s govuk-util__inline-block govuk-!-margin-right-1">From:</h2>
     <p class="govuk-util__inline-block">
       {{ notification.typeContent.requestorName ? notification.typeContent.requestorName : 'Skills For Care' }},
       {{ notification.created | longDate }}
     </p>
     <br />
     <div data-testid="subject">
-      <h2 class="govuk-heading-s govuk-util__inline-block govuk-!-margin-right-2">Subject:</h2>
+      <h2 class="govuk-heading-s govuk-util__inline-block govuk-!-margin-right-1">Subject:</h2>
       <p class="govuk-util__inline-block">
         {{ notification?.type | notificationType }}<span *ngIf="showStatus">: {{ approvalStatus | lowercase }}</span>
       </p>
@@ -50,7 +50,7 @@
   </div>
   <div class="govuk-grid-row" *ngIf="displayActionButtons" data-testid="actionButtons">
     <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-!-margin-top-2 notificationButtons">
+      <div class="govuk-!-margin-top-6 notificationButtons">
         <button (click)="approveRequest()" type="submit" class="govuk-button">Approve request</button>
         <span class="govuk-visually-hidden">or</span>
         <button

--- a/src/app/features/notifications/notification/notification.component.scss
+++ b/src/app/features/notifications/notification/notification.component.scss
@@ -1,0 +1,7 @@
+.notificationTable {
+  width: 70%;
+}
+
+.notificationButtons {
+  width: 65%;
+}

--- a/src/app/features/notifications/notification/notification.component.spec.ts
+++ b/src/app/features/notifications/notification/notification.component.spec.ts
@@ -190,7 +190,7 @@ describe('Notification', () => {
     it('should show status in subject for become a parent is approved', async () => {
       const { component, fixture, queryByTestId } = await setup('BECOMEAPARENT', null);
 
-      component.approvalStatus = 'Approved';
+      component.approvalStatus = 'approved';
       const subjectTestId = queryByTestId('subject');
 
       fixture.detectChanges();

--- a/src/app/features/notifications/notification/notification.component.spec.ts
+++ b/src/app/features/notifications/notification/notification.component.spec.ts
@@ -11,13 +11,13 @@ import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentServ
 import { MockNotificationsService } from '@core/test-utils/MockNotificationsService';
 import { NotificationTypePipe } from '@shared/pipes/notification-type.pipe';
 import { SharedModule } from '@shared/shared.module';
-import { fireEvent, render } from '@testing-library/angular';
+import { fireEvent, render, within } from '@testing-library/angular';
 import { of } from 'rxjs';
 import { NotificationComponent } from './notification.component';
 
 import createSpy = jasmine.createSpy;
 
-describe('NotificationBecomeAParentComponent', () => {
+describe('Notification', () => {
   async function setup(notificationType, approvalStatus = 'APPROVED') {
     const notificationStub = {
       created: '2020-01-01',
@@ -25,6 +25,7 @@ describe('NotificationBecomeAParentComponent', () => {
       type: notificationType,
       typeContent: {
         approvalStatus: approvalStatus,
+        status: 'Approved',
       },
     };
 
@@ -135,6 +136,42 @@ describe('NotificationBecomeAParentComponent', () => {
       const actionButtons = component.queryByTestId('actionButtons');
 
       expect(actionButtons).toBeNull();
+    });
+  });
+
+  describe('Subject', () => {
+    it('should show the subejct line', async () => {
+      const { component } = await setup('OWNERCHANGE');
+      const subjectText = component.queryByTestId('subject');
+
+      expect(subjectText).toBeTruthy();
+    });
+
+    it('should show status when owner change is approved', async () => {
+      const { component } = await setup('OWNERCHANGE', 'APPROVED');
+
+      const subjectTestId = component.queryByTestId('subject');
+      const subjectText = 'Subject: Change data owner request: approved';
+
+      expect(subjectTestId.textContent).toBe(subjectText);
+    });
+
+    it('should not show status when owner change is requested', async () => {
+      const { component } = await setup('OWNERCHANGE', 'REQUESTED');
+
+      const subjectTestId = component.queryByTestId('subject');
+      const subjectText = 'Subject: Change data owner request';
+
+      expect(subjectTestId.textContent).toBe(subjectText);
+    });
+
+    it('should show status when become a parent request is approved', async () => {
+      const { component } = await setup('BECOMEAPARENT', null);
+
+      const subjectTestId = component.queryByTestId('subject');
+      const subjectText = 'Subject: Parent request: approved';
+
+      expect(subjectTestId.textContent).toBe(subjectText);
     });
   });
 });

--- a/src/app/features/notifications/notification/notification.component.spec.ts
+++ b/src/app/features/notifications/notification/notification.component.spec.ts
@@ -29,50 +29,61 @@ describe('Notification', () => {
       },
     };
 
-    const component = await render(NotificationComponent, {
-      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
-      declarations: [NotificationTypePipe],
-      providers: [
-        {
-          provide: BreadcrumbService,
-          useClass: MockBreadcrumbService,
-        },
-        {
-          provide: EstablishmentService,
-          useClass: MockEstablishmentService,
-        },
-        {
-          provide: NotificationsService,
-          useValue: {
-            getNotificationDetails() {
-              return of(notificationStub);
-            },
-            setNotificationViewed() {
-              return of({
-                establishmentNotification: true,
-                notification: notificationStub,
-              });
-            },
+    const { fixture, getByText, queryByTestId, queryByText, getByLabelText, getByTestId } = await render(
+      NotificationComponent,
+      {
+        imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+        declarations: [NotificationTypePipe],
+        providers: [
+          {
+            provide: BreadcrumbService,
+            useClass: MockBreadcrumbService,
           },
-        },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            snapshot: {
-              params: {
-                notificationUid: '',
+          {
+            provide: EstablishmentService,
+            useClass: MockEstablishmentService,
+          },
+          {
+            provide: NotificationsService,
+            useValue: {
+              getNotificationDetails() {
+                return of(notificationStub);
+              },
+              setNotificationViewed() {
+                return of({
+                  establishmentNotification: true,
+                  notification: notificationStub,
+                });
               },
             },
           },
-        },
-      ],
-    });
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                params: {
+                  notificationUid: '',
+                },
+              },
+            },
+          },
+        ],
+        componentProperties: {},
+      },
+    );
 
+    const component = fixture.componentInstance;
     const injector = getTestBed();
     const establishmentService = injector.inject(EstablishmentService) as EstablishmentService;
 
     return {
       component,
+      fixture,
+      getByText,
+      queryByTestId,
+      getByLabelText,
+      getByTestId,
+      queryByText,
     };
   }
 
@@ -82,58 +93,58 @@ describe('Notification', () => {
   });
 
   it('should render notification-become-a-parent component if notificationType of BECOMEAPARENT', async () => {
-    const { component } = await setup('BECOMEAPARENT');
-    component.getByTestId('BECOMEAPARENT');
+    const { component, getByTestId } = await setup('BECOMEAPARENT');
+    expect(getByTestId('BECOMEAPARENT')).toBeTruthy();
   });
 
   it('should render notification-link-to-parent component if notificationType of LINKTOPARENTREQUEST', async () => {
-    const { component } = await setup('LINKTOPARENTREQUEST');
-    component.getByTestId('LINKTOPARENT');
+    const { component, getByTestId } = await setup('LINKTOPARENTREQUEST');
+    expect(getByTestId('LINKTOPARENT')).toBeTruthy();
   });
 
   it('should render notification-link-to-parent component if notificationType of LINKTOPARENTAPPROVED', async () => {
-    const { component } = await setup('LINKTOPARENTAPPROVED');
-    component.getByTestId('LINKTOPARENT');
+    const { component, getByTestId } = await setup('LINKTOPARENTAPPROVED');
+    expect(getByTestId('LINKTOPARENT')).toBeTruthy();
   });
 
   it('should render notification-link-to-parent component if notificationType of LINKTOPARENTREJECTED', async () => {
-    const { component } = await setup('LINKTOPARENTREJECTED');
-    component.getByTestId('LINKTOPARENT');
+    const { component, getByTestId } = await setup('LINKTOPARENTREJECTED');
+    expect(getByTestId('LINKTOPARENT')).toBeTruthy();
   });
 
   it('should render notification-delink-to-parent component if notificationType of DELINKTOPARENT', async () => {
-    const { component } = await setup('DELINKTOPARENT');
-    component.getByTestId('DELINKTOPARENT');
+    const { component, getByTestId } = await setup('DELINKTOPARENT');
+    expect(getByTestId('DELINKTOPARENT')).toBeTruthy();
   });
 
   it('should render notification-delink-to-parent component if notificationType of OWNERCHANGE', async () => {
-    const { component } = await setup('OWNERCHANGE');
-    component.getByTestId('OWNERCHANGE');
+    const { component, getByTestId } = await setup('OWNERCHANGE');
+    expect(getByTestId('OWNERCHANGE')).toBeTruthy();
   });
 
   describe('Action Buttons', async () => {
     it('should render when approval status is REQUESTED', async () => {
-      const { component } = await setup('BECOMEAPARENT', 'REQUESTED');
-      component.getByTestId('actionButtons');
+      const { component, getByTestId } = await setup('BECOMEAPARENT', 'REQUESTED');
+      expect(getByTestId('actionButtons')).toBeTruthy();
     });
 
     it('should render when approval status is CANCELLED', async () => {
-      const { component } = await setup('BECOMEAPARENT', 'CANCELLED');
-      component.getByTestId('actionButtons');
+      const { component, getByTestId } = await setup('BECOMEAPARENT', 'CANCELLED');
+      expect(getByTestId('actionButtons')).toBeTruthy();
     });
 
     it('should not render when approval status is APPROVED', async () => {
-      const { component } = await setup('BECOMEAPARENT', 'APPROVED');
+      const { component, queryByTestId } = await setup('BECOMEAPARENT', 'APPROVED');
 
-      const actionButtons = component.queryByTestId('actionButtons');
+      const actionButtons = queryByTestId('actionButtons');
 
       expect(actionButtons).toBeNull();
     });
 
     it('should not render when approval status is REJECTED', async () => {
-      const { component } = await setup('BECOMEAPARENT', 'REJECTED');
+      const { component, queryByTestId } = await setup('BECOMEAPARENT', 'REJECTED');
 
-      const actionButtons = component.queryByTestId('actionButtons');
+      const actionButtons = queryByTestId('actionButtons');
 
       expect(actionButtons).toBeNull();
     });
@@ -141,37 +152,61 @@ describe('Notification', () => {
 
   describe('Subject', () => {
     it('should show the subejct line', async () => {
-      const { component } = await setup('OWNERCHANGE');
-      const subjectText = component.queryByTestId('subject');
+      const { component, queryByTestId } = await setup('OWNERCHANGE');
+      const subjectText = queryByTestId('subject');
 
       expect(subjectText).toBeTruthy();
     });
 
     it('should show status when owner change is approved', async () => {
-      const { component } = await setup('OWNERCHANGE', 'APPROVED');
+      const { component, queryByTestId } = await setup('OWNERCHANGE', 'APPROVED');
 
-      const subjectTestId = component.queryByTestId('subject');
+      const subjectTestId = queryByTestId('subject');
       const subjectText = 'Subject: Change data owner request: approved';
 
       expect(subjectTestId.textContent).toBe(subjectText);
     });
 
     it('should not show status when owner change is requested', async () => {
-      const { component } = await setup('OWNERCHANGE', 'REQUESTED');
+      const { component, queryByTestId } = await setup('OWNERCHANGE', 'REQUESTED');
 
-      const subjectTestId = component.queryByTestId('subject');
+      const subjectTestId = queryByTestId('subject');
       const subjectText = 'Subject: Change data owner request';
 
       expect(subjectTestId.textContent).toBe(subjectText);
     });
 
     it('should show status when become a parent request is approved', async () => {
-      const { component } = await setup('BECOMEAPARENT', null);
+      const { component, queryByTestId } = await setup('BECOMEAPARENT', null);
 
-      const subjectTestId = component.queryByTestId('subject');
+      const subjectTestId = queryByTestId('subject');
       const subjectText = 'Subject: Parent request: approved';
 
       expect(subjectTestId.textContent).toBe(subjectText);
+    });
+  });
+
+  describe('', () => {
+    it('should ', async () => {
+      const { component, fixture } = await setup('BECOMEAPARENT', null);
+
+      component.approvalStatus = 'Approved';
+
+      fixture.detectChanges();
+
+      expect(component.showStatus).toBeTrue();
+    });
+
+    it('should ', async () => {
+      const { component } = await setup('OWNERCHANGE', 'APPROVED');
+
+      expect(component.showStatus).toBeTrue();
+    });
+
+    it('should ', async () => {
+      const { component } = await setup('OWNERCHANGE', 'REQUESTED');
+
+      expect(component.showStatus).toBeFalse();
     });
   });
 });

--- a/src/app/features/notifications/notification/notification.component.spec.ts
+++ b/src/app/features/notifications/notification/notification.component.spec.ts
@@ -186,25 +186,39 @@ describe('Notification', () => {
     });
   });
 
-  describe('', () => {
-    it('should ', async () => {
-      const { component, fixture } = await setup('BECOMEAPARENT', null);
+  describe('showStatus', () => {
+    it('should show status in subject for become a parent is approved', async () => {
+      const { component, fixture, queryByTestId } = await setup('BECOMEAPARENT', null);
 
       component.approvalStatus = 'Approved';
+      const subjectTestId = queryByTestId('subject');
 
       fixture.detectChanges();
 
       expect(component.showStatus).toBeTrue();
+      expect(subjectTestId.textContent).toContain('approved');
     });
 
-    it('should ', async () => {
-      const { component } = await setup('OWNERCHANGE', 'APPROVED');
+    it('should show status in subject when owner change request is approved ', async () => {
+      const { component, queryByTestId } = await setup('OWNERCHANGE', 'APPROVED');
+
+      const subjectTestId = queryByTestId('subject');
 
       expect(component.showStatus).toBeTrue();
+      expect(subjectTestId.textContent).toContain('approved');
     });
 
-    it('should ', async () => {
-      const { component } = await setup('OWNERCHANGE', 'REQUESTED');
+    it('should not show status in subject when owner change is requested ', async () => {
+      const { component, queryByTestId } = await setup('OWNERCHANGE', 'REQUESTED');
+
+      const subjectTestId = queryByTestId('subject');
+
+      expect(component.showStatus).toBeFalse();
+      expect(subjectTestId.textContent).not.toContain('approved');
+    });
+
+    it('should be false when link to parent is approved ', async () => {
+      const { component } = await setup('LINKTOPARENTAPPROVED');
 
       expect(component.showStatus).toBeFalse();
     });

--- a/src/app/features/notifications/notification/notification.component.spec.ts
+++ b/src/app/features/notifications/notification/notification.component.spec.ts
@@ -190,12 +190,12 @@ describe('Notification', () => {
     it('should show status in subject for become a parent is approved', async () => {
       const { component, fixture, queryByTestId } = await setup('BECOMEAPARENT', null);
 
-      component.approvalStatus = 'approved';
       const subjectTestId = queryByTestId('subject');
 
       fixture.detectChanges();
 
-      expect(component.showStatus).toBeTrue();
+      expect(component.approvalStatus).toBe('approved');
+      expect(component.showStatus).toBe(true);
       expect(subjectTestId.textContent).toContain('approved');
     });
 
@@ -204,7 +204,7 @@ describe('Notification', () => {
 
       const subjectTestId = queryByTestId('subject');
 
-      expect(component.showStatus).toBeTrue();
+      expect(component.showStatus).toBe(true);
       expect(subjectTestId.textContent).toContain('approved');
     });
 
@@ -213,14 +213,14 @@ describe('Notification', () => {
 
       const subjectTestId = queryByTestId('subject');
 
-      expect(component.showStatus).toBeFalse();
+      expect(component.showStatus).toBe(false);
       expect(subjectTestId.textContent).not.toContain('approved');
     });
 
     it('should be false when link to parent is approved ', async () => {
       const { component } = await setup('LINKTOPARENTAPPROVED');
 
-      expect(component.showStatus).toBeFalse();
+      expect(component.showStatus).toBe(false);
     });
   });
 });

--- a/src/app/features/notifications/notification/notification.component.ts
+++ b/src/app/features/notifications/notification/notification.component.ts
@@ -66,10 +66,11 @@ export class NotificationComponent implements OnInit, OnDestroy {
       ? notification.typeContent?.approvalStatus.toUpperCase()
       : notification.typeContent?.status.toUpperCase();
 
-    if (this.approvalStatus === 'APPROVED') {
-      if (notification.type === 'BECOMEAPARENT' || notification.type === 'OWNERCHANGE') {
-        this.showStatus = true;
-      }
+    if (
+      (this.approvalStatus === 'APPROVED' && notification.type === 'BECOMEAPARENT') ||
+      (this.approvalStatus === 'APPROVED' && notification.type === 'OWNERCHANGE')
+    ) {
+      this.showStatus = true;
     } else {
       this.showStatus = false;
     }

--- a/src/app/features/notifications/notification/notification.component.ts
+++ b/src/app/features/notifications/notification/notification.component.ts
@@ -56,19 +56,19 @@ export class NotificationComponent implements OnInit, OnDestroy {
       this.displayActionButtons =
         details.typeContent.approvalStatus === 'REQUESTED' || details.typeContent.approvalStatus === 'CANCELLED';
 
-      this.showStatusInSubject(this.notification);
+      this.approvalStatus = this.notification.typeContent?.approvalStatus
+        ? this.notification.typeContent?.approvalStatus.toLowerCase()
+        : this.notification.typeContent?.status.toLowerCase();
+
+      this.showStatusInSubject(this.notification.type, this.approvalStatus);
     });
     this.setNotificationViewed(this.notificationUid);
   }
 
-  public showStatusInSubject(notification): void {
-    this.approvalStatus = notification.typeContent?.approvalStatus
-      ? notification.typeContent?.approvalStatus.toUpperCase()
-      : notification.typeContent?.status.toUpperCase();
-
+  public showStatusInSubject(notificationType, approvalStatus): void {
     if (
-      (this.approvalStatus === 'APPROVED' && notification.type === 'BECOMEAPARENT') ||
-      (this.approvalStatus === 'APPROVED' && notification.type === 'OWNERCHANGE')
+      (approvalStatus === 'approved' && notificationType === 'BECOMEAPARENT') ||
+      (approvalStatus === 'approved' && notificationType === 'OWNERCHANGE')
     ) {
       this.showStatus = true;
     } else {

--- a/src/app/features/notifications/notification/notification.component.ts
+++ b/src/app/features/notifications/notification/notification.component.ts
@@ -17,6 +17,7 @@ const OWNERSHIP_REJECTED = 'OWNERCHANGEREJECTED';
 @Component({
   selector: 'app-notification',
   templateUrl: './notification.component.html',
+  styleUrls: ['./notification.component.scss'],
 })
 export class NotificationComponent implements OnInit, OnDestroy {
   public workplace: Establishment;
@@ -28,6 +29,9 @@ export class NotificationComponent implements OnInit, OnDestroy {
   public ownerShipRequestedFrom: string;
   public ownerShipRequestedTo: string;
   public isSubWorkplace: boolean;
+  public notificationsForDeletion: Array<any> = [];
+  public approvalStatus: string;
+  public showStatus: boolean;
 
   eventsSubject: Subject<string> = new Subject<string>();
 
@@ -36,6 +40,7 @@ export class NotificationComponent implements OnInit, OnDestroy {
     private breadcrumbService: BreadcrumbService,
     private establishmentService: EstablishmentService,
     private notificationsService: NotificationsService,
+    private router: Router,
   ) {}
 
   ngOnInit() {
@@ -50,8 +55,17 @@ export class NotificationComponent implements OnInit, OnDestroy {
 
       this.displayActionButtons =
         details.typeContent.approvalStatus === 'REQUESTED' || details.typeContent.approvalStatus === 'CANCELLED';
+
+      this.showStatusInSubject(this.notification);
     });
     this.setNotificationViewed(this.notificationUid);
+  }
+
+  public showStatusInSubject(notification): void {
+    this.approvalStatus = notification.typeContent?.approvalStatus
+      ? notification.typeContent?.approvalStatus.toUpperCase()
+      : notification.typeContent?.status.toUpperCase();
+    this.showStatus = this.approvalStatus === 'APPROVED' ? true : false;
   }
 
   public approveRequest() {

--- a/src/app/features/notifications/notification/notification.component.ts
+++ b/src/app/features/notifications/notification/notification.component.ts
@@ -65,7 +65,14 @@ export class NotificationComponent implements OnInit, OnDestroy {
     this.approvalStatus = notification.typeContent?.approvalStatus
       ? notification.typeContent?.approvalStatus.toUpperCase()
       : notification.typeContent?.status.toUpperCase();
-    this.showStatus = this.approvalStatus === 'APPROVED' ? true : false;
+
+    if (this.approvalStatus === 'APPROVED') {
+      if (notification.type === 'BECOMEAPARENT' || notification.type === 'OWNERCHANGE') {
+        this.showStatus = true;
+      }
+    } else {
+      this.showStatus = false;
+    }
   }
 
   public approveRequest() {

--- a/src/app/features/notifications/notification/notification.component.ts
+++ b/src/app/features/notifications/notification/notification.component.ts
@@ -31,7 +31,7 @@ export class NotificationComponent implements OnInit, OnDestroy {
   public isSubWorkplace: boolean;
   public notificationsForDeletion: Array<any> = [];
   public approvalStatus: string;
-  public showStatus: boolean;
+  public showStatus: boolean = false;
 
   eventsSubject: Subject<string> = new Subject<string>();
 
@@ -71,8 +71,6 @@ export class NotificationComponent implements OnInit, OnDestroy {
       (approvalStatus === 'approved' && notificationType === 'OWNERCHANGE')
     ) {
       this.showStatus = true;
-    } else {
-      this.showStatus = false;
     }
   }
 

--- a/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -101,7 +101,7 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
 
   private async getPdfCount() {
     const pdf = await this.downloadAsPDF(false);
-    const numberOfPages = pdf.getNumberOfPages();
+    const numberOfPages = pdf?.getNumberOfPages();
 
     return (this.pdfCount = numberOfPages);
   }


### PR DESCRIPTION
#### Work done
- [Ticket worked on](https://trello.com/c/OyG4ewg6/1376-notification-changes)
- Update text and styling
- Add parent and sub postcodes to the change ownership response

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
