### PR TITLE
View sub benchmark as parent

### DIFF
--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmark.component.scss
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmark.component.scss
@@ -1,0 +1,62 @@
+.comparison-row-header,
+.comparison-group-cell,
+.workplace-cell {
+  border-bottom: 0;
+}
+
+.comparison-group-cell {
+  background-color: #6f72af;
+  color: #ffffff;
+  opacity: 1;
+}
+
+.workplace-cell {
+  background-color: #28a197;
+  border-right: 5px #ffffff solid;
+  color: #ffffff;
+  opacity: 1;
+}
+
+td {
+  text-align: center;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.comparison-table-header {
+  width: 30.3%;
+}
+
+.comparison-table-body {
+  border-top: 1px solid #b1b4b6;
+  border-bottom: 1px solid #b1b4b6;
+}
+
+tr :first-child {
+  th,
+  td {
+    padding-top: 30px;
+  }
+}
+
+tr :not(.first-row, .last-row) th,
+td {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.first-row {
+  th,
+  td {
+    padding-top: 24px;
+    padding-bottom: 12px;
+  }
+}
+
+.last-row {
+  th,
+  td {
+    padding-top: 12px;
+    padding-bottom: 24px;
+  }
+}

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.html
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.html
@@ -1,1 +1,46 @@
-PLACEHOLDER
+<app-new-dashboard-header
+  [tab]="'benchmarks'"
+  [updatedDate]="tilesData?.meta.lastUpdated"
+  data-html2canvas-ignore
+></app-new-dashboard-header>
+
+<div class="govuk-width-container govuk-!-margin-top-7">
+  <!-- <div id="benchmarks-tiles"> -->
+
+    <app-new-comparison-group-header
+      [canViewFullContent]="canViewFullBenchmarks"
+      [meta]="tilesData?.meta"
+      [workplaceID]="subsidiaryWorkplace.uid"
+      (downloadPDF)="downloadAsPDF()"
+    ></app-new-comparison-group-header>
+
+  <div class="govuk-grid-row">
+    <app-benchmark-tile
+      [canViewFullContent]="canViewFullBenchmarks"
+      [content]="payContent"
+      [tile]="payTile"
+      [workplaceID]="subsidiaryWorkplace.uid"
+    >
+    </app-benchmark-tile>
+    <app-benchmark-tile
+      [canViewFullContent]="canViewFullBenchmarks"
+      [content]="turnoverContent"
+      [tile]="turnoverTile"
+      [workplaceID]="subsidiaryWorkplace.uid"
+    >
+    </app-benchmark-tile>
+    <app-benchmark-tile
+      [canViewFullContent]="canViewFullBenchmarks"
+      [content]="sicknessContent"
+      [tile]="sicknessTile"
+      [workplaceID]="subsidiaryWorkplace.uid"
+    >
+    </app-benchmark-tile>
+    <app-benchmark-tile
+      [canViewFullContent]="canViewFullBenchmarks"
+      [content]="qualificationsContent"
+      [tile]="qualificationsTile"
+      [workplaceID]="subsidiaryWorkplace.uid"
+    >
+    </app-benchmark-tile>
+  </div>

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.html
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.html
@@ -1,46 +1,104 @@
-<app-new-dashboard-header
-  [tab]="'benchmarks'"
-  [updatedDate]="tilesData?.meta.lastUpdated"
-  data-html2canvas-ignore
-></app-new-dashboard-header>
+<div [ngClass]="{ 'govuk-width-container': newDashboard, 'govuk-!-margin-top-7': newDashboard }">
+  <app-benchmarks-select-view-panel
+    data-testid="selectCategoryLinks"
+    [falseSelectionName]="'Pay'"
+    [trueSelectionName]="'Recruitment and retention'"
+    (handleViewToggle)="handleViewBenchmarksByCategory($event)"
+  >
+  </app-benchmarks-select-view-panel>
 
-<div class="govuk-width-container govuk-!-margin-top-7">
-  <!-- <div id="benchmarks-tiles"> -->
-
-    <app-new-comparison-group-header
-      [canViewFullContent]="canViewFullBenchmarks"
-      [meta]="tilesData?.meta"
-      [workplaceID]="subsidiaryWorkplace.uid"
-      (downloadPDF)="downloadAsPDF()"
-    ></app-new-comparison-group-header>
+  <div class="govuk-!-margin-top-7" data-testid="benchmarksCategoryHeading">
+    <ng-container *ngIf="viewBenchmarksByCategory; else payCategory">
+      <h2 class="govuk-heading-m govuk-!-font-size-27">Recruitment and retention</h2>
+    </ng-container>
+    <ng-template #payCategory>
+      <h2 class="govuk-heading-m govuk-!-font-size-27">Pay</h2>
+    </ng-template>
+  </div>
 
   <div class="govuk-grid-row">
-    <app-benchmark-tile
-      [canViewFullContent]="canViewFullBenchmarks"
-      [content]="payContent"
-      [tile]="payTile"
-      [workplaceID]="subsidiaryWorkplace.uid"
-    >
-    </app-benchmark-tile>
-    <app-benchmark-tile
-      [canViewFullContent]="canViewFullBenchmarks"
-      [content]="turnoverContent"
-      [tile]="turnoverTile"
-      [workplaceID]="subsidiaryWorkplace.uid"
-    >
-    </app-benchmark-tile>
-    <app-benchmark-tile
-      [canViewFullContent]="canViewFullBenchmarks"
-      [content]="sicknessContent"
-      [tile]="sicknessTile"
-      [workplaceID]="subsidiaryWorkplace.uid"
-    >
-    </app-benchmark-tile>
-    <app-benchmark-tile
-      [canViewFullContent]="canViewFullBenchmarks"
-      [content]="qualificationsContent"
-      [tile]="qualificationsTile"
-      [workplaceID]="subsidiaryWorkplace.uid"
-    >
-    </app-benchmark-tile>
+    <div class="govuk-grid-column-one-third">
+      <div class="govuk-!-margin-top-1">
+        <app-about-the-data-link></app-about-the-data-link>
+      </div>
+
+      <div *ngIf="tilesData?.meta.lastUpdated" data-testid="benchmarksLastUpdatedDate" class="govuk-!-margin-top-5">
+        <p>The comparison group data was refreshed on {{ tilesData?.meta.lastUpdated | date: 'd MMMM y' }}.</p>
+      </div>
+
+      <app-benchmarks-select-comparison-group
+        [comparisonDataExists]="comparisonDataExists"
+        [viewBenchmarksComparisonGroups]="viewBenchmarksComparisonGroups"
+        (handleViewToggle)="handleViewComparisonGroups($event)"
+        [mainServiceName]="workplace.mainService.name"
+        [localAuthorityLocation]="tilesData?.meta.localAuthority"
+      >
+      </app-benchmarks-select-comparison-group>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      <ng-container *ngIf="viewBenchmarksComparisonGroups; else nonGoodCqcComparisonGroup">
+        <h3 class="govuk-heading-m">
+          Good and outstanding CQC providers in {{ tilesData?.meta.localAuthority | formatAmpersand }}
+        </h3>
+      </ng-container>
+      <ng-template #nonGoodCqcComparisonGroup>
+        <h3 class="govuk-heading-m">
+          {{ workplace.mainService.name | serviceName }} providers in
+          {{ tilesData?.meta.localAuthority | formatAmpersand }}
+        </h3>
+      </ng-template>
+      <ng-container *ngIf="comparisonDataExists">
+        <ng-container *ngIf="viewBenchmarksComparisonGroups; else nonGoodCqcComparisonGroup">
+          <p>
+            Your selected comparison group is a maximum
+            <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.staffGoodCqc | number }}</span>
+            staff from
+            <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.workplacesGoodCqc | number }}</span>
+            workplaces using ASC-WDS, rated as good or outstanding CQC providers and providing
+            <span class="govuk-body govuk-!-font-weight-bold">{{
+              workplace.mainService.name | serviceName | lowercase
+            }}</span>
+            in {{ tilesData?.meta.localAuthority | formatAmpersand }}.
+          </p>
+        </ng-container>
+        <ng-template #nonGoodCqcComparisonGroup>
+          <p class="govuk-body">
+            Your selected comparison group is a maximum
+            <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.staff | number }}</span>
+            staff from
+            <span class="govuk-body govuk-!-font-weight-bold">{{ tilesData?.meta.workplaces | number }}</span>
+            workplaces using ASC-WDS and providing
+            <span class="govuk-body govuk-!-font-weight-bold">{{
+              workplace.mainService.name | serviceName | lowercase
+            }}</span>
+            in {{ tilesData?.meta.localAuthority | formatAmpersand }}.
+          </p>
+        </ng-template>
+      </ng-container>
+
+      <ng-container *ngIf="viewBenchmarksByCategory; else showPay">
+        <app-data-area-recruitment-and-retention
+          [data]="tilesData"
+          [rankingsData]="rankingsData"
+          [viewBenchmarksComparisonGroups]="viewBenchmarksComparisonGroups"
+          data-testid="recruitmentAndRetentionArea"
+        ></app-data-area-recruitment-and-retention>
+      </ng-container>
+      <ng-template #showPay>
+        <app-data-area-pay
+          [data]="tilesData"
+          [rankingsData]="rankingsData"
+          data-testid="payArea"
+          [viewBenchmarksComparisonGroups]="viewBenchmarksComparisonGroups"
+          [showRegisteredNurseSalary]="showRegisteredNurseSalary"
+        ></app-data-area-pay>
+      </ng-template>
+    </div>
+    <!-- <app-data-area-about-the-data
+      #aboutData
+      class="govuk-visually-hidden"
+      [workplace]="workplace"
+    ></app-data-area-about-the-data> -->
   </div>
+</div>

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.spec.ts
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.spec.ts
@@ -1,0 +1,126 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
+import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { WindowRef } from '@core/services/window.ref';
+import { MockBenchmarksService } from '@core/test-utils/MockBenchmarkService';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import {
+  BenchmarksSelectViewPanelComponent,
+} from '@shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render, within } from '@testing-library/angular';
+
+import { ViewSubsidiaryBenchmarksComponent } from './view-subsidiary-benchmarks.component';
+
+
+describe('ViewSubsidiaryBenchmarksComponent', () => {
+  const setup = async (newDashboard = true) => {
+    const establishment = establishmentBuilder() as Establishment;
+    const { fixture, getByText, getByTestId, queryByTestId } = await render(ViewSubsidiaryBenchmarksComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+      providers: [
+        WindowRef,
+        {
+          provide: FeatureFlagsService,
+          useClass: MockFeatureFlagsService,
+        },
+        {
+          provide: PermissionsService,
+          useClass: MockPermissionsService,
+        },
+        {
+          provide: BreadcrumbService,
+          useClass: MockBreadcrumbService,
+        },
+        {
+          provide: BenchmarksServiceBase,
+          useClass: MockBenchmarksService,
+        },
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
+        },
+      ],
+      declarations: [BenchmarksSelectViewPanelComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      componentProperties: {
+        workplace: establishment,
+        newDashboard,
+      },
+    });
+
+    const component = fixture.componentInstance;
+
+    return {
+      component,
+      fixture,
+      getByText,
+      getByTestId,
+      queryByTestId,
+    };
+  };
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the pay area and the correct heading when viewBenchmarksByCategory is false', async () => {
+    const { component, fixture, getByTestId, queryByTestId } = await setup();
+
+    component.viewBenchmarksByCategory = false;
+    fixture.detectChanges();
+
+    const categoryHeading = getByTestId('benchmarksCategoryHeading');
+
+    expect(getByTestId('payArea')).toBeTruthy();
+    expect(within(categoryHeading).getByText('Pay')).toBeTruthy();
+    expect(queryByTestId('recruitmentAndRetentionArea')).toBeFalsy();
+    expect(within(categoryHeading).queryByText('Recruitment and retention')).toBeFalsy();
+  });
+
+  it('should render the recruitment and retention area and the correct heading when viewBenchmarksByCategory is true', async () => {
+    const { component, fixture, getByTestId, queryByTestId } = await setup();
+
+    component.viewBenchmarksByCategory = true;
+    fixture.detectChanges();
+
+    const selectCategoryLinks = getByTestId('selectCategoryLinks');
+
+    fireEvent.click(within(selectCategoryLinks).getByText('Recruitment and retention'));
+    const categoryHeading = getByTestId('benchmarksCategoryHeading');
+
+    expect(getByTestId('recruitmentAndRetentionArea')).toBeTruthy();
+    expect(within(categoryHeading).getByText('Recruitment and retention')).toBeTruthy();
+    expect(queryByTestId('payArea')).toBeFalsy();
+    expect(within(categoryHeading).queryByText('Pay')).toBeFalsy();
+  });
+
+  it('should check the pay benchmarks data to see if there is comparison data', async () => {
+    const { component } = await setup();
+    const noCompData = {
+      value: 0,
+      stateMessage: 'no-data',
+      hasValue: false,
+    };
+    component.tilesData.careWorkerPay.comparisonGroup = noCompData;
+    component.tilesData.seniorCareWorkerPay.comparisonGroup = noCompData;
+    component.tilesData.registeredNursePay.comparisonGroup = noCompData;
+    component.tilesData.registeredManagerPay.comparisonGroup = noCompData;
+
+    component.checkComparisonDataExists();
+
+    expect(component.comparisonDataExists).toBeFalsy();
+  });
+});

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
@@ -1,146 +1,102 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
-import { BenchmarksResponse, Meta, MetricsContent, Tile } from '@core/model/benchmarks.model';
+import { AllRankingsResponse, BenchmarksResponse, MetricsContent } from '@core/model/benchmarks-v2.model';
 import { Establishment } from '@core/model/establishment.model';
-import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
-import { URLStructure } from '@core/model/url.model';
-import { Worker } from '@core/model/worker.model';
 import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
-import { EstablishmentService } from '@core/services/establishment.service';
-import { PdfService } from '@core/services/pdf.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TabsService } from '@core/services/tabs.service';
-import { BenchmarksAboutTheDataComponent } from '@shared/components/benchmarks-tab/about-the-data/about-the-data.component';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { DataAreaAboutTheDataComponent } from '@shared/components/data-area-tab/about-the-data/about-the-data.component';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
   selector: 'app-view-subsidiary-benchmarks',
   templateUrl: './view-subsidiary-benchmarks.component.html',
+  styleUrls: ['./view-subsidiary-benchmark.component.scss'],
 })
-export class ViewSubsidiaryBenchmarksComponent implements OnInit {
-  @Input() workplace: Establishment;
-  @ViewChild('aboutData') private aboutData: BenchmarksAboutTheDataComponent;
-  @Output() downloadPDF = new EventEmitter();
+export class ViewSubsidiaryBenchmarksComponent implements OnInit, OnDestroy {
+  @ViewChild('aboutData') private aboutData: DataAreaAboutTheDataComponent;
 
-  public primaryEstablishment: Establishment;
-  public subsidiaryWorkplace: Establishment;
-  public summaryReturnUrl: URLStructure;
-  public canDeleteEstablishment: boolean;
-  public canViewListOfUsers: boolean;
-  public canViewListOfWorkers: boolean;
-  public canViewBenchmarks: boolean;
-  public meta: Meta;
-  public workplaceID: string;
-  public totalStaffRecords: number;
-  public trainingAlert: number;
-  public workers: Worker[];
-  public trainingCounts: TrainingCounts;
-  public workerCount: number;
-  public showSharingPermissionsBanner: boolean;
-  private showBanner = false;
-  public newDataAreaFlag: boolean;
-  public canSeeNewDataArea: boolean;
-  public subsidiaryBenchmark: Establishment;
-  public tilesData: BenchmarksResponse;
-  protected router: Router;
   public canViewFullBenchmarks: boolean;
   public payContent = MetricsContent.Pay;
   public turnoverContent = MetricsContent.Turnover;
   public qualificationsContent = MetricsContent.Qualifications;
   public sicknessContent = MetricsContent.Sickness;
+  public viewBenchmarksByCategory = false;
+  public viewBenchmarksComparisonGroups = false;
+  public viewBenchmarksPosition = false;
+  public downloadRecruitmentBenchmarksText: string;
+  public tilesData: BenchmarksResponse;
+  public showRegisteredNurseSalary: boolean;
+  public rankingsData: AllRankingsResponse;
+  public comparisonDataExists: boolean;
+  public workplace: Establishment;
+  public newDashboard: boolean;
+  private subsidiaryUid: string;
+
   constructor(
-    // private alertService: AlertService,
-    private breadcrumbService: BreadcrumbService,
-    // private dialogService: DialogService,
-    // private establishmentService: EstablishmentService,
-    private benchmarksService: BenchmarksServiceBase,
     private permissionsService: PermissionsService,
-    // private router: Router,
-    // private userService: UserService,
-    // private workerService: WorkerService,
-    // private route: ActivatedRoute,
-    // private featureFlagsService: FeatureFlagsService,
+    private breadcrumbService: BreadcrumbService,
+    protected benchmarksService: BenchmarksServiceBase,
+    protected router: Router,
     private tabsService: TabsService,
-    private route: ActivatedRoute,
-    private establishmentService: EstablishmentService,
     private parentSubsidiaryViewService: ParentSubsidiaryViewService,
-    private featureFlagService: FeatureFlagsService,
-    private pdfService: PdfService,
-    private elRef: ElementRef,
   ) {}
 
   ngOnInit(): void {
-    // this.showBanner = history.state?.showBanner;
-
-
-
-
-
-    // this.establishmentService.setCheckCQCDetailsBanner(false);
+    this.tabsService.selectedTab = 'benchmark';
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
+    this.newDashboard = true;
 
-    this.parentSubsidiaryViewService.getObservableSubsidiary().subscribe(subsidiary => {
-      this.subsidiaryWorkplace = subsidiary;
-      this.workplaceID = this.subsidiaryWorkplace.uid;
-      this.canViewBenchmarks = this.permissionsService.can(this.subsidiaryWorkplace.uid, 'canViewBenchmarks');
-      this.canViewFullBenchmarks = this.permissionsService.can(this.subsidiaryWorkplace.uid, 'canViewBenchmarks');
-      this.tilesData = this.featureFlagService.newBenchmarksDataArea
-      ? this.benchmarksService.benchmarksData.oldBenchmarks
-      : this.benchmarksService.benchmarksData;
+    this.parentSubsidiaryViewService.getObservableSubsidiary().subscribe(subsidiaryWorkplace => {
+      if (subsidiaryWorkplace) {
+        this.workplace = subsidiaryWorkplace;
+        this.subsidiaryUid = this.workplace?.uid;
+        this.tilesData = this.benchmarksService.benchmarksData.newBenchmarks;
+        this.rankingsData = this.benchmarksService.rankingsData;
+        this.canViewFullBenchmarks = this.permissionsService.can(this.subsidiaryUid, 'canViewBenchmarks');
+        this.setDownloadBenchmarksText();
+        this.checkComparisonDataExists();
+        this.showRegisteredNurseSalary = this.workplace.mainService.reportingID === 1;
+      }
     });
-
-    // this.primaryEstablishment = this.establishmentService.primaryWorkplace;
-    // this.workplace = this.establishmentService.establishment;
-
-    // this.canViewListOfUsers = this.permissionsService.can(this.workplace.uid, 'canViewListOfUsers');
-    // this.canViewListOfWorkers = this.permissionsService.can(this.workplace.uid, 'canViewListOfWorkers');
-    // this.canDeleteEstablishment = this.permissionsService.can(this.workplace.uid, 'canDeleteEstablishment');
-    // this.newDataAreaFlag = this.featureFlagsService.newBenchmarksDataArea;
-    // this.canSeeNewDataArea = [1, 2, 8].includes(this.workplace.mainService.reportingID);
-
-
   }
 
+  public checkComparisonDataExists(): void {
+    const noComparisonData = 'no-data';
 
-  public async downloadAsPDF() {
-    return await this.pdfService.BuildBenchmarksPdf(
-      this.elRef,
-      this.aboutData.aboutData,
-      this.subsidiaryWorkplace,
-      'Benchmarks.pdf',
-    );
+    if (
+      this.tilesData?.careWorkerPay.comparisonGroup.stateMessage === noComparisonData &&
+      this.tilesData?.seniorCareWorkerPay.comparisonGroup.stateMessage === noComparisonData &&
+      this.tilesData?.registeredNursePay.comparisonGroup.stateMessage === noComparisonData &&
+      this.tilesData?.registeredManagerPay.comparisonGroup.stateMessage === noComparisonData
+    ) {
+      this.comparisonDataExists = false;
+    } else this.comparisonDataExists = true;
   }
 
-  get payTile(): Tile {
-    return this.tilesData?.pay;
+  public setDownloadBenchmarksText(): void {
+    const fileSize = this.viewBenchmarksByCategory ? '385KB' : '430KB';
+    const section = this.viewBenchmarksByCategory ? 'recruitment and retention' : 'pay';
+
+    this.downloadRecruitmentBenchmarksText = `Download ${section} benchmarks (PDF, ${fileSize}, 2 pages)`;
   }
 
-
-  get turnoverTile(): Tile {
-    return this.tilesData?.turnover;
+  public handleViewBenchmarksByCategory(visible: boolean): void {
+    this.viewBenchmarksByCategory = visible;
+    this.setDownloadBenchmarksText();
   }
 
-  get sicknessTile(): Tile {
-    return this.tilesData?.sickness;
+  public handleViewComparisonGroups(visible: boolean): void {
+    this.viewBenchmarksComparisonGroups = visible;
   }
 
-  get qualificationsTile(): Tile {
-    return this.tilesData?.qualifications;
-  }
-
-
-  public setReturn() {
-    this.benchmarksService.setReturnTo({
-      url: [this.router.url.split('#')[0]],
-      fragment: 'benchmarks',
-    });
+  public handleViewBenchmarkPosition(visible: boolean): void {
+    this.viewBenchmarksPosition = visible;
   }
 
   ngOnDestroy(): void {
     this.breadcrumbService.removeRoutes();
   }
-
 }

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
@@ -1,25 +1,39 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { BenchmarksResponse, Meta, MetricsContent, Tile } from '@core/model/benchmarks.model';
 import { Establishment } from '@core/model/establishment.model';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { URLStructure } from '@core/model/url.model';
 import { Worker } from '@core/model/worker.model';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
+import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { PdfService } from '@core/services/pdf.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { TabsService } from '@core/services/tabs.service';
+import { BenchmarksAboutTheDataComponent } from '@shared/components/benchmarks-tab/about-the-data/about-the-data.component';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
   selector: 'app-view-subsidiary-benchmarks',
   templateUrl: './view-subsidiary-benchmarks.component.html',
 })
 export class ViewSubsidiaryBenchmarksComponent implements OnInit {
+  @Input() workplace: Establishment;
+  @ViewChild('aboutData') private aboutData: BenchmarksAboutTheDataComponent;
+  @Output() downloadPDF = new EventEmitter();
+
   public primaryEstablishment: Establishment;
-  public workplace: Establishment;
+  public subsidiaryWorkplace: Establishment;
   public summaryReturnUrl: URLStructure;
   public canDeleteEstablishment: boolean;
   public canViewListOfUsers: boolean;
   public canViewListOfWorkers: boolean;
   public canViewBenchmarks: boolean;
+  public meta: Meta;
+  public workplaceID: string;
   public totalStaffRecords: number;
   public trainingAlert: number;
   public workers: Worker[];
@@ -29,34 +43,104 @@ export class ViewSubsidiaryBenchmarksComponent implements OnInit {
   private showBanner = false;
   public newDataAreaFlag: boolean;
   public canSeeNewDataArea: boolean;
-
+  public subsidiaryBenchmark: Establishment;
+  public tilesData: BenchmarksResponse;
+  protected router: Router;
+  public canViewFullBenchmarks: boolean;
+  public payContent = MetricsContent.Pay;
+  public turnoverContent = MetricsContent.Turnover;
+  public qualificationsContent = MetricsContent.Qualifications;
+  public sicknessContent = MetricsContent.Sickness;
   constructor(
     // private alertService: AlertService,
     private breadcrumbService: BreadcrumbService,
     // private dialogService: DialogService,
     // private establishmentService: EstablishmentService,
-    // private benchmarksService: BenchmarksServiceBase,
-    // private permissionsService: PermissionsService,
+    private benchmarksService: BenchmarksServiceBase,
+    private permissionsService: PermissionsService,
     // private router: Router,
     // private userService: UserService,
     // private workerService: WorkerService,
     // private route: ActivatedRoute,
     // private featureFlagsService: FeatureFlagsService,
+    private tabsService: TabsService,
+    private route: ActivatedRoute,
+    private establishmentService: EstablishmentService,
     private parentSubsidiaryViewService: ParentSubsidiaryViewService,
+    private featureFlagService: FeatureFlagsService,
+    private pdfService: PdfService,
+    private elRef: ElementRef,
   ) {}
 
   ngOnInit(): void {
     // this.showBanner = history.state?.showBanner;
 
+
+
+
+
     // this.establishmentService.setCheckCQCDetailsBanner(false);
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
+
+    this.parentSubsidiaryViewService.getObservableSubsidiary().subscribe(subsidiary => {
+      this.subsidiaryWorkplace = subsidiary;
+      this.workplaceID = this.subsidiaryWorkplace.uid;
+      this.canViewBenchmarks = this.permissionsService.can(this.subsidiaryWorkplace.uid, 'canViewBenchmarks');
+      this.canViewFullBenchmarks = this.permissionsService.can(this.subsidiaryWorkplace.uid, 'canViewBenchmarks');
+      this.tilesData = this.featureFlagService.newBenchmarksDataArea
+      ? this.benchmarksService.benchmarksData.oldBenchmarks
+      : this.benchmarksService.benchmarksData;
+    });
+
     // this.primaryEstablishment = this.establishmentService.primaryWorkplace;
     // this.workplace = this.establishmentService.establishment;
-    // this.canViewBenchmarks = this.permissionsService.can(this.workplace.uid, 'canViewBenchmarks');
+
     // this.canViewListOfUsers = this.permissionsService.can(this.workplace.uid, 'canViewListOfUsers');
     // this.canViewListOfWorkers = this.permissionsService.can(this.workplace.uid, 'canViewListOfWorkers');
     // this.canDeleteEstablishment = this.permissionsService.can(this.workplace.uid, 'canDeleteEstablishment');
     // this.newDataAreaFlag = this.featureFlagsService.newBenchmarksDataArea;
     // this.canSeeNewDataArea = [1, 2, 8].includes(this.workplace.mainService.reportingID);
+
+
   }
+
+
+  public async downloadAsPDF() {
+    return await this.pdfService.BuildBenchmarksPdf(
+      this.elRef,
+      this.aboutData.aboutData,
+      this.subsidiaryWorkplace,
+      'Benchmarks.pdf',
+    );
+  }
+
+  get payTile(): Tile {
+    return this.tilesData?.pay;
+  }
+
+
+  get turnoverTile(): Tile {
+    return this.tilesData?.turnover;
+  }
+
+  get sicknessTile(): Tile {
+    return this.tilesData?.sickness;
+  }
+
+  get qualificationsTile(): Tile {
+    return this.tilesData?.qualifications;
+  }
+
+
+  public setReturn() {
+    this.benchmarksService.setReturnTo({
+      url: [this.router.url.split('#')[0]],
+      fragment: 'benchmarks',
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.removeRoutes();
+  }
+
 }

--- a/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
@@ -1,23 +1,20 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { EditUserPermissionsGuard } from '@core/guards/edit-user-permissions/edit-user-permissions.guard';
-import { ParentGuard } from '@core/guards/parent/parent.guard';
-import { CheckPermissionsGuard } from '@core/guards/permissions/check-permissions/check-permissions.guard';
-import { HasPermissionsGuard } from '@core/guards/permissions/has-permissions/has-permissions.guard';
-import { ChildWorkplacesResolver } from '@core/resolvers/child-workplaces.resolver';
-import { ViewSubsidiaryHomeComponent } from './home/view-subsidiary-home.component';
-import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
-import { ViewSubsidiaryStaffRecordsComponent } from './staff-records/view-subsidiary-staff-records.component';
-import { ViewSubsidiaryTrainingAndQualificationsComponent } from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
-import { ViewSubsidiaryBenchmarksComponent } from './benchmarks/view-subsidiary-benchmarks.component';
-import { ViewSubsidiaryWorkplaceUsersComponent } from './workplace-users/view-subsidiary-workplace-users.component';
-
-import { GetMissingCqcLocationsResolver } from '@core/resolvers/getMissingCqcLocations/getMissingCqcLocations.resolver';
+import { ArticleListResolver } from '@core/resolvers/article-list.resolver';
+import { BenchmarksResolver } from '@core/resolvers/benchmarks.resolver';
 import { AllUsersForEstablishmentResolver } from '@core/resolvers/dashboard/all-users-for-establishment.resolver';
+import { RankingsResolver } from '@core/resolvers/rankings.resolver';
 import { SubsidiaryResolver } from '@core/resolvers/subsidiary.resolver';
 import { WorkersResolver } from '@core/resolvers/workers.resolver';
-import { ArticleListResolver } from '@core/resolvers/article-list.resolver';
-import { SubsidiaryWorkerResolver } from '@core/resolvers/subsidiary-worker.resolver';
+
+import { ViewSubsidiaryBenchmarksComponent } from './benchmarks/view-subsidiary-benchmarks.component';
+import { ViewSubsidiaryHomeComponent } from './home/view-subsidiary-home.component';
+import { ViewSubsidiaryStaffRecordsComponent } from './staff-records/view-subsidiary-staff-records.component';
+import {
+  ViewSubsidiaryTrainingAndQualificationsComponent,
+} from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
+import { ViewSubsidiaryWorkplaceUsersComponent } from './workplace-users/view-subsidiary-workplace-users.component';
+import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
 
 // eslint-disable-next-line max-len
 const routes: Routes = [
@@ -75,6 +72,9 @@ const routes: Routes = [
     data: { title: 'Benchmarks' },
     resolve: {
       subsidiaryResolver: SubsidiaryResolver,
+      benchmarksResolver: BenchmarksResolver,
+      rankingsResolver: RankingsResolver,
+
     },
   },
   {

--- a/frontend/src/app/features/subsidiary/subsidiary.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary.module.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { SubsidiaryResolver } from '@core/resolvers/subsidiary.resolver';
+import { BenchmarksModule } from '@shared/components/benchmarks-tab/benchmarks.module';
+import { DataAreaTabModule } from '@shared/components/data-area-tab/data-area-tab.module';
 import { SharedModule } from '@shared/shared.module';
 
 import { ViewSubsidiaryBenchmarksComponent } from './benchmarks/view-subsidiary-benchmarks.component';
@@ -14,12 +16,13 @@ import {
 import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
 
 @NgModule({
-  imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, SubsidiaryRoutingModule],
+  imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, SubsidiaryRoutingModule,  BenchmarksModule,DataAreaTabModule,],
   declarations: [
     ViewSubsidiaryHomeComponent,
     ViewSubsidiaryWorkplaceComponent,
-    ViewSubsidiaryBenchmarksComponent,
+    ViewSubsidiaryHomeComponent,
     ViewSubsidiaryTrainingAndQualificationsComponent,
+    ViewSubsidiaryBenchmarksComponent,
   ],
   providers: [SubsidiaryResolver],
 })

--- a/frontend/src/app/features/subsidiary/subsidiary.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary.module.ts
@@ -2,21 +2,23 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
 import { SubsidiaryResolver } from '@core/resolvers/subsidiary.resolver';
 import { SharedModule } from '@shared/shared.module';
 
-import { SubsidiaryRoutingModule } from './subsidiary-routing.module';
+import { ViewSubsidiaryBenchmarksComponent } from './benchmarks/view-subsidiary-benchmarks.component';
 import { ViewSubsidiaryHomeComponent } from './home/view-subsidiary-home.component';
-
+import { SubsidiaryRoutingModule } from './subsidiary-routing.module';
+import {
+  ViewSubsidiaryTrainingAndQualificationsComponent,
+} from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
 import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
-import { ViewSubsidiaryTrainingAndQualificationsComponent } from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, SubsidiaryRoutingModule],
   declarations: [
     ViewSubsidiaryHomeComponent,
     ViewSubsidiaryWorkplaceComponent,
+    ViewSubsidiaryBenchmarksComponent,
     ViewSubsidiaryTrainingAndQualificationsComponent,
   ],
   providers: [SubsidiaryResolver],

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -1,5 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -11,10 +13,8 @@ import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 import dayjs from 'dayjs';
 
-import { Establishment } from '../../../../../mockdata/establishment';
+import { Establishment } from '../../../../mockdata/establishment';
 import { SummarySectionComponent } from './summary-section.component';
-import { RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 
 describe('Summary section', () => {
   const setup = async (


### PR DESCRIPTION
#### Work done
- This PR allows the parent to view the subsidiary benchmark tab of pay and comparison group data

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
