### PR TITLE
Remove unused logic which breaks benchmarks pdf download from sub view

### DIFF
--- a/frontend/src/app/core/services/pdf.service.ts
+++ b/frontend/src/app/core/services/pdf.service.ts
@@ -98,9 +98,6 @@ export class PdfService {
 
   private appendElRef(html: HTMLElement, elRef: ElementRef): void {
     const elements = elRef.nativeElement.cloneNode(true);
-    if (elements.nodeName === 'APP-NEW-BENCHMARKS-TAB') {
-      elements.children[1].classList.remove('govuk-width-container');
-    }
     html.append(elements);
   }
 


### PR DESCRIPTION
The Benchmarks PDF wasn't downloading due to an error throwing when trying to remove a class from a child element which didn't exist. As you cannot download a PDF currently in the new version of benchmarks, we can remove it for now.  

#### Work done
- Removed unused logic which breaks benchmarks pdf download from sub view

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
