### PR TITLE
Fix/set parent as workplace when navigating from sub

### DIFF
--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
@@ -1,6 +1,6 @@
 <div id="content">
   <div *ngIf="isParentSubsidiaryView">
-    <app-back-to-parent-link [parentWorkplaceName]="parentWorkplaceName"></app-back-to-parent-link>
+    <app-back-to-parent-link [parentWorkplace]="parentWorkplace"></app-back-to-parent-link>
   </div>
   <div class="asc-tabs-container">
     <div class="govuk-width-container">

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
-import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TabsService } from '@core/services/tabs.service';
@@ -29,6 +27,7 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
   public canViewBenchmarks: boolean;
   public tabs: { title: string; slug: string; active: boolean }[];
   public isParentSubsidiaryView: boolean;
+  public parentWorkplace: Establishment;
   public parentWorkplaceName: string;
   public subWorkplace: Establishment;
   public subId: string;
@@ -43,14 +42,12 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
     private permissionsService: PermissionsService,
     private tabsService: TabsService,
     private benchmarksService: BenchmarksServiceBase,
-    private breadcrumbService: BreadcrumbService,
     private parentSubsidiaryViewService: ParentSubsidiaryViewService,
-    private route: ActivatedRoute,
-    private router: Router,
   ) {}
 
   ngOnInit(): void {
     const { uid, id, name } = this.establishmentService.primaryWorkplace;
+    this.parentWorkplace = this.establishmentService.primaryWorkplace;
     this.workplaceUid = uid;
     this.workplaceId = id;
     this.getPermissions();

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
@@ -28,11 +28,9 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
   public tabs: { title: string; slug: string; active: boolean }[];
   public isParentSubsidiaryView: boolean;
   public parentWorkplace: Establishment;
-  public parentWorkplaceName: string;
   public subWorkplace: Establishment;
   public subId: string;
   public selectedTab: string;
-  public parentUid: string;
   public subsidiaryWorkplace: Establishment;
   public canEditWorker: boolean;
   public hasWorkers: boolean;
@@ -46,7 +44,7 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnInit(): void {
-    const { uid, id, name } = this.establishmentService.primaryWorkplace;
+    const { uid, id } = this.establishmentService.primaryWorkplace;
     this.parentWorkplace = this.establishmentService.primaryWorkplace;
     this.workplaceUid = uid;
     this.workplaceId = id;
@@ -57,8 +55,6 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
     this.subId = this.parentSubsidiaryViewService.getSubsidiaryUid();
 
     this.setWorkplace();
-
-    this.parentWorkplaceName = name;
 
     this.parentSubsidiaryViewService.canShowBannerObservable.subscribe((canShowBanner) => {
       this.canShowBanner = canShowBanner;
@@ -85,8 +81,6 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
       this.establishmentService.getEstablishment(this.subId, true).subscribe((workplace) => {
         this.subWorkplace = workplace;
         this.establishmentService.setState(workplace);
-        this.parentWorkplaceName = this.subWorkplace?.parentName;
-        this.parentUid = this.subWorkplace?.parentUid;
       }),
     );
     this.selectedTab = 'home';

--- a/frontend/src/app/shared/components/back-to-parent-link/back-to-parent-link.component.html
+++ b/frontend/src/app/shared/components/back-to-parent-link/back-to-parent-link.component.html
@@ -6,7 +6,7 @@
       id="backToParentLink"
       (click)="backToParentLinkClick($event)"
       class="govuk-!-font-size-19 govuk-!-font-weight-bold"
-      >Back to {{ parentWorkplaceName }}
+      >Back to {{ parentWorkplace?.name }}
     </a>
   </div>
 </div>

--- a/frontend/src/app/shared/components/back-to-parent-link/back-to-parent-link.component.spec.ts
+++ b/frontend/src/app/shared/components/back-to-parent-link/back-to-parent-link.component.spec.ts
@@ -1,0 +1,85 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { WindowRef } from '@core/services/window.ref';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
+import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render } from '@testing-library/angular';
+
+import { BackToParentComponent } from './back-to-parent-link.component';
+
+describe('BackToParentLinkComponent', () => {
+  const setup = async () => {
+    const establishment = establishmentBuilder() as Establishment;
+
+    const { fixture, getByText } = await render(BackToParentComponent, {
+      imports: [SharedModule, RouterTestingModule, HttpClientTestingModule],
+      providers: [WindowRef],
+      componentProperties: {
+        parentWorkplace: establishment,
+      },
+    });
+
+    const component = fixture.componentInstance;
+
+    const injector = getTestBed();
+
+    const router = injector.inject(Router) as Router;
+    const routerSpy = spyOn(router, 'navigate').and.callThrough();
+
+    const parentSubsidiaryViewService = injector.inject(ParentSubsidiaryViewService) as ParentSubsidiaryViewService;
+    const parentSubsidiaryViewServiceSpy = spyOn(
+      parentSubsidiaryViewService,
+      'clearViewingSubAsParent',
+    ).and.callThrough();
+
+    const establishmentService = injector.inject(EstablishmentService) as EstablishmentService;
+
+    return {
+      component,
+      fixture,
+      getByText,
+      routerSpy,
+      parentSubsidiaryViewServiceSpy,
+      establishmentService,
+    };
+  };
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should display Back to parent name', async () => {
+    const { component, getByText } = await setup();
+
+    const expectedMessage = `Back to ${component.parentWorkplace.name}`;
+    expect(getByText(expectedMessage)).toBeTruthy();
+  });
+
+  it('should clear viewing as sub on click of Back to parent name', async () => {
+    const { component, getByText, parentSubsidiaryViewServiceSpy } = await setup();
+
+    const backToParentLink = getByText(`Back to ${component.parentWorkplace.name}`);
+
+    fireEvent.click(backToParentLink);
+    expect(parentSubsidiaryViewServiceSpy).toHaveBeenCalled();
+  });
+
+  it('should set parent as workplace and primaryWorkplace in establishment service on click of Back to parent name', async () => {
+    const { component, getByText, establishmentService } = await setup();
+
+    const setWorkplaceSpy = spyOn(establishmentService, 'setWorkplace');
+    const setPrimaryWorkplaceSpy = spyOn(establishmentService, 'setPrimaryWorkplace');
+
+    const backToParentLink = getByText(`Back to ${component.parentWorkplace.name}`);
+
+    fireEvent.click(backToParentLink);
+    expect(setWorkplaceSpy).toHaveBeenCalledWith(component.parentWorkplace);
+    expect(setPrimaryWorkplaceSpy).toHaveBeenCalledWith(component.parentWorkplace);
+  });
+});

--- a/frontend/src/app/shared/components/back-to-parent-link/back-to-parent-link.component.ts
+++ b/frontend/src/app/shared/components/back-to-parent-link/back-to-parent-link.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { Establishment } from '@core/model/establishment.model';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
@@ -8,15 +10,21 @@ import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-
   styleUrls: ['./back-to-parent-link.component.scss'],
 })
 export class BackToParentComponent implements OnInit {
-  @Input() parentWorkplaceName: string;
+  @Input() parentWorkplace: Establishment;
 
-  constructor(private router: Router, private parentSubsidiaryViewService: ParentSubsidiaryViewService) {}
+  constructor(
+    private router: Router,
+    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
+    private establishmentService: EstablishmentService,
+  ) {}
 
   ngOnInit() {}
 
   public backToParentLinkClick(event: Event) {
     event.preventDefault();
     this.parentSubsidiaryViewService.clearViewingSubAsParent();
+    this.establishmentService.setWorkplace(this.parentWorkplace);
+    this.establishmentService.setPrimaryWorkplace(this.parentWorkplace);
     this.router.navigate(['/dashboard']);
   }
 }

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
@@ -4,6 +4,7 @@ import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
 import { Roles } from '@core/model/roles.enum';
 import { AuthService } from '@core/services/auth.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -12,7 +13,7 @@ import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { MockAuthService } from '@core/test-utils/MockAuthService';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
@@ -437,6 +438,26 @@ describe('NewDashboardHeaderComponent', () => {
       confirm.click();
 
       expect(routerSpy).toHaveBeenCalledWith(['workplace', 'view-all-workplaces']);
+    });
+
+    it('should set parent workplace as primaryWorkplace and workplace after parent deletes a sub workplace', async () => {
+      const { establishmentService, getByText } = await setup('home', false, true, false, true, false, 0, true);
+      const mockEstablishment = establishmentBuilder() as Establishment;
+      spyOn(establishmentService, 'deleteWorkplace').and.callFake(() => of({}));
+      spyOn(establishmentService, 'getEstablishment').and.callFake(() => of(mockEstablishment));
+
+      const setPrimaryWorkplaceSpy = spyOn(establishmentService, 'setPrimaryWorkplace').and.callFake(() => of({}));
+      const setWorkplaceSpy = spyOn(establishmentService, 'setWorkplace').and.callFake(() => of({}));
+
+      const deleteWorkplace = getByText('Delete Workplace');
+      deleteWorkplace.click();
+
+      const dialog = await within(document.body).findByRole('dialog');
+      const confirm = within(dialog).getByText('Delete workplace');
+      confirm.click();
+
+      expect(setPrimaryWorkplaceSpy).toHaveBeenCalledWith(mockEstablishment);
+      expect(setWorkplaceSpy).toHaveBeenCalledWith(mockEstablishment);
     });
 
     it('should redirect an admin user deleting a sub from parent view to view-all-workplaces of parent', async () => {

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
@@ -90,8 +90,11 @@ describe('NewDashboardHeaderComponent', () => {
     });
 
     const component = fixture.componentInstance;
+    const mockEstablishment = establishmentBuilder() as Establishment;
     const injector = getTestBed();
     const establishmentService = injector.inject(EstablishmentService) as EstablishmentService;
+    const deleteWorkplaceSpy = spyOn(establishmentService, 'deleteWorkplace').and.callFake(() => of({}));
+    spyOn(establishmentService, 'getEstablishment').and.callFake(() => of(mockEstablishment));
 
     const router = injector.inject(Router) as Router;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
@@ -106,6 +109,8 @@ describe('NewDashboardHeaderComponent', () => {
       router,
       fixture,
       routerSpy,
+      mockEstablishment,
+      deleteWorkplaceSpy,
     };
   };
 
@@ -402,9 +407,7 @@ describe('NewDashboardHeaderComponent', () => {
     });
 
     it('should send a DELETE request once the user confirms to Delete Workplace', async () => {
-      const { establishmentService, getByText } = await setup('home', false, true, false, true, true);
-
-      const deleteWorkplaceSpy = spyOn(establishmentService, 'deleteWorkplace').and.returnValue(of({}));
+      const { deleteWorkplaceSpy, getByText } = await setup('home', false, true, false, true, true);
 
       const deleteWorkplace = getByText('Delete Workplace');
       deleteWorkplace.click();
@@ -417,19 +420,7 @@ describe('NewDashboardHeaderComponent', () => {
     });
 
     it('should redirect a parent user to view-all-workplaces after deleting a workplace', async () => {
-      const { establishmentService, routerSpy, getByText } = await setup(
-        'home',
-        false,
-        true,
-        false,
-        true,
-        false,
-        0,
-        true,
-      );
-      spyOn(establishmentService, 'deleteWorkplace').and.callFake(() => of({}));
-      spyOn(establishmentService, 'getEstablishment').and.callFake(() => of({}));
-
+      const { routerSpy, getByText } = await setup('home', false, true, false, true, false, 0, true);
       const deleteWorkplace = getByText('Delete Workplace');
       deleteWorkplace.click();
 
@@ -441,10 +432,16 @@ describe('NewDashboardHeaderComponent', () => {
     });
 
     it('should set parent workplace as primaryWorkplace and workplace after parent deletes a sub workplace', async () => {
-      const { establishmentService, getByText } = await setup('home', false, true, false, true, false, 0, true);
-      const mockEstablishment = establishmentBuilder() as Establishment;
-      spyOn(establishmentService, 'deleteWorkplace').and.callFake(() => of({}));
-      spyOn(establishmentService, 'getEstablishment').and.callFake(() => of(mockEstablishment));
+      const { establishmentService, getByText, mockEstablishment } = await setup(
+        'home',
+        false,
+        true,
+        false,
+        true,
+        false,
+        0,
+        true,
+      );
 
       const setPrimaryWorkplaceSpy = spyOn(establishmentService, 'setPrimaryWorkplace').and.callFake(() => of({}));
       const setWorkplaceSpy = spyOn(establishmentService, 'setWorkplace').and.callFake(() => of({}));
@@ -461,18 +458,7 @@ describe('NewDashboardHeaderComponent', () => {
     });
 
     it('should redirect an admin user deleting a sub from parent view to view-all-workplaces of parent', async () => {
-      const { establishmentService, routerSpy, getByText } = await setup(
-        'home',
-        false,
-        true,
-        false,
-        true,
-        true,
-        0,
-        true,
-      );
-      spyOn(establishmentService, 'deleteWorkplace').and.callFake(() => of({}));
-      spyOn(establishmentService, 'getEstablishment').and.callFake(() => of({}));
+      const { routerSpy, getByText } = await setup('home', false, true, false, true, true, 0, true);
 
       const deleteWorkplace = getByText('Delete Workplace');
       deleteWorkplace.click();
@@ -485,9 +471,7 @@ describe('NewDashboardHeaderComponent', () => {
     });
 
     it('should redirect an admin user deleting a standalone to workplace search page after deleting a workplace', async () => {
-      const { establishmentService, getByText, routerSpy } = await setup('home', false, true, false, true, true);
-
-      spyOn(establishmentService, 'deleteWorkplace').and.returnValue(of({}));
+      const { getByText, routerSpy } = await setup('home', false, true, false, true, true);
 
       const deleteWorkplace = getByText('Delete Workplace');
       deleteWorkplace.click();

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
@@ -1,9 +1,8 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { AlertService } from '@core/services/alert.service';
-import { AuthService } from '@core/services/auth.service';
 import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -48,9 +47,7 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
     private establishmentService: EstablishmentService,
     private dialogService: DialogService,
     private permissionsService: PermissionsService,
-    private authService: AuthService,
     private router: Router,
-    private route: ActivatedRoute,
     private alertService: AlertService,
     private userService: UserService,
     private parentSubsidiaryViewService: ParentSubsidiaryViewService,
@@ -142,6 +139,7 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
           if (this.isParentSubsidiaryView) {
             this.establishmentService.getEstablishment(this.workplace.parentUid).subscribe((workplace) => {
               this.establishmentService.setPrimaryWorkplace(workplace);
+              this.establishmentService.setWorkplace(workplace);
               this.parentSubsidiaryViewService.clearViewingSubAsParent();
 
               this.router.navigate(['workplace', 'view-all-workplaces']).then(() => {


### PR DESCRIPTION
When going back to parent from sub, workplace questions contained data from the sub and making changes on the question pages would not update the parent when you saved. This was due to the workplace in the establishment service not being updated when you navigate from a sub to a parent.
#### Work done
- Set workplace and primaryWorkplace in establishment when navigating to a parent from deleting sub or using back to parent link

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
