### PR TITLE
changed sub router service to override navigateByUrl rather than Navi…

### DIFF
--- a/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
@@ -10,7 +10,7 @@ describe('SubsidiaryRouterService', () => {
   let routerSpy: jasmine.Spy;
 
   beforeEach(() => {
-    const spy = jasmine.createSpyObj('ParentSubsidiaryViewService', ['getViewingSubAsParent', 'getSubsidiaryUid']);
+    const parentSubViewSpy = jasmine.createSpyObj('ParentSubsidiaryViewService', ['getViewingSubAsParent', 'getSubsidiaryUid', 'clearViewingSubAsParent']);
     routerSpy = spyOn(Router.prototype, 'navigateByUrl');
 
     TestBed.configureTestingModule({
@@ -19,7 +19,7 @@ describe('SubsidiaryRouterService', () => {
         SubsidiaryRouterService,
         {
           provide: ParentSubsidiaryViewService,
-          useValue: spy,
+          useValue: parentSubViewSpy,
         }],
     });
 
@@ -42,6 +42,42 @@ describe('SubsidiaryRouterService', () => {
       expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
     });
   });
+
+  describe('When hitting exit sub view pages', () => {
+    it('should clear the value for the view sub service at login page', async () => {
+      subViewServiceSpy.getViewingSubAsParent.and.returnValue(false);
+      const urlTree = service.createUrlTree(['login']);
+      const expectedUrlTree = service.createUrlTree(['login'], undefined);
+
+      service.navigateByUrl(urlTree);
+
+      expect(subViewServiceSpy.clearViewingSubAsParent).toHaveBeenCalled();
+      expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
+    });
+
+    it('should clear the value for the view sub service at notifications page', async () => {
+      subViewServiceSpy.getViewingSubAsParent.and.returnValue(false);
+      const urlTree = service.createUrlTree(['notifications']);
+      const expectedUrlTree = service.createUrlTree(['notifications'], undefined);
+
+      service.navigateByUrl(urlTree);
+
+      expect(subViewServiceSpy.clearViewingSubAsParent).toHaveBeenCalled();
+      expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
+    });
+
+    it('should clear the value for the view sub service at notifications page', async () => {
+      subViewServiceSpy.getViewingSubAsParent.and.returnValue(false);
+      const urlTree = service.createUrlTree(['satisfaction-survey']);
+      const expectedUrlTree = service.createUrlTree(['satisfaction-survey'], undefined);
+
+      service.navigateByUrl(urlTree);
+
+      expect(subViewServiceSpy.clearViewingSubAsParent).toHaveBeenCalled();
+      expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
+    });
+  });
+
 
   describe('When viewing sub as a parent', () => {
     it('should prepend the route with the subsidiary route', async() => {

--- a/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SubsidiaryRouterService } from './subsidiary-router-service';
 import { ParentSubsidiaryViewService } from './parent-subsidiary-view.service';
-import { Router } from '@angular/router';
+import { Router, UrlSegmentGroup, UrlTree } from '@angular/router';
 
 describe('SubsidiaryRouterService', () => {
   let service: SubsidiaryRouterService;
@@ -11,7 +11,7 @@ describe('SubsidiaryRouterService', () => {
 
   beforeEach(() => {
     const spy = jasmine.createSpyObj('ParentSubsidiaryViewService', ['getViewingSubAsParent', 'getSubsidiaryUid']);
-    routerSpy = spyOn(Router.prototype, 'navigate');
+    routerSpy = spyOn(Router.prototype, 'navigateByUrl');
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -34,44 +34,67 @@ describe('SubsidiaryRouterService', () => {
   describe('When not viewing sub as parent', () => {
     it('should navigate to the provided route', async() => {
       subViewServiceSpy.getViewingSubAsParent.and.returnValue(false);
-      service.navigate(['expected', 'test', 'route']);
-      expect(routerSpy).toHaveBeenCalledWith(['expected', 'test', 'route'], undefined);
+      const urlTree = service.createUrlTree(['expected', 'test', 'route']);
+      const expectedUrlTree = service.createUrlTree(['expected', 'test', 'route'], undefined);
+
+      service.navigateByUrl(urlTree);
+
+      expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
     });
   });
 
   describe('When viewing sub as a parent', () => {
     it('should prepend the route with the subsidiary route', async() => {
       subViewServiceSpy.getViewingSubAsParent.and.returnValue(true);
-      service.navigate(['expected', 'test', 'route']);
-      expect(routerSpy).toHaveBeenCalledWith(['subsidiary', 'expected', 'test', 'route'], undefined);
+      const urlTree = service.createUrlTree(['expected', 'test', 'route']);
+      const expectedUrlTree = service.createUrlTree(['subsidiary', 'expected', 'test', 'route'], undefined);
+
+      service.navigateByUrl(urlTree);
+
+      expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
     })
 
     it('should remove forward slashes from the route', async() => {
       subViewServiceSpy.getViewingSubAsParent.and.returnValue(true);
-      service.navigate(['/expected', '/test/route'], undefined);
-      expect(routerSpy).toHaveBeenCalledWith(['subsidiary', 'expected', 'test', 'route'], undefined);
+      const urlTree = service.createUrlTree(['/expected', '/test/route'], undefined);
+      const expectedUrlTree = service.createUrlTree(['subsidiary', 'expected', 'test', 'route'], undefined);
+
+      service.navigateByUrl(urlTree);
+
+      expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
     })
 
     describe('fragments', () => {
       it('should reroute to the sub equivalent pages on dashboard', async() => {
         subViewServiceSpy.getViewingSubAsParent.and.returnValue(true);
         subViewServiceSpy.getSubsidiaryUid.and.returnValue('1234');
-        service.navigate(['dashboard', 'test', 'route'], {fragment: 'test-fragment'});
-        expect(routerSpy).toHaveBeenCalledWith(['subsidiary', 'test-fragment', '1234'], undefined);
+        const urlTree = service.createUrlTree(['dashboard', 'test', 'route'], {fragment: 'test-fragment'});
+        const expectedUrlTree = service.createUrlTree(['subsidiary', 'test-fragment', '1234'], undefined);
+
+        service.navigateByUrl(urlTree);
+
+        expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
       })
 
       it('should reroute to the sub equivalent pages on dashboard when a leading slash is present', async() => {
         subViewServiceSpy.getViewingSubAsParent.and.returnValue(true);
         subViewServiceSpy.getSubsidiaryUid.and.returnValue('1234');
-        service.navigate(['/dashboard', 'test', 'route'], {fragment: 'test-fragment'});
-        expect(routerSpy).toHaveBeenCalledWith(['subsidiary', 'test-fragment', '1234'], undefined);
+        const urlTree = service.createUrlTree(['/dashboard', 'test', 'route'], {fragment: 'test-fragment'});
+        const expectedUrlTree = service.createUrlTree(['subsidiary', 'test-fragment', '1234'], undefined);
+
+        service.navigateByUrl(urlTree);
+
+        expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
       })
 
       it('should use default fragments', async() => {
         subViewServiceSpy.getViewingSubAsParent.and.returnValue(true);
-        subViewServiceSpy.getSubsidiaryUid.and.returnValue('1234');
-        service.navigate(['expected', 'test', 'route'], {fragment: 'test-fragment'});
-        expect(routerSpy).toHaveBeenCalledWith(['subsidiary', 'expected', 'test', 'route'], {fragment: 'test-fragment'});
+        const urlTree = service.createUrlTree(['expected', 'test', 'route'], {fragment: 'test-fragment'});
+        const expectedUrlTree = service.createUrlTree(['subsidiary', 'expected', 'test', 'route'], {fragment: 'test-fragment'});
+
+        service.navigateByUrl(urlTree);
+
+        expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
       })
     })
   })

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -20,12 +20,19 @@ export class SubsidiaryRouterService extends Router {
     super()
   }
 
-  getNewRoute(commands: any[], extras?: any) {
-
-    if (exitSubsidiaryViewPages.some(command => commands[0].includes(command))) {
-      this.parentSubsidiaryViewService.clearViewingSubAsParent();
+  getCommands(urlTree: UrlTree) {
+    let commands = [];
+    for(let segment of urlTree.root.children.primary.segments) {
+      commands.push(segment.path);
+    }
+    const navigationExtras = {
+      fragment: urlTree.fragment
     }
 
+    return { commands, navigationExtras }
+  }
+
+  getNewRoute(commands: any[], extras?: any) {
     if (this.parentSubsidiaryViewService.getViewingSubAsParent() && (!commands[0].includes('subsidiary'))) {
       // If routing to the dashboard, override fragments
       if(commands[0].toLowerCase().includes('dashboard') && extras?.fragment) {
@@ -45,17 +52,15 @@ export class SubsidiaryRouterService extends Router {
   }
 
   navigateByUrl(url: UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean> {
+    const {commands, navigationExtras} = this.getCommands(url);
 
-    let urlArray = [];
-    for(let segment of url.root.children.primary.segments) {
-      urlArray.push(segment.path);
-    }
-    const navigationExtras = {
-      fragment: url.fragment
+    if (exitSubsidiaryViewPages.some(command => commands[0].includes(command))) {
+      this.parentSubsidiaryViewService.clearViewingSubAsParent();
+    } else {
+      const newRoute = this.getNewRoute(commands, navigationExtras);
+      url = super.createUrlTree(newRoute.commands, newRoute.extras);
     }
 
-    const newRoute = this.getNewRoute(urlArray, navigationExtras);
-    url = super.createUrlTree(newRoute.commands, newRoute.extras);
 
     return super.navigateByUrl(url, extras);
   }

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { NavigationBehaviorOptions, Router, UrlSegment, UrlSegmentGroup, UrlTree } from '@angular/router';
 import { ParentSubsidiaryViewService } from './parent-subsidiary-view.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { URLStructure } from '@core/model/url.model';
@@ -13,8 +13,7 @@ export class SubsidiaryRouterService extends Router {
     super()
   }
 
-  navigate(commands: any[], extras?: any): Promise<boolean> {
-    console.log('SubsidiaryRouterService.navigate', commands, extras);
+  getNewRoute(commands: any[], extras?: any) {
     if (this.parentSubsidiaryViewService.getViewingSubAsParent() && (!commands[0].includes('subsidiary'))) {
       // If routing to the dashboard, override fragments
       if(commands[0].toLowerCase().includes('dashboard') && extras?.fragment) {
@@ -30,15 +29,21 @@ export class SubsidiaryRouterService extends Router {
       commands.unshift('subsidiary');
       console.log('SubsidiaryRouterService navigate modified: ', commands, extras);
     }
+    return { commands, extras };
+  }
 
-    // const returnURL: URLStructure = {
-    //   url: commands,
-    //   fragment: (extras && extras.fragment) ? extras.fragment : null,
-    //   queryParams: (extras && extras.queryParams) ? extras.queryParams : null,
-    // };
+  navigateByUrl(url: UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean> {
+    let urlArray = [];
+    for(let segment of url.root.children.primary.segments) {
+      urlArray.push(segment.path);
+    }
+    const navigationExtras = {
+      fragment: url.fragment
+    }
 
-    // console.log('SubsidiaryRouterService setReturnTo: ', returnURL);
-    // this.establishmentService.setReturnTo(returnURL);
-    return super.navigate(commands, extras);
+    const newRoute = this.getNewRoute(urlArray, navigationExtras);
+    url = super.createUrlTree(newRoute.commands, newRoute.extras);
+
+    return super.navigateByUrl(url, extras);
   }
 }


### PR DESCRIPTION
#### Work done
- Changed the subsidiary-router-service to override `router.navigateByUrl()` rather than `router.navigate()`, this should resolve the issues we're seeing when using the `[routerLink]` directive

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
