### PR TITLE
Add fragment to the route to navigate to the right flow in the benchmark breadcrumbs

### DIFF
--- a/frontend/src/app/core/breadcrumb/journey.workplaces.spec.ts
+++ b/frontend/src/app/core/breadcrumb/journey.workplaces.spec.ts
@@ -1,0 +1,16 @@
+import { benchmarksTabJourney } from './journey.workplaces';
+
+describe('JourneyWorkplaces', () => {
+  function returnAboutTheDataPath(isOldTab = false){
+    let journeyWorkplaces = benchmarksTabJourney(isOldTab);
+    return journeyWorkplaces.children[0].children[0].path
+  }
+
+  it('should return the correct about the data path for old benchmark journey', () => {
+    expect(returnAboutTheDataPath(true)).toBe('/workplace/:workplaceUid/benchmarks/about-the-data');
+  });
+
+  it('should return the correct about the data path for new benchmark journey', () => {
+    expect(returnAboutTheDataPath()).toBe('/workplace/:workplaceUid/data-area/about-the-data');
+  });
+});

--- a/frontend/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/frontend/src/app/core/breadcrumb/journey.workplaces.ts
@@ -86,10 +86,6 @@ export const benchmarksTabJourney: JourneyRoute = {
         {
           title: 'About the data',
           path: Path.ABOUT_DATA,
-          referrer: {
-            path: Path.DASHBOARD,
-            fragment: 'benchmarks',
-          },
         },
       ],
     },
@@ -106,10 +102,6 @@ export const oldBenchmarksDataJourney: JourneyRoute = {
         {
           title: 'About the data',
           path: Path.BENCHMARKS_ABOUT_DATA,
-          referrer: {
-            path: Path.DASHBOARD,
-            fragment: 'benchmarks',
-          },
         },
       ],
     },

--- a/frontend/src/app/core/breadcrumb/journey.workplaces.ts
+++ b/frontend/src/app/core/breadcrumb/journey.workplaces.ts
@@ -76,38 +76,21 @@ export const trainingAndQualificationsTabJourney: JourneyRoute = {
   ],
 };
 
-export const benchmarksTabJourney: JourneyRoute = {
-  children: [
-    {
-      title: 'Benchmarks',
-      path: Path.DASHBOARD,
-      fragment: 'benchmarks',
-      children: [
-        {
-          title: 'About the data',
-          path: Path.ABOUT_DATA,
-        },
-      ],
-    },
-  ],
-};
 
-export const oldBenchmarksDataJourney: JourneyRoute = {
-  children: [
-    {
-      title: 'Benchmarks',
-      path: Path.DASHBOARD,
-      fragment: 'benchmarks',
-      children: [
-        {
-          title: 'About the data',
-          path: Path.BENCHMARKS_ABOUT_DATA,
-        },
-      ],
-    },
-  ],
-};
 
+export function benchmarksTabJourney(isOldTab: boolean = false): JourneyRoute {
+  return {children: [ {
+    title: 'Benchmarks',
+    path: Path.DASHBOARD,
+    fragment: 'benchmarks',
+    children: [
+      {
+        title: 'About the data',
+        path: isOldTab ?  Path.BENCHMARKS_ABOUT_DATA : Path.ABOUT_DATA,
+      },
+    ],
+  },]}
+};
 
 export const myWorkplaceJourney: JourneyRoute = {
   children: [

--- a/frontend/src/app/core/services/breadcrumb.service.ts
+++ b/frontend/src/app/core/services/breadcrumb.service.ts
@@ -40,7 +40,6 @@ import {
   allWorkplacesJourney,
   benchmarksTabJourney,
   myWorkplaceJourney,
-  oldBenchmarksDataJourney,
   staffRecordsTabJourney,
   trainingAndQualificationsTabJourney,
   workplaceTabJourney,
@@ -122,7 +121,7 @@ export class BreadcrumbService {
         routes.push({
           title,
           path: this.getPath(path, segments),
-          fragment: child.fragment,
+          fragment: (referrer ? '' : child.fragment),
           ...(referrer && { referrer: this.getReferrer(referrer, segments) }),
         });
       }
@@ -298,11 +297,11 @@ export class BreadcrumbService {
         break;
       }
       case JourneyType.BENCHMARKS_TAB: {
-        routes = benchmarksTabJourney;
+        routes = benchmarksTabJourney();
         break;
       }
       case JourneyType.OLD_BENCHMARKS_DATA_TAB: {
-        routes = oldBenchmarksDataJourney;
+        routes = benchmarksTabJourney(true);
         break;
       }
 

--- a/frontend/src/app/core/services/breadcrumb.service.ts
+++ b/frontend/src/app/core/services/breadcrumb.service.ts
@@ -121,7 +121,7 @@ export class BreadcrumbService {
         routes.push({
           title,
           path: this.getPath(path, segments),
-          fragment: (referrer ? '' : child.fragment),
+          fragment: child.fragment,
           ...(referrer && { referrer: this.getReferrer(referrer, segments) }),
         });
       }

--- a/frontend/src/app/core/services/breadcrumb.service.ts
+++ b/frontend/src/app/core/services/breadcrumb.service.ts
@@ -122,6 +122,7 @@ export class BreadcrumbService {
         routes.push({
           title,
           path: this.getPath(path, segments),
+          fragment: child.fragment,
           ...(referrer && { referrer: this.getReferrer(referrer, segments) }),
         });
       }


### PR DESCRIPTION
#### Work done
- Included fragment to the get route instead of in the referrer object. This will apply the fragment to both home and benchmark routes. 
#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
