### PR TITLE
Removed setting primary workplace in sub view and update benefits bundle to use establishment

### DIFF
--- a/frontend/src/app/core/resolvers/primary-workplace.resolver.ts
+++ b/frontend/src/app/core/resolvers/primary-workplace.resolver.ts
@@ -15,6 +15,7 @@ export class PrimaryWorkplaceResolver implements Resolve<any> {
       return this.establishmentService.getEstablishment(workplaceUid).pipe(
         tap((workplace) => {
           this.establishmentService.setPrimaryWorkplace(workplace);
+          this.establishmentService.setWorkplace(workplace);
           const standAloneAccount = !(workplace?.isParent || workplace?.parentUid);
           this.establishmentService.standAloneAccount = standAloneAccount;
         }),

--- a/frontend/src/app/features/benefits-bundle/benefit-tailored-seminars/benefit-tailored-seminars.component.ts
+++ b/frontend/src/app/features/benefits-bundle/benefit-tailored-seminars/benefit-tailored-seminars.component.ts
@@ -22,8 +22,8 @@ export class TailoredSeminarsComponent implements OnInit {
 
   ngOnInit(): void {
     this.pages = this.route.snapshot.data.pages?.data[0];
-    this.workplaceName = this.establishmentService.primaryWorkplace.name;
-    this.workplaceID = this.establishmentService.primaryWorkplace.nmdsId;
+    this.workplaceName = this.establishmentService.establishment.name;
+    this.workplaceID = this.establishmentService.establishment.nmdsId;
     this.breadcrumbService.show(JourneyType.BENEFITS_BUNDLE);
   }
 }

--- a/frontend/src/app/features/benefits-bundle/benefits-bundle.component.html
+++ b/frontend/src/app/features/benefits-bundle/benefits-bundle.component.html
@@ -94,9 +94,7 @@
           to the social care sector.
         </p>
         <p>
-          <a href="/benefits-bundle/training-discounts"
-            >View discounts from Skills for Care's endorsed training providers</a
-          >
+          <a [routerLink]="['training-discounts']">View discounts from Skills for Care's endorsed training providers</a>
         </p>
       </app-benefit-accordion>
 

--- a/frontend/src/app/features/benefits-bundle/benefits-bundle.component.spec.ts
+++ b/frontend/src/app/features/benefits-bundle/benefits-bundle.component.spec.ts
@@ -13,6 +13,7 @@ import { BenefitAccordionComponent } from './benefit-accordion/benefit-accordion
 import { BenefitsBundleComponent } from './benefits-bundle.component';
 
 describe('BenefitsBundleComponent', () => {
+  const workplaceName = 'Test Workplace Name';
   async function setup() {
     const { fixture, getByText, getByTestId, getAllByText, queryByText } = await render(BenefitsBundleComponent, {
       imports: [SharedModule, RouterTestingModule, HttpClientTestingModule],
@@ -20,7 +21,7 @@ describe('BenefitsBundleComponent', () => {
       providers: [
         {
           provide: EstablishmentService,
-          useClass: MockEstablishmentService,
+          useFactory: MockEstablishmentService.factory(null, true, { name: workplaceName }),
         },
         {
           provide: BreadcrumbService,
@@ -59,9 +60,8 @@ describe('BenefitsBundleComponent', () => {
 
   it('should display the workplace name', async () => {
     const { getByText } = await setup();
-
-    const workplaceName = getByText('Test Workplace');
-    expect(workplaceName).toBeTruthy();
+    const workplaceNameOnPage = getByText(workplaceName);
+    expect(workplaceNameOnPage).toBeTruthy();
   });
 
   it(`should display the "What's the ASC-WDS Benefits Bundle?" reveal and its contents`, async () => {

--- a/frontend/src/app/features/benefits-bundle/benefits-bundle.component.ts
+++ b/frontend/src/app/features/benefits-bundle/benefits-bundle.component.ts
@@ -9,7 +9,6 @@ import { EstablishmentService } from '@core/services/establishment.service';
 })
 export class BenefitsBundleComponent implements OnInit {
   public workplaceName: string;
-  public workplaceId: string;
   public revealTitle = `What's the ASC-WDS Benefits Bundle?`;
   public allOpen = false;
   public endorsedProvidersLinkFlag: boolean;
@@ -39,8 +38,7 @@ export class BenefitsBundleComponent implements OnInit {
   constructor(private establishmentService: EstablishmentService, private breadcrumbService: BreadcrumbService) {}
 
   public async ngOnInit(): Promise<void> {
-    this.workplaceName = this.establishmentService.primaryWorkplace.name;
-    this.workplaceId = this.establishmentService.primaryWorkplace.nmdsId;
+    this.workplaceName = this.establishmentService.establishment.name;
     this.breadcrumbService.show(JourneyType.BENEFITS_BUNDLE);
   }
 

--- a/frontend/src/app/features/benefits-bundle/benefits-elearning/benefits-elearning.component.ts
+++ b/frontend/src/app/features/benefits-bundle/benefits-elearning/benefits-elearning.component.ts
@@ -21,7 +21,7 @@ export class BenefitsELearningComponent implements OnInit {
 
   ngOnInit(): void {
     this.pages = this.route.snapshot.data.pages?.data[0];
-    this.workplaceName = this.establishmentService.primaryWorkplace.name;
+    this.workplaceName = this.establishmentService.establishment.name;
     this.breadcrumbService.show(JourneyType.BENEFITS_BUNDLE);
   }
 }

--- a/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.ts
+++ b/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.ts
@@ -22,7 +22,7 @@ export class BenefitsTrainingDiscountsComponent implements OnInit {
 
   ngOnInit(): void {
     this.pages = this.route.snapshot.data.pages?.data[0];
-    this.workplaceName = this.establishmentService.primaryWorkplace.name;
+    this.workplaceName = this.establishmentService.establishment.name;
     this.breadcrumbService.show(JourneyType.BENEFITS_BUNDLE);
   }
 }

--- a/frontend/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
+++ b/frontend/src/app/features/workplace/user-account-saved/user-account-saved.component.ts
@@ -1,9 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';
 import { UserDetails } from '@core/model/userDetails.model';
-import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
@@ -14,20 +12,12 @@ import { take } from 'rxjs/operators';
 })
 export class UserAccountSavedComponent implements OnInit {
   private subscriptions: Subscription = new Subscription();
-  public workplace: Establishment;
 
-  constructor(
-    private userService: UserService,
-    private route: ActivatedRoute,
-    private establishmentService: EstablishmentService,
-  ) {}
-
-  // public returnUrl$: Observable<URLStructure>;
+  constructor(private userService: UserService, private route: ActivatedRoute) {}
   public userDetails: UserDetails = this.route.snapshot.data.user;
   public return: URLStructure;
 
   ngOnInit() {
-    this.workplace = this.establishmentService.primaryWorkplace;
     this.subscriptions.add(
       this.userService.returnUrl.pipe(take(1)).subscribe((returnUrl) => {
         this.return = returnUrl;

--- a/frontend/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
+++ b/frontend/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
@@ -14,7 +14,7 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
   public breadcrumbs: JourneyRoute[];
   public overrideMessage: string;
   private subscriptions: Subscription = new Subscription();
-  private workplace: Establishment;
+  public workplace: Establishment;
 
   constructor(
     private breadcrumbService: BreadcrumbService,
@@ -24,7 +24,7 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.subscriptions.add(
-      this.establishmentService.primaryWorkplace$.subscribe((workplace) => {
+      this.establishmentService.establishment$.subscribe((workplace) => {
         this.workplace = workplace;
       }),
     );

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -24,6 +24,7 @@ export class ParentSubsidiaryViewService {
   clearViewingSubAsParent(): void {
     this.subsidiaryUid = null;
     this.viewingSubAsParent = false;
+    this.establishmentService.setWorkplace(this.establishmentService.primaryWorkplace);
   }
 
   getViewingSubAsParentDashboard(navUrl): boolean {

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -16,7 +16,6 @@ export class ParentSubsidiaryViewService {
 
     this.establishmentService.getEstablishment(subsidiaryUid).subscribe((workplace) => {
       if (workplace) {
-        this.establishmentService.setPrimaryWorkplace(workplace);
         this.establishmentService.setWorkplace(workplace);
       }
     });


### PR DESCRIPTION
The way have been setting state in the establishment class for subsidiary workplaces is different from the original way of having primary workplace which is the logged in workplace, and establishment, which is set either as the primary workplace or the subsidiary which is being viewed. This created problems with setting permissions and meant that original navigating logic in the question sections was being ignored and then handled by the subsidiary router service. 

#### Work done
- Removed setting primaryWorkplace from parent subsidiary service
- Changed primaryWorkplaceResolver to set establishment as well so that sections outside of question areas can access it from parent view
- Updated benefits bundle area to use establishment instead of primary workplace to display correct name in sub view

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [X] No, I found it difficult to test
- [ ] No, they are not required for this change
