### PR TITLE
Fix/move header in parent sub view

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -12,10 +12,10 @@
   >
     <app-stand-alone-account
       *ngIf="!parentSubsidiaryViewService.getViewingSubAsParent()"
-      [dashboardView]="dashboardView">
+      [dashboardView]="dashboardView"
+    >
     </app-stand-alone-account>
-    <app-subsidiary-account
-      *ngIf="parentSubsidiaryViewService.getViewingSubAsParent()">
+    <app-subsidiary-account *ngIf="parentSubsidiaryViewService.getViewingSubAsParent()" [dashboardView]="dashboardView">
     </app-subsidiary-account>
   </ng-container>
   <ng-template #otherView>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -27,6 +27,8 @@ export class AppComponent implements OnInit {
   public newDataAreaFlag: boolean;
   public parentAccount: boolean;
   public subsAccount: boolean;
+  public viewedSubsidiaryUid: string;
+  public subsidiaryDashboardUrls = [];
   @ViewChild('top') top: ElementRef;
   @ViewChild('content') content: ElementRef;
 
@@ -61,9 +63,26 @@ export class AppComponent implements OnInit {
 
   async ngOnInit(): Promise<void> {
     await this.featureFlagsService.start();
+
+    this.parentSubsidiaryViewService.getObservableSubsidiary().subscribe((subsidiary) => {
+      this.viewedSubsidiaryUid = subsidiary?.uid;
+      this.subsidiaryDashboardUrls = [
+        `/subsidiary/home/${this.viewedSubsidiaryUid}`,
+        `/subsidiary/workplace/${this.viewedSubsidiaryUid}`,
+        `/subsidiary/staff-records/${this.viewedSubsidiaryUid}`,
+        `/subsidiary/training-and-qualifications/${this.viewedSubsidiaryUid}`,
+        `/subsidiary/benchmarks/${this.viewedSubsidiaryUid}`,
+        `/subsidiary/workplace-users/${this.viewedSubsidiaryUid}`,
+      ];
+    });
+
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe((nav: NavigationEnd) => {
       this.isAdminSection = nav.url.includes('sfcadmin');
-      this.dashboardView = nav.url.includes('dashboard') || nav.url === '/';
+      this.dashboardView =
+        nav.url.includes('dashboard') ||
+        nav.url === '/' ||
+        this.subsidiaryDashboardUrls.find((subsidiaryDashboardUrl) => subsidiaryDashboardUrl === nav.url);
+      console.log(nav);
       if (nav.url === '/') this.tabsService.selectedTab = 'home';
       this.standAloneAccount = this.establishmentService.standAloneAccount;
       this.parentAccount = this.establishmentService.primaryWorkplace?.isParent;

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -64,24 +64,12 @@ export class AppComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     await this.featureFlagsService.start();
 
-    this.parentSubsidiaryViewService.getObservableSubsidiary().subscribe((subsidiary) => {
-      this.viewedSubsidiaryUid = subsidiary?.uid;
-      this.subsidiaryDashboardUrls = [
-        `/subsidiary/home/${this.viewedSubsidiaryUid}`,
-        `/subsidiary/workplace/${this.viewedSubsidiaryUid}`,
-        `/subsidiary/staff-records/${this.viewedSubsidiaryUid}`,
-        `/subsidiary/training-and-qualifications/${this.viewedSubsidiaryUid}`,
-        `/subsidiary/benchmarks/${this.viewedSubsidiaryUid}`,
-        `/subsidiary/workplace-users/${this.viewedSubsidiaryUid}`,
-      ];
-    });
-
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe((nav: NavigationEnd) => {
       this.isAdminSection = nav.url.includes('sfcadmin');
       this.dashboardView =
         nav.url.includes('dashboard') ||
         nav.url === '/' ||
-        this.subsidiaryDashboardUrls.find((subsidiaryDashboardUrl) => subsidiaryDashboardUrl === nav.url);
+        this.parentSubsidiaryViewService.getViewingSubAsParentDashboard(nav.url);
       if (nav.url === '/') this.tabsService.selectedTab = 'home';
       this.standAloneAccount = this.establishmentService.standAloneAccount;
       this.parentAccount = this.establishmentService.primaryWorkplace?.isParent;

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -27,8 +27,6 @@ export class AppComponent implements OnInit {
   public newDataAreaFlag: boolean;
   public parentAccount: boolean;
   public subsAccount: boolean;
-  public viewedSubsidiaryUid: string;
-  public subsidiaryDashboardUrls = [];
   @ViewChild('top') top: ElementRef;
   @ViewChild('content') content: ElementRef;
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -82,7 +82,6 @@ export class AppComponent implements OnInit {
         nav.url.includes('dashboard') ||
         nav.url === '/' ||
         this.subsidiaryDashboardUrls.find((subsidiaryDashboardUrl) => subsidiaryDashboardUrl === nav.url);
-      console.log(nav);
       if (nav.url === '/') this.tabsService.selectedTab = 'home';
       this.standAloneAccount = this.establishmentService.standAloneAccount;
       this.parentAccount = this.establishmentService.primaryWorkplace?.isParent;

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
@@ -16,15 +16,6 @@
     </div>
   </div>
 
-  <!-- <app-new-dashboard-header
-    *ngIf="canShowBanner"
-    [canAddWorker]="canAddWorker"
-    [canEditWorker]="canEditWorker"
-    [updatedDate]="updatedDate"
-    [tab]="selectedTab"
-  >
-  </app-new-dashboard-header> -->
-
   <div [class]="{ 'govuk-width-container': !dashboardView }">
     <ng-container *ngIf="!dashboardView">
       <app-alert></app-alert>

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
@@ -16,14 +16,14 @@
     </div>
   </div>
 
-  <app-new-dashboard-header
+  <!-- <app-new-dashboard-header
     *ngIf="canShowBanner"
     [canAddWorker]="canAddWorker"
     [canEditWorker]="canEditWorker"
     [updatedDate]="updatedDate"
     [tab]="selectedTab"
   >
-  </app-new-dashboard-header>
+  </app-new-dashboard-header> -->
 
   <div [class]="{ 'govuk-width-container': !dashboardView }">
     <ng-container *ngIf="!dashboardView">
@@ -33,7 +33,7 @@
     <main
       id="main-content"
       class="govuk-main-wrapper app-main-class govuk-util__no-focus"
-      [ngClass]="{ 'govuk-!-padding-top-0': canShowBanner }"
+      [ngClass]="{ 'govuk-!-padding-top-0': dashboardView }"
       #content
       role="main"
       tabindex="-1"

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
@@ -80,7 +80,7 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
 
   ngOnChanges(): void {
     this.isParentSubsidiaryView = this.parentSubsidiaryViewService.getViewingSubAsParent();
-    this.getPermissions();
+    //this.getPermissions();
   }
 
   private setWorkplace(): void {

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
@@ -16,9 +16,7 @@ import { Subscription } from 'rxjs';
 })
 export class SubsidiaryAccountComponent implements OnInit, OnChanges {
   @Input() dashboardView: boolean;
-  public canShowBanner = true;
   @Input() canAddWorker = false;
-  public updatedDate: string;
 
   private subscriptions: Subscription = new Subscription();
   public workplaceUid: string;
@@ -43,10 +41,7 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
     private permissionsService: PermissionsService,
     private tabsService: TabsService,
     private benchmarksService: BenchmarksServiceBase,
-    private breadcrumbService: BreadcrumbService,
     private parentSubsidiaryViewService: ParentSubsidiaryViewService,
-    private route: ActivatedRoute,
-    private router: Router,
   ) {}
 
   ngOnInit(): void {
@@ -63,24 +58,15 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
 
     this.parentWorkplaceName = name;
 
-    this.parentSubsidiaryViewService.canShowBannerObservable.subscribe((canShowBanner) => {
-      this.canShowBanner = canShowBanner;
-    });
-
     this.subscriptions.add(
       this.tabsService.selectedTab$.subscribe((selectedTab) => {
         this.selectedTab = selectedTab;
       }),
     );
-
-    this.parentSubsidiaryViewService.getLastUpdatedDateObservable.subscribe((getLastUpdatedDate) => {
-      this.updatedDate = getLastUpdatedDate;
-    });
   }
 
   ngOnChanges(): void {
     this.isParentSubsidiaryView = this.parentSubsidiaryViewService.getViewingSubAsParent();
-    //this.getPermissions();
   }
 
   private setWorkplace(): void {

--- a/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/benchmarks-tab/benchmarks-tab.component.html
@@ -1,6 +1,7 @@
 <app-new-dashboard-header
   *ngIf="!isParentViewingSubsidiary"
   [tab]="'benchmarks'"
+  [workplace]="workplace"
   [updatedDate]="tilesData?.meta.lastUpdated"
   data-html2canvas-ignore
   data-testid="dashboardHeader"
@@ -9,12 +10,12 @@
 <div class="govuk-width-container govuk-!-margin-top-7">
   <!-- <div id="benchmarks-tiles"> -->
 
-    <app-new-comparison-group-header
-      [canViewFullContent]="canViewFullBenchmarks"
-      [meta]="tilesData?.meta"
-      [workplaceID]="workplace.uid"
-      (downloadPDF)="downloadAsPDF()"
-    ></app-new-comparison-group-header>
+  <app-new-comparison-group-header
+    [canViewFullContent]="canViewFullBenchmarks"
+    [meta]="tilesData?.meta"
+    [workplaceID]="workplace.uid"
+    (downloadPDF)="downloadAsPDF()"
+  ></app-new-comparison-group-header>
 
   <div class="govuk-grid-row">
     <app-benchmark-tile
@@ -52,5 +53,3 @@
     ></app-benchmarks-about-the-data>
   </div>
 </div>
-
-

--- a/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
@@ -1,4 +1,4 @@
-<app-new-dashboard-header tab="home"></app-new-dashboard-header>
+<app-new-dashboard-header tab="home" [workplace]="workplace"></app-new-dashboard-header>
 <div class="govuk-width-container govuk-!-margin-top-7">
   <ng-container *ngIf="newHomeDesignParentFlag || newHomeDesignParentFlag">
     <app-alert></app-alert>

--- a/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
@@ -1,4 +1,4 @@
-<app-new-dashboard-header tab="home"></app-new-dashboard-header>
+<app-new-dashboard-header tab="home" [workplace]="workplace"></app-new-dashboard-header>
 <div class="govuk-width-container govuk-!-margin-top-7">
   <ng-container *ngIf="newHomeDesignParentFlag && isParentApprovedBannerViewed === false">
     <app-alert

--- a/frontend/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.ts
+++ b/frontend/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.ts
@@ -39,8 +39,6 @@ export class StaffBasicRecord implements OnInit, OnDestroy {
     this.workerNotCompleted = this.getWorkersNotCompleted(workersNotCompleted);
 
     this.setBackLink();
-
-    this.parentSubsidiaryViewService.canShowBanner = false;
   }
 
   getWorkersNotCompleted(workersNotCompleted: any) {

--- a/frontend/src/app/features/new-dashboard/staff-tab/staff-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/staff-tab/staff-tab.component.html
@@ -1,5 +1,6 @@
 <app-new-dashboard-header
   [tab]="'staff-records'"
+  [workplace]="workplace"
   [canAddWorker]="canAddWorker"
   [updatedDate]="staffLastUpdated"
   data-cy="dashboard-header"

--- a/frontend/src/app/features/new-dashboard/training-tab/training-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/training-tab/training-tab.component.html
@@ -1,5 +1,6 @@
 <app-new-dashboard-header
   [tab]="'training-and-qualifications'"
+  [workplace]="workplace"
   [canEditWorker]="canEditWorker"
   [updatedDate]="tAndQsLastUpdated"
   [tAndQCount]="totalRecords"

--- a/frontend/src/app/features/new-dashboard/workplace-tab/workplace-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/workplace-tab/workplace-tab.component.html
@@ -1,4 +1,8 @@
-<app-new-dashboard-header [tab]="'workplace'" [updatedDate]="workplace.updated"></app-new-dashboard-header>
+<app-new-dashboard-header
+  [tab]="'workplace'"
+  [workplace]="workplace"
+  [updatedDate]="workplace.updated"
+></app-new-dashboard-header>
 <div class="govuk-width-container govuk-!-padding-top-2">
   <ng-container *ngIf="canEditEstablishment && addWorkplaceDetailsBanner">
     <app-inset-text [color]="'todo'">

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.html
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.html
@@ -1,6 +1,13 @@
+<app-new-dashboard-header tab="benchmarks" [workplace]="workplace"> </app-new-dashboard-header>
+
 <ng-container>
   <ng-container *ngIf="newDataAreaFlag && canSeeNewDataArea; else benchmarksTab">
-    <app-data-area-tab [workplace]="workplace" [newDashboard]="true" [showBanner]="false" data-testid="data-area-tab"></app-data-area-tab>
+    <app-data-area-tab
+      [workplace]="workplace"
+      [newDashboard]="true"
+      [showBanner]="false"
+      data-testid="data-area-tab"
+    ></app-data-area-tab>
   </ng-container>
   <ng-template #benchmarksTab>
     <app-new-benchmarks-tab

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
@@ -34,7 +34,6 @@ export class ViewSubsidiaryBenchmarksComponent implements OnInit, OnDestroy {
   public comparisonDataExists: boolean;
   public workplace: Establishment;
   public newDashboard: boolean;
-  private subsidiaryUid: string;
   public canSeeNewDataArea: boolean;
   public newDataAreaFlag: boolean;
 

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
@@ -36,6 +36,7 @@ export class ViewSubsidiaryBenchmarksComponent implements OnInit, OnDestroy {
   public newDashboard: boolean;
   public canSeeNewDataArea: boolean;
   public newDataAreaFlag: boolean;
+  public lastUpdatedDate: string
 
   constructor(
     private permissionsService: PermissionsService,
@@ -58,8 +59,7 @@ export class ViewSubsidiaryBenchmarksComponent implements OnInit, OnDestroy {
         this.canSeeNewDataArea = [1, 2, 8].includes(this.workplace.mainService.reportingID);
       }
     });
-    this.parentSubsidiaryViewService.canShowBanner = true;
-    this.parentSubsidiaryViewService.getLastUpdatedDate = this.tilesData?.meta.lastUpdated.toString();
+    this.lastUpdatedDate = this.tilesData?.meta.lastUpdated.toString();
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
@@ -1,3 +1,12 @@
+<app-new-dashboard-header
+  [workplace]="subsidiaryWorkplace"
+  [canAddWorker]="canAddWorker"
+  [canEditWorker]="canEditWorker"
+  [updatedDate]="updatedDate"
+  tab="home"
+>
+</app-new-dashboard-header>
+
 <div class="govuk-width-container govuk-!-margin-top-7">
   <ng-container *ngIf="(newHomeDesignParentFlag && workplace) || newHomeDesignParentFlag">
     <app-alert></app-alert>

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
@@ -1,10 +1,4 @@
-<app-new-dashboard-header
-  [workplace]="subsidiaryWorkplace"
-  [canAddWorker]="canAddWorker"
-  [canEditWorker]="canEditWorker"
-  [updatedDate]="updatedDate"
-  tab="home"
->
+<app-new-dashboard-header [workplace]="subsidiaryWorkplace" [canAddWorker]="canAddWorker" tab="home">
 </app-new-dashboard-header>
 
 <div class="govuk-width-container govuk-!-margin-top-7">

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -66,7 +66,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
   public workplacesCount: number;
   public isParentSubsidiaryView: boolean;
   public tilesData: BenchmarksResponse;
-  public selectedTab: string;
 
   constructor(
     private userService: UserService,
@@ -157,7 +156,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
   public navigateToTab(event: Event, selectedTab: string): void {
     event.preventDefault();
     this.tabsService.selectedTab = selectedTab;
-    this.selectedTab = selectedTab;
   }
 
   private setBenchmarksCard(): void {

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -67,6 +67,10 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
   public workplacesCount: number;
   public isParentSubsidiaryView: boolean;
   public tilesData: BenchmarksResponse;
+  public canEditWorker: boolean;
+  public updatedDate: string;
+  public canShowBanner = true;
+  public selectedTab: string;
 
   constructor(
     private userService: UserService,
@@ -161,6 +165,7 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
   public navigateToTab(event: Event, selectedTab: string): void {
     event.preventDefault();
     this.tabsService.selectedTab = selectedTab;
+    this.selectedTab = selectedTab;
   }
 
   private setBenchmarksCard(): void {

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -1,11 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { URLStructure } from '@core/model/url.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { Worker } from '@core/model/worker.model';
-import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TabsService } from '@core/services/tabs.service';
 import { UserService } from '@core/services/user.service';
@@ -67,9 +66,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
   public workplacesCount: number;
   public isParentSubsidiaryView: boolean;
   public tilesData: BenchmarksResponse;
-  public canEditWorker: boolean;
-  public updatedDate: string;
-  public canShowBanner = true;
   public selectedTab: string;
 
   constructor(
@@ -78,9 +74,7 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     private tabsService: TabsService,
     public route: ActivatedRoute,
     private featureFlagsService: FeatureFlagsService,
-    private router: Router,
     public parentSubsidiaryViewService: ParentSubsidiaryViewService,
-    private breadcrumbService: BreadcrumbService,
     protected benchmarksService: BenchmarksServiceBase,
     private serviceNamePipe: ServiceNamePipe,
   ) {}
@@ -104,7 +98,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     this.newHomeDesignParentFlag = this.featureFlagsService.newHomeDesignParentFlag;
 
     this.isParentSubsidiaryView = this.parentSubsidiaryViewService.getViewingSubAsParent();
-    this.parentSubsidiaryViewService.getLastUpdatedDate = null;
 
     this.bigThreeServices = [1, 2, 8].includes(this.subsidiaryWorkplace.mainService.reportingID);
 

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -104,7 +104,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     this.newHomeDesignParentFlag = this.featureFlagsService.newHomeDesignParentFlag;
 
     this.isParentSubsidiaryView = this.parentSubsidiaryViewService.getViewingSubAsParent();
-    this.parentSubsidiaryViewService.canShowBanner = true;
     this.parentSubsidiaryViewService.getLastUpdatedDate = null;
 
     this.bigThreeServices = [1, 2, 8].includes(this.subsidiaryWorkplace.mainService.reportingID);

--- a/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.html
+++ b/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.html
@@ -1,3 +1,10 @@
+<app-new-dashboard-header
+  [workplace]="workplace"
+  [tab]="'staff-records'"
+  [canAddWorker]="canAddWorker"
+  [updatedDate]="staffLastUpdatedDate"
+></app-new-dashboard-header>
+
 <div class="govuk-width-container govuk-!-margin-top-2">
   <div class="govuk-!-margin-top-7">
     <ng-container *ngIf="workers?.length > 0; else noStaffRecords">

--- a/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
+++ b/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
@@ -44,11 +44,11 @@ export class ViewSubsidiaryStaffRecordsComponent implements OnInit {
 
     this.parentSubsidiaryViewService.setHasWorkers(this.workerCount);
 
-    this.getStaffLastUpdatedDate();
+    this.staffLastUpdatedDate = this.getStaffLastUpdatedDate();
   }
 
-  private getStaffLastUpdatedDate(): void {
+  private getStaffLastUpdatedDate(): string {
     const lastUpdatedDates = this.workers.map((worker) => new Date(worker.updated).getTime());
-    this.staffLastUpdatedDate = new Date(Math.max(...lastUpdatedDates)).toISOString();
+    return new Date(Math.max(...lastUpdatedDates)).toISOString();
   }
 }

--- a/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
+++ b/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
@@ -20,6 +20,7 @@ export class ViewSubsidiaryStaffRecordsComponent implements OnInit {
   public createStaffResponse = null;
   public errors;
   public canAddWorker: boolean;
+  public staffLastUpdatedDate: string;
 
   constructor(
     private breadcrumbService: BreadcrumbService,
@@ -43,7 +44,14 @@ export class ViewSubsidiaryStaffRecordsComponent implements OnInit {
 
     this.parentSubsidiaryViewService.setHasWorkers(this.workerCount);
     this.parentSubsidiaryViewService.canShowBanner = true;
+    // const lastUpdatedDates = this.workers.map((worker) => new Date(worker.updated).getTime());
+    // this.parentSubsidiaryViewService.getLastUpdatedDate = new Date(Math.max(...lastUpdatedDates)).toISOString();
+
+    this.getStaffLastUpdatedDate();
+  }
+
+  private getStaffLastUpdatedDate(): void {
     const lastUpdatedDates = this.workers.map((worker) => new Date(worker.updated).getTime());
-    this.parentSubsidiaryViewService.getLastUpdatedDate = new Date(Math.max(...lastUpdatedDates)).toISOString();
+    this.staffLastUpdatedDate = new Date(Math.max(...lastUpdatedDates)).toISOString();
   }
 }

--- a/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
+++ b/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
@@ -43,9 +43,6 @@ export class ViewSubsidiaryStaffRecordsComponent implements OnInit {
     this.canAddWorker = this.permissionsService.can(this.workplace.uid, 'canAddWorker');
 
     this.parentSubsidiaryViewService.setHasWorkers(this.workerCount);
-    this.parentSubsidiaryViewService.canShowBanner = true;
-    // const lastUpdatedDates = this.workers.map((worker) => new Date(worker.updated).getTime());
-    // this.parentSubsidiaryViewService.getLastUpdatedDate = new Date(Math.max(...lastUpdatedDates)).toISOString();
 
     this.getStaffLastUpdatedDate();
   }

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.html
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.html
@@ -1,3 +1,12 @@
+<app-new-dashboard-header
+  [workplace]="workplace"
+  [tab]="'training-and-qualifications'"
+  [canEditWorker]="canEditWorker"
+  [updatedDate]="tAndQsLastUpdated"
+  [tAndQCount]="totalRecords"
+  [hasWorkers]="workers?.length > 0"
+></app-new-dashboard-header>
+
 <div class="govuk-width-container govuk-!-padding-top-2">
   <div class="govuk-!-margin-top-6">
     <ng-container *ngIf="workers?.length > 0; else noStaffRecords">

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
@@ -90,8 +90,8 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
     this.getAllTrainingByCategory();
     this.trainingTotals();
 
-    this.parentSubsidiaryViewService.canShowBanner = true;
-    this.parentSubsidiaryViewService.getLastUpdatedDate = this.tAndQsLastUpdated;
+    //this.parentSubsidiaryViewService.canShowBanner = true;
+    //this.parentSubsidiaryViewService.getLastUpdatedDate = this.tAndQsLastUpdated;
   }
 
   public ngOnChanges(changes: SimpleChanges): void {

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
@@ -68,8 +68,6 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
 
     this.parentSubsidiaryViewService.setHasWorkers(this.workerCount);
 
-    this.parentSubsidiaryViewService.canShowBanner = true;
-
     this.workplace = this.route.snapshot.data.establishment;
 
     const alertMessage = history.state?.alertMessage;
@@ -89,9 +87,6 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
 
     this.getAllTrainingByCategory();
     this.trainingTotals();
-
-    //this.parentSubsidiaryViewService.canShowBanner = true;
-    //this.parentSubsidiaryViewService.getLastUpdatedDate = this.tAndQsLastUpdated;
   }
 
   public ngOnChanges(changes: SimpleChanges): void {

--- a/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.html
+++ b/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.html
@@ -1,3 +1,6 @@
+<app-new-dashboard-header tab="workplace-users" [workplace]="workplace" [updatedDate]="lastUpdatedDate">
+</app-new-dashboard-header>
+
 <div class="govuk-width-container govuk-!-margin-top-7">
   <app-user-accounts-summary [workplace]="workplace" [setReturnUrl]="setUserServiceReturnUrl()">
   </app-user-accounts-summary>

--- a/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.spec.ts
+++ b/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.spec.ts
@@ -13,12 +13,24 @@ import { render } from '@testing-library/angular';
 
 import { Establishment } from '../../../../mockdata/establishment';
 import { ViewSubsidiaryWorkplaceUsersComponent } from './view-subsidiary-workplace-users.component';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { NewDashboardHeaderComponent } from '@shared/components/new-dashboard-header/dashboard-header.component';
+import { AuthService } from '@core/services/auth.service';
+import { MockAuthService } from '@core/test-utils/MockAuthService';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { AlertService } from '@core/services/alert.service';
+import { WindowRef } from '@core/services/window.ref';
+import { DialogService } from '@core/services/dialog.service';
 
 describe('ViewSubsidiaryWorkplaceUsersComponent', () => {
-  const setup = async () => {
+  const setup = async (isAdmin = true, establishment = Establishment) => {
     const { fixture } = await render(ViewSubsidiaryWorkplaceUsersComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       providers: [
+        AlertService,
+        WindowRef,
+        DialogService,
         {
           provide: PermissionsService,
           useFactory: MockPermissionsService.factory(['canAddUser', 'canViewUser']),
@@ -29,16 +41,26 @@ describe('ViewSubsidiaryWorkplaceUsersComponent', () => {
           useClass: MockBreadcrumbService,
         },
         {
+          provide: FeatureFlagsService,
+          useClass: MockFeatureFlagsService,
+        },
+        {
+          provide: AuthService,
+          useFactory: MockAuthService.factory(true, isAdmin),
+          deps: [HttpClient, Router, EstablishmentService, UserService, PermissionsService],
+        },
+        {
           provide: ActivatedRoute,
           useValue: {
             snapshot: {
               data: {
-                establishment: establishmentBuilder() as Establishment,
+                establishment: establishment,
               },
             },
           },
         },
       ],
+      declarations: [NewDashboardHeaderComponent],
     });
     const component = fixture.componentInstance;
 
@@ -47,8 +69,7 @@ describe('ViewSubsidiaryWorkplaceUsersComponent', () => {
 
   it('should render a View Subsidiary Workplace Users Component', async () => {
     const { component } = await setup();
+
     expect(component).toBeTruthy();
   });
 });
-
-

--- a/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
@@ -24,8 +24,6 @@ export class ViewSubsidiaryWorkplaceUsersComponent implements OnInit {
   ngOnInit(): void {
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
     this.workplace = this.route.snapshot.data.establishment;
-    this.parentSubsidiaryViewService.getLastUpdatedDate = this.workplace.updated.toString();
-    this.parentSubsidiaryViewService.canShowBanner = true;
     this.lastUpdatedDate = this.workplace.updated.toString();
   }
 

--- a/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
@@ -12,7 +12,8 @@ import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-
 })
 export class ViewSubsidiaryWorkplaceUsersComponent implements OnInit {
   public workplace: Establishment;
-  
+  public lastUpdatedDate: string;
+
   constructor(
     private route: ActivatedRoute,
     private userService: UserService,
@@ -25,6 +26,7 @@ export class ViewSubsidiaryWorkplaceUsersComponent implements OnInit {
     this.workplace = this.route.snapshot.data.establishment;
     this.parentSubsidiaryViewService.getLastUpdatedDate = this.workplace.updated.toString();
     this.parentSubsidiaryViewService.canShowBanner = true;
+    this.lastUpdatedDate = this.workplace.updated.toString();
   }
 
   public setUserServiceReturnUrl(): void {

--- a/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.html
+++ b/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.html
@@ -1,15 +1,17 @@
-<div class="govuk-width-container govuk-!-padding-top-2"
-  *ngIf="workplace">
+<app-new-dashboard-header [workplace]="workplace" tab="workplace" [updatedDate]="workplace.updated">
+</app-new-dashboard-header>
+
+<div class="govuk-width-container govuk-!-padding-top-2" *ngIf="workplace">
   <ng-container *ngIf="canEditEstablishment && addWorkplaceDetailsBanner">
     <app-inset-text [color]="'todo'">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-          <a *ngIf="!isParentViewingSubsidiary"
-            [routerLink]="['/workplace', workplace?.uid, 'start']">
-              Start to add more details about your workplace</a>
-          <a *ngIf="isParentViewingSubsidiary"
-            [routerLink]="['/subsidiary/workplace', workplace?.uid, 'start']">
-              Start to add more details about your workplace</a>
+          <a *ngIf="!isParentViewingSubsidiary" [routerLink]="['/workplace', workplace?.uid, 'start']">
+            Start to add more details about your workplace</a
+          >
+          <a *ngIf="isParentViewingSubsidiary" [routerLink]="['/subsidiary/workplace', workplace?.uid, 'start']">
+            Start to add more details about your workplace</a
+          >
         </div>
       </div>
     </app-inset-text>

--- a/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
@@ -6,7 +6,6 @@ import { URLStructure } from '@core/model/url.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { TabsService } from '@core/services/tabs.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
@@ -27,7 +26,6 @@ export class ViewSubsidiaryWorkplaceComponent implements OnInit {
     private breadcrumbService: BreadcrumbService,
     private establishmentService: EstablishmentService,
     private permissionsService: PermissionsService,
-    private tabsService: TabsService,
     private parentSubsidiaryViewService: ParentSubsidiaryViewService,
     private route: ActivatedRoute,
   ) {}
@@ -40,7 +38,6 @@ export class ViewSubsidiaryWorkplaceComponent implements OnInit {
     this.workerCount = this.route.snapshot.data.workers?.workerCount;
     this.addWorkplaceDetailsBanner = this.workplace.showAddWorkplaceDetailsBanner;
     this.canEditEstablishment = this.permissionsService.can(this.workplace?.uid, 'canEditEstablishment');
-    // this.parentSubsidiaryViewService.getLastUpdatedDate = this.workplace?.updated.toString();
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
@@ -40,8 +40,7 @@ export class ViewSubsidiaryWorkplaceComponent implements OnInit {
     this.workerCount = this.route.snapshot.data.workers?.workerCount;
     this.addWorkplaceDetailsBanner = this.workplace.showAddWorkplaceDetailsBanner;
     this.canEditEstablishment = this.permissionsService.can(this.workplace?.uid, 'canEditEstablishment');
-    this.parentSubsidiaryViewService.canShowBanner = true;
-    this.parentSubsidiaryViewService.getLastUpdatedDate = this.workplace?.updated.toString()
+    // this.parentSubsidiaryViewService.getLastUpdatedDate = this.workplace?.updated.toString();
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/shared/components/data-area-tab/data-area-tab.component.html
+++ b/frontend/src/app/shared/components/data-area-tab/data-area-tab.component.html
@@ -1,5 +1,10 @@
 <ng-container *ngIf="newDashboard && showBanner">
-  <app-new-dashboard-header [tab]="'benchmarks'" data-testid="newDashboardHeader" data-html2canvas-ignore></app-new-dashboard-header>
+  <app-new-dashboard-header
+    [tab]="'benchmarks'"
+    [workplace]="workplace"
+    data-testid="newDashboardHeader"
+    data-html2canvas-ignore
+  ></app-new-dashboard-header>
 </ng-container>
 
 <div [ngClass]="{ 'govuk-width-container': newDashboard, 'govuk-!-margin-top-7': newDashboard }">

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
@@ -12,7 +12,7 @@ import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { MockAuthService } from '@core/test-utils/MockAuthService';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockEstablishmentService, establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
@@ -22,6 +22,7 @@ import { render, within } from '@testing-library/angular';
 import { of } from 'rxjs';
 
 import { NewDashboardHeaderComponent } from './dashboard-header.component';
+import { Establishment } from '@core/model/establishment.model';
 
 const MockWindow = {
   dataLayer: {
@@ -32,6 +33,7 @@ const MockWindow = {
 };
 
 describe('NewDashboardHeaderComponent', () => {
+  const establishment = establishmentBuilder() as Establishment;
   const setup = async (
     tab = 'home',
     updateDate = false,
@@ -42,6 +44,7 @@ describe('NewDashboardHeaderComponent', () => {
     subsidiaries = 0,
     viewingSubAsParent = false,
     canDeleteEstablishment = true,
+    workplace = establishment,
   ) => {
     const role = isAdmin ? Roles.Admin : Roles.Edit;
     const updatedDate = updateDate ? '01/02/2023' : null;
@@ -85,6 +88,7 @@ describe('NewDashboardHeaderComponent', () => {
         canEditWorker,
         hasWorkers,
         isParent: false,
+        workplace,
       },
     });
 

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
@@ -28,7 +28,6 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
   @Input() hasWorkers = false;
   @Input() workplace: Establishment;
 
-  //public workplace: Establishment;
   public canDeleteEstablishment: boolean;
   public workplaceUid: string;
   public subsidiaryCount: number;

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
@@ -58,13 +58,7 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnInit(): void {
-    //subscribe to changes in the subsidiaryUid. Need to really subscribe to a parent workplace request change
-    // (Use the resolver)
-    // this.parentSubsidiaryViewService.getObservableSubsidiaryUid().subscribe((subsidiaryUid) => {
-    //   this.setWorkplace(subsidiaryUid);
-    // });
-
-    this.isParent = this.establishmentService.primaryWorkplace?.isParent;
+    this.isParent = this.workplace.isParent;
 
     this.setIsParentSubsidiaryView();
 
@@ -75,7 +69,6 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
     this.getPermissions();
 
     this.getHeader();
-    //this.getValuesForHeader();
   }
 
   ngOnChanges(): void {
@@ -83,37 +76,11 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
     this.setSubsidiaryCount();
     this.getPermissions();
     this.getHeader();
-    //this.getValuesForHeader();
   }
 
   public setIsParentSubsidiaryView(): void {
     this.isParentSubsidiaryView = this.parentSubsidiaryViewService.getViewingSubAsParent();
   }
-
-  private setWorkplace(subsidiaryUid: string) {
-    if (subsidiaryUid == '') {
-      this.workplace = this.establishmentService.primaryWorkplace;
-      this.workplaceUid = this.workplace ? this.workplace.uid : null;
-    } else {
-      this.establishmentService.getEstablishment(subsidiaryUid).subscribe((workplace) => {
-        if (workplace) {
-          this.establishmentService.setWorkplace(workplace);
-          this.workplace = this.establishmentService.primaryWorkplace;
-          this.workplaceUid = this.workplace ? this.workplace.uid : null;
-        }
-      });
-    }
-  }
-
-  // public getValuesForHeader(): void {
-  //   if (this.isParentSubsidiaryView) {
-  //     this.hasWorkers = this.parentSubsidiaryViewService.getHasWorkers();
-
-  //     this.parentSubsidiaryViewService.totalTrainingRecords$.subscribe((totalTrainingRecords) => {
-  //       this.tAndQCount = totalTrainingRecords;
-  //     });
-  //   }
-  // }
 
   public onDeleteWorkplace(event: Event): void {
     event.preventDefault();
@@ -175,12 +142,12 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
     this.user = this.userService.loggedInUser;
     if (isAdminRole(this.user?.role)) {
       this.canDeleteEstablishment = this.permissionsService.can(
-        this.establishmentService.primaryWorkplace.uid,
+        this.establishmentService.primaryWorkplace?.uid,
         'canDeleteAllEstablishments',
       );
     } else {
       this.canDeleteEstablishment = this.permissionsService.can(
-        this.establishmentService.primaryWorkplace.uid,
+        this.establishmentService.primaryWorkplace?.uid,
         'canDeleteEstablishment',
       );
     }

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
@@ -26,8 +26,9 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
   @Input() tAndQCount = 0;
   @Input() canEditWorker = false;
   @Input() hasWorkers = false;
+  @Input() workplace: Establishment;
 
-  public workplace: Establishment;
+  //public workplace: Establishment;
   public canDeleteEstablishment: boolean;
   public workplaceUid: string;
   public subsidiaryCount: number;
@@ -59,9 +60,9 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     //subscribe to changes in the subsidiaryUid. Need to really subscribe to a parent workplace request change
     // (Use the resolver)
-    this.parentSubsidiaryViewService.getObservableSubsidiaryUid().subscribe((subsidiaryUid) => {
-      this.setWorkplace(subsidiaryUid);
-    });
+    // this.parentSubsidiaryViewService.getObservableSubsidiaryUid().subscribe((subsidiaryUid) => {
+    //   this.setWorkplace(subsidiaryUid);
+    // });
 
     this.isParent = this.establishmentService.primaryWorkplace?.isParent;
 
@@ -74,16 +75,15 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
     this.getPermissions();
 
     this.getHeader();
-    this.getValuesForHeader();
+    //this.getValuesForHeader();
   }
 
   ngOnChanges(): void {
     this.setIsParentSubsidiaryView();
     this.setSubsidiaryCount();
     this.getPermissions();
-
     this.getHeader();
-    this.getValuesForHeader();
+    //this.getValuesForHeader();
   }
 
   public setIsParentSubsidiaryView(): void {
@@ -105,15 +105,15 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
     }
   }
 
-  public getValuesForHeader(): void {
-    if (this.isParentSubsidiaryView) {
-      this.hasWorkers = this.parentSubsidiaryViewService.getHasWorkers();
+  // public getValuesForHeader(): void {
+  //   if (this.isParentSubsidiaryView) {
+  //     this.hasWorkers = this.parentSubsidiaryViewService.getHasWorkers();
 
-      this.parentSubsidiaryViewService.totalTrainingRecords$.subscribe((totalTrainingRecords) => {
-        this.tAndQCount = totalTrainingRecords;
-      });
-    }
-  }
+  //     this.parentSubsidiaryViewService.totalTrainingRecords$.subscribe((totalTrainingRecords) => {
+  //       this.tAndQCount = totalTrainingRecords;
+  //     });
+  //   }
+  // }
 
   public onDeleteWorkplace(event: Event): void {
     event.preventDefault();

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -66,8 +66,7 @@ export class SummarySectionComponent implements OnInit, OnChanges {
 
   public async onClick(event: Event, fragment: string, route: string[]): Promise<void> {
     event.preventDefault();
-
-    if (this.isParentSubsidiaryView) {
+    if (this.isParentSubsidiaryView && route) {
       this.tabsService.selectedTab = fragment;
       await this.router.navigate(route);
     } else if (route) {

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.spec.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.spec.ts
@@ -25,14 +25,57 @@ describe('ParentSubsidiaryViewService', () => {
   });
 
   describe('getViewingSubAsParentDashboard', () => {
-    it('should return true if url is included', async () => {
-      const subUid = 'some-uid';
-      service.setViewingSubAsParent(subUid);
+    describe('url is on checked list', () => {
+      it('should return true if url is included for home page', async () => {
+        const subUid = 'some-uid';
+        service.setViewingSubAsParent(subUid);
 
-      expect(service.getViewingSubAsParentDashboard(`/subsidiary/home/${subUid}`)).toBeTruthy();
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/home/${subUid}`)).toBeTruthy();
+      });
+      it('should return true if url is included for workplace page', async () => {
+        const subUid = 'some-uid';
+        service.setViewingSubAsParent(subUid);
+
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/workplace/${subUid}`)).toBeTruthy();
+      });
+      it('should return true if url is included for staff-records page', async () => {
+        const subUid = 'some-uid';
+        service.setViewingSubAsParent(subUid);
+
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/staff-records/${subUid}`)).toBeTruthy();
+      });
+      it('should return true if url is included for training-and-qualifications page', async () => {
+        const subUid = 'some-uid';
+        service.setViewingSubAsParent(subUid);
+
+        expect(
+          service.getViewingSubAsParentDashboard(`/subsidiary/training-and-qualifications/${subUid}`),
+        ).toBeTruthy();
+      });
+      it('should return true if url is included for benchmarks page', async () => {
+        const subUid = 'some-uid';
+        service.setViewingSubAsParent(subUid);
+
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/benchmarks/${subUid}`)).toBeTruthy();
+      });
+      it('should return true if url is included for workplace-users page', async () => {
+        const subUid = 'some-uid';
+        service.setViewingSubAsParent(subUid);
+
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/workplace-users/${subUid}`)).toBeTruthy();
+      });
     });
-    it('should return false if url is not included', async () => {
-      expect(service.getViewingSubAsParentDashboard('/home')).toBeFalsy();
+
+    describe('url is not on checked list', () => {
+      it('should return false if url has partial match to url in checked list', async () => {
+        expect(service.getViewingSubAsParentDashboard('/subsidiary/home')).toBeFalsy();
+      });
+      it('should return false if url has additional characters after url in checked list', async () => {
+        const subUid = 'some-uid';
+        service.setViewingSubAsParent(subUid);
+
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/home/${subUid}/benchmarks`)).toBeFalsy();
+      });
     });
   });
 });

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.spec.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.spec.ts
@@ -16,4 +16,23 @@ describe('ParentSubsidiaryViewService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('returns the uid set', async () => {
+    const subUid = 'some-uid';
+    service.setViewingSubAsParent(subUid);
+
+    expect(service.getSubsidiaryUid()).toEqual(subUid);
+  });
+
+  describe('getViewingSubAsParentDashboard', () => {
+    it('should return true if url is included', async () => {
+      const subUid = 'some-uid';
+      service.setViewingSubAsParent(subUid);
+
+      expect(service.getViewingSubAsParentDashboard(`/subsidiary/home/${subUid}`)).toBeTruthy();
+    });
+    it('should return false if url is not included', async () => {
+      expect(service.getViewingSubAsParentDashboard('/home')).toBeFalsy();
+    });
+  });
 });

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -54,6 +54,18 @@ export class ParentSubsidiaryViewService {
     this.subsidiaryWorkplace.next(null);
   }
 
+  getViewingSubAsParentDashboard(navUrl): boolean {
+    const subsidiaryDashboardUrls = [
+      `/subsidiary/home/${this.subsidiaryUid}`,
+      `/subsidiary/workplace/${this.subsidiaryUid}`,
+      `/subsidiary/staff-records/${this.subsidiaryUid}`,
+      `/subsidiary/training-and-qualifications/${this.subsidiaryUid}`,
+      `/subsidiary/benchmarks/${this.subsidiaryUid}`,
+      `/subsidiary/workplace-users/${this.subsidiaryUid}`,
+    ];
+    return subsidiaryDashboardUrls.includes(navUrl);
+  }
+
   getHasWorkers() {
     return this.hasWorkers;
   }

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -9,7 +9,6 @@ import { BehaviorSubject, Observable } from 'rxjs';
 export class ParentSubsidiaryViewService {
   private subsidiaryUidSubject: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private subsidiaryWorkplace: BehaviorSubject<Establishment> = new BehaviorSubject<Establishment>(null);
-  private _canShowBanner$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
   private _getLastUpdatedDate$: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private _totalRecords$: BehaviorSubject<number> = new BehaviorSubject<number>(0);
   public readonly totalTrainingRecords$: Observable<any> = this._totalRecords$.asObservable();
@@ -86,14 +85,6 @@ export class ParentSubsidiaryViewService {
   // Method to get the current subsidiary as an observable
   getObservableSubsidiary(): Observable<Establishment> {
     return this.subsidiaryWorkplace.asObservable();
-  }
-
-  public get canShowBannerObservable(): Observable<boolean> {
-    return this._canShowBanner$.asObservable();
-  }
-
-  public set canShowBanner(canShowBanner: boolean) {
-    this._canShowBanner$.next(canShowBanner);
   }
 
   public get getLastUpdatedDateObservable(): Observable<string> {

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -27,16 +27,12 @@ export class SubsidiaryRouterService extends Router {
       if (commands[0].toLowerCase().includes('dashboard')) {
         commands = [extras.fragment ? extras.fragment : 'home', this.parentSubsidiaryViewService.getSubsidiaryUid()];
         extras = undefined;
-
-        // this.parentSubsidiaryViewService.canShowBanner = true;
       } else {
         // Remove forward slashes from the route
         for (let i = 0; i < commands.length; i++) {
           const splitString = commands[i].split('/').filter((command) => command.length > 0);
           Array.prototype.splice.apply(commands, [i, 1].concat(splitString));
         }
-
-        // this.parentSubsidiaryViewService.canShowBanner = false;
       }
       commands.unshift('subsidiary');
     }

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -28,7 +28,7 @@ export class SubsidiaryRouterService extends Router {
         commands = [extras.fragment ? extras.fragment : 'home', this.parentSubsidiaryViewService.getSubsidiaryUid()];
         extras = undefined;
 
-        this.parentSubsidiaryViewService.canShowBanner = true;
+        // this.parentSubsidiaryViewService.canShowBanner = true;
       } else {
         // Remove forward slashes from the route
         for (let i = 0; i < commands.length; i++) {
@@ -36,7 +36,7 @@ export class SubsidiaryRouterService extends Router {
           Array.prototype.splice.apply(commands, [i, 1].concat(splitString));
         }
 
-        this.parentSubsidiaryViewService.canShowBanner = false;
+        // this.parentSubsidiaryViewService.canShowBanner = false;
       }
       commands.unshift('subsidiary');
     }
@@ -48,8 +48,7 @@ export class SubsidiaryRouterService extends Router {
 
     if (this.isNotSubsidiaryPage(commands)) {
       this.parentSubsidiaryViewService.clearViewingSubAsParent();
-    }
-    else {
+    } else {
       const newRoute = this.getNewRoute(commands, navigationExtras);
       url = super.createUrlTree(newRoute.commands, newRoute.extras);
     }
@@ -57,18 +56,12 @@ export class SubsidiaryRouterService extends Router {
     return super.navigateByUrl(url, extras);
   }
 
-  isNotSubsidiaryPage(commands: any[]){
-    const exitSubsidiaryViewPages = [
-      'account-management',
-      'login',
-      'notifications',
-      'satisfaction-survey',
-      'sfcadmin',
-    ];
+  isNotSubsidiaryPage(commands: any[]) {
+    const exitSubsidiaryViewPages = ['account-management', 'login', 'notifications', 'satisfaction-survey', 'sfcadmin'];
 
     if (commands.length === 1) {
       return exitSubsidiaryViewPages.includes(commands[0]);
-     }
+    }
 
     if (commands.length === 3) {
       return commands[0] === 'workplace' && commands[2] === 'users';


### PR DESCRIPTION
#### Work done
This was to fix the flickering that was occurring when navigating in the parent view sub pages with the dashboard header
- Move dashboard header from subsidiary account into the view subsidiary tab pages
- Add check in parent-subsidiary-view service to check urls of parent sub pages that need to show the dashboard
- Refactor dashboard header to take workplace as an input
- Remove canShowBanner from parent-subsidiary-view service due to above dashboard header work
- Existing tests were updated

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
