### PR TITLE
Fix/remove unneeded parent sub code

### DIFF
--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.html
@@ -1,5 +1,5 @@
 <div id="content">
-  <div *ngIf="isParentSubsidiaryView">
+  <div>
     <app-back-to-parent-link [parentWorkplaceName]="parentWorkplaceName"></app-back-to-parent-link>
   </div>
   <div class="asc-tabs-container">

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
@@ -1,8 +1,6 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component, Input, OnInit } from '@angular/core';
 import { Establishment } from '@core/model/establishment.model';
 import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
-import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TabsService } from '@core/services/tabs.service';
@@ -14,7 +12,7 @@ import { Subscription } from 'rxjs';
   templateUrl: './subsidiaryAccount.component.html',
   styleUrls: ['./subsidiaryAccount.component.scss'],
 })
-export class SubsidiaryAccountComponent implements OnInit, OnChanges {
+export class SubsidiaryAccountComponent implements OnInit {
   @Input() dashboardView: boolean;
   @Input() canAddWorker = false;
 
@@ -26,7 +24,6 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
   public canViewListOfWorkers: boolean;
   public canViewBenchmarks: boolean;
   public tabs: { title: string; slug: string; active: boolean }[];
-  public isParentSubsidiaryView: boolean;
   public parentWorkplaceName: string;
   public subWorkplace: Establishment;
   public subId: string;
@@ -50,8 +47,6 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
     this.workplaceId = id;
     this.getPermissions();
     this.setTabs();
-    this.isParentSubsidiaryView = this.parentSubsidiaryViewService.getViewingSubAsParent();
-
     this.subId = this.parentSubsidiaryViewService.getSubsidiaryUid();
 
     this.setWorkplace();
@@ -63,10 +58,6 @@ export class SubsidiaryAccountComponent implements OnInit, OnChanges {
         this.selectedTab = selectedTab;
       }),
     );
-  }
-
-  ngOnChanges(): void {
-    this.isParentSubsidiaryView = this.parentSubsidiaryViewService.getViewingSubAsParent();
   }
 
   private setWorkplace(): void {

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.spec.ts
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
 import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
@@ -14,12 +14,10 @@ import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import {
-  BenchmarksSelectViewPanelComponent,
-} from '@shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component';
+import { BenchmarksSelectViewPanelComponent } from '@shared/components/benchmarks-select-view-panel/benchmarks-select-view-panel.component';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
-import { fireEvent, render, within } from '@testing-library/angular';
+import { render } from '@testing-library/angular';
 
 import { ViewSubsidiaryBenchmarksComponent } from './view-subsidiary-benchmarks.component';
 
@@ -60,11 +58,18 @@ describe('ViewSubsidiaryBenchmarksComponent', () => {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
         },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: { establishment },
+            },
+          },
+        },
       ],
       declarations: [BenchmarksSelectViewPanelComponent],
       schemas: [NO_ERRORS_SCHEMA],
       componentProperties: {
-        workplace: establishment,
         newDashboard,
         tilesData: tileData,
       },
@@ -86,30 +91,28 @@ describe('ViewSubsidiaryBenchmarksComponent', () => {
     expect(component).toBeTruthy();
   });
 
-
   describe('can see new data area', () => {
     it('should render the new data area tab component', async () => {
       const { component, fixture, getByTestId, queryByTestId } = await setup();
 
-      component.canSeeNewDataArea = true
-      component.newDataAreaFlag = true
+      component.canSeeNewDataArea = true;
+      component.newDataAreaFlag = true;
       fixture.detectChanges();
 
       expect(queryByTestId('data-area-tab')).toBeTruthy();
     });
-  })
+  });
 
   describe('can not see new data area', () => {
     it('should render the old benchmarks tab', async () => {
       const { component, fixture, getByTestId, queryByTestId } = await setup();
 
-      component.canSeeNewDataArea = false
-      component.newDataAreaFlag = true
+      component.canSeeNewDataArea = false;
+      component.newDataAreaFlag = true;
       component.viewBenchmarksByCategory = true;
       fixture.detectChanges();
 
       expect(queryByTestId('old-benchmarks-tab')).toBeTruthy();
     });
-  })
-
+  });
 });

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
@@ -5,6 +5,7 @@ import { AllRankingsResponse, BenchmarksResponse, MetricsContent } from '@core/m
 import { Establishment } from '@core/model/establishment.model';
 import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { TabsService } from '@core/services/tabs.service';
 import { DataAreaAboutTheDataComponent } from '@shared/components/data-area-tab/about-the-data/about-the-data.component';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
@@ -40,13 +41,14 @@ export class ViewSubsidiaryBenchmarksComponent implements OnInit, OnDestroy {
     protected benchmarksService: BenchmarksServiceBase,
     public route: ActivatedRoute,
     private featureFlagsService: FeatureFlagsService,
+    private tabsService: TabsService,
   ) {}
 
   ngOnInit(): void {
     this.newDataAreaFlag = this.featureFlagsService.newBenchmarksDataArea;
 
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
-    this.tabsService.selectedTab = 'benchmarks'
+    this.tabsService.selectedTab = 'benchmarks';
 
     this.workplace = this.route.snapshot.data.establishment;
     this.canSeeNewDataArea = [1, 2, 8].includes(this.workplace.mainService.reportingID);

--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
@@ -5,11 +5,8 @@ import { AllRankingsResponse, BenchmarksResponse, MetricsContent } from '@core/m
 import { Establishment } from '@core/model/establishment.model';
 import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
-import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { TabsService } from '@core/services/tabs.service';
 import { DataAreaAboutTheDataComponent } from '@shared/components/data-area-tab/about-the-data/about-the-data.component';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
   selector: 'app-view-subsidiary-benchmarks',
@@ -36,15 +33,12 @@ export class ViewSubsidiaryBenchmarksComponent implements OnInit, OnDestroy {
   public newDashboard: boolean;
   public canSeeNewDataArea: boolean;
   public newDataAreaFlag: boolean;
-  public lastUpdatedDate: string
+  public lastUpdatedDate: string;
 
   constructor(
-    private permissionsService: PermissionsService,
     private breadcrumbService: BreadcrumbService,
     protected benchmarksService: BenchmarksServiceBase,
     public route: ActivatedRoute,
-    private tabsService: TabsService,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
     private featureFlagsService: FeatureFlagsService,
   ) {}
 
@@ -53,12 +47,9 @@ export class ViewSubsidiaryBenchmarksComponent implements OnInit, OnDestroy {
 
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
 
-    this.parentSubsidiaryViewService.getObservableSubsidiary().subscribe((subsidiaryWorkplace) => {
-      if (subsidiaryWorkplace) {
-        this.workplace = subsidiaryWorkplace;
-        this.canSeeNewDataArea = [1, 2, 8].includes(this.workplace.mainService.reportingID);
-      }
-    });
+    this.workplace = this.route.snapshot.data.establishment;
+    this.canSeeNewDataArea = [1, 2, 8].includes(this.workplace.mainService.reportingID);
+
     this.lastUpdatedDate = this.tilesData?.meta.lastUpdated.toString();
   }
 

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
@@ -15,7 +15,7 @@
     [workersNotCompleted]="workersNotCompleted"
     [(navigateToTab)]="navigateToTab"
     [canViewEstablishment]="canViewEstablishment"
-    [isParentSubsidiaryView]="isParentSubsidiaryView"
+    [isParentSubsidiaryView]="true"
   ></app-summary-section>
 </div>
 <div class="govuk-width-container govuk-!-margin-top-7">
@@ -61,7 +61,7 @@
       <app-other-links
         [canBulkUpload]="canBulkUpload"
         [canViewReports]="canViewReports"
-        [isParentSubsidiaryView]="isParentSubsidiaryView"
+        [isParentSubsidiaryView]="true"
       ></app-other-links>
     </div>
   </div>

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.spec.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.spec.ts
@@ -17,13 +17,11 @@ import { WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { MockEstablishmentServiceCheckCQCDetails } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
-import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
 import { NewArticleListComponent } from '@features/articles/new-article-list/new-article-list.component';
 import { SummarySectionComponent } from '@shared/components/summary-section/summary-section.component';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, queryByText, render } from '@testing-library/angular';
 import { of } from 'rxjs';
@@ -79,7 +77,6 @@ describe('ViewSubsidiaryHomeComponent', () => {
               },
             },
           },
-          { provide: ParentSubsidiaryViewService, useClass: MockParentSubsidiaryViewService },
           {
             provide: ActivatedRoute,
             useValue: {

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.spec.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.spec.ts
@@ -1,11 +1,13 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { TestBed, getTestBed } from '@angular/core/testing';
+import { getTestBed, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BenchmarksResponse } from '@core/model/benchmarks-v2.model';
 import { Roles } from '@core/model/roles.enum';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
+import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { ParentRequestsService } from '@core/services/parent-requests.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -15,21 +17,20 @@ import { WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { MockEstablishmentServiceCheckCQCDetails } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
 import { NewArticleListComponent } from '@features/articles/new-article-list/new-article-list.component';
+import { SummarySectionComponent } from '@shared/components/summary-section/summary-section.component';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, queryByText, render } from '@testing-library/angular';
 import { of } from 'rxjs';
+
 import { Establishment } from '../../../../mockdata/establishment';
 import { NewDashboardHeaderComponent } from '../../../shared/components/new-dashboard-header/dashboard-header.component';
 import { ViewSubsidiaryHomeComponent } from './view-subsidiary-home.component';
-import { SummarySectionComponent } from '@shared/components/summary-section/summary-section.component';
-import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
-import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
-import { BenchmarksResponse } from '@core/model/benchmarks-v2.model';
 
 const MockWindow = {
   dataLayer: {
@@ -165,7 +166,6 @@ describe('ViewSubsidiaryHomeComponent', () => {
         const { queryByText, component, fixture } = await setup();
 
         component.canBulkUpload = false;
-        component.isParentSubsidiaryView = true;
         fixture.detectChanges();
 
         expect(queryByText('Bulk upload your data')).toBeFalsy();
@@ -173,18 +173,15 @@ describe('ViewSubsidiaryHomeComponent', () => {
     });
 
     describe('Does your data meet WDF requirements link', () => {
-      it('should render the link with the correct href', async () => {
-        const { getByText, component, fixture } = await setup();
-        component.canViewReports = true;
-        fixture.detectChanges();
-        const link = getByText('Does your data meet WDF requirements?');
-        expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual('/wdf');
+      it('should not render the link as WDF not shown in sub pages', async () => {
+        const { queryByText, component, fixture } = await setup();
+
+        expect(queryByText('Does your data meet WDF requirements?')).toBeFalsy();
       });
 
-      it('should not render the link with the correct href when view reports is false', async () => {
+      it('should still not render the link when view reports is true', async () => {
         const { queryByText, component, fixture } = await setup();
-        component.canViewReports = false;
+        component.canViewReports = true;
         fixture.detectChanges();
         expect(queryByText('Does your data meet WDF requirements?')).toBeFalsy();
       });

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -13,7 +13,6 @@ import { UserService } from '@core/services/user.service';
 import { isAdminRole } from '@core/utils/check-role-util';
 import { ServiceNamePipe } from '@shared/pipes/service-name.pipe';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -64,7 +63,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
   public showMissingCqcMessage: boolean;
   public locationId: string;
   public workplacesCount: number;
-  public isParentSubsidiaryView: boolean;
   public tilesData: BenchmarksResponse;
 
   constructor(
@@ -73,7 +71,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     private tabsService: TabsService,
     public route: ActivatedRoute,
     private featureFlagsService: FeatureFlagsService,
-    public parentSubsidiaryViewService: ParentSubsidiaryViewService,
     protected benchmarksService: BenchmarksServiceBase,
     private serviceNamePipe: ServiceNamePipe,
   ) {}
@@ -92,8 +89,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     this.subId = this.route.snapshot.data.establishment.uid;
 
     this.newHomeDesignParentFlag = this.featureFlagsService.newHomeDesignParentFlag;
-
-    this.isParentSubsidiaryView = this.parentSubsidiaryViewService.getViewingSubAsParent();
 
     this.bigThreeServices = [1, 2, 8].includes(this.subsidiaryWorkplace.mainService.reportingID);
 

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { BenchmarksResponse } from '@core/model/benchmarks-v2.model';
 import { Establishment } from '@core/model/establishment.model';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { URLStructure } from '@core/model/url.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { Worker } from '@core/model/worker.model';
+import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TabsService } from '@core/services/tabs.service';
 import { UserService } from '@core/services/user.service';
@@ -13,8 +15,6 @@ import { ServiceNamePipe } from '@shared/pipes/service-name.pipe';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Subscription } from 'rxjs';
-import { BenchmarksResponse } from '@core/model/benchmarks-v2.model';
-import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 
 @Component({
   selector: 'app-view-subsidiary-home',
@@ -85,7 +85,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     this.trainingCounts = this.route.snapshot.data.workers?.trainingCounts;
     this.workersNotCompleted = this.route.snapshot.data.workers?.workersNotCompleted;
 
-    this.parentSubsidiaryViewService.setHasWorkers(this.workerCount);
     this.parentSubsidiaryViewService.setTotalTrainingRecords(this.trainingCounts.totalRecords);
 
     this.user = this.userService.loggedInUser;

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -85,8 +85,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     this.trainingCounts = this.route.snapshot.data.workers?.trainingCounts;
     this.workersNotCompleted = this.route.snapshot.data.workers?.workersNotCompleted;
 
-    this.parentSubsidiaryViewService.setTotalTrainingRecords(this.trainingCounts.totalRecords);
-
     this.user = this.userService.loggedInUser;
     this.addWorkplaceDetailsBanner = this.subsidiaryWorkplace.showAddWorkplaceDetailsBanner;
     this.setPermissionLinks();

--- a/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
+++ b/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
@@ -5,9 +5,7 @@ import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { TabsService } from '@core/services/tabs.service';
 import { WorkerService } from '@core/services/worker.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
   selector: 'app-view-subsidiary-staff-records',
@@ -27,8 +25,6 @@ export class ViewSubsidiaryStaffRecordsComponent implements OnInit {
     private permissionsService: PermissionsService,
     private workerService: WorkerService,
     private route: ActivatedRoute,
-    private tabsService: TabsService,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
   ) {}
 
   ngOnInit(): void {

--- a/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
+++ b/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
@@ -5,6 +5,7 @@ import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { TabsService } from '@core/services/tabs.service';
 import { WorkerService } from '@core/services/worker.service';
 
 @Component({
@@ -25,6 +26,7 @@ export class ViewSubsidiaryStaffRecordsComponent implements OnInit {
     private permissionsService: PermissionsService,
     private workerService: WorkerService,
     private route: ActivatedRoute,
+    private tabsService: TabsService,
   ) {}
 
   ngOnInit(): void {

--- a/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
+++ b/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
@@ -42,8 +42,6 @@ export class ViewSubsidiaryStaffRecordsComponent implements OnInit {
     this.workplace = this.route.snapshot.data.establishment;
     this.canAddWorker = this.permissionsService.can(this.workplace.uid, 'canAddWorker');
 
-    this.parentSubsidiaryViewService.setHasWorkers(this.workerCount);
-
     this.staffLastUpdatedDate = this.getStaffLastUpdatedDate();
   }
 

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
@@ -134,7 +134,6 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
     this.totalExpiringTraining = this.trainingCounts.totalExpiringTraining;
     this.missingMandatoryTraining = this.trainingCounts.missingMandatoryTraining;
     this.staffMissingMandatoryTraining = this.trainingCounts.staffMissingMandatoryTraining;
-    this.parentSubsidiaryViewService.setTotalTrainingRecords(this.trainingCounts.totalRecords);
   }
 
   public handleViewTrainingByCategory(visible: boolean): void {

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
@@ -65,9 +65,6 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
     this.workerCount = this.route.snapshot.data.workers?.workerCount;
     this.trainingCounts = this.route.snapshot.data.workers?.trainingCounts;
     this.tAndQsLastUpdated = this.route.snapshot.data.workers?.tAndQsLastUpdated;
-
-    this.parentSubsidiaryViewService.setHasWorkers(this.workerCount);
-
     this.workplace = this.route.snapshot.data.establishment;
 
     const alertMessage = history.state?.alertMessage;

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
@@ -12,7 +12,6 @@ import { PermissionsService } from '@core/services/permissions/permissions.servi
 import { TabsService } from '@core/services/tabs.service';
 import { TrainingCategoryService } from '@core/services/training-category.service';
 import { TrainingService } from '@core/services/training.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -50,7 +49,6 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
     private establishmentService: EstablishmentService,
     private router: Router,
     private route: ActivatedRoute,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
     private trainingCategoryService: TrainingCategoryService,
     private trainingService: TrainingService,
     private permissionsService: PermissionsService,

--- a/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
@@ -4,7 +4,6 @@ import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { UserService } from '@core/services/user.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
   selector: 'app-view-subsidiary-workplace-users',
@@ -18,7 +17,6 @@ export class ViewSubsidiaryWorkplaceUsersComponent implements OnInit {
     private route: ActivatedRoute,
     private userService: UserService,
     private breadcrumbService: BreadcrumbService,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
   ) {}
 
   ngOnInit(): void {

--- a/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
@@ -6,7 +6,6 @@ import { URLStructure } from '@core/model/url.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
   selector: 'app-view-subsidiary-workplace',
@@ -17,7 +16,6 @@ export class ViewSubsidiaryWorkplaceComponent implements OnInit {
   public canEditEstablishment: boolean;
   public addWorkplaceDetailsBanner: boolean;
   public showCqcDetailsBanner: boolean;
-  public isParentViewingSubsidiary: boolean;
 
   public workplace: Establishment;
   public workerCount: number;
@@ -26,12 +24,10 @@ export class ViewSubsidiaryWorkplaceComponent implements OnInit {
     private breadcrumbService: BreadcrumbService,
     private establishmentService: EstablishmentService,
     private permissionsService: PermissionsService,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
     private route: ActivatedRoute,
   ) {}
 
   ngOnInit(): void {
-    this.isParentViewingSubsidiary = true; // TODO use original component and use this to differentiate
     this.establishmentService.setInStaffRecruitmentFlow(false);
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
     this.workplace = this.route.snapshot.data.establishment;

--- a/frontend/src/app/features/workplace/start/start.component.html
+++ b/frontend/src/app/features/workplace/start/start.component.html
@@ -66,14 +66,13 @@
       </li>
       <li><p class="govuk-!-margin-left-3 govuk-!-margin-bottom-0">whether we can share your data?</p></li>
     </ul>
-    <a
-      [routerLink]="setContinueLink()"
+    <button
       (click)="removeAddDetailsBanner($event)"
       role="button"
       draggable="false"
       class="govuk-button govuk-!-margin-top-5"
     >
       Continue
-    </a>
+    </button>
   </div>
 </div>

--- a/frontend/src/app/features/workplace/start/start.component.spec.ts
+++ b/frontend/src/app/features/workplace/start/start.component.spec.ts
@@ -1,16 +1,16 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { getTestBed, TestBed } from '@angular/core/testing';
+import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BackService } from '@core/services/back.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
+import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { fireEvent, render } from '@testing-library/angular';
 
 import { WorkplaceModule } from '../workplace.module';
 import { StartComponent } from './start.component';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
-import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
 
 describe('StartComponent (workplace)', () => {
   async function setup(navigatedFromFragment = '') {
@@ -32,8 +32,12 @@ describe('StartComponent (workplace)', () => {
     });
 
     const component = fixture.componentInstance;
+    const injector = getTestBed();
+    const router = injector.inject(Router) as Router;
 
-    return { component, fixture, getByText };
+    const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+
+    return { component, fixture, getByText, routerSpy };
   }
 
   it('should render a StartComponent', async () => {
@@ -42,25 +46,15 @@ describe('StartComponent (workplace)', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have link to type of employer page on continue button', async () => {
-    const { component, getByText } = await setup();
+  it('should navigate to type of employer page after clicking continue button', async () => {
+    const { component, getByText, routerSpy } = await setup();
 
     const workplaceUid = component.establishment.uid;
     const continueButton = getByText('Continue');
 
-    expect(continueButton.getAttribute('href')).toBe('/workplace/' + workplaceUid + '/other-services');
-  });
+    fireEvent.click(continueButton);
 
-  it('should have link to type of employer page on continue button if isViewingSubAsParent is true', async () => {
-    const { component, getByText, fixture } = await setup();
-
-    const workplaceUid = component.establishment.uid;
-    const continueButton = getByText('Continue');
-
-    component.isViewingSubAsParent = true;
-    fixture.detectChanges();
-
-    expect(continueButton.getAttribute('href')).toBe('/subsidiary/workplace/' + workplaceUid + '/other-services');
+    expect(routerSpy).toHaveBeenCalledWith(['workplace', workplaceUid, 'other-services']);
   });
 
   it('should call the updateSingleEstablishmentField when clicking the Continue button', async () => {

--- a/frontend/src/app/features/workplace/start/start.component.spec.ts
+++ b/frontend/src/app/features/workplace/start/start.component.spec.ts
@@ -5,8 +5,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BackService } from '@core/services/back.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { fireEvent, render } from '@testing-library/angular';
 
 import { WorkplaceModule } from '../workplace.module';
@@ -23,10 +21,6 @@ describe('StartComponent (workplace)', () => {
         {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
-        },
-        {
-          provide: ParentSubsidiaryViewService,
-          useClass: MockParentSubsidiaryViewService,
         },
       ],
     });

--- a/frontend/src/app/features/workplace/start/start.component.ts
+++ b/frontend/src/app/features/workplace/start/start.component.ts
@@ -33,19 +33,11 @@ export class StartComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.isViewingSubAsParent = this.parentSubsidiaryViewService.getViewingSubAsParent();
 
-    if (this.parentSubsidiaryViewService.getViewingSubAsParent()) {
-      this.parentSubsidiaryViewService.getObservableSubsidiary().subscribe((subsidiaryWorkplace) => {
-        if (subsidiaryWorkplace) {
-          this.establishment = subsidiaryWorkplace;
-        }
-      });
-    } else {
-      this.subscriptions.add(
-        this.establishmentService.establishment$.pipe(take(1)).subscribe((establishment) => {
-          this.establishment = establishment;
-        }),
-      );
-    }
+    this.subscriptions.add(
+      this.establishmentService.establishment$.pipe(take(1)).subscribe((establishment) => {
+        this.establishment = establishment;
+      }),
+    );
 
     this.fragment = history.state?.navigatedFromFragment;
     this.setReturnLink();
@@ -72,7 +64,7 @@ export class StartComponent implements OnInit, OnDestroy {
 
     const data = { property: 'showAddWorkplaceDetailsBanner', value: false };
     this.establishmentService.updateSingleEstablishmentField(this.establishment.uid, data).subscribe();
-    this.setContinueLink();
+    this.router.navigate(['workplace', this.establishment.uid, 'other-services']);
   }
 
   public setRecuritmentBannerToTrue(): void {
@@ -80,13 +72,5 @@ export class StartComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.establishmentService.updateSingleEstablishmentField(this.establishment.uid, data).subscribe(),
     );
-  }
-
-  public setContinueLink(): any {
-    if (this.isViewingSubAsParent) {
-      return ['/subsidiary/workplace', this.establishment.uid, 'other-services'];
-    } else {
-      return ['/workplace', this.establishment.uid, 'other-services'];
-    }
   }
 }

--- a/frontend/src/app/features/workplace/start/start.component.ts
+++ b/frontend/src/app/features/workplace/start/start.component.ts
@@ -4,7 +4,6 @@ import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';
 import { BackService } from '@core/services/back.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -26,13 +25,10 @@ export class StartComponent implements OnInit, OnDestroy {
   constructor(
     public backService: BackService,
     private establishmentService: EstablishmentService,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
     private router: Router,
   ) {}
 
   ngOnInit(): void {
-    this.isViewingSubAsParent = this.parentSubsidiaryViewService.getViewingSubAsParent();
-
     this.subscriptions.add(
       this.establishmentService.establishment$.pipe(take(1)).subscribe((establishment) => {
         this.establishment = establishment;

--- a/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
+++ b/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
@@ -17,29 +17,16 @@ import { TabsService } from '@core/services/tabs.service';
 import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { isAdminRole } from '@core/utils/check-role-util';
-import {
-  BecomeAParentCancelDialogComponent,
-} from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
+import { BecomeAParentCancelDialogComponent } from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
 import { BecomeAParentDialogComponent } from '@shared/components/become-a-parent/become-a-parent-dialog.component';
-import {
-  CancelDataOwnerDialogComponent,
-} from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
-import {
-  ChangeDataOwnerDialogComponent,
-} from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
-import {
-  LinkToParentCancelDialogComponent,
-} from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
+import { CancelDataOwnerDialogComponent } from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
+import { ChangeDataOwnerDialogComponent } from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
+import { LinkToParentCancelDialogComponent } from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
 import { LinkToParentDialogComponent } from '@shared/components/link-to-parent/link-to-parent-dialog.component';
-import {
-  OwnershipChangeMessageDialogComponent,
-} from '@shared/components/ownership-change-message/ownership-change-message-dialog.component';
-import {
-  SetDataPermissionDialogComponent,
-} from '@shared/components/set-data-permission/set-data-permission-dialog.component';
+import { OwnershipChangeMessageDialogComponent } from '@shared/components/ownership-change-message/ownership-change-message-dialog.component';
+import { SetDataPermissionDialogComponent } from '@shared/components/set-data-permission/set-data-permission-dialog.component';
 import { ServiceNamePipe } from '@shared/pipes/service-name.pipe';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import saveAs from 'file-saver';
 import { Subscription } from 'rxjs';
 
@@ -113,7 +100,6 @@ export class NewHomeTabDirective implements OnInit, OnDestroy, OnChanges {
     private alertService: AlertService,
     private router: Router,
     public establishmentService: EstablishmentService,
-    public parentSubsidiaryViewService: ParentSubsidiaryViewService,
   ) {}
 
   ngOnInit(): void {

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -7,7 +7,6 @@ import { BehaviorSubject, Observable } from 'rxjs';
   providedIn: 'root',
 })
 export class ParentSubsidiaryViewService {
-  private subsidiaryUidSubject: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private subsidiaryWorkplace: BehaviorSubject<Establishment> = new BehaviorSubject<Establishment>(null);
   private viewingSubAsParent = false;
   private subsidiaryUid: string;
@@ -17,7 +16,6 @@ export class ParentSubsidiaryViewService {
   setViewingSubAsParent(subsidiaryUid: string) {
     this.subsidiaryUid = subsidiaryUid;
     this.viewingSubAsParent = true;
-    this.subsidiaryUidSubject.next(subsidiaryUid);
 
     this.establishmentService.getEstablishment(subsidiaryUid).subscribe((workplace) => {
       if (workplace) {
@@ -31,7 +29,6 @@ export class ParentSubsidiaryViewService {
   clearViewingSubAsParent() {
     this.subsidiaryUid = null;
     this.viewingSubAsParent = false;
-    this.subsidiaryUidSubject.next('');
     this.subsidiaryWorkplace.next(null);
   }
 
@@ -53,11 +50,6 @@ export class ParentSubsidiaryViewService {
 
   getSubsidiaryUid() {
     return this.subsidiaryUid;
-  }
-
-  // Method to get the current UID as an observable
-  getObservableSubsidiaryUid(): Observable<string> {
-    return this.subsidiaryUidSubject.asObservable();
   }
 
   // Method to get the current subsidiary as an observable

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -16,7 +16,6 @@ export class ParentSubsidiaryViewService {
 
   private viewingSubAsParent = false;
   private subsidiaryUid: string;
-  private hasWorkers = false;
 
   constructor(private establishmentService: EstablishmentService) {}
 
@@ -32,10 +31,6 @@ export class ParentSubsidiaryViewService {
         this.subsidiaryWorkplace.next(workplace);
       }
     });
-  }
-
-  setHasWorkers(workersCount: number) {
-    return (this.hasWorkers = workersCount > 0);
   }
 
   getTotalTrainingRecords(): BehaviorSubject<number> {
@@ -63,10 +58,6 @@ export class ParentSubsidiaryViewService {
       `/subsidiary/workplace-users/${this.subsidiaryUid}`,
     ];
     return subsidiaryDashboardUrls.includes(navUrl);
-  }
-
-  getHasWorkers() {
-    return this.hasWorkers;
   }
 
   getViewingSubAsParent() {

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -16,6 +16,7 @@ export class ParentSubsidiaryViewService {
 
     this.establishmentService.getEstablishment(subsidiaryUid).subscribe((workplace) => {
       if (workplace) {
+        this.establishmentService.setPrimaryWorkplace(workplace);
         this.establishmentService.setWorkplace(workplace);
       }
     });

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -1,13 +1,10 @@
 import { Injectable } from '@angular/core';
-import { Establishment } from '@core/model/establishment.model';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { BehaviorSubject, Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ParentSubsidiaryViewService {
-  private subsidiaryWorkplace: BehaviorSubject<Establishment> = new BehaviorSubject<Establishment>(null);
   private viewingSubAsParent = false;
   private subsidiaryUid: string;
 
@@ -19,9 +16,7 @@ export class ParentSubsidiaryViewService {
 
     this.establishmentService.getEstablishment(subsidiaryUid).subscribe((workplace) => {
       if (workplace) {
-        this.establishmentService.setPrimaryWorkplace(workplace);
         this.establishmentService.setWorkplace(workplace);
-        this.subsidiaryWorkplace.next(workplace);
       }
     });
   }
@@ -29,7 +24,6 @@ export class ParentSubsidiaryViewService {
   clearViewingSubAsParent() {
     this.subsidiaryUid = null;
     this.viewingSubAsParent = false;
-    this.subsidiaryWorkplace.next(null);
   }
 
   getViewingSubAsParentDashboard(navUrl): boolean {
@@ -50,10 +44,5 @@ export class ParentSubsidiaryViewService {
 
   getSubsidiaryUid() {
     return this.subsidiaryUid;
-  }
-
-  // Method to get the current subsidiary as an observable
-  getObservableSubsidiary(): Observable<Establishment> {
-    return this.subsidiaryWorkplace.asObservable();
   }
 }

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -9,9 +9,6 @@ import { BehaviorSubject, Observable } from 'rxjs';
 export class ParentSubsidiaryViewService {
   private subsidiaryUidSubject: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private subsidiaryWorkplace: BehaviorSubject<Establishment> = new BehaviorSubject<Establishment>(null);
-  private _getLastUpdatedDate$: BehaviorSubject<string> = new BehaviorSubject<string>('');
-  private _totalRecords$: BehaviorSubject<number> = new BehaviorSubject<number>(0);
-  public readonly totalTrainingRecords$: Observable<any> = this._totalRecords$.asObservable();
   private viewingSubAsParent = false;
   private subsidiaryUid: string;
 
@@ -66,13 +63,5 @@ export class ParentSubsidiaryViewService {
   // Method to get the current subsidiary as an observable
   getObservableSubsidiary(): Observable<Establishment> {
     return this.subsidiaryWorkplace.asObservable();
-  }
-
-  public get getLastUpdatedDateObservable(): Observable<string> {
-    return this._getLastUpdatedDate$.asObservable();
-  }
-
-  public set getLastUpdatedDate(lastUpdatedDate: string) {
-    this._getLastUpdatedDate$.next(lastUpdatedDate);
   }
 }

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -12,8 +12,6 @@ export class ParentSubsidiaryViewService {
   private _getLastUpdatedDate$: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private _totalRecords$: BehaviorSubject<number> = new BehaviorSubject<number>(0);
   public readonly totalTrainingRecords$: Observable<any> = this._totalRecords$.asObservable();
-  private totalRecords: BehaviorSubject<number> = new BehaviorSubject<number>(0);
-
   private viewingSubAsParent = false;
   private subsidiaryUid: string;
 
@@ -31,14 +29,6 @@ export class ParentSubsidiaryViewService {
         this.subsidiaryWorkplace.next(workplace);
       }
     });
-  }
-
-  getTotalTrainingRecords(): BehaviorSubject<number> {
-    return this.totalRecords;
-  }
-
-  setTotalTrainingRecords(totalRecords: number) {
-    this._totalRecords$.next(totalRecords);
   }
 
   clearViewingSubAsParent() {


### PR DESCRIPTION
#### Work done
- There was a lot of code referencing parent sub fields which wasn't needed. Removing this code makes it easier to see what functionality is required for the parent sub view service and is the first step to change the way the sub ID and isParentViewingSub are set in the service, which is required to resolve issues with refreshing and the browser back button.

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
