### PR TITLE
Show breadcrumb for about the data link 

### DIFF
--- a/frontend/src/app/core/breadcrumb/breadcrumb.model.ts
+++ b/frontend/src/app/core/breadcrumb/breadcrumb.model.ts
@@ -35,6 +35,7 @@ export enum JourneyType {
   LINK_TO_PARENT,
   CHANGE_DATA_OWNER,
   SUBSIDIARY,
+  OLD_BENCHMARKS_DATA_TAB,
 }
 
 export interface JourneyRoute {

--- a/frontend/src/app/core/breadcrumb/journey.subsidiary.ts
+++ b/frontend/src/app/core/breadcrumb/journey.subsidiary.ts
@@ -7,7 +7,6 @@ enum Path {
   TRAINING_AND_QUALIFICATIONS = '/subsidiary/training-and-qualifications/:establishmentuid',
   BENCHMARKS = '/subsidiary/benchmarks/:establishmentuid',
   WORKPLACE_USERS = '/subsidiary/workplace-users/:establishmentuid',
-  ABOUT_DATA = '/subsidiary/workplace/:establishmentuid/data-area/about-the-data',
 }
 
 export const subsidiaryJourney: JourneyRoute = {
@@ -41,11 +40,6 @@ export const subsidiaryJourney: JourneyRoute = {
       title: 'Workplace users',
       path: Path.WORKPLACE_USERS,
       fragment: 'workplace-users',
-    },
-    {
-      title: 'About the data',
-      path: Path.ABOUT_DATA,
-      fragment: 'benchmark',
     },
   ],
 };

--- a/frontend/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/frontend/src/app/core/breadcrumb/journey.workplaces.ts
@@ -13,6 +13,7 @@ enum Path {
   TRAINING_AND_QUALIFICATIONS_RECORD = '/workplace/:workplaceUid/training-and-qualifications-record/:workerUid/training',
   MANDATORY_TRAINING = '/workplace/:workplaceUid/add-and-manage-mandatory-training',
   ABOUT_DATA = '/workplace/:workplaceUid/data-area/about-the-data',
+  BECNHMARKS_ABOUT_DATA = '/workplace/:workplaceUid/benchmarks/about-the-data',
   OTHER_WORKPLACES = '/workplace/other-workplaces',
   CHANGE_DATA_OWNER = '/workplace/change-data-owner',
 }
@@ -94,6 +95,27 @@ export const brenchmarksTabJourney: JourneyRoute = {
     },
   ],
 };
+
+export const oldBrenchmarksDataJourney: JourneyRoute = {
+  children: [
+    {
+      title: 'Benchmarks',
+      path: Path.DASHBOARD,
+      fragment: 'benchmarks',
+      children: [
+        {
+          title: 'About the data',
+          path: Path.BECNHMARKS_ABOUT_DATA,
+          referrer: {
+            path: Path.DASHBOARD,
+            fragment: 'benchmarks',
+          },
+        },
+      ],
+    },
+  ],
+};
+
 
 export const myWorkplaceJourney: JourneyRoute = {
   children: [

--- a/frontend/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/frontend/src/app/core/breadcrumb/journey.workplaces.ts
@@ -13,7 +13,7 @@ enum Path {
   TRAINING_AND_QUALIFICATIONS_RECORD = '/workplace/:workplaceUid/training-and-qualifications-record/:workerUid/training',
   MANDATORY_TRAINING = '/workplace/:workplaceUid/add-and-manage-mandatory-training',
   ABOUT_DATA = '/workplace/:workplaceUid/data-area/about-the-data',
-  BECNHMARKS_ABOUT_DATA = '/workplace/:workplaceUid/benchmarks/about-the-data',
+  BENCHMARKS_ABOUT_DATA = '/workplace/:workplaceUid/benchmarks/about-the-data',
   OTHER_WORKPLACES = '/workplace/other-workplaces',
   CHANGE_DATA_OWNER = '/workplace/change-data-owner',
 }
@@ -76,7 +76,7 @@ export const trainingAndQualificationsTabJourney: JourneyRoute = {
   ],
 };
 
-export const brenchmarksTabJourney: JourneyRoute = {
+export const benchmarksTabJourney: JourneyRoute = {
   children: [
     {
       title: 'Benchmarks',
@@ -96,7 +96,7 @@ export const brenchmarksTabJourney: JourneyRoute = {
   ],
 };
 
-export const oldBrenchmarksDataJourney: JourneyRoute = {
+export const oldBenchmarksDataJourney: JourneyRoute = {
   children: [
     {
       title: 'Benchmarks',
@@ -105,7 +105,7 @@ export const oldBrenchmarksDataJourney: JourneyRoute = {
       children: [
         {
           title: 'About the data',
-          path: Path.BECNHMARKS_ABOUT_DATA,
+          path: Path.BENCHMARKS_ABOUT_DATA,
           referrer: {
             path: Path.DASHBOARD,
             fragment: 'benchmarks',

--- a/frontend/src/app/core/services/breadcrumb.service.ts
+++ b/frontend/src/app/core/services/breadcrumb.service.ts
@@ -40,11 +40,11 @@ import {
   allWorkplacesJourney,
   brenchmarksTabJourney,
   myWorkplaceJourney,
+  oldBrenchmarksDataJourney,
   staffRecordsTabJourney,
   trainingAndQualificationsTabJourney,
   workplaceTabJourney,
 } from '@core/breadcrumb/journey.workplaces';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { parse } from 'url';
@@ -298,6 +298,10 @@ export class BreadcrumbService {
       }
       case JourneyType.BENCHMARKS_TAB: {
         routes = brenchmarksTabJourney;
+        break;
+      }
+      case JourneyType.OLD_BENCHMARKS_DATA_TAB: {
+        routes = oldBrenchmarksDataJourney;
         break;
       }
 

--- a/frontend/src/app/core/services/breadcrumb.service.ts
+++ b/frontend/src/app/core/services/breadcrumb.service.ts
@@ -38,9 +38,9 @@ import { subsidiaryJourney } from '@core/breadcrumb/journey.subsidiary';
 import { wdfJourney, wdfParentJourney } from '@core/breadcrumb/journey.wdf';
 import {
   allWorkplacesJourney,
-  brenchmarksTabJourney,
+  benchmarksTabJourney,
   myWorkplaceJourney,
-  oldBrenchmarksDataJourney,
+  oldBenchmarksDataJourney,
   staffRecordsTabJourney,
   trainingAndQualificationsTabJourney,
   workplaceTabJourney,
@@ -297,11 +297,11 @@ export class BreadcrumbService {
         break;
       }
       case JourneyType.BENCHMARKS_TAB: {
-        routes = brenchmarksTabJourney;
+        routes = benchmarksTabJourney;
         break;
       }
       case JourneyType.OLD_BENCHMARKS_DATA_TAB: {
-        routes = oldBrenchmarksDataJourney;
+        routes = oldBenchmarksDataJourney;
         break;
       }
 

--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
@@ -1,5 +1,5 @@
 <app-new-dashboard-header
-  *ngIf="showBanner"
+  *ngIf="!isParentViewingSubsidiary"
   [tab]="'benchmarks'"
   [updatedDate]="tilesData?.meta.lastUpdated"
   data-html2canvas-ignore

--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
@@ -3,7 +3,7 @@
   [tab]="'benchmarks'"
   [updatedDate]="tilesData?.meta.lastUpdated"
   data-html2canvas-ignore
-  data-testid="isParentViewingSubsidiaryTestId"
+  data-testid="dashboardHeader"
 ></app-new-dashboard-header>
 
 <div class="govuk-width-container govuk-!-margin-top-7">

--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
@@ -3,7 +3,7 @@
   [tab]="'benchmarks'"
   [updatedDate]="tilesData?.meta.lastUpdated"
   data-html2canvas-ignore
-  data-testid="showBannerTestId"
+  data-testid="isParentViewingSubsidiaryTestId"
 ></app-new-dashboard-header>
 
 <div class="govuk-width-container govuk-!-margin-top-7">

--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
@@ -122,4 +122,9 @@ describe('NewBenchmarksTabComponent', () => {
     const {queryByTestId } = await setup(true, 0, true);
     expect(queryByTestId("isParentViewingSubsidiaryTestId")).toBeFalsy();
   });
+
+  it('should render the banner when in parent view of benchmark tab', async () => {
+    const {queryByTestId } = await setup(true, 0, false);
+    expect(queryByTestId("isParentViewingSubsidiaryTestId")).toBeTruthy();
+  });
 });

--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
@@ -39,7 +39,7 @@ const MockWindow = {
 };
 
 describe('NewBenchmarksTabComponent', () => {
-  const setup = async (isAdmin = true, subsidiaries = 0, showBanner = true) => {
+  const setup = async (isAdmin = true, subsidiaries = 0, isParentViewingSubsidiary = false) => {
     const establishment = establishmentBuilder() as Establishment;
     const role = isAdmin ? Roles.Admin : Roles.Edit;
     const { fixture, getByText, queryByTestId } = await render(NewBenchmarksTabComponent, {
@@ -86,7 +86,7 @@ describe('NewBenchmarksTabComponent', () => {
       schemas: [NO_ERRORS_SCHEMA],
       componentProperties: {
         workplace: establishment,
-        showBanner: showBanner,
+        isParentViewingSubsidiary: isParentViewingSubsidiary,
       },
     });
 
@@ -119,7 +119,7 @@ describe('NewBenchmarksTabComponent', () => {
   });
 
   it('should not render the banner when in subsidiary view of benchmark tab', async () => {
-    const {queryByTestId } = await setup(true, 0, false);
-    expect(queryByTestId("showBannerTestId")).toBeFalsy();
+    const {queryByTestId } = await setup(true, 0, true);
+    expect(queryByTestId("isParentViewingSubsidiaryTestId")).toBeFalsy();
   });
 });

--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
@@ -120,11 +120,11 @@ describe('NewBenchmarksTabComponent', () => {
 
   it('should not render the banner when in subsidiary view of benchmark tab', async () => {
     const {queryByTestId } = await setup(true, 0, true);
-    expect(queryByTestId("isParentViewingSubsidiaryTestId")).toBeFalsy();
+    expect(queryByTestId("dashboardHeader")).toBeFalsy();
   });
 
   it('should render the banner when in parent view of benchmark tab', async () => {
     const {queryByTestId } = await setup(true, 0, false);
-    expect(queryByTestId("isParentViewingSubsidiaryTestId")).toBeTruthy();
+    expect(queryByTestId("dashboardHeader")).toBeTruthy();
   });
 });

--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.ts
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.ts
@@ -18,7 +18,7 @@ import { Subscription } from 'rxjs';
 export class NewBenchmarksTabComponent implements OnInit, OnDestroy {
   @Input() workplace: Establishment;
   @ViewChild('aboutData') private aboutData: BenchmarksAboutTheDataComponent;
-  @Input() showBanner = true
+  @Input() isParentViewingSubsidiary = false
   private subscriptions: Subscription = new Subscription();
   public canViewFullBenchmarks: boolean;
   public payContent = MetricsContent.Pay;
@@ -42,7 +42,10 @@ export class NewBenchmarksTabComponent implements OnInit, OnDestroy {
     this.tilesData = this.featureFlagService.newBenchmarksDataArea
       ? this.benchmarksService.benchmarksData.oldBenchmarks
       : this.benchmarksService.benchmarksData;
-    this.breadcrumbService.show(JourneyType.BENCHMARKS_TAB);
+
+    if(!this.isParentViewingSubsidiary){
+      this.breadcrumbService.show(JourneyType.OLD_BENCHMARKS_DATA_TAB);
+    }
   }
 
   public async downloadAsPDF() {

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.html
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.html
@@ -7,7 +7,7 @@
       class="asc-benchmarks-tab"
       [workplace]="workplace"
       data-testid="old-benchmarks-tab"
-      [showBanner]="false"
+      [isParentViewingSubsidiary]="true"
     ></app-new-benchmarks-tab>
   </ng-template>
 </ng-container>

--- a/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
@@ -128,6 +128,15 @@ const routes: Routes = [
     },
     children: [
       {
+        path: 'benchmarks',
+        loadChildren: () =>
+          import('@shared/components/benchmarks-tab/benchmarks.module').then((m) => m.BenchmarksModule),
+
+        data: {
+          title: 'Benchmarks',
+        },
+      },
+      {
         path: 'data-area',
         loadChildren: () =>
           import('@shared/components/data-area-tab/data-area-tab.module').then((m) => m.DataAreaTabModule),

--- a/frontend/src/app/shared/components/benchmarks-tab/about-the-data/about-the-data.component.spec.ts
+++ b/frontend/src/app/shared/components/benchmarks-tab/about-the-data/about-the-data.component.spec.ts
@@ -4,15 +4,17 @@ import { BrowserModule, By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
+import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { MockBenchmarksService } from '@core/test-utils/MockBenchmarkService';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { BenchmarksAboutTheDataComponent } from '@shared/components/benchmarks-tab/about-the-data/about-the-data.component';
 import { BenchmarksModule } from '@shared/components/benchmarks-tab/benchmarks.module';
 import { within } from '@testing-library/angular';
 
 import { Establishment as MockEstablishment } from '../../../../../mockdata/establishment';
-import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 
 describe('BenchmarksAboutTheDataComponent', () => {
   let component: BenchmarksAboutTheDataComponent;
@@ -26,6 +28,10 @@ describe('BenchmarksAboutTheDataComponent', () => {
         {
           provide: BenchmarksServiceBase,
           useClass: MockBenchmarksService,
+        },
+        {
+          provide: BreadcrumbService,
+          useClass: MockBreadcrumbService,
         },
         {
           provide: ActivatedRoute,

--- a/frontend/src/app/shared/components/benchmarks-tab/about-the-data/about-the-data.component.ts
+++ b/frontend/src/app/shared/components/benchmarks-tab/about-the-data/about-the-data.component.ts
@@ -1,9 +1,11 @@
 import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Meta } from '@core/model/benchmarks.model';
 import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';
 import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { Subscription } from 'rxjs';
 
@@ -25,6 +27,7 @@ export class BenchmarksAboutTheDataComponent implements OnInit, OnDestroy {
     protected router: Router,
     protected route: ActivatedRoute,
     protected benchmarksService: BenchmarksServiceBase,
+    private breadcrumbService: BreadcrumbService,
     private permissionsService: PermissionsService,
   ) {}
 
@@ -38,6 +41,8 @@ export class BenchmarksAboutTheDataComponent implements OnInit, OnDestroy {
     if (canViewBenchmarks) {
       this.meta = this.benchmarksService.benchmarksData.meta;
     }
+
+    this.breadcrumbService.show(JourneyType.OLD_BENCHMARKS_DATA_TAB);
   }
 
   public pluralizeWorkplaces(workplaces) {

--- a/frontend/src/app/shared/components/benchmarks-tab/benchmarks-tab.component.spec.ts
+++ b/frontend/src/app/shared/components/benchmarks-tab/benchmarks-tab.component.spec.ts
@@ -1,16 +1,18 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { MockBenchmarksService } from '@core/test-utils/MockBenchmarkService';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { FormatUtil } from '@core/utils/format-util';
 import { BenchmarksTabComponent } from '@shared/components/benchmarks-tab/benchmarks-tab.component';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 import { Establishment } from '../../../../mockdata/establishment';
-import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
-import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 
 describe('BenchmarksTabComponent', () => {
   let component: BenchmarksTabComponent;
@@ -25,6 +27,10 @@ describe('BenchmarksTabComponent', () => {
           {
             provide: BenchmarksServiceBase,
             useClass: MockBenchmarksService,
+          },
+          {
+            provide: BreadcrumbService,
+            useClass: MockBreadcrumbService,
           },
           {
             provide: FeatureFlagsService,


### PR DESCRIPTION
#### Work done
- Added benchmark module to the subsidiary routing module
- Added breadcrumb journey for old benchmark about the data 
- Removed `about the data` journey from subsidiary journey

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
