### PR TITLE
Add migration to fix name of positive behaviour training category

### DIFF
--- a/backend/migrations/20240501131241-fixTrainingCategoryName.js
+++ b/backend/migrations/20240501131241-fixTrainingCategoryName.js
@@ -1,0 +1,27 @@
+'use strict';
+const models = require('../server/models/index');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up() {
+    return await models.workerTrainingCategories.update(
+      { category: 'Positive behaviour support and non-restrictive practice' },
+      {
+        where: {
+          id: 32,
+        },
+      },
+    );
+  },
+
+  async down() {
+    return await models.workerTrainingCategories.update(
+      { category: 'Positive behaviour and support and non-restrictive practice' },
+      {
+        where: {
+          id: 32,
+        },
+      },
+    );
+  },
+};


### PR DESCRIPTION
#### Work done
- Added migration to fix name of 'Positive behaviour support and non-restrictive practice' category

#### Note
Added as separate migration as the changes to training categories branch has already been deployed to staging

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
