### PR TITLE
Set margins to be same above and below across components which use summary-section component

### DIFF
--- a/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
@@ -14,7 +14,7 @@
     [canViewEstablishment]="canViewEstablishment"
   ></app-summary-section>
 </div>
-<div class="govuk-width-container govuk-!-margin-top-4">
+<div class="govuk-width-container govuk-!-margin-top-7">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-grid-row">

--- a/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
@@ -22,7 +22,7 @@
   [showMissingCqcMessage]="showMissingCqcMessage"
   [workplacesCount]="workplacesCount"
 ></app-summary-section>
-<div class="govuk-width-container govuk-!-margin-top-4">
+<div class="govuk-width-container govuk-!-margin-top-7">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-!-padding-left-2 govuk-!-padding-right-2">
       <div class="govuk-grid-column-one-third asc-card">

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
@@ -15,7 +15,7 @@
     [isParentSubsidiaryView]="isParentSubsidiaryView"
   ></app-summary-section>
 </div>
-<div class="govuk-width-container govuk-!-margin-top-4">
+<div class="govuk-width-container govuk-!-margin-top-7">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-grid-row">

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.html
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-width-container govuk-!-margin-top-4 summary-box" data-testid="summaryBox">
+<div class="govuk-width-container govuk-!-margin-top-4 govuk-!-margin-bottom-4 summary-box" data-testid="summaryBox">
   <ng-container *ngFor="let section of sections; index as index">
     <div class="summary-section" [attr.data-testid]="section.fragment + '-row'">
       <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-3 govuk-body-l summary-section__links">


### PR DESCRIPTION
#### Work done
- Set margins to be same above and below across components which use summary-section component

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
