### PR TITLE
fix/staff-basic-records-with-mandatory-data

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,9 +1,7 @@
 import { NgModule } from '@angular/core';
 import { Router, RouterModule, Routes } from '@angular/router';
 import { PageNotFoundComponent } from '@core/components/error/page-not-found/page-not-found.component';
-import {
-  ProblemWithTheServiceComponent,
-} from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
+import { ProblemWithTheServiceComponent } from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
 import { AuthGuard } from '@core/guards/auth/auth.guard';
 import { LoggedOutGuard } from '@core/guards/logged-out/logged-out.guard';
 import { MigratedUserGuard } from '@core/guards/migrated-user/migrated-user.guard';
@@ -25,15 +23,14 @@ import { UsefulLinkPayResolver } from '@core/resolvers/useful-link-pay.resolver'
 import { UsefulLinkRecruitmentResolver } from '@core/resolvers/useful-link-recruitment.resolver';
 import { WizardResolver } from '@core/resolvers/wizard/wizard.resolver';
 import { WorkersResolver } from '@core/resolvers/workers.resolver';
+import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
 import { AdminComponent } from '@features/admin/admin.component';
 import { AscWdsCertificateComponent } from '@features/dashboard/asc-wds-certificate/asc-wds-certificate.component';
 import { FirstLoginPageComponent } from '@features/first-login-page/first-login-page.component';
 import { ForgotYourPasswordComponent } from '@features/forgot-your-password/forgot-your-password.component';
 import { LoginComponent } from '@features/login/login.component';
 import { LogoutComponent } from '@features/logout/logout.component';
-import {
-  MigratedUserTermsConditionsComponent,
-} from '@features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
+import { MigratedUserTermsConditionsComponent } from '@features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
 import { BecomeAParentComponent } from '@features/new-dashboard/become-a-parent/become-a-parent.component';
 import { DashboardWrapperComponent } from '@features/new-dashboard/dashboard-wrapper.component';
 import { LinkToParentComponent } from '@features/new-dashboard/link-to-parent/link-to-parent.component';
@@ -174,6 +171,7 @@ const routes: Routes = [
         component: StaffBasicRecord,
         resolve: {
           workers: WorkersResolver,
+          establishment: WorkplaceResolver,
         },
         data: { title: 'Staff Basic Records' },
       },
@@ -221,7 +219,8 @@ const routes: Routes = [
       },
       {
         path: 'benefits-bundle',
-        loadChildren: () => import('@features/benefits-bundle/benefits-bundle.module').then((m) => m.BenefitsBundleModule),
+        loadChildren: () =>
+          import('@features/benefits-bundle/benefits-bundle.module').then((m) => m.BenefitsBundleModule),
       },
       {
         path: 'become-a-parent',
@@ -262,8 +261,8 @@ const routes: Routes = [
   providers: [
     {
       provide: Router,
-      useClass: SubsidiaryRouterService
-    }
+      useClass: SubsidiaryRouterService,
+    },
   ],
 })
 export class AppRoutingModule {}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -4,9 +4,7 @@ import { ErrorHandler, NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import {
-  ProblemWithTheServiceComponent,
-} from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
+import { ProblemWithTheServiceComponent } from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
 import { ServiceUnavailableComponent } from '@core/components/error/service-unavailable/service-unavailable.component';
 import { FooterComponent } from '@core/components/footer/footer.component';
 import { HeaderComponent } from '@core/components/header/header.component';
@@ -49,12 +47,8 @@ import { windowProvider, WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
 import { AdminSkipService } from '@features/bulk-upload/admin-skip.service';
-import {
-  ParentWorkplaceAccounts,
-} from '@features/create-account/workplace/parent-workplace-accounts/parent-workplace-accounts.component';
-import {
-  SelectMainServiceComponent,
-} from '@features/create-account/workplace/select-main-service/select-main-service.component';
+import { ParentWorkplaceAccounts } from '@features/create-account/workplace/parent-workplace-accounts/parent-workplace-accounts.component';
+import { SelectMainServiceComponent } from '@features/create-account/workplace/select-main-service/select-main-service.component';
 import { AscWdsCertificateComponent } from '@features/dashboard/asc-wds-certificate/asc-wds-certificate.component';
 import { DashboardHeaderComponent } from '@features/dashboard/dashboard-header/dashboard-header.component';
 import { DashboardComponent } from '@features/dashboard/dashboard.component';
@@ -89,14 +83,11 @@ import { HighchartsChartModule } from 'highcharts-angular';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import {
-  StaffMismatchBannerComponent,
-} from './features/dashboard/home-tab/staff-mismatch-banner/staff-mismatch-banner.component';
-import {
-  MigratedUserTermsConditionsComponent,
-} from './features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
+import { StaffMismatchBannerComponent } from './features/dashboard/home-tab/staff-mismatch-banner/staff-mismatch-banner.component';
+import { MigratedUserTermsConditionsComponent } from './features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
 import { SatisfactionSurveyComponent } from './features/satisfaction-survey/satisfaction-survey.component';
 import { SentryErrorHandler } from './SentryErrorHandler.component';
+import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
 
 @NgModule({
   declarations: [
@@ -206,6 +197,7 @@ import { SentryErrorHandler } from './SentryErrorHandler.component';
     UsefulLinkPayResolver,
     UsefulLinkRecruitmentResolver,
     GetMissingCqcLocationsResolver,
+    WorkplaceResolver,
   ],
   bootstrap: [AppComponent],
 })

--- a/frontend/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.spec.ts
@@ -36,7 +36,7 @@ describe('StaffBasicRecord', () => {
           useValue: {
             snapshot: {
               data: {
-                primaryWorkplace: establishment,
+                establishment: establishment,
                 workers: { workersNotCompleted: workers },
               },
             },

--- a/frontend/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.ts
+++ b/frontend/src/app/features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component.ts
@@ -6,7 +6,6 @@ import { Worker } from '@core/model/worker.model';
 import { BackLinkService } from '@core/services/backLink.service';
 
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import dayjs from 'dayjs';
 
 @Component({
@@ -26,11 +25,10 @@ export class StaffBasicRecord implements OnInit, OnDestroy {
     protected backLinkService: BackLinkService,
     private route: ActivatedRoute,
     private permissionsService: PermissionsService,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
   ) {}
 
   ngOnInit(): void {
-    this.workplace = this.route.snapshot.data.primaryWorkplace;
+    this.workplace = this.route.snapshot.data.establishment;
     const { workersNotCompleted } = this.route.snapshot.data.workers;
     this.workerCount = workersNotCompleted?.length;
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');


### PR DESCRIPTION
#### Work done
- Change workplace to use establishment resolver in staff basic records
- This fixes issues with staff-basic-records not loading staff records correctly in sub view and records with only mandatory data added links not going to correct place. Clicking add more details should go to date of birth.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
