### PR TITLE
notification service now returns correctly updated isViewed value

### DIFF
--- a/backend/server/routes/notification/index.js
+++ b/backend/server/routes/notification/index.js
@@ -185,7 +185,7 @@ const setNotificationRead = async (req, res) => {
     } else {
       await notifications.markUserNotificationAsRead(params);
     }
-    notificationData.isViewed = true;
+    notificationData.notification.isViewed = true;
 
     await addTypeContent(notificationData);
 


### PR DESCRIPTION
#### Work done
- notifications service was previously setting isViewed incorrectly on the returned notification data.
- I looked into adding some tests for the notification service, however this would likely also involve substantially rewriting the data access layer to use models rather than the raw sql that the notifications service currently uses. This would unfortunately go beyond the scope of a fix and introduce more risk into an already large feature.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [x] No, I found it difficult to test
- [ ] No, they are not required for this change
