### PR TITLE
Fix change data owner page

### DIFF
--- a/frontend/src/app/features/workplace/change-data-owner/change-data-owner.component.spec.ts
+++ b/frontend/src/app/features/workplace/change-data-owner/change-data-owner.component.spec.ts
@@ -70,7 +70,6 @@ describe('ChangeDataOwnerComponent', async () => {
             provide: ActivatedRoute,
             useValue: {
               snapshot: {
-                queryParams: { changeDataOwnerFrom: 'workplace-id-1' },
                 data: {
                   childWorkplaces: {
                     childWorkplaces: [
@@ -178,6 +177,8 @@ describe('ChangeDataOwnerComponent', async () => {
           component.primaryWorkplace.parentUid = null;
           component.primaryWorkplace.parentPostcode = null;
 
+          window.history.pushState({ changeDataOwnerFrom: 'workplace-id-1'}, '', '');
+
           component.ngOnInit();
           fixture.detectChanges();
 
@@ -194,6 +195,8 @@ describe('ChangeDataOwnerComponent', async () => {
           component.primaryWorkplace.parentName = null;
           component.primaryWorkplace.parentUid = null;
           component.primaryWorkplace.parentPostcode = null;
+
+          window.history.pushState({ changeDataOwnerFrom: 'workplace-id-1'}, '', '');
 
           component.ngOnInit();
           fixture.detectChanges();
@@ -308,7 +311,6 @@ describe('ChangeDataOwnerComponent', async () => {
             provide: ActivatedRoute,
             useValue: {
               snapshot: {
-                queryParams: { changeDataOwnerFrom: 'workplace-id-1' },
                 data: {
                   childWorkplaces: {
                     childWorkplaces: [

--- a/frontend/src/app/features/workplace/change-data-owner/change-data-owner.component.ts
+++ b/frontend/src/app/features/workplace/change-data-owner/change-data-owner.component.ts
@@ -66,7 +66,7 @@ export class ChangeDataOwnerComponent implements OnInit, AfterViewInit {
   }
 
   public setSubWorkplace(): void {
-    const changeDataOwnerFromUid = this.route.snapshot.queryParams?.changeDataOwnerFrom;
+    const changeDataOwnerFromUid = history.state?.changeDataOwnerFrom;
     if (this.isParent && changeDataOwnerFromUid) {
       const childWorkplaces = this.route.snapshot.data.childWorkplaces.childWorkplaces;
       this.subWorkplace = childWorkplaces.find((sub) => sub.uid === changeDataOwnerFromUid);

--- a/frontend/src/app/features/workplace/workplace-info-panel/workplace-info-panel.component.ts
+++ b/frontend/src/app/features/workplace/workplace-info-panel/workplace-info-panel.component.ts
@@ -8,13 +8,19 @@ import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
-import { CancelDataOwnerDialogComponent } from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
-import { ChangeDataOwnerDialogComponent } from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
+import {
+  CancelDataOwnerDialogComponent,
+} from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
+import {
+  ChangeDataOwnerDialogComponent,
+} from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
 import { MoveWorkplaceDialogComponent } from '@shared/components/move-workplace/move-workplace-dialog.component';
-import { SetDataPermissionDialogComponent } from '@shared/components/set-data-permission/set-data-permission-dialog.component';
-import { Subscription } from 'rxjs';
+import {
+  SetDataPermissionDialogComponent,
+} from '@shared/components/set-data-permission/set-data-permission-dialog.component';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-workplace-info-panel',
@@ -144,7 +150,7 @@ export class WorkplaceInfoPanelComponent implements OnInit, OnDestroy {
   public navigateToChangeDataOwner(event: Event): void {
     event.preventDefault();
     this.router.navigate(['/workplace/change-data-owner'], {
-      queryParams: { changeDataOwnerFrom: this.workplace.uid },
+      state: { changeDataOwnerFrom: this.workplace.uid },
     });
   }
 


### PR DESCRIPTION
#### Work done
- Used state in router navigate to pass data from `view-all-workplace` page to the change data owner page

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
