### PR TITLE
Fix/change order of sub tab urls to reduce calls to resolvers

### DIFF
--- a/frontend/src/app/core/breadcrumb/journey.subsidiary.ts
+++ b/frontend/src/app/core/breadcrumb/journey.subsidiary.ts
@@ -1,12 +1,12 @@
 import { JourneyRoute } from './breadcrumb.model';
 
 enum Path {
-  DASHBOARD = '/subsidiary/home/:establishmentuid',
-  WORKPLACE = '/subsidiary/workplace/:establishmentuid',
-  STAFF_RECORDS = '/subsidiary/staff-records/:establishmentuid',
-  TRAINING_AND_QUALIFICATIONS = '/subsidiary/training-and-qualifications/:establishmentuid',
-  BENCHMARKS = '/subsidiary/benchmarks/:establishmentuid',
-  WORKPLACE_USERS = '/subsidiary/workplace-users/:establishmentuid',
+  DASHBOARD = '/subsidiary/:establishmentuid/home',
+  WORKPLACE = '/subsidiary/:establishmentuid/workplace',
+  STAFF_RECORDS = '/subsidiary/:establishmentuid/staff-records',
+  TRAINING_AND_QUALIFICATIONS = '/subsidiary/:establishmentuid/training-and-qualifications',
+  BENCHMARKS = '/subsidiary/:establishmentuid/benchmarks',
+  WORKPLACE_USERS = '/subsidiary/:establishmentuid/workplace-users',
   USER_DETAILS = 'subsidiary/workplace/:establishmentuid/user/:useruid',
   PERMISSIONS = 'subsidiary/workplace/:establishmentuid/user/:useruid/permissions',
 }
@@ -16,32 +16,26 @@ export const subsidiaryJourney: JourneyRoute = {
     {
       title: 'Dashboard',
       path: Path.DASHBOARD,
-      fragment: 'home',
     },
     {
       title: 'Workplace',
       path: Path.WORKPLACE,
-      fragment: 'workplace',
     },
     {
       title: 'Staff records',
       path: Path.STAFF_RECORDS,
-      fragment: 'staff-records',
     },
     {
       title: 'Training and qualifications',
       path: Path.TRAINING_AND_QUALIFICATIONS,
-      fragment: 'training-and-qualifications',
     },
     {
       title: 'Benchmarks',
       path: Path.BENCHMARKS,
-      fragment: 'benchmarks',
     },
     {
       title: 'Workplace users',
       path: Path.WORKPLACE_USERS,
-      fragment: 'workplace-users',
       children: [
         {
           title: 'User details',

--- a/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
+++ b/frontend/src/app/core/components/subsidiaryAccount/subsidiaryAccount.component.ts
@@ -4,7 +4,6 @@ import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { TabsService } from '@core/services/tabs.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -36,7 +35,6 @@ export class SubsidiaryAccountComponent implements OnInit, OnDestroy {
     private permissionsService: PermissionsService,
     private tabsService: TabsService,
     private benchmarksService: BenchmarksServiceBase,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
   ) {}
 
   ngOnInit(): void {

--- a/frontend/src/app/core/services/breadcrumb.service.spec.ts
+++ b/frontend/src/app/core/services/breadcrumb.service.spec.ts
@@ -1,6 +1,8 @@
-import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { UrlSegment } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
 import { BreadcrumbService } from './breadcrumb.service';
 
 describe('BreadcrumbService', () => {
@@ -16,5 +18,42 @@ describe('BreadcrumbService', () => {
 
   it('should create the service', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('getPath', () => {
+    const createUrlSegment = (path) => {
+      return { path } as UrlSegment;
+    };
+
+    it('should return same url when no parameters', () => {
+      const expected = '/test-url/workplace';
+      const result = service.getPath('/test-url/workplace', [
+        createUrlSegment('test-url'),
+        createUrlSegment('workplace'),
+      ]);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should return url with parameter replaced by corresponding url segment', () => {
+      const expected = '/test-url/fakeUid123';
+      const result = service.getPath('/test-url/:establishmentuid', [
+        createUrlSegment('test-url'),
+        createUrlSegment('fakeUid123'),
+      ]);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should return url with parameter replaced by following url segment when param is establishmentuid and corresponding segment is workplace', () => {
+      const expected = '/test-url/fakeUid123';
+      const result = service.getPath('/test-url/:establishmentuid', [
+        createUrlSegment('test-url'),
+        createUrlSegment('workplace'),
+        createUrlSegment('fakeUid123'),
+      ]);
+
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/frontend/src/app/core/services/breadcrumb.service.ts
+++ b/frontend/src/app/core/services/breadcrumb.service.ts
@@ -134,9 +134,12 @@ export class BreadcrumbService {
     return routes;
   }
 
-  private getPath(url: string, segments: UrlSegment[]) {
+  public getPath(url: string, segments: UrlSegment[]) {
     const path = this.getParts(url).map((part, index) => {
       if (this.isParameter(part)) {
+        if (part === ':establishmentuid' && segments[index].path === 'workplace') {
+          return segments[index + 1].path;
+        }
         return segments[index] ? segments[index].path : part;
       }
       return part;

--- a/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
@@ -106,33 +106,67 @@ const routes: Routes = [
     loadChildren: () => import('@features/benefits-bundle/benefits-bundle.module').then((m) => m.BenefitsBundleModule),
   },
   {
-    path: 'home/:establishmentuid',
+    path: ':establishmentuid',
     canActivate: [HasPermissionsGuard],
+    resolve: {
+      users: AllUsersForEstablishmentResolver,
+      establishment: WorkplaceResolver,
+      workers: WorkersResolver,
+      totalStaffRecords: TotalStaffRecordsResolver,
+      articleList: ArticleListResolver,
+      subsidiary: SubsidiaryResolver,
+      benchmarksResolver: BenchmarksResolver,
+      rankingsResolver: RankingsResolver,
+      usefulLinksPay: UsefulLinkPayResolver,
+      usefulLinkRecruitment: UsefulLinkRecruitmentResolver,
+    },
     children: [
       {
-        path: '',
-        component: ViewSubsidiaryHomeComponent,
-        resolve: {
-          users: AllUsersForEstablishmentResolver,
-          establishment: WorkplaceResolver,
-          workers: WorkersResolver,
-          totalStaffRecords: TotalStaffRecordsResolver,
-          articleList: ArticleListResolver,
-          subsidiary: SubsidiaryResolver,
-        },
-        canActivate: [CheckPermissionsGuard],
-        data: {
-          permissions: ['canViewEstablishment'],
-          title: 'Dashboard',
-          workerPagination: true,
-        },
+        path: 'home',
+        canActivate: [HasPermissionsGuard],
+        children: [
+          {
+            path: '',
+            component: ViewSubsidiaryHomeComponent,
+            canActivate: [CheckPermissionsGuard],
+            data: {
+              permissions: ['canViewEstablishment'],
+              title: 'Dashboard',
+              workerPagination: true,
+            },
+          },
+        ],
+      },
+      {
+        path: 'staff-records',
+        component: ViewSubsidiaryStaffRecordsComponent,
+        data: { title: 'Staff Records' },
+      },
+      {
+        path: 'training-and-qualifications',
+        component: ViewSubsidiaryTrainingAndQualificationsComponent,
+        data: { title: 'Training and qualifications' },
+      },
+      {
+        path: 'benchmarks',
+        component: ViewSubsidiaryBenchmarksComponent,
+        data: { title: 'Benchmarks' },
+      },
+      {
+        path: 'workplace-users',
+        component: ViewSubsidiaryWorkplaceUsersComponent,
+        data: { title: 'Workplace users' },
+      },
+      {
+        path: 'workplace',
+        component: ViewSubsidiaryWorkplaceComponent,
+        data: { title: 'Workplace' },
       },
     ],
   },
   {
     path: 'workplace/:establishmentuid',
     component: EditWorkplaceComponent,
-    data: { title: 'Workplace' },
     canActivate: [HasPermissionsGuard],
     resolve: {
       users: AllUsersForEstablishmentResolver,
@@ -171,17 +205,6 @@ const routes: Routes = [
           permissions: ['canEditWorker'],
           title: 'Add Mandatory Training',
         },
-      },
-      {
-        path: '',
-        component: ViewSubsidiaryWorkplaceComponent,
-        resolve: {
-          users: AllUsersForEstablishmentResolver,
-          establishment: WorkplaceResolver,
-          workers: WorkersResolver,
-          subsidiary: SubsidiaryResolver,
-        },
-        data: { title: 'Workplace' },
       },
       {
         path: 'start',
@@ -567,17 +590,6 @@ const routes: Routes = [
     ],
   },
   {
-    path: 'staff-records/:establishmentuid',
-    component: ViewSubsidiaryStaffRecordsComponent,
-    data: { title: 'Staff Records' },
-    canActivate: [HasPermissionsGuard],
-    resolve: {
-      establishment: WorkplaceResolver,
-      workers: WorkersResolver,
-      subsidiary: SubsidiaryResolver,
-    },
-  },
-  {
     path: 'staff-basic-records/:establishmentuid',
     component: StaffBasicRecord,
     resolve: {
@@ -585,42 +597,6 @@ const routes: Routes = [
       workers: WorkersResolver,
     },
     data: { title: 'Staff Basic Records' },
-  },
-  {
-    path: 'training-and-qualifications/:establishmentuid',
-    component: ViewSubsidiaryTrainingAndQualificationsComponent,
-    data: { title: 'Training and qualifications' },
-    canActivate: [HasPermissionsGuard],
-    resolve: {
-      establishment: WorkplaceResolver,
-      workers: WorkersResolver,
-      subsidiary: SubsidiaryResolver,
-    },
-  },
-  {
-    path: 'benchmarks/:establishmentuid',
-    component: ViewSubsidiaryBenchmarksComponent,
-    data: { title: 'Benchmarks' },
-    canActivate: [HasPermissionsGuard],
-    resolve: {
-      establishment: WorkplaceResolver,
-      benchmarksResolver: BenchmarksResolver,
-      rankingsResolver: RankingsResolver,
-      usefulLinksPay: UsefulLinkPayResolver,
-      usefulLinkRecruitment: UsefulLinkRecruitmentResolver,
-      subsidiary: SubsidiaryResolver,
-    },
-  },
-  {
-    path: 'workplace-users/:establishmentuid',
-    component: ViewSubsidiaryWorkplaceUsersComponent,
-    canActivate: [HasPermissionsGuard],
-    data: { title: 'Workplace users' },
-    resolve: {
-      establishment: WorkplaceResolver,
-      users: AllUsersForEstablishmentResolver,
-      subsidiary: SubsidiaryResolver,
-    },
   },
 ];
 

--- a/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
+++ b/frontend/src/app/features/subsidiary/training-and-qualifications/view-subsidiary-training-and-qualifications.component.ts
@@ -122,7 +122,7 @@ export class ViewSubsidiaryTrainingAndQualificationsComponent implements OnInit 
   public navigateToStaffRecords(event: Event): void {
     event.preventDefault();
     this.tabsService.selectedTab = 'staff-records';
-    this.router.navigate(['/subsidiary/staff-records', this.workplace.uid]);
+    this.router.navigate(['/subsidiary', this.workplace.uid, 'staff-records']);
   }
 
   private trainingTotals(): void {

--- a/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
+++ b/frontend/src/app/features/subsidiary/workplace-users/view-subsidiary-workplace-users.component.ts
@@ -27,7 +27,7 @@ export class ViewSubsidiaryWorkplaceUsersComponent implements OnInit {
 
   public setUserServiceReturnUrl(): void {
     this.userService.updateReturnUrl({
-      url: ['/workplace-users', this.workplace.uid],
+      url: [`/${this.workplace.uid}`, 'workplace-users'],
     });
   }
 }

--- a/frontend/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/frontend/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -73,7 +73,12 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
   }
 
   public getBreadcrumbsJourney(): JourneyType {
+    console.log(
+      'this.parentSubsidiaryViewService.getViewingSubAsParent(): ',
+      this.parentSubsidiaryViewService.getViewingSubAsParent(),
+    );
     if (this.parentSubsidiaryViewService.getViewingSubAsParent()) {
+      console.log('returned sub');
       return JourneyType.SUBSIDIARY;
     } else if (this.return.fragment == null) {
       return JourneyType.MY_WORKPLACE;

--- a/frontend/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/frontend/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -73,12 +73,7 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
   }
 
   public getBreadcrumbsJourney(): JourneyType {
-    console.log(
-      'this.parentSubsidiaryViewService.getViewingSubAsParent(): ',
-      this.parentSubsidiaryViewService.getViewingSubAsParent(),
-    );
     if (this.parentSubsidiaryViewService.getViewingSubAsParent()) {
-      console.log('returned sub');
       return JourneyType.SUBSIDIARY;
     } else if (this.return.fragment == null) {
       return JourneyType.MY_WORKPLACE;

--- a/frontend/src/app/features/workplace/workplace-info-panel/workplace-info-panel.component.ts
+++ b/frontend/src/app/features/workplace/workplace-info-panel/workplace-info-panel.component.ts
@@ -12,9 +12,9 @@ import { CancelDataOwnerDialogComponent } from '@shared/components/cancel-data-o
 import { ChangeDataOwnerDialogComponent } from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
 import { MoveWorkplaceDialogComponent } from '@shared/components/move-workplace/move-workplace-dialog.component';
 import { SetDataPermissionDialogComponent } from '@shared/components/set-data-permission/set-data-permission-dialog.component';
-import { Subscription } from 'rxjs';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-workplace-info-panel',
@@ -158,7 +158,7 @@ export class WorkplaceInfoPanelComponent implements OnInit, OnDestroy {
         this.router.navigate(['/workplace', this.workplace.uid, 'type-of-employer']);
       } else {
         this.parentSubsidiaryViewService.setViewingSubAsParent(this.workplace.uid);
-        this.router.navigate(['/subsidiary/home/', this.workplace.uid]);
+        this.router.navigate(['/subsidiary', this.workplace.uid, 'home']);
       }
     });
   }

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
@@ -162,7 +162,7 @@ describe('NewTabsComponent', () => {
       const tAndQTab = getByTestId('tab_training-and-qualifications');
       fireEvent.click(tAndQTab);
 
-      expect(routerSpy).toHaveBeenCalledWith([`/subsidiary/training-and-qualifications/${subId}`]);
+      expect(routerSpy).toHaveBeenCalledWith([`/subsidiary/${subId}/training-and-qualifications`]);
     });
   });
 
@@ -249,7 +249,7 @@ describe('NewTabsComponent', () => {
     });
 
     it('should return tab slug when 3 segments and second segment matches tab slug', async () => {
-      const urlSegments = [{ path: 'subsidiary' }, { path: 'training-and-qualifications' }, { path: 'testuid' }];
+      const urlSegments = [{ path: 'subsidiary' }, { path: 'testuid' }, { path: 'training-and-qualifications' }];
 
       const { component } = await setup(true, urlSegments);
       const returned = component.getTabSlugInSubView();

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -147,7 +147,7 @@ describe('Summary section', () => {
       const workplaceDetailsMessage = getByText('Add more details to your workplace');
       fireEvent.click(workplaceDetailsMessage);
 
-      expect(routerSpy).toHaveBeenCalledWith(['subsidiary', 'workplace', Establishment.uid]);
+      expect(routerSpy).toHaveBeenCalledWith(['subsidiary', Establishment.uid, 'workplace']);
     });
 
     it('should show the check cqc details message if checkCQCDetails banner is true and the showAddWorkplaceDetailsBanner is false', async () => {
@@ -291,7 +291,7 @@ describe('Summary section', () => {
       const staffRecordMessage = getByText('You can start to add your staff records now');
       fireEvent.click(staffRecordMessage);
 
-      expect(routerSpy).toHaveBeenCalledWith(['subsidiary', 'staff-records', Establishment.uid]);
+      expect(routerSpy).toHaveBeenCalledWith(['subsidiary', Establishment.uid, 'staff-records']);
     });
 
     it('should show staff record does not match message when the number of staff is more than the staff record', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -78,7 +78,7 @@ export class SummarySectionComponent implements OnInit, OnChanges {
 
   private navigateInSubView = async (fragment: string, route: string[]) => {
     this.tabsService.selectedTab = fragment;
-    await this.router.navigate(route ? route : ['subsidiary', fragment, this.workplace.uid]);
+    await this.router.navigate(route ? route : ['subsidiary', this.workplace.uid, fragment]);
   };
 
   public getWorkplaceSummaryMessage(): void {

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.spec.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.spec.ts
@@ -1,5 +1,6 @@
-import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
 import { ParentSubsidiaryViewService } from './parent-subsidiary-view.service';
 
 describe('ParentSubsidiaryViewService', () => {
@@ -30,39 +31,39 @@ describe('ParentSubsidiaryViewService', () => {
         const subUid = 'some-uid';
         service.setViewingSubAsParent(subUid);
 
-        expect(service.getViewingSubAsParentDashboard(`/subsidiary/home/${subUid}`)).toBeTruthy();
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/${subUid}/home`)).toBeTruthy();
       });
       it('should return true if url is included for workplace page', async () => {
         const subUid = 'some-uid';
         service.setViewingSubAsParent(subUid);
 
-        expect(service.getViewingSubAsParentDashboard(`/subsidiary/workplace/${subUid}`)).toBeTruthy();
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/${subUid}/workplace`)).toBeTruthy();
       });
       it('should return true if url is included for staff-records page', async () => {
         const subUid = 'some-uid';
         service.setViewingSubAsParent(subUid);
 
-        expect(service.getViewingSubAsParentDashboard(`/subsidiary/staff-records/${subUid}`)).toBeTruthy();
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/${subUid}/staff-records`)).toBeTruthy();
       });
       it('should return true if url is included for training-and-qualifications page', async () => {
         const subUid = 'some-uid';
         service.setViewingSubAsParent(subUid);
 
         expect(
-          service.getViewingSubAsParentDashboard(`/subsidiary/training-and-qualifications/${subUid}`),
+          service.getViewingSubAsParentDashboard(`/subsidiary/${subUid}/training-and-qualifications`),
         ).toBeTruthy();
       });
       it('should return true if url is included for benchmarks page', async () => {
         const subUid = 'some-uid';
         service.setViewingSubAsParent(subUid);
 
-        expect(service.getViewingSubAsParentDashboard(`/subsidiary/benchmarks/${subUid}`)).toBeTruthy();
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/${subUid}/benchmarks`)).toBeTruthy();
       });
       it('should return true if url is included for workplace-users page', async () => {
         const subUid = 'some-uid';
         service.setViewingSubAsParent(subUid);
 
-        expect(service.getViewingSubAsParentDashboard(`/subsidiary/workplace-users/${subUid}`)).toBeTruthy();
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/${subUid}/workplace-users`)).toBeTruthy();
       });
     });
 
@@ -70,11 +71,12 @@ describe('ParentSubsidiaryViewService', () => {
       it('should return false if url has partial match to url in checked list', async () => {
         expect(service.getViewingSubAsParentDashboard('/subsidiary/home')).toBeFalsy();
       });
+
       it('should return false if url has additional characters after url in checked list', async () => {
         const subUid = 'some-uid';
         service.setViewingSubAsParent(subUid);
 
-        expect(service.getViewingSubAsParentDashboard(`/subsidiary/home/${subUid}/benchmarks`)).toBeFalsy();
+        expect(service.getViewingSubAsParentDashboard(`/subsidiary/workplace/${subUid}/benchmarks`)).toBeFalsy();
       });
     });
   });

--- a/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
+++ b/frontend/src/app/shared/services/parent-subsidiary-view.service.ts
@@ -29,12 +29,12 @@ export class ParentSubsidiaryViewService {
 
   getViewingSubAsParentDashboard(navUrl): boolean {
     const subsidiaryDashboardUrls = [
-      `/subsidiary/home/${this.subsidiaryUid}`,
-      `/subsidiary/workplace/${this.subsidiaryUid}`,
-      `/subsidiary/staff-records/${this.subsidiaryUid}`,
-      `/subsidiary/training-and-qualifications/${this.subsidiaryUid}`,
-      `/subsidiary/benchmarks/${this.subsidiaryUid}`,
-      `/subsidiary/workplace-users/${this.subsidiaryUid}`,
+      `/subsidiary/${this.subsidiaryUid}/home`,
+      `/subsidiary/${this.subsidiaryUid}/workplace`,
+      `/subsidiary/${this.subsidiaryUid}/staff-records`,
+      `/subsidiary/${this.subsidiaryUid}/training-and-qualifications`,
+      `/subsidiary/${this.subsidiaryUid}/benchmarks`,
+      `/subsidiary/${this.subsidiaryUid}/workplace-users`,
     ];
     return subsidiaryDashboardUrls.includes(navUrl);
   }

--- a/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
@@ -81,7 +81,7 @@ describe('SubsidiaryRouterService', () => {
       expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
     });
 
-    it('should clear the value for the view sub service at notifications page', async () => {
+    it('should clear the value for the view sub service when navigating to satisfaction survey page', async () => {
       const urlTree = service.createUrlTree(['satisfaction-survey']);
       const expectedUrlTree = service.createUrlTree(['satisfaction-survey'], undefined);
 
@@ -101,7 +101,7 @@ describe('SubsidiaryRouterService', () => {
       expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
     });
 
-    it('should clear the value for the view sub service at account-management page', async () => {
+    it('should clear the value for the view sub service when navigating to the admin page', async () => {
       const urlTree = service.createUrlTree(['sfcadmin']);
       const expectedUrlTree = service.createUrlTree(['sfcadmin'], undefined);
 
@@ -162,7 +162,7 @@ describe('SubsidiaryRouterService', () => {
     describe('fragments', () => {
       it('should reroute to the sub equivalent pages on dashboard', async () => {
         const urlTree = service.createUrlTree(['dashboard', 'test', 'route'], { fragment: 'test-fragment' });
-        const expectedUrlTree = service.createUrlTree(['subsidiary', 'test-fragment', '1234'], undefined);
+        const expectedUrlTree = service.createUrlTree(['subsidiary', '1234', 'test-fragment'], undefined);
 
         service.navigateByUrl(urlTree);
 
@@ -171,7 +171,7 @@ describe('SubsidiaryRouterService', () => {
 
       it('should reroute to the home tab equivalent page on dashboard when no fragments provided', async () => {
         const urlTree = service.createUrlTree(['/dashboard'], undefined);
-        const expectedUrlTree = service.createUrlTree(['subsidiary', 'home', '1234'], undefined);
+        const expectedUrlTree = service.createUrlTree(['subsidiary', '1234', 'home'], undefined);
 
         service.navigateByUrl(urlTree);
 
@@ -180,7 +180,7 @@ describe('SubsidiaryRouterService', () => {
 
       it('should reroute to the sub equivalent pages on dashboard when a leading slash is present', async () => {
         const urlTree = service.createUrlTree(['/dashboard', 'test', 'route'], { fragment: 'test-fragment' });
-        const expectedUrlTree = service.createUrlTree(['subsidiary', 'test-fragment', '1234'], undefined);
+        const expectedUrlTree = service.createUrlTree(['subsidiary', '1234', 'test-fragment'], undefined);
 
         service.navigateByUrl(urlTree);
 

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -26,7 +26,7 @@ export class SubsidiaryRouterService extends Router {
     if (this.parentSubsidiaryViewService.getViewingSubAsParent() && !commands[0].includes('subsidiary')) {
       // If routing to the dashboard, override fragments
       if (commands[0].toLowerCase().includes('dashboard')) {
-        commands = [extras.fragment ? extras.fragment : 'home', this.parentSubsidiaryViewService.getSubsidiaryUid()];
+        commands = [this.parentSubsidiaryViewService.getSubsidiaryUid(), extras.fragment ? extras.fragment : 'home'];
         extras = undefined;
       } else {
         // Remove forward slashes from the route


### PR DESCRIPTION
Due to the workplace uid being after the tab name in the url, resolvers were getting run on navigation to tabs (resolvers require the uid to load data). This slowed down the sub view. Changing it so the uid comes before the tab name means that all tabs can be children of a route with the uid, and all resolvers can be run once for all of them on load of the sub view.

#### Work done
- Changed the order of the urls for the sub view tabs so the uid comes before the tab name
- Added logic to tabs service for edge case where uid doesn't match up with current page url

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
