### PR TITLE
Updated dashboard header to set permissions based on workplace uid instead of primary

### DIFF
--- a/frontend/src/app/core/test-utils/MockParentSubsidiaryViewService.ts
+++ b/frontend/src/app/core/test-utils/MockParentSubsidiaryViewService.ts
@@ -17,4 +17,6 @@ export class MockParentSubsidiaryViewService extends ParentSubsidiaryViewService
   public getViewingSubAsParent() {
     return this.mockViewingSubAsParent;
   }
+
+  public clearViewingSubAsParent(): void {}
 }

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
@@ -4,6 +4,7 @@ import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
 import { Roles } from '@core/model/roles.enum';
 import { AuthService } from '@core/services/auth.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -12,7 +13,7 @@ import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { MockAuthService } from '@core/test-utils/MockAuthService';
-import { MockEstablishmentService, establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
+import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
@@ -22,7 +23,6 @@ import { render, within } from '@testing-library/angular';
 import { of } from 'rxjs';
 
 import { NewDashboardHeaderComponent } from './dashboard-header.component';
-import { Establishment } from '@core/model/establishment.model';
 
 const MockWindow = {
   dataLayer: {
@@ -430,8 +430,7 @@ describe('NewDashboardHeaderComponent', () => {
         0,
         true,
       );
-      spyOn(establishmentService, 'deleteWorkplace').and.callFake(() => of({}));
-      spyOn(establishmentService, 'getEstablishment').and.callFake(() => of({}));
+      spyOn(establishmentService, 'deleteWorkplace').and.returnValue(of({}));
 
       const deleteWorkplace = getByText('Delete Workplace');
       deleteWorkplace.click();
@@ -454,8 +453,7 @@ describe('NewDashboardHeaderComponent', () => {
         0,
         true,
       );
-      spyOn(establishmentService, 'deleteWorkplace').and.callFake(() => of({}));
-      spyOn(establishmentService, 'getEstablishment').and.callFake(() => of({}));
+      spyOn(establishmentService, 'deleteWorkplace').and.returnValue(of({}));
 
       const deleteWorkplace = getByText('Delete Workplace');
       deleteWorkplace.click();

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
@@ -1,9 +1,8 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { AlertService } from '@core/services/alert.service';
-import { AuthService } from '@core/services/auth.service';
 import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -48,9 +47,7 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
     private establishmentService: EstablishmentService,
     private dialogService: DialogService,
     private permissionsService: PermissionsService,
-    private authService: AuthService,
     private router: Router,
-    private route: ActivatedRoute,
     private alertService: AlertService,
     private userService: UserService,
     private parentSubsidiaryViewService: ParentSubsidiaryViewService,
@@ -106,13 +103,10 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
       this.establishmentService.deleteWorkplace(this.workplace.uid).subscribe(
         () => {
           if (this.isParentSubsidiaryView) {
-            this.establishmentService.getEstablishment(this.workplace.parentUid).subscribe((workplace) => {
-              this.establishmentService.setPrimaryWorkplace(workplace);
-              this.parentSubsidiaryViewService.clearViewingSubAsParent();
+            this.parentSubsidiaryViewService.clearViewingSubAsParent();
 
-              this.router.navigate(['workplace', 'view-all-workplaces']).then(() => {
-                this.displaySuccessfullyDeletedAlert();
-              });
+            this.router.navigate(['workplace', 'view-all-workplaces']).then(() => {
+              this.displaySuccessfullyDeletedAlert();
             });
           } else {
             this.router.navigate(['sfcadmin', 'search', 'workplace']).then(() => {
@@ -140,15 +134,9 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
   private getPermissions(): void {
     this.user = this.userService.loggedInUser;
     if (isAdminRole(this.user?.role)) {
-      this.canDeleteEstablishment = this.permissionsService.can(
-        this.establishmentService.primaryWorkplace?.uid,
-        'canDeleteAllEstablishments',
-      );
+      this.canDeleteEstablishment = this.permissionsService.can(this.workplace?.uid, 'canDeleteAllEstablishments');
     } else {
-      this.canDeleteEstablishment = this.permissionsService.can(
-        this.establishmentService.primaryWorkplace?.uid,
-        'canDeleteEstablishment',
-      );
+      this.canDeleteEstablishment = this.permissionsService.can(this.workplace?.uid, 'canDeleteEstablishment');
     }
   }
 


### PR DESCRIPTION
Changing it so that the sub is not set as primaryWorkplace meant that the Delete workplace link was no longer displaying in the sub view.

#### Work done
- Updated dashboard header to set permissions based on workplace uid instead of primary

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
