### PR TITLE
Set same breadcrumbs as stand alone on staff record page when in sub …

### DIFF
--- a/frontend/src/app/core/services/breadcrumb.service.ts
+++ b/frontend/src/app/core/services/breadcrumb.service.ts
@@ -114,7 +114,7 @@ export class BreadcrumbService {
 
       const isCurrentRoute = this.isCurrentRoute(path, segments);
 
-      if (isCurrentRoute || index === children.length - 1) {
+      if (isCurrentRoute || index === children?.length - 1) {
         routes.push({
           title,
           path: this.getPath(path, segments),

--- a/frontend/src/app/core/test-utils/MockWorkerService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkerService.ts
@@ -61,6 +61,7 @@ export const workerBuilder = build('Worker', {
     countryOfBirth: {
       value: 'United Kingdom',
     },
+    updated: '2024-05-01T06:50:45.882Z',
   },
 });
 

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -11,6 +11,7 @@ import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { WorkerService } from '@core/services/worker.service';
+import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -41,6 +42,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     private workerService: WorkerService,
     protected backLinkService: BackLinkService,
     public breadcrumbService: BreadcrumbService,
+    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
   ) {}
 
   ngOnInit(): void {
@@ -56,10 +58,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     );
 
     if (!this.insideFlow) {
-      const journey = this.establishmentService.isOwnWorkplace()
-        ? JourneyType.MY_WORKPLACE
-        : JourneyType.ALL_WORKPLACES;
-      this.breadcrumbService.show(journey);
+      this.breadcrumbService.show(this.getBreadcrumbsJourney());
     } else {
       this.backLinkService.showBackLink();
     }
@@ -122,7 +121,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
   }
 
   public returnToHomeTab() {
-    this.router.navigate(['/dashboard'], { fragment: 'staff-records', state: { showBanner: true } }).then(()=>{
+    this.router.navigate(['/dashboard'], { fragment: 'staff-records', state: { showBanner: true } }).then(() => {
       this.alertService.addAlert({
         type: 'success',
         message: 'Staff record saved',
@@ -138,6 +137,11 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     this.workerService.setReturnTo(this.returnToRecord);
   }
 
+  public getBreadcrumbsJourney(): JourneyType {
+    return this.parentSubsidiaryViewService.getViewingSubAsParent() || this.establishmentService.isOwnWorkplace()
+      ? JourneyType.MY_WORKPLACE
+      : JourneyType.ALL_WORKPLACES;
+  }
 
   ngOnDestroy(): void {
     this.breadcrumbService.removeRoutes();


### PR DESCRIPTION
#### Work done
- Set same breadcrumbs as stand alone on staff record page when in sub view (it was showing the all workplaces breadcrumbs and would error on click of all workplaces link)

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
