### PR TITLE
Fix alert banners 

### DIFF
--- a/frontend/src/app/features/new-dashboard/workplace-tab/workplace-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/workplace-tab/workplace-tab.component.html
@@ -4,6 +4,7 @@
   [updatedDate]="workplace.updated"
 ></app-new-dashboard-header>
 <div class="govuk-width-container govuk-!-padding-top-2">
+  <app-alert></app-alert>
   <ng-container *ngIf="canEditEstablishment && addWorkplaceDetailsBanner">
     <app-inset-text [color]="'todo'">
       <div class="govuk-grid-row">

--- a/frontend/src/app/features/new-dashboard/workplace-tab/workplace-tab.component.ts
+++ b/frontend/src/app/features/new-dashboard/workplace-tab/workplace-tab.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';
+import { AlertService } from '@core/services/alert.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -23,6 +24,7 @@ export class NewWorkplaceTabComponent implements OnInit, OnDestroy {
     private breadcrumbService: BreadcrumbService,
     private establishmentService: EstablishmentService,
     private permissionsService: PermissionsService,
+    private alertService: AlertService,
   ) {}
 
   ngOnInit(): void {
@@ -37,5 +39,6 @@ export class NewWorkplaceTabComponent implements OnInit, OnDestroy {
     // need to manually remove breadcrumbs on tabs, because a
     // navigation event isn't called when going from one tab to another
     this.breadcrumbService.removeRoutes();
+    this.alertService.removeAlert();
   }
 }

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.html
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.html
@@ -8,6 +8,7 @@
 ></app-new-dashboard-header>
 
 <div class="govuk-width-container govuk-!-padding-top-2">
+  <app-alert></app-alert>
   <div class="govuk-!-margin-top-6">
     <ng-container *ngIf="workers?.length > 0; else noStaffRecords">
       <app-new-training-link-panel

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
@@ -145,6 +145,8 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
   }
 
   ngOnDestroy(): void {
+    this.alertService.removeAlert()
     this.subscriptions.unsubscribe();
+    this.breadcrumbService.removeRoutes();
   }
 }

--- a/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.html
+++ b/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.html
@@ -2,6 +2,7 @@
 </app-new-dashboard-header>
 
 <div class="govuk-width-container govuk-!-padding-top-2" *ngIf="workplace">
+  <app-alert></app-alert>
   <ng-container *ngIf="canEditEstablishment && addWorkplaceDetailsBanner">
     <app-inset-text [color]="'todo'">
       <div class="govuk-grid-row">

--- a/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';
+import { AlertService } from '@core/services/alert.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -22,6 +23,7 @@ export class ViewSubsidiaryWorkplaceComponent implements OnInit {
   public workerCount: number;
 
   constructor(
+    private alertService: AlertService,
     private breadcrumbService: BreadcrumbService,
     private establishmentService: EstablishmentService,
     private permissionsService: PermissionsService,
@@ -42,6 +44,7 @@ export class ViewSubsidiaryWorkplaceComponent implements OnInit {
   ngOnDestroy(): void {
     // need to manually remove breadcrumbs on tabs, because a
     // navigation event isn't called when going from one tab to another
+    this.alertService.removeAlert()
     this.breadcrumbService.removeRoutes();
   }
 }

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -79,6 +79,9 @@ describe('StaffRecordComponent', () => {
     const workplaceUid = component.workplace.uid;
     const workerUid = component.worker.uid;
 
+    const alert = injector.inject(AlertService) as AlertService;
+    const alertSpy = spyOn(alert, 'addAlert').and.callThrough();
+
     return {
       component,
       fixture,
@@ -91,6 +94,7 @@ describe('StaffRecordComponent', () => {
       queryByText,
       workplaceUid,
       workerUid,
+      alertSpy,
     };
   }
 
@@ -271,6 +275,25 @@ describe('StaffRecordComponent', () => {
       expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], {
         fragment: 'staff-records',
         state: { showBanner: true },
+      });
+    });
+
+    it('should display a confirmation alert when the confirm record details button has been clicked', async () => {
+      const { getByText, alertSpy, fixture, component } = await setup();
+
+      component.canEditWorker = true;
+      component.workplace.uid = 'mock-uid';
+      component.worker.completed = false;
+      fixture.detectChanges();
+
+      const button = getByText('Confirm record details');
+      fireEvent.click(button);
+
+      fixture.whenStable().then(() => {
+        expect(alertSpy).toHaveBeenCalledWith({
+          type: 'success',
+          message: 'Staff record saved',
+        });
       });
     });
 

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -76,10 +76,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
   }
 
-  ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
-  }
-
   deleteWorker(event: Event): void {
     event.preventDefault();
     this.dialogService.open(DeleteWorkerDialogComponent, {
@@ -126,8 +122,12 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
   }
 
   public returnToHomeTab() {
-    const isLoggedInWorkplace = this.establishmentService.establishmentId === this.workplace.uid;
-    this.router.navigate(['/dashboard'], { fragment: 'staff-records', state: { showBanner: true } });
+    this.router.navigate(['/dashboard'], { fragment: 'staff-records', state: { showBanner: true } }).then(()=>{
+      this.alertService.addAlert({
+        type: 'success',
+        message: 'Staff record saved',
+      });
+    });
   }
 
   public setReturnTo(): void {
@@ -136,5 +136,12 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
       fragment: 'staff-record',
     };
     this.workerService.setReturnTo(this.returnToRecord);
+  }
+
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.removeRoutes();
+    this.alertService.removeAlert();
+    this.subscriptions.unsubscribe();
   }
 }

--- a/frontend/src/app/features/workplace/check-answers/check-answers.component.spec.ts
+++ b/frontend/src/app/features/workplace/check-answers/check-answers.component.spec.ts
@@ -93,10 +93,12 @@ describe('CheckAnswersComponent', () => {
     fireEvent.click(confirmDetailButton);
     fixture.detectChanges();
 
-    expect(alertSpy).toHaveBeenCalledWith({
-      type: 'success',
-      message: `You've confirmed the workplace details that you added`,
-    } as Alert);
+    fixture.whenStable().then(() => {
+      expect(alertSpy).toHaveBeenCalledWith({
+        type: 'success',
+        message: `You've confirmed the workplace details that you added`,
+      } as Alert);
+    });
   });
 
   describe('setBackLink', () => {

--- a/frontend/src/app/features/workplace/check-answers/check-answers.component.ts
+++ b/frontend/src/app/features/workplace/check-answers/check-answers.component.ts
@@ -57,15 +57,17 @@ export class CheckAnswersComponent implements OnInit, OnDestroy {
     this.backService.setBackLink({ url: ['/workplace', this.establishment.uid, 'sharing-data'] });
   }
 
-  ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
+  public showConfirmWorkplaceDetailsAlert(): void {
+    this.router.navigate(['/dashboard'], { fragment: 'workplace' })
+    .then(()=>{
+      this.alertService.addAlert({
+        type: 'success',
+        message: `You've confirmed the workplace details that you added`,
+      });})
   }
 
-  public showConfirmWorkplaceDetailsAlert(): void {
-    this.router.navigate(['/dashboard'], { fragment: 'workplace' });
-    this.alertService.addAlert({
-      type: 'success',
-      message: `You've confirmed the workplace details that you added`,
-    });
+  ngOnDestroy(): void {
+    this.alertService.removeAlert();
+    this.subscriptions.unsubscribe();
   }
 }


### PR DESCRIPTION
#### Work done
- Allowed alert banner to show after the user has confirmed the workplace details
- Fixed alert confirm staff record detail banner in parent staff record tab
- Fixed alert confirm workplace details banner in sub workplace record tab
- Fixed alert banner to display after adding multiple training records 

#### Todo
- Fix alert confirm staff record detail banner in sub staff record tab
- Moving away from state alert messages from staff and training and qualification tabs. This makes the banner stay even after navigating from other page. 
- Fix delete staff record confirmation banner in the sub

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
