### PR TITLE
feat/1320-create-an-account-head-office-text

### DIFF
--- a/src/app/features/create-account/workplace/parent-workplace-accounts/parent-workplace-accounts.component.html
+++ b/src/app/features/create-account/workplace/parent-workplace-accounts/parent-workplace-accounts.component.html
@@ -15,7 +15,7 @@
     <p>
       This type of account is sometimes called a
       <span class="govuk-body govuk-!-font-weight-bold">parent workplace account</span> as it lets you manage workplace
-      details staff records, and training and qualification records for other workplaces.
+      details, staff records, and training and qualification records for other workplaces.
     </p>
     <p>
       To manage another workplace's data you'll need to click on the 'Become a parent and manage other workplaces' data'
@@ -48,6 +48,6 @@
 
 <app-registration-submit-buttons
   (click)="onClick()"
-  [insideFlow]="insideFlow"
+  [insideFlow]="true"
   [returnRoute]="flow"
 ></app-registration-submit-buttons>

--- a/src/app/features/create-account/workplace/parent-workplace-accounts/parent-workplace-accounts.component.spec.ts
+++ b/src/app/features/create-account/workplace/parent-workplace-accounts/parent-workplace-accounts.component.spec.ts
@@ -155,7 +155,7 @@ describe('ParentWorkplaceAccounts', () => {
     it('should show the save and return button', async () => {
       const { getByText } = await setup(false, false);
 
-      const buttonText = getByText('Save and return');
+      const buttonText = getByText('Continue');
 
       expect(buttonText).toBeTruthy();
     });
@@ -167,7 +167,7 @@ describe('ParentWorkplaceAccounts', () => {
 
       fixture.detectChanges();
 
-      const continueButton = getByText('Save and return');
+      const continueButton = getByText('Continue');
       fireEvent.click(continueButton);
 
       expect(spy).toHaveBeenCalledWith(['registration/confirm-details']);


### PR DESCRIPTION
#### Work done
- Have 'Continue' as button text on parent-workplace-accounts for in and out of create account flow
- Add comma to text

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
