### PR TITLE
Make breadcrumb show workplace name 

### DIFF
--- a/frontend/src/app/shared/components/breadcrumbs/breadcrumbs.component.html
+++ b/frontend/src/app/shared/components/breadcrumbs/breadcrumbs.component.html
@@ -1,11 +1,6 @@
 <ng-container *ngIf="breadcrumbs">
   <div class="govuk-breadcrumbs govuk-!-margin-top-0 govuk-!-padding-top-3">
-    <ng-container *ngIf="overrideMessage; else defaultMessage">
-      {{ overrideMessage }}:
-    </ng-container>
-    <ng-template #defaultMessage>
-      Go back to:
-    </ng-template>
+    {{ workplace?.name ? workplace?.name : "Go back to: "}}:
     <ol class="govuk-breadcrumbs__list">
       <li
         class="govuk-breadcrumbs__list-item"

--- a/frontend/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
+++ b/frontend/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
@@ -4,6 +4,8 @@ import { JourneyRoute } from '@core/breadcrumb/breadcrumb.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { TabsService } from '@core/services/tabs.service';
 import { Subscription } from 'rxjs';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { Establishment } from '@core/model/establishment.model';
 
 @Component({
   selector: 'app-breadcrumbs',
@@ -13,10 +15,17 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
   public breadcrumbs: JourneyRoute[];
   public overrideMessage: string;
   private subscriptions: Subscription = new Subscription();
+  private workplace: Establishment;
 
-  constructor(private breadcrumbService: BreadcrumbService, private router: Router, private tabsService: TabsService) {}
+  constructor(
+    private breadcrumbService: BreadcrumbService,
+    private tabsService: TabsService,
+    private establishmentService: EstablishmentService,
+  ) {}
 
   ngOnInit(): void {
+    this.workplace = this.establishmentService.primaryWorkplace;
+
     this.subscriptions.add(
       this.breadcrumbService.routes$.subscribe((routes) => {
         this.breadcrumbs = routes ? this.getBreadcrumbs(routes) : null;


### PR DESCRIPTION
#### Work done
- Made beginning of breadcrumb show the establishment name if no override provided
- Removed one override that was establishment name

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
