### PR TITLE
Fix/navigating back to parent

### DIFF
--- a/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
+++ b/frontend/src/app/features/subsidiary/benchmarks/view-subsidiary-benchmarks.component.ts
@@ -48,7 +48,6 @@ export class ViewSubsidiaryBenchmarksComponent implements OnInit, OnDestroy {
     this.newDataAreaFlag = this.featureFlagsService.newBenchmarksDataArea;
 
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
-    this.tabsService.selectedTab = 'benchmarks';
 
     this.workplace = this.route.snapshot.data.establishment;
     this.canSeeNewDataArea = [1, 2, 8].includes(this.workplace.mainService.reportingID);

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -82,7 +82,6 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     this.workerCount = this.route.snapshot.data.workers?.workerCount;
     this.trainingCounts = this.route.snapshot.data.workers?.trainingCounts;
     this.workersNotCompleted = this.route.snapshot.data.workers?.workersNotCompleted;
-    this.tabsService.selectedTab = 'home';
 
     this.user = this.userService.loggedInUser;
     this.addWorkplaceDetailsBanner = this.subsidiaryWorkplace.showAddWorkplaceDetailsBanner;

--- a/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
+++ b/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.ts
@@ -5,7 +5,6 @@ import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { TabsService } from '@core/services/tabs.service';
 import { WorkerService } from '@core/services/worker.service';
 
 @Component({
@@ -24,12 +23,10 @@ export class ViewSubsidiaryStaffRecordsComponent implements OnInit {
     private permissionsService: PermissionsService,
     private workerService: WorkerService,
     private route: ActivatedRoute,
-    private tabsService: TabsService,
   ) {}
 
   ngOnInit(): void {
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
-    this.tabsService.selectedTab = 'staff-records';
     this.workerService.setAddStaffRecordInProgress(false);
 
     this.workers = this.route.snapshot.data.workers?.workers;

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
@@ -58,7 +58,6 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
   ngOnInit(): void {
     this.establishmentService.setCheckCQCDetailsBanner(false);
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
-    this.tabsService.selectedTab = 'training-and-qualifications'
 
     this.workers = this.route.snapshot.data.workers?.workers;
     this.workerCount = this.route.snapshot.data.workers?.workerCount;
@@ -145,7 +144,7 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
   }
 
   ngOnDestroy(): void {
-    this.alertService.removeAlert()
+    this.alertService.removeAlert();
     this.subscriptions.unsubscribe();
     this.breadcrumbService.removeRoutes();
   }

--- a/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
-import { TabsService } from '@core/services/tabs.service';
 import { UserService } from '@core/services/user.service';
 
 @Component({
@@ -18,12 +17,10 @@ export class ViewSubsidiaryWorkplaceUsersComponent implements OnInit {
     private route: ActivatedRoute,
     private userService: UserService,
     private breadcrumbService: BreadcrumbService,
-    private tabsService: TabsService,
   ) {}
 
   ngOnInit(): void {
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
-    this.tabsService.selectedTab = 'workplace-users';
     this.workplace = this.route.snapshot.data.establishment;
     this.lastUpdatedDate = this.workplace.updated.toString();
   }

--- a/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace/view-subsidiary-workplace.component.ts
@@ -7,7 +7,6 @@ import { AlertService } from '@core/services/alert.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { TabsService } from '@core/services/tabs.service';
 
 @Component({
   selector: 'app-view-subsidiary-workplace',
@@ -28,11 +27,9 @@ export class ViewSubsidiaryWorkplaceComponent implements OnInit {
     private establishmentService: EstablishmentService,
     private permissionsService: PermissionsService,
     private route: ActivatedRoute,
-    private tabsService: TabsService,
   ) {}
 
   ngOnInit(): void {
-    this.tabsService.selectedTab = 'workplace';
     this.establishmentService.setInStaffRecruitmentFlow(false);
     this.breadcrumbService.show(JourneyType.SUBSIDIARY);
     this.workplace = this.route.snapshot.data.establishment;
@@ -44,7 +41,7 @@ export class ViewSubsidiaryWorkplaceComponent implements OnInit {
   ngOnDestroy(): void {
     // need to manually remove breadcrumbs on tabs, because a
     // navigation event isn't called when going from one tab to another
-    this.alertService.removeAlert()
+    this.alertService.removeAlert();
     this.breadcrumbService.removeRoutes();
   }
 }

--- a/frontend/src/app/shared/components/back-to-parent-link/back-to-parent-link.component.ts
+++ b/frontend/src/app/shared/components/back-to-parent-link/back-to-parent-link.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { TabsService } from '@core/services/tabs.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
@@ -10,13 +11,19 @@ import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-
 export class BackToParentComponent implements OnInit {
   @Input() parentWorkplaceName: string;
 
-  constructor(private router: Router, private parentSubsidiaryViewService: ParentSubsidiaryViewService) {}
+  constructor(
+    private router: Router,
+    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
+    private tabsService: TabsService,
+  ) {}
 
   ngOnInit() {}
 
   public backToParentLinkClick(event: Event) {
     event.preventDefault();
+
     this.parentSubsidiaryViewService.clearViewingSubAsParent();
+    this.tabsService.selectedTab = 'home';
     this.router.navigate(['/dashboard', { fragment: 'home' }]);
   }
 }

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
@@ -13,14 +13,24 @@ import userEvent from '@testing-library/user-event';
 import { NewTabsComponent } from './new-tabs.component';
 
 describe('NewTabsComponent', () => {
-  const setup = async (dashboardView = true, snapshot = {}) => {
+  const setup = async (dashboardView = true, urlSegments = []) => {
     const { fixture, getByTestId } = await render(NewTabsComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
         TabsService,
         {
           provide: ActivatedRoute,
-          useValue: { snapshot },
+          useValue: {
+            snapshot: {
+              _urlSegment: {
+                children: {
+                  primary: {
+                    segments: urlSegments,
+                  },
+                },
+              },
+            },
+          },
         },
       ],
       declarations: [],
@@ -210,65 +220,38 @@ describe('NewTabsComponent', () => {
 
   describe('getTabSlugInSubView', () => {
     it('should return null when fewer than 3 segments in url path', async () => {
-      const snapshot = {
-        _urlSegment: {
-          children: {
-            primary: {
-              segments: [{ path: 'dashboard' }],
-            },
-          },
-        },
-      };
+      const urlSegments = [{ path: 'dashboard' }];
 
-      const { component } = await setup(true, snapshot);
+      const { component } = await setup(true, urlSegments);
       const returned = component.getTabSlugInSubView();
       expect(returned).toEqual(null);
     });
 
     it('should return null when more than 3 segments in url path', async () => {
-      const snapshot = {
-        _urlSegment: {
-          children: {
-            primary: {
-              segments: [{ path: 'subsidiary' }, { path: 'workplace' }, { path: 'testuid' }, { path: 'staff-record' }],
-            },
-          },
-        },
-      };
+      const urlSegments = [
+        { path: 'subsidiary' },
+        { path: 'workplace' },
+        { path: 'testuid' },
+        { path: 'staff-record' },
+      ];
 
-      const { component } = await setup(true, snapshot);
+      const { component } = await setup(true, urlSegments);
       const returned = component.getTabSlugInSubView();
       expect(returned).toEqual(null);
     });
 
     it('should return null when 3 segments but second segment does not match tab slug name', async () => {
-      const snapshot = {
-        _urlSegment: {
-          children: {
-            primary: {
-              segments: [{ path: 'subsidiary' }, { path: 'articles' }, { path: 'news-article' }],
-            },
-          },
-        },
-      };
+      const urlSegments = [{ path: 'subsidiary' }, { path: 'articles' }, { path: 'news-article' }];
 
-      const { component } = await setup(true, snapshot);
+      const { component } = await setup(true, urlSegments);
       const returned = component.getTabSlugInSubView();
       expect(returned).toEqual(null);
     });
 
     it('should return tab slug when 3 segments and second segment matches tab slug', async () => {
-      const snapshot = {
-        _urlSegment: {
-          children: {
-            primary: {
-              segments: [{ path: 'subsidiary' }, { path: 'training-and-qualifications' }, { path: 'testuid' }],
-            },
-          },
-        },
-      };
+      const urlSegments = [{ path: 'subsidiary' }, { path: 'training-and-qualifications' }, { path: 'testuid' }];
 
-      const { component } = await setup(true, snapshot);
+      const { component } = await setup(true, urlSegments);
       const returned = component.getTabSlugInSubView();
       expect(returned).toEqual('training-and-qualifications');
     });

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
@@ -2,7 +2,7 @@ import { Location } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TabsService } from '@core/services/tabs.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
@@ -13,10 +13,16 @@ import userEvent from '@testing-library/user-event';
 import { NewTabsComponent } from './new-tabs.component';
 
 describe('NewTabsComponent', () => {
-  const setup = async (dashboardView = true) => {
+  const setup = async (dashboardView = true, snapshot = {}) => {
     const { fixture, getByTestId } = await render(NewTabsComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
-      providers: [TabsService],
+      providers: [
+        TabsService,
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot },
+        },
+      ],
       declarations: [],
       componentProperties: {
         tabs: [
@@ -199,6 +205,72 @@ describe('NewTabsComponent', () => {
 
       expect(keyDownSpy).toHaveBeenCalled();
       expect(selectTabSpy).toHaveBeenCalledWith(new KeyboardEvent('End'), 4);
+    });
+  });
+
+  describe('getTabSlugInSubView', () => {
+    it('should return null when fewer than 3 segments in url path', async () => {
+      const snapshot = {
+        _urlSegment: {
+          children: {
+            primary: {
+              segments: [{ path: 'dashboard' }],
+            },
+          },
+        },
+      };
+
+      const { component } = await setup(true, snapshot);
+      const returned = component.getTabSlugInSubView();
+      expect(returned).toEqual(null);
+    });
+
+    it('should return null when more than 3 segments in url path', async () => {
+      const snapshot = {
+        _urlSegment: {
+          children: {
+            primary: {
+              segments: [{ path: 'subsidiary' }, { path: 'workplace' }, { path: 'testuid' }, { path: 'staff-record' }],
+            },
+          },
+        },
+      };
+
+      const { component } = await setup(true, snapshot);
+      const returned = component.getTabSlugInSubView();
+      expect(returned).toEqual(null);
+    });
+
+    it('should return null when 3 segments but second segment does not match tab slug name', async () => {
+      const snapshot = {
+        _urlSegment: {
+          children: {
+            primary: {
+              segments: [{ path: 'subsidiary' }, { path: 'articles' }, { path: 'news-article' }],
+            },
+          },
+        },
+      };
+
+      const { component } = await setup(true, snapshot);
+      const returned = component.getTabSlugInSubView();
+      expect(returned).toEqual(null);
+    });
+
+    it('should return tab slug when 3 segments and second segment matches tab slug', async () => {
+      const snapshot = {
+        _urlSegment: {
+          children: {
+            primary: {
+              segments: [{ path: 'subsidiary' }, { path: 'training-and-qualifications' }, { path: 'testuid' }],
+            },
+          },
+        },
+      };
+
+      const { component } = await setup(true, snapshot);
+      const returned = component.getTabSlugInSubView();
+      expect(returned).toEqual('training-and-qualifications');
     });
   });
 });

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.ts
@@ -36,7 +36,8 @@ export class NewTabsComponent implements OnInit, OnDestroy {
     this.selectedTabSubscription();
     this.isParentViewingSub = this.parentSubsidiaryViewService.getViewingSubAsParent();
 
-    const hash = this.route.snapshot.fragment;
+    const hash = this.isParentViewingSub ? this.getTabSlugInSubView() : this.route.snapshot.fragment;
+
     if (hash) {
       const activeTab = this.tabs.findIndex((tab) => tab.slug === hash);
       if (activeTab) {
@@ -122,6 +123,16 @@ export class NewTabsComponent implements OnInit, OnDestroy {
 
   private unselectTabs() {
     this.tabs.forEach((t) => (t.active = false));
+  }
+
+  public getTabSlugInSubView(): string {
+    const urlSegmentGroup = this.route.snapshot['_urlSegment'];
+    const urlSegments = urlSegmentGroup.children?.primary?.segments;
+    if (urlSegments?.length == 3) {
+      const tabSlug = urlSegments[1].path;
+      return this.tabs.find((tab) => tab.slug === tabSlug) ? tabSlug : null;
+    }
+    return null;
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Setting the selected tab on load of the sub tab pages was causing a navigation to that tab instead of going back to the home page when clicking the back to parent link. Removing that means we need to set tab on reload of page from the new-tabs component for sub view in a similar way to the logic which gets the fragment for the stand alone view.

#### Work done
- Removed setting selected tab from sub dashboard pages
- Added logic to set tab on reload of page using url segment
- Updated subsidiaryAccount to set establishment from service instead of making call to backend as call has been made in resolvers

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
