### PR TITLE
Add navigation in sub view when link clicked from summary section

### DIFF
--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BenchmarksResponse } from '@core/model/benchmarks-v2.model';
 import { Establishment } from '@core/model/establishment.model';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
@@ -73,6 +73,7 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     private featureFlagsService: FeatureFlagsService,
     protected benchmarksService: BenchmarksServiceBase,
     private serviceNamePipe: ServiceNamePipe,
+    private router: Router,
   ) {}
 
   ngOnInit(): void {
@@ -149,6 +150,7 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
   public navigateToTab(event: Event, selectedTab: string): void {
     event.preventDefault();
     this.tabsService.selectedTab = selectedTab;
+    this.router.navigate(['dashboard'], { fragment: selectedTab });
   }
 
   private setBenchmarksCard(): void {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { RouterModule } from '@angular/router';
+import { getTestBed } from '@angular/core/testing';
+import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
@@ -10,7 +11,7 @@ import { MockEstablishmentServiceCheckCQCDetails } from '@core/test-utils/MockEs
 import { MockTabsService } from '@core/test-utils/MockTabsService';
 import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
-import { render, within } from '@testing-library/angular';
+import { fireEvent, render, within } from '@testing-library/angular';
 import dayjs from 'dayjs';
 
 import { Establishment } from '../../../../mockdata/establishment';
@@ -26,6 +27,7 @@ describe('Summary section', () => {
     workersNotCompleted = [workerBuilder()] as Worker[],
     canViewListOfWorkers = true,
     canViewEstablishment = true,
+    isParentSubsidiaryView = false,
   ) => {
     const { fixture, getByText, queryByText, getByTestId, queryByTestId } = await render(SummarySectionComponent, {
       imports: [SharedModule, HttpClientTestingModule, RouterModule, RouterTestingModule],
@@ -54,10 +56,15 @@ describe('Summary section', () => {
         canViewEstablishment: canViewEstablishment,
         showMissingCqcMessage: false,
         workplacesCount: 0,
+        isParentSubsidiaryView,
       },
     });
 
     const component = fixture.componentInstance;
+    const injector = getTestBed();
+
+    const router = injector.inject(Router) as Router;
+    const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
 
     return {
       component,
@@ -66,6 +73,7 @@ describe('Summary section', () => {
       queryByText,
       getByTestId,
       queryByTestId,
+      routerSpy,
     };
   };
 
@@ -130,6 +138,16 @@ describe('Summary section', () => {
       const workplaceRow = getByTestId('workplace-row');
       expect(within(workplaceRow).getByText('Add more details to your workplace')).toBeTruthy();
       expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+    });
+
+    it('should navigate to sub workplace page when clicking the add workplace details message in sub view', async () => {
+      const establishment = { ...Establishment, showAddWorkplaceDetailsBanner: true };
+      const { getByText, routerSpy } = await setup(true, establishment, 0, {}, [], [], true, true, true);
+
+      const workplaceDetailsMessage = getByText('Add more details to your workplace');
+      fireEvent.click(workplaceDetailsMessage);
+
+      expect(routerSpy).toHaveBeenCalledWith(['subsidiary', 'workplace', Establishment.uid]);
     });
 
     it('should show the check cqc details message if checkCQCDetails banner is true and the showAddWorkplaceDetailsBanner is false', async () => {
@@ -267,6 +285,15 @@ describe('Summary section', () => {
       expect(getByTestId('orange-flag')).toBeTruthy();
     });
 
+    it('should navigate to sub staff records page when clicking on start to add your staff message in sub view', async () => {
+      const { getByText, routerSpy } = await setup(false, Establishment, 0, {}, [], [], true, true, true);
+
+      const staffRecordMessage = getByText('You can start to add your staff records now');
+      fireEvent.click(staffRecordMessage);
+
+      expect(routerSpy).toHaveBeenCalledWith(['subsidiary', 'staff-records', Establishment.uid]);
+    });
+
     it('should show staff record does not match message when the number of staff is more than the staff record', async () => {
       const establishment = {
         ...Establishment,
@@ -365,55 +392,77 @@ describe('Summary section', () => {
       expect(within(staffRecordsRow).queryByText('No staff records added in the last 12 months')).toBeFalsy();
     });
 
-    it('should show "Some records only have mandatory data added" message when staff records are not completed and worker added date is more than 1 month ago', async () => {
-      const date = new Date();
+    describe('"Some records only have mandatory data added" link', () => {
+      const workerCreatedDate = (timeframe) => {
+        return [
+          {
+            ...workerBuilder(),
+            completed: false,
+            created: dayjs().subtract(2, timeframe).toISOString(),
+          },
+        ] as Worker[];
+      };
 
-      const workerCreatedDate = [
-        {
-          ...workerBuilder(),
-          completed: false,
-          created: dayjs().subtract(2, 'month').toISOString(),
-        },
-      ] as Worker[];
-      const { fixture, getByTestId } = await setup(false, Establishment, 12, {}, [dayjs()], workerCreatedDate);
+      it('should show "Some records only have mandatory data added" message when staff records are not completed and worker added date is more than 1 month ago', async () => {
+        const { fixture, getByTestId } = await setup(
+          false,
+          Establishment,
+          12,
+          {},
+          [dayjs()],
+          workerCreatedDate('month'),
+        );
 
-      fixture.detectChanges();
-      const staffRecordsRow = getByTestId('staff-records-row');
-      expect(within(staffRecordsRow).queryByText('Some records only have mandatory data added')).toBeTruthy();
-    });
+        const staffRecordsRow = getByTestId('staff-records-row');
+        expect(within(staffRecordsRow).queryByText('Some records only have mandatory data added')).toBeTruthy();
+      });
 
-    it('should not show "Some records only have mandatory data added" message when staff records are not completed and worker added date is less than 1 month ago', async () => {
-      const date = new Date();
+      it('should navigate to basic-staff-records when "Some records only have mandatory data added" clicked', async () => {
+        const { getByText, routerSpy } = await setup(
+          false,
+          Establishment,
+          12,
+          {},
+          [dayjs()],
+          workerCreatedDate('month'),
+        );
 
-      const workerCreatedDate = [
-        {
-          ...workerBuilder(),
-          completed: false,
-          created: dayjs().subtract(1, 'week').toISOString(),
-        },
-      ] as Worker[];
-      const { fixture, getByTestId } = await setup(false, Establishment, 12, {}, [dayjs()], workerCreatedDate);
+        const basicStaffRecordsLink = getByText('Some records only have mandatory data added');
+        fireEvent.click(basicStaffRecordsLink);
+        expect(routerSpy).toHaveBeenCalledWith(['/staff-basic-records']);
+      });
 
-      fixture.detectChanges();
-      const staffRecordsRow = getByTestId('staff-records-row');
-      expect(within(staffRecordsRow).queryByText('Some records only have mandatory data added')).toBeFalsy();
-    });
+      it('should navigate to basic-staff-records with uid when "Some records only have mandatory data added" clicked in sub view', async () => {
+        const { getByText, routerSpy } = await setup(
+          false,
+          Establishment,
+          12,
+          {},
+          [dayjs()],
+          workerCreatedDate('month'),
+          true,
+          true,
+          true,
+        );
 
-    it('should not show "Some records only have mandatory data added" message when staff records are completed and worker added date is less than 1 month ago', async () => {
-      const date = new Date();
+        const basicStaffRecordsLink = getByText('Some records only have mandatory data added');
+        fireEvent.click(basicStaffRecordsLink);
+        expect(routerSpy).toHaveBeenCalledWith(['/staff-basic-records', Establishment.uid]);
+      });
 
-      const workerCreatedDate = [
-        {
-          ...workerBuilder(),
-          completed: true,
-          created: dayjs().subtract(1, 'week').toISOString(),
-        },
-      ] as Worker[];
-      const { fixture, getByTestId } = await setup(false, Establishment, 12, {}, [dayjs()], workerCreatedDate);
+      it('should not show "Some records only have mandatory data added" message when staff records are not completed and worker added date is less than 1 month ago', async () => {
+        const { getByTestId } = await setup(false, Establishment, 12, {}, [dayjs()], workerCreatedDate('week'));
 
-      fixture.detectChanges();
-      const staffRecordsRow = getByTestId('staff-records-row');
-      expect(within(staffRecordsRow).queryByText('Some records only have mandatory data added')).toBeFalsy();
+        const staffRecordsRow = getByTestId('staff-records-row');
+        expect(within(staffRecordsRow).queryByText('Some records only have mandatory data added')).toBeFalsy();
+      });
+
+      it('should not show "Some records only have mandatory data added" message when staff records are completed and worker added date is less than 1 month ago', async () => {
+        const { getByTestId } = await setup(false, Establishment, 12, {}, [dayjs()], workerCreatedDate('week'));
+
+        const staffRecordsRow = getByTestId('staff-records-row');
+        expect(within(staffRecordsRow).queryByText('Some records only have mandatory data added')).toBeFalsy();
+      });
     });
   });
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -66,9 +66,8 @@ export class SummarySectionComponent implements OnInit, OnChanges {
 
   public async onClick(event: Event, fragment: string, route: string[]): Promise<void> {
     event.preventDefault();
-    if (this.isParentSubsidiaryView && route) {
-      this.tabsService.selectedTab = fragment;
-      await this.router.navigate(route);
+    if (this.isParentSubsidiaryView) {
+      await this.navigateInSubView(fragment, route);
     } else if (route) {
       await this.router.navigate(route);
       this.tabsService.selectedTab = fragment;
@@ -76,6 +75,11 @@ export class SummarySectionComponent implements OnInit, OnChanges {
       this.tabsService.selectedTab = fragment;
     }
   }
+
+  private navigateInSubView = async (fragment: string, route: string[]) => {
+    this.tabsService.selectedTab = fragment;
+    await this.router.navigate(route ? route : ['subsidiary', fragment, this.workplace.uid]);
+  };
 
   public getWorkplaceSummaryMessage(): void {
     const { showAddWorkplaceDetailsBanner, numberOfStaff, vacancies, starters, leavers } = this.workplace;


### PR DESCRIPTION
#### Work done
- Added call to router navigate for links in summary section in the parent sub view
- This resolves an issue with navigating to tabs in the sub view from the summary section, which was caused by only navigating on change of tab when triggered by click event (changes introduced to stop switching tabs on reload)

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
