### PR TITLE
Show the breadcrumb only in parent view

### DIFF
--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
@@ -49,6 +49,7 @@
       #aboutData
       class="govuk-visually-hidden"
       [workplace]="workplace"
+      [isParentViewingSubsidiary]=isParentViewingSubsidiary
     ></app-benchmarks-about-the-data>
   </div>
 </div>

--- a/frontend/src/app/shared/components/benchmarks-tab/about-the-data/about-the-data.component.ts
+++ b/frontend/src/app/shared/components/benchmarks-tab/about-the-data/about-the-data.component.ts
@@ -15,6 +15,7 @@ import { Subscription } from 'rxjs';
 })
 export class BenchmarksAboutTheDataComponent implements OnInit, OnDestroy {
   @Input() workplace: Establishment;
+  @Input() isParentViewingSubsidiary: boolean;
   @ViewChild('aboutData') public aboutData: ElementRef;
 
   protected subscriptions: Subscription = new Subscription();
@@ -42,7 +43,9 @@ export class BenchmarksAboutTheDataComponent implements OnInit, OnDestroy {
       this.meta = this.benchmarksService.benchmarksData.meta;
     }
 
-    this.breadcrumbService.show(JourneyType.OLD_BENCHMARKS_DATA_TAB);
+    if(!this.isParentViewingSubsidiary){
+      this.breadcrumbService.show(JourneyType.OLD_BENCHMARKS_DATA_TAB);
+    }
   }
 
   public pluralizeWorkplaces(workplaces) {


### PR DESCRIPTION
#### Work done
- Added an if check only show old benchmark tab breadcrumbs in parent view only
- Subview breadcrumbs are all populated from `journey.subsidiary` 

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
