### PR TITLE
Add check to subsidiary router service to prevent error being thrown on login

### DIFF
--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -41,6 +41,10 @@ export class SubsidiaryRouterService extends Router {
   }
 
   navigateByUrl(url: UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean> {
+    if (!url.root?.children?.primary?.segments) {
+      return super.navigateByUrl(url, extras);
+    }
+
     const { commands, navigationExtras } = this.getCommands(url);
 
     if (!this.isSubsidiaryPage(commands)) {


### PR DESCRIPTION
#### Work done
- Added checks for format of url tree to prevent error being thrown on login after timeout in subsidiary view

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
