### PR TITLE
resolved issue with downloading pdf on old benchmarks

### DIFF
--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
@@ -45,53 +45,12 @@
       [workplaceID]="workplace.uid"
     >
     </app-benchmark-tile>
-  </div>
-    <!-- <div class="govuk-grid-row" data-cy="benchmarks-tiles">
-      <app-benchmark-tile
-      [canViewFullContent]="canViewFullBenchmarks"
-      [content]="payContent"
-      [tile]="payTile"
-      [workplaceID]="workplace.uid"
-    >
-    </app-benchmark-tile>
-      <app-benchmark-tile
-        [canViewFullContent]="canViewFullBenchmarks"
-        [content]="payContent"
-        [tile]="tilesData?.pay"
-        [workplaceID]="workplace.uid"
-      >
-
-      </app-benchmark-tile>
-      [tile]="tilesData?.careWorkerPay"
-      <app-benchmark-tile
-        [canViewFullContent]="canViewFullBenchmarks"
-        [content]="turnoverContent"
-        [tile]="tilesData?.turnover"
-        [workplaceID]="workplace.uid"
-      >
-      [tile]="tilesData?.turnoverRate"
-      </app-benchmark-tile>
-      <app-benchmark-tile
-        [canViewFullContent]="canViewFullBenchmarks"
-        [content]="sicknessContent"
-        [tile]="tilesData?.sickness"
-        [workplaceID]="workplace.uid"
-      >
-      </app-benchmark-tile>
-      <app-benchmark-tile
-        [canViewFullContent]="canViewFullBenchmarks"
-        [content]="qualificationsContent"
-        [tile]="tilesData?.qualifications"
-        [workplaceID]="workplace.uid"
-      >
-      </app-benchmark-tile>
-    </div> -->
-    <!-- <app-benchmarks-about-the-data
+    <app-benchmarks-about-the-data
       #aboutData
       class="govuk-visually-hidden"
       [workplace]="workplace"
-    ></app-benchmarks-about-the-data> -->
-  <!-- </div> -->
+    ></app-benchmarks-about-the-data>
+  </div>
 </div>
 
 

--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.spec.ts
@@ -107,7 +107,7 @@ describe('NewBenchmarksTabComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  xit('should download the page as a pdf when the the download as pdf link is clicked', async () => {
+  it('should download the page as a pdf when the the download as pdf link is clicked', async () => {
     const { component, getByText, pdfService } = await setup();
 
     const downloadFunctionSpy = spyOn(component, 'downloadAsPDF').and.callThrough();


### PR DESCRIPTION
#### Work done
- uncommented a usage of the about the data component used on the old benchmarks tab, this was commented out during the initial benchmarks rollback and should've been reintroduced with the benchmarks 2.0 deployment.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
