### PR TITLE
Fix/navigation after deleting workplace

### DIFF
--- a/frontend/src/app/core/test-utils/MockParentSubsidiaryViewService.ts
+++ b/frontend/src/app/core/test-utils/MockParentSubsidiaryViewService.ts
@@ -1,9 +1,20 @@
 import { Injectable } from '@angular/core';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
+import { MockEstablishmentService } from './MockEstablishmentService';
+
 @Injectable()
 export class MockParentSubsidiaryViewService extends ParentSubsidiaryViewService {
+  private mockViewingSubAsParent: boolean = false;
+  public static factory(viewingSubAsParent = false) {
+    return (establishmentService: MockEstablishmentService) => {
+      const service = new MockParentSubsidiaryViewService(establishmentService);
+      service.mockViewingSubAsParent = viewingSubAsParent;
+      return service;
+    };
+  }
+
   public getViewingSubAsParent() {
-    return false;
+    return this.mockViewingSubAsParent;
   }
 }

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
@@ -41,6 +41,7 @@ describe('NewDashboardHeaderComponent', () => {
     isAdmin = true,
     subsidiaries = 0,
     viewingSubAsParent = false,
+    canDeleteEstablishment = true,
   ) => {
     const role = isAdmin ? Roles.Admin : Roles.Edit;
     const updatedDate = updateDate ? '01/02/2023' : null;
@@ -57,7 +58,7 @@ describe('NewDashboardHeaderComponent', () => {
         },
         {
           provide: PermissionsService,
-          useFactory: MockPermissionsService.factory(['canDeleteEstablishment'], isAdmin),
+          useFactory: MockPermissionsService.factory(canDeleteEstablishment ? ['canDeleteEstablishment'] : [], isAdmin),
           deps: [HttpClient, Router, UserService],
         },
         {
@@ -374,13 +375,13 @@ describe('NewDashboardHeaderComponent', () => {
     });
 
     it('should not display a Delete Workplace link if the workplace has subsidiaries', async () => {
-      const { component, queryByText } = await setup('home', false, true, false, true, false);
+      const { queryByText } = await setup('home', false, true, false, true, false, 2);
 
       expect(queryByText('Delete Workplace')).toBeNull();
     });
 
-    it('should not display a Delete Workplace link if user not an admin', async () => {
-      const { component, queryByText } = await setup('home', false, true, false, true, false);
+    it('should not display a Delete Workplace link if user not an admin and does not have canDeleteEstablishment permission', async () => {
+      const { component, queryByText } = await setup('home', false, true, false, true, false, 0, true, false);
 
       expect(queryByText('Delete Workplace')).toBeNull();
     });
@@ -414,7 +415,8 @@ describe('NewDashboardHeaderComponent', () => {
 
     it('should redirect a parent user to view-all-workplaces after deleting a workplace', async () => {
       const { establishmentService, router, getByText } = await setup('home', false, true, false, true, false, 0, true);
-      spyOn(establishmentService, 'deleteWorkplace').and.returnValue(of({}));
+      spyOn(establishmentService, 'deleteWorkplace').and.callFake(() => of({}));
+      spyOn(establishmentService, 'getEstablishment').and.callFake(() => of({}));
       const spy = spyOn(router, 'navigate');
       spy.and.returnValue(Promise.resolve(true));
 
@@ -430,7 +432,8 @@ describe('NewDashboardHeaderComponent', () => {
 
     it('should redirect an admin user deleting a sub from parent view to view-all-workplaces of parent', async () => {
       const { establishmentService, router, getByText } = await setup('home', false, true, false, true, true, 0, true);
-      spyOn(establishmentService, 'deleteWorkplace').and.returnValue(of({}));
+      spyOn(establishmentService, 'deleteWorkplace').and.callFake(() => of({}));
+      spyOn(establishmentService, 'getEstablishment').and.callFake(() => of({}));
       const spy = spyOn(router, 'navigate');
       spy.and.returnValue(Promise.resolve(true));
 

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
@@ -140,19 +140,17 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
       this.establishmentService.deleteWorkplace(this.workplace.uid).subscribe(
         () => {
           if (this.isParentSubsidiaryView) {
-            this.parentSubsidiaryViewService.clearViewingSubAsParent();
-            this.router.navigate(['workplace', 'view-all-workplaces']).then(() => {
-              this.alertService.addAlert({
-                type: 'success',
-                message: `${this.workplace.name} has been permanently deleted.`,
+            this.establishmentService.getEstablishment(this.workplace.parentUid).subscribe((workplace) => {
+              this.establishmentService.setPrimaryWorkplace(workplace);
+              this.parentSubsidiaryViewService.clearViewingSubAsParent();
+
+              this.router.navigate(['workplace', 'view-all-workplaces']).then(() => {
+                this.displaySuccessfullyDeletedAlert();
               });
             });
           } else {
             this.router.navigate(['sfcadmin', 'search', 'workplace']).then(() => {
-              this.alertService.addAlert({
-                type: 'success',
-                message: `${this.workplace.name} has been permanently deleted.`,
-              });
+              this.displaySuccessfullyDeletedAlert();
             });
           }
         },
@@ -164,6 +162,13 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
         },
       ),
     );
+  }
+
+  private displaySuccessfullyDeletedAlert(): void {
+    this.alertService.addAlert({
+      type: 'success',
+      message: `${this.workplace.name} has been permanently deleted.`,
+    });
   }
 
   private getPermissions(): void {


### PR DESCRIPTION
#### Work done
- Updated dashboard header to navigate back to view-all-workplaces when parent has deleted a sub or sub deleted by admin from parent view
- Updated navigation to admin workplace search page when stand alone or sub viewed directly deleted

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
