### PR TITLE
Add resolvers to subsidiary module to resolve null injector errors on…

### DIFF
--- a/frontend/src/app/features/subsidiary/subsidiary.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary.module.ts
@@ -2,22 +2,28 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { BenchmarksResolver } from '@core/resolvers/benchmarks.resolver';
+import { ExpiresSoonAlertDatesResolver } from '@core/resolvers/expiresSoonAlertDates.resolver';
+import { GetMissingCqcLocationsResolver } from '@core/resolvers/getMissingCqcLocations/getMissingCqcLocations.resolver';
+import { JobsResolver } from '@core/resolvers/jobs.resolver';
+import { RankingsResolver } from '@core/resolvers/rankings.resolver';
 import { SubsidiaryResolver } from '@core/resolvers/subsidiary.resolver';
+import { UsefulLinkPayResolver } from '@core/resolvers/useful-link-pay.resolver';
+import { UsefulLinkRecruitmentResolver } from '@core/resolvers/useful-link-recruitment.resolver';
+import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
+import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
+import { DialogService } from '@core/services/dialog.service';
 import { BenchmarksModule } from '@shared/components/benchmarks-tab/benchmarks.module';
 import { DataAreaTabModule } from '@shared/components/data-area-tab/data-area-tab.module';
 import { SharedModule } from '@shared/shared.module';
-import { SubsidiaryRoutingModule } from './subsidiary-routing.module';
 
 import { ViewSubsidiaryBenchmarksComponent } from './benchmarks/view-subsidiary-benchmarks.component';
 import { ViewSubsidiaryHomeComponent } from './home/view-subsidiary-home.component';
-import {
-  ViewSubsidiaryTrainingAndQualificationsComponent,
-} from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
-import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
 import { ViewSubsidiaryStaffRecordsComponent } from './staff-records/view-subsidiary-staff-records.component';
+import { SubsidiaryRoutingModule } from './subsidiary-routing.module';
+import { ViewSubsidiaryTrainingAndQualificationsComponent } from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
 import { ViewSubsidiaryWorkplaceUsersComponent } from './workplace-users/view-subsidiary-workplace-users.component';
-import { ExpiresSoonAlertDatesResolver } from '@core/resolvers/expiresSoonAlertDates.resolver';
-import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
+import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
 
 @NgModule({
   imports: [
@@ -36,12 +42,20 @@ import { UserAccountResolver } from '@core/resolvers/user-account.resolver';
     ViewSubsidiaryStaffRecordsComponent,
     ViewSubsidiaryTrainingAndQualificationsComponent,
     ViewSubsidiaryBenchmarksComponent,
-    ViewSubsidiaryWorkplaceUsersComponent
+    ViewSubsidiaryWorkplaceUsersComponent,
   ],
   providers: [
-    ExpiresSoonAlertDatesResolver,
+    DialogService,
+    WorkplaceResolver,
     SubsidiaryResolver,
     UserAccountResolver,
+    ExpiresSoonAlertDatesResolver,
+    JobsResolver,
+    BenchmarksResolver,
+    RankingsResolver,
+    UsefulLinkPayResolver,
+    UsefulLinkRecruitmentResolver,
+    GetMissingCqcLocationsResolver,
   ],
 })
 export class SubsidiaryModule {}


### PR DESCRIPTION
#### Work done
- Several pages (starters, leavers, vacancies) were throwing a NullInjector error when trying to navigate to them, preventing the pages from loading. This was due to the resolvers not being provided in the subsidiary module. This PR adds the resolvers to the subsidiary module so that they can be accessed by the subsidiary routing. 

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
