### PR TITLE
Fix/show staff basic records in parent view sub

### DIFF
--- a/frontend/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.ts
+++ b/frontend/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.ts
@@ -6,6 +6,7 @@ import { Worker } from '@core/model/worker.model';
 import { BackLinkService } from '@core/services/backLink.service';
 
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import dayjs from 'dayjs';
 
 @Component({
@@ -25,6 +26,7 @@ export class StaffBasicRecord implements OnInit, OnDestroy {
     protected backLinkService: BackLinkService,
     private route: ActivatedRoute,
     private permissionsService: PermissionsService,
+    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
   ) {}
 
   ngOnInit(): void {
@@ -37,6 +39,8 @@ export class StaffBasicRecord implements OnInit, OnDestroy {
     this.workerNotCompleted = this.getWorkersNotCompleted(workersNotCompleted);
 
     this.setBackLink();
+
+    this.parentSubsidiaryViewService.canShowBanner = false;
   }
 
   getWorkersNotCompleted(workersNotCompleted: any) {

--- a/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
@@ -61,6 +61,7 @@ import { ViewSubsidiaryStaffRecordsComponent } from './staff-records/view-subsid
 import { ViewSubsidiaryTrainingAndQualificationsComponent } from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
 import { ViewSubsidiaryWorkplaceUsersComponent } from './workplace-users/view-subsidiary-workplace-users.component';
 import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
+import { StaffBasicRecord } from '@features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component';
 
 // eslint-disable-next-line max-len
 const routes: Routes = [
@@ -538,6 +539,15 @@ const routes: Routes = [
       establishment: WorkplaceResolver,
       workers: WorkersResolver,
     },
+  },
+  {
+    path: 'staff-basic-records/:establishmentuid',
+    component: StaffBasicRecord,
+    resolve: {
+      establishment: WorkplaceResolver,
+      workers: WorkersResolver,
+    },
+    data: { title: 'Staff Basic Records' },
   },
   {
     path: 'training-and-qualifications/:establishmentuid',

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -68,13 +68,14 @@ export class SummarySectionComponent implements OnInit, OnChanges {
     event.preventDefault();
 
     if (this.isParentSubsidiaryView) {
-      await this.router.navigate(['/subsidiary/', fragment, this.workplace.uid]);
-    }
-    if (route) {
+      this.tabsService.selectedTab = fragment;
       await this.router.navigate(route);
+    } else if (route) {
+      await this.router.navigate(route);
+      this.tabsService.selectedTab = fragment;
+    } else {
+      this.tabsService.selectedTab = fragment;
     }
-
-    this.tabsService.selectedTab = fragment;
   }
 
   public getWorkplaceSummaryMessage(): void {
@@ -118,7 +119,11 @@ export class SummarySectionComponent implements OnInit, OnChanges {
       this.sections[1].message = 'No staff records added in the last 12 months';
     } else if (this.workersNotCompleted?.length > 0 && this.getStaffCreatedDate()) {
       this.sections[1].message = 'Some records only have mandatory data added';
-      this.sections[1].route = ['/staff-basic-records'];
+      if (this.isParentSubsidiaryView) {
+        this.sections[1].route = ['/staff-basic-records', this.workplace.uid];
+      } else {
+        this.sections[1].route = ['/staff-basic-records'];
+      }
     }
     this.showViewSummaryLinks(this.sections[1].linkText);
   }


### PR DESCRIPTION
#### Work done
- Add staff-basic-records to subsidiary routing
- Update summary section to navigate correctly
- Stop showing header in staff-basic-records

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
