### PR TITLE
Add changes to run migrations in all environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	npm install --prefix backend
 
 run:
-	(cd backend && npm run new-start) & \
+	(cd backend && npm run dev-start) & \
 	(cd frontend && npm run build:watch)
 
 test-fe:
@@ -16,3 +16,7 @@ test-fe:
 
 test-be:
 	npm run server:test:unit --prefix backend
+
+db-migrate:
+	cd backend && export NODE_ENV=localhost & \
+	cd backend && npm run db:migrate

--- a/backend/bin/run-db-migrations.js
+++ b/backend/bin/run-db-migrations.js
@@ -1,8 +1,6 @@
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
-const instance_index = process.env.CF_INSTANCE_INDEX;
-
 async function runMigrations() {
   try {
     const command = 'npm run db:migrate';
@@ -21,6 +19,4 @@ async function runMigrations() {
   }
 }
 
-if (instance_index === '0') {
-  runMigrations();
-}
+runMigrations();

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,8 +2,9 @@
   "name": "ng-sfc-v2",
   "version": "0.0.1",
   "scripts": {
-    "new-start": "npm run api:server",
-    "start": "npm run cf:migrate && node --max-old-space-size=4096 server.js",
+    "dev-start": "npm run api:server",
+    "new-start": "npm run db:migrate:pipeline && npm run api:server",
+    "start": "npm run db:migrate:pipeline && node --max-old-space-size=4096 server.js",
     "build": "node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build --no-progress",
     "build:clean": "rimraf dist",
     "build:watch": "ng serve --proxy-config proxy.conf.json",
@@ -32,7 +33,7 @@
     "db:migration:generate": "sequelize migration:generate",
     "db:migrate": "sequelize db:migrate",
     "db:migrate:undo": "sequelize db:migrate:undo",
-    "cf:migrate": "node ./bin/cf-migrate.js",
+    "db:migrate:pipeline": "node ./bin/run-db-migrations.js",
     "test:server": "npm run server"
   },
   "private": true,

--- a/backend/server/config/sequelize.js
+++ b/backend/server/config/sequelize.js
@@ -11,7 +11,11 @@ module.exports = async () => {
 
   return {
     production: {
-      use_env_variable: 'DATABASE_URL',
+      username: config.get('db.username'),
+      password: config.get('db.password'),
+      database: config.get('db.database'),
+      host: config.get('db.host'),
+      port: config.get('db.port'),
       dialect: config.get('db.dialect'),
       dialectOptions: {
         ssl: config.get('db.ssl'),
@@ -19,7 +23,11 @@ module.exports = async () => {
       migrationStorageTableSchema: 'cqc',
     },
     preproduction: {
-      use_env_variable: 'DATABASE_URL',
+      username: config.get('db.username'),
+      password: config.get('db.password'),
+      database: config.get('db.database'),
+      host: config.get('db.host'),
+      port: config.get('db.port'),
       dialect: config.get('db.dialect'),
       dialectOptions: {
         ssl: config.get('db.ssl'),
@@ -27,7 +35,11 @@ module.exports = async () => {
       migrationStorageTableSchema: 'cqc',
     },
     test: {
-      use_env_variable: 'DATABASE_URL',
+      username: config.get('db.username'),
+      password: config.get('db.password'),
+      database: config.get('db.database'),
+      host: config.get('db.host'),
+      port: config.get('db.port'),
       dialect: config.get('db.dialect'),
       dialectOptions: {
         ssl: config.get('db.ssl'),
@@ -35,7 +47,11 @@ module.exports = async () => {
       migrationStorageTableSchema: 'cqc',
     },
     benchmarks: {
-      use_env_variable: 'DATABASE_URL',
+      username: config.get('db.username'),
+      password: config.get('db.password'),
+      database: config.get('db.database'),
+      host: config.get('db.host'),
+      port: config.get('db.port'),
       dialect: config.get('db.dialect'),
       dialectOptions: {
         ssl: config.get('db.ssl'),


### PR DESCRIPTION
#### Work done
- Added changes to run migrations in all environments on completion of pipeline

#### Note
We had intended to use the inactive workplaces ticket to move database migrations through to live, however that ticket needs more work as the changes cause a timeout in pre-prod where there is a lot of data. After consideration, this ticket has minimal risk as there are no code changes reliant on the database changes in the event that the migration does not run successfully in live. 

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
