### PR TITLE
Set dashboard as return in change expires soon alert page and handle sub navigation through sub router service

### DIFF
--- a/frontend/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
+++ b/frontend/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.spec.ts
@@ -14,7 +14,7 @@ import { WorkplaceModule } from '../workplace.module';
 import { ChangeExpiresSoonAlertsComponent } from './change-expires-soon-alerts.component';
 
 describe('ChangeExpiresSoonAlertsComponent', () => {
-  async function setup(isPrimary = true) {
+  async function setup() {
     const { fixture, getByText, getAllByText } = await render(ChangeExpiresSoonAlertsComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkplaceModule],
       providers: [
@@ -28,7 +28,7 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
                   expiresSoonAlertDate: '90',
                 },
                 establishment: {
-                  uid: isPrimary ? '98a83eef-e1e1-49f3-89c5-b1287a3cc8de' : '1446-uid-54638',
+                  uid: '98a83eef-e1e1-49f3-89c5-b1287a3cc8de',
                 },
               },
             },
@@ -91,6 +91,14 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
     expect(component.form.value.expiresSoonAlerts).toBe('90');
   });
 
+  it('should have url for the training and quals tab on Cancel button', async () => {
+    const { getByText } = await setup();
+
+    const cancelButton = getByText('Cancel');
+
+    expect(cancelButton.getAttribute('href')).toEqual('/dashboard#training-and-qualifications');
+  });
+
   describe('onSubmit', () => {
     it('should update the expires soon dates on submit', async () => {
       const { component, establishmentSpy, getByText } = await setup();
@@ -105,7 +113,7 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
       expect(establishmentSpy).toHaveBeenCalledWith('98a83eef-e1e1-49f3-89c5-b1287a3cc8de', '60');
     });
 
-    it('should navigate to the training and quals tab on submit if user is primary user', async () => {
+    it('should navigate to the training and quals tab on submit', async () => {
       const { component, routerSpy, getByText } = await setup();
 
       const saveAndReturnButton = getByText('Save and return');
@@ -113,18 +121,6 @@ describe('ChangeExpiresSoonAlertsComponent', () => {
 
       expect(component.form.valid).toBeTruthy();
       expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'training-and-qualifications' });
-    });
-
-    it(`should navigate to the sub's training and quals tab on submit if user is not primary user`, async () => {
-      const { component, routerSpy, getByText } = await setup(false);
-
-      const saveAndReturnButton = getByText('Save and return');
-      fireEvent.click(saveAndReturnButton);
-
-      expect(component.form.valid).toBeTruthy();
-      expect(routerSpy).toHaveBeenCalledWith(['/workplace', component.workplaceUid], {
-        fragment: 'training-and-qualifications',
-      });
     });
 
     it('should display an alert when the "Save and return" button is clicked', async () => {

--- a/frontend/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
+++ b/frontend/src/app/features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component.ts
@@ -17,7 +17,6 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   public expiresSoonDate: string;
   public workplaceUid: string;
   public returnUrl: URLStructure;
-  public isPrimary: boolean;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -32,7 +31,6 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   public ngOnInit(): void {
     this.workplaceUid = this.route.snapshot.data.establishment.uid;
     this.expiresSoonDate = this.route.snapshot.data.expiresSoonAlertDate.expiresSoonAlertDate;
-    this.isPrimary = this.establishmentService.primaryWorkplace.uid === this.workplaceUid;
     this.setupForm();
     this.setReturnUrl();
     this.setBackLink();
@@ -45,8 +43,7 @@ export class ChangeExpiresSoonAlertsComponent implements OnInit {
   }
 
   private setReturnUrl(): void {
-    const url = this.isPrimary ? ['/dashboard'] : ['/workplace', this.workplaceUid];
-    this.returnUrl = { url, fragment: 'training-and-qualifications' };
+    this.returnUrl = { url: ['/dashboard'], fragment: 'training-and-qualifications' };
   }
 
   public setBackLink(): void {


### PR DESCRIPTION
In the sub view, after setting training expiry dates, it was navigating to the workplace tab instead of going back to the training and quals tab

#### Work done
- Set dashboard as return in change expires soon alert page and handle sub navigation through sub router service

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
