### PR TITLE
Use AWS Public ECR Libary for backend image to avoid rate limiting

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:alpine
+FROM --platform=linux/amd64 public.ecr.aws/docker/library/node:alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
#### Work done
- Use AWS Public ECR Libary for backend image to avoid rate limiting

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
