### PR TITLE
fix/about-parents-cta

### DIFF
--- a/frontend/src/app/core/services/previous-route.service.spec.ts
+++ b/frontend/src/app/core/services/previous-route.service.spec.ts
@@ -14,33 +14,34 @@ describe('PreviousRouteService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should set the previous url', () => {
-    const previousUrl = '/workplace';
-    service.setPreviousTab(previousUrl);
-    expect(service.getPreviousUrl()).toEqual(previousUrl);
+  it('should return the lastSelectedTab if the previousUrl includes `dashboard`', () => {
+    const lastSelectedTab = 'workplace';
+    service.previousUrl = '/dashboard#workplace';
+    service.setLastSelectedTab(lastSelectedTab);
+    expect(service.getPreviousPage()).toEqual('workplace');
   });
 
-  it('should return the second part of the url if there is a hashtag in between', () => {
-    const previousUrl = '/dashboard#workplace';
-    service.setPreviousTab(previousUrl);
+  it('should return the previousUrl if the previousUrl doesn`t include `dashboard`', () => {
+    const lastSelectedTab = 'staff-records';
+    service.previousUrl = '/workplace';
+    service.setLastSelectedTab(lastSelectedTab);
     expect(service.getPreviousPage()).toEqual('workplace');
   });
 
   it('should return the second part of the url if there is a slash in between', () => {
-    const previousUrl = '/workplace/view-all-workplaces';
-    service.setPreviousTab(previousUrl);
+    service.previousUrl = '/workplace/view-all-workplaces';
     expect(service.getPreviousPage()).toEqual('view-all-workplaces');
   });
 
   it('should return null when an empty string is set as previous page', () => {
-    const previousUrl = '';
-    service.setPreviousTab(previousUrl);
+    const lastSelectedTab = '';
+    service.setLastSelectedTab(lastSelectedTab);
     expect(service.getPreviousPage()).toEqual(null);
   });
 
   it('should return null if there is not a previous page', () => {
-    const previousUrl = null;
-    service.setPreviousTab(previousUrl);
-    expect(service.getPreviousPage()).toEqual(previousUrl);
+    const lastSelectedTab = null;
+    service.setLastSelectedTab(lastSelectedTab);
+    expect(service.getPreviousPage()).toEqual(lastSelectedTab);
   });
 });

--- a/frontend/src/app/core/services/previous-route.service.ts
+++ b/frontend/src/app/core/services/previous-route.service.ts
@@ -8,6 +8,7 @@ import { filter } from 'rxjs/operators';
 export class PreviousRouteService {
   public previousUrl: string;
   private currentUrl: string;
+  private lastSelectedTab: string;
 
   constructor(private router: Router) {
     this.currentUrl = this.router.url;
@@ -17,12 +18,17 @@ export class PreviousRouteService {
       .pipe(filter((event: RouterEvent) => event instanceof NavigationEnd))
       .subscribe((event: NavigationEnd) => {
         this.previousUrl = this.currentUrl;
+
+        if (this.previousUrl.includes('dashboard')) {
+          this.previousUrl = this.lastSelectedTab;
+        }
+
         this.currentUrl = event.urlAfterRedirects;
       });
   }
 
-  public setPreviousTab(url: string) {
-    this.previousUrl = url;
+  public setLastSelectedTab(tab: string) {
+    this.lastSelectedTab = tab;
   }
 
   public getPreviousUrl() {

--- a/frontend/src/app/core/services/tabs.service.ts
+++ b/frontend/src/app/core/services/tabs.service.ts
@@ -19,9 +19,7 @@ export class TabsService {
   public benchmarksTab: Tab = { title: 'Benchmarks', slug: 'benchmarks', active: false };
   public workplaceUsers: Tab = { title: 'Workplace users', slug: 'workplace-users', active: false };
 
-  constructor(
-    private previousRouteService: PreviousRouteService,
-  ) {}
+  constructor(private previousRouteService: PreviousRouteService) {}
 
   private _selectedTab$: BehaviorSubject<string> = new BehaviorSubject<string>(null);
 
@@ -34,7 +32,7 @@ export class TabsService {
   }
 
   public set selectedTab(tab: string) {
-    this.previousRouteService.setPreviousTab(this.selectedTab);
+    this.previousRouteService.setLastSelectedTab(tab);
     this._selectedTab$.next(tab);
   }
 }


### PR DESCRIPTION
#### Work done
- Update previous route service to set the lastSelectedTab so the correct text, of which page to go back to, is shown on the about parents button

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
