### PR TITLE
Remove first-login-wizard from exitSubsidiaryViewPages

### DIFF
--- a/frontend/src/app/core/breadcrumb/journey.public.ts
+++ b/frontend/src/app/core/breadcrumb/journey.public.ts
@@ -10,6 +10,7 @@ enum Path {
   CONTACT_US_OR_LEAVE_FEEDBACK = '/contact-us-or-leave-feedback',
   THANK_YOU = '/thank-you',
   CERTIFICATES = '/asc-wds-certificate',
+  FIRST_LOGIN_WIZARD = '/first-login-wizard'
 }
 
 export const publicJourney: JourneyRoute = {
@@ -17,6 +18,10 @@ export const publicJourney: JourneyRoute = {
     {
       title: 'Get your ASC-WDS certificate',
       path: Path.CERTIFICATES,
+    },
+    {
+      title: 'Help to get you started',
+      path: Path.FIRST_LOGIN_WIZARD,
     },
     {
       title: 'Cookie policy',

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
@@ -33,6 +33,7 @@
     <main
       id="main-content"
       class="govuk-main-wrapper app-main-class govuk-util__no-focus govuk-!-padding-top-0"
+      [ngClass]="{ 'govuk-!-padding-top-0': canShowBanner }"
       #content
       role="main"
       tabindex="-1"

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
@@ -32,7 +32,7 @@
 
     <main
       id="main-content"
-      class="govuk-main-wrapper app-main-class govuk-util__no-focus govuk-!-padding-top-0"
+      class="govuk-main-wrapper app-main-class govuk-util__no-focus"
       [ngClass]="{ 'govuk-!-padding-top-0': canShowBanner }"
       #content
       role="main"

--- a/frontend/src/app/features/first-login-wizard/first-login-wizard.component.spec.ts
+++ b/frontend/src/app/features/first-login-wizard/first-login-wizard.component.spec.ts
@@ -1,8 +1,10 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { WizardService } from '@core/services/wizard.service';
 import { MockActivatedRoute } from '@core/test-utils/MockActivatedRoute';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockWizardService } from '@core/test-utils/MockWizardService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
@@ -26,6 +28,10 @@ describe('FirstLoginWizardComponent', () => {
               },
             },
           }),
+        },
+        {
+          provide: BreadcrumbService,
+          useClass: MockBreadcrumbService,
         },
       ],
     });

--- a/frontend/src/app/features/first-login-wizard/first-login-wizard.component.ts
+++ b/frontend/src/app/features/first-login-wizard/first-login-wizard.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Wizard } from '@core/model/wizard.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { environment } from 'src/environments/environment';
 
 @Component({
@@ -16,9 +18,10 @@ export class FirstLoginWizardComponent {
   public imageUrl: string;
   public rawVideoUrl: string;
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(private route: ActivatedRoute, private breadcrumbService: BreadcrumbService,) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.show(JourneyType.PUBLIC);
     this.wizards = this.route.snapshot.data.wizard.data;
     this.imageUrl = `${environment.cmsUri}/assets/`;
     this.currentIndex = 0;

--- a/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
@@ -13,12 +13,20 @@ import { SubsidiaryResolver } from '@core/resolvers/subsidiary.resolver';
 import { UsefulLinkPayResolver } from '@core/resolvers/useful-link-pay.resolver';
 import { UsefulLinkRecruitmentResolver } from '@core/resolvers/useful-link-recruitment.resolver';
 import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
+import { WizardResolver } from '@core/resolvers/wizard/wizard.resolver';
 import { WorkersResolver } from '@core/resolvers/workers.resolver';
 import { AscWdsCertificateComponent } from '@features/dashboard/asc-wds-certificate/asc-wds-certificate.component';
-import { AcceptPreviousCareCertificateComponent } from '@features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component';
-import { BenefitsStatutorySickPayComponent } from '@features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component';
+import { FirstLoginPageComponent } from '@features/first-login-page/first-login-page.component';
+import {
+  AcceptPreviousCareCertificateComponent,
+} from '@features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component';
+import {
+  BenefitsStatutorySickPayComponent,
+} from '@features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component';
 import { CheckAnswersComponent } from '@features/workplace/check-answers/check-answers.component';
-import { ConfirmStaffRecruitmentAndBenefitsComponent } from '@features/workplace/confirm-staff-recruitment/confirm-staff-recruitment-and-benefits.component';
+import {
+  ConfirmStaffRecruitmentAndBenefitsComponent,
+} from '@features/workplace/confirm-staff-recruitment/confirm-staff-recruitment-and-benefits.component';
 import { CreateUserAccountComponent } from '@features/workplace/create-user-account/create-user-account.component';
 import { DataSharingComponent } from '@features/workplace/data-sharing/data-sharing.component';
 import { DeleteUserAccountComponent } from '@features/workplace/delete-user-account/delete-user-account.component';
@@ -27,26 +35,42 @@ import { LeaversComponent } from '@features/workplace/leavers/leavers.component'
 import { NumberOfInterviewsComponent } from '@features/workplace/number-of-interviews/number-of-interviews.component';
 import { OtherServicesComponent } from '@features/workplace/other-services/other-services.component';
 import { PensionsComponent } from '@features/workplace/pensions/pensions.component';
-import { RecruitmentAdvertisingCostComponent } from '@features/workplace/recruitment-advertising-cost/recruitment-advertising-cost.component';
+import {
+  RecruitmentAdvertisingCostComponent,
+} from '@features/workplace/recruitment-advertising-cost/recruitment-advertising-cost.component';
 import { RegulatedByCqcComponent } from '@features/workplace/regulated-by-cqc/regulated-by-cqc.component';
-import { SelectMainServiceCqcConfirmComponent } from '@features/workplace/select-main-service/select-main-service-cqc-confirm.component';
+import {
+  SelectMainServiceCqcConfirmComponent,
+} from '@features/workplace/select-main-service/select-main-service-cqc-confirm.component';
 import { SelectMainServiceCqcComponent } from '@features/workplace/select-main-service/select-main-service-cqc.component';
 import { SelectMainServiceComponent } from '@features/workplace/select-main-service/select-main-service.component';
-import { SelectPrimaryUserDeleteComponent } from '@features/workplace/select-primary-user-delete/select-primary-user-delete.component';
+import {
+  SelectPrimaryUserDeleteComponent,
+} from '@features/workplace/select-primary-user-delete/select-primary-user-delete.component';
 import { SelectPrimaryUserComponent } from '@features/workplace/select-primary-user/select-primary-user.component';
 import { SelectWorkplaceComponent } from '@features/workplace/select-workplace/select-workplace.component';
 import { ServiceUsersComponent } from '@features/workplace/service-users/service-users.component';
 import { ServicesCapacityComponent } from '@features/workplace/services-capacity/services-capacity.component';
-import { StaffBenefitCashLoyaltyComponent } from '@features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component';
-import { StaffBenefitHolidayLeaveComponent } from '@features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component';
-import { StaffRecruitmentCaptureTrainingRequirementComponent } from '@features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component';
+import {
+  StaffBenefitCashLoyaltyComponent,
+} from '@features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component';
+import {
+  StaffBenefitHolidayLeaveComponent,
+} from '@features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component';
+import {
+  StaffRecruitmentCaptureTrainingRequirementComponent,
+} from '@features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component';
 import { StaffRecruitmentStartComponent } from '@features/workplace/staff-recruitment/staff-recruitment-start.component';
 import { StartComponent } from '@features/workplace/start/start.component';
 import { StartersComponent } from '@features/workplace/starters/starters.component';
 import { TotalStaffQuestionComponent } from '@features/workplace/total-staff-question/total-staff-question.component';
 import { TypeOfEmployerComponent } from '@features/workplace/type-of-employer/type-of-employer.component';
-import { UserAccountEditDetailsComponent } from '@features/workplace/user-account-edit-details/user-account-edit-details.component';
-import { UserAccountEditPermissionsComponent } from '@features/workplace/user-account-edit-permissions/user-account-edit-permissions.component';
+import {
+  UserAccountEditDetailsComponent,
+} from '@features/workplace/user-account-edit-details/user-account-edit-details.component';
+import {
+  UserAccountEditPermissionsComponent,
+} from '@features/workplace/user-account-edit-permissions/user-account-edit-permissions.component';
 import { UserAccountSavedComponent } from '@features/workplace/user-account-saved/user-account-saved.component';
 import { UserAccountViewComponent } from '@features/workplace/user-account-view/user-account-view.component';
 import { UsersComponent } from '@features/workplace/users/users.component';
@@ -57,7 +81,9 @@ import { WorkplaceNotFoundComponent } from '@features/workplace/workplace-not-fo
 import { ViewSubsidiaryBenchmarksComponent } from './benchmarks/view-subsidiary-benchmarks.component';
 import { ViewSubsidiaryHomeComponent } from './home/view-subsidiary-home.component';
 import { ViewSubsidiaryStaffRecordsComponent } from './staff-records/view-subsidiary-staff-records.component';
-import { ViewSubsidiaryTrainingAndQualificationsComponent } from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
+import {
+  ViewSubsidiaryTrainingAndQualificationsComponent,
+} from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
 import { ViewSubsidiaryWorkplaceUsersComponent } from './workplace-users/view-subsidiary-workplace-users.component';
 import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
 
@@ -86,6 +112,14 @@ const routes: Routes = [
     path: 'asc-wds-certificate',
     component: AscWdsCertificateComponent,
     data: { title: 'Certificate' },
+  },
+  {
+    path: 'first-login-wizard',
+    component: FirstLoginPageComponent,
+    resolve: {
+      wizard: WizardResolver,
+    },
+    data: { title: 'First Login Wizard' },
   },
   {
     path: 'benefits-bundle',

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -9,7 +9,6 @@ const exitSubsidiaryViewPages = [
   'notifications',
   'satisfaction-survey',
   'sfcadmin',
-  'first-login-wizard',
 ];
 
 @Injectable()
@@ -55,7 +54,7 @@ export class SubsidiaryRouterService extends Router {
   navigateByUrl(url: UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean> {
     const { commands, navigationExtras } = this.getCommands(url);
 
-    if (exitSubsidiaryViewPages.some((command) => commands[0].includes(command))) {
+    if (exitSubsidiaryViewPages.includes(commands[0])) {
       this.parentSubsidiaryViewService.clearViewingSubAsParent();
     } else {
       const newRoute = this.getNewRoute(commands, navigationExtras);


### PR DESCRIPTION
#### Work done
- Removed first-login-wizard from exitSubsidiaryViewPages
- Fixed if statement check to return false when checking if first-login-wizard exists in the array
- Removed padding for pages with banner which adds padding spacing between breadcrumbs and content on other links pages
- Added breadcrumb for first login wizard - help you get started page

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
