### PR TITLE
Fix/remove logic for setting links to old view workplace

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-staff/select-staff.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-staff/select-staff.component.spec.ts
@@ -544,32 +544,14 @@ describe('SelectStaffComponent', () => {
   });
 
   describe('onCancel()', () => {
-    it('should reset selected staff in training service and navigate to dashboard if primary user', async () => {
-      const { component, fixture, getByText, spy, trainingSpy } = await setup();
-
-      component.primaryWorkplaceUid = '1234-5678';
-      component.setReturnLink();
-      fixture.detectChanges();
+    it('should reset selected staff in training service and navigate to dashboard after clicking Cancel', async () => {
+      const { getByText, spy, trainingSpy } = await setup();
 
       const cancelButton = getByText('Cancel');
       fireEvent.click(cancelButton);
 
       expect(trainingSpy).toHaveBeenCalled();
       expect(spy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'training-and-qualifications' });
-    });
-
-    it(`should reset selected staff in training service and navigate to subsidiary's dashboard if not primary user`, async () => {
-      const { component, fixture, getByText, spy, trainingSpy } = await setup();
-
-      component.primaryWorkplaceUid = '5678-9001';
-      component.setReturnLink();
-      fixture.detectChanges();
-
-      const cancelButton = getByText('Cancel');
-      fireEvent.click(cancelButton);
-
-      expect(trainingSpy).toHaveBeenCalled();
-      expect(spy).toHaveBeenCalledWith(['/workplace', '1234-5678'], { fragment: 'training-and-qualifications' });
     });
 
     it('should navigate to the confirm training page when page has been accessed from that page and pressing Cancel', async () => {
@@ -581,28 +563,6 @@ describe('SelectStaffComponent', () => {
 
       expect(trainingSpy).not.toHaveBeenCalled();
       expect(spy.calls.mostRecent().args[0]).toEqual(['../']);
-    });
-  });
-
-  describe('setReturnLink', () => {
-    it('should set returnLink to the dashboard if the establishment uid is the same as the primary uid', async () => {
-      const { component, fixture } = await setup();
-
-      component.primaryWorkplaceUid = '1234-5678';
-      component.setReturnLink();
-      fixture.detectChanges();
-
-      expect(component.returnLink).toEqual(['/dashboard']);
-    });
-
-    it(`should set returnLink to the subsidiary's dashboard if the establishment uid is not the same as the primary uid`, async () => {
-      const { component, fixture } = await setup();
-
-      component.primaryWorkplaceUid = '5678-9001';
-      component.setReturnLink();
-      fixture.detectChanges();
-
-      expect(component.returnLink).toEqual(['/workplace', '1234-5678']);
     });
   });
 });

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-staff/select-staff.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-staff/select-staff.component.ts
@@ -23,7 +23,6 @@ export class SelectStaffComponent implements OnInit, AfterViewInit {
   public form: UntypedFormGroup;
   public submitted: boolean;
   public primaryWorkplaceUid: string;
-  public returnLink: Array<string>;
   public selectAll = false;
   public errorsMap: Array<ErrorDetails>;
   public workplaceUid: string;
@@ -53,14 +52,12 @@ export class SelectStaffComponent implements OnInit, AfterViewInit {
 
   ngOnInit(): void {
     this.workplaceUid = this.route.snapshot.params.establishmentuid;
-    this.primaryWorkplaceUid = this.establishmentService.primaryWorkplace.uid;
     this.workers = this.route.snapshot.data.workers.workers;
     this.totalWorkerCount = this.workers.length;
     this.getPageOfWorkers();
     this.showSearchBar = this.totalWorkerCount > this.itemsPerPage;
     this.prefill();
     this.setupErrorsMap();
-    this.setReturnLink();
     this.setBackLink();
     this.accessedFromSummary = this.route.snapshot.parent.url[0].path.includes('confirm-training');
     this.submitButtonText = this.accessedFromSummary ? 'Save and return' : 'Continue';
@@ -123,11 +120,6 @@ export class SelectStaffComponent implements OnInit, AfterViewInit {
         ],
       },
     ];
-  }
-
-  public setReturnLink(): void {
-    this.returnLink =
-      this.workplaceUid === this.primaryWorkplaceUid ? ['/dashboard'] : ['/workplace', this.workplaceUid];
   }
 
   public setBackLink(): void {
@@ -210,7 +202,7 @@ export class SelectStaffComponent implements OnInit, AfterViewInit {
       this.router.navigate(['../'], { relativeTo: this.route });
     } else {
       this.trainingService.resetSelectedStaff();
-      this.router.navigate(this.returnLink, { fragment: 'training-and-qualifications' });
+      this.router.navigate(['/dashboard'], { fragment: 'training-and-qualifications' });
     }
   }
 

--- a/frontend/src/app/features/training-and-qualifications/expired-and-expiring-training/expired-and-expiring-training.directive.ts
+++ b/frontend/src/app/features/training-and-qualifications/expired-and-expiring-training/expired-and-expiring-training.directive.ts
@@ -16,7 +16,6 @@ export class ExpiredAndExpiringTrainingDirective implements OnInit {
   public workers;
   public workplaceUid: string;
   public canEditWorker: boolean;
-  public primaryWorkplaceUid: string;
   public flagText: string;
   public img: string;
   public searchTerm = '';
@@ -46,7 +45,6 @@ export class ExpiredAndExpiringTrainingDirective implements OnInit {
     alertMessage && this.showAlert(alertMessage);
     this.setTrainingAndCount();
     this.workplaceUid = this.route.snapshot.params.establishmentuid;
-    this.primaryWorkplaceUid = this.establishmentService.primaryWorkplace.uid;
     this.init();
     this.canEditWorker = this.permissionsService.can(this.workplaceUid, 'canEditWorker');
     this.backLinkService.showBackLink();
@@ -76,9 +74,7 @@ export class ExpiredAndExpiringTrainingDirective implements OnInit {
   }
 
   public returnToHome(): void {
-    const returnLink =
-      this.workplaceUid === this.primaryWorkplaceUid ? ['/dashboard'] : ['/workplace', this.workplaceUid];
-    this.router.navigate(returnLink, { fragment: 'training-and-qualifications' });
+    this.router.navigate(['/dashboard'], { fragment: 'training-and-qualifications' });
   }
 
   public getTrainingByStatus(properties: {

--- a/frontend/src/app/features/training-and-qualifications/expired-training/expired-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/expired-training/expired-training.component.spec.ts
@@ -264,25 +264,14 @@ describe('ExpiredTrainingComponent', () => {
     expect(tableRow4CategoryCell.getAttribute('class')).not.toContain('asc-table__cell-no-border__bottom-row');
   });
 
-  it('should navigate back to the dashboard when clicking the return to home button in a parent or stand alone account', async () => {
-    const { getByText, component, fixture, routerSpy } = await setup();
-
-    component.primaryWorkplaceUid = '1234-5678';
-    const button = getByText('Return to home');
-    fireEvent.click(button);
-    fixture.detectChanges();
-
-    expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'training-and-qualifications' });
-  });
-
-  it('should navigate back to the workplace page when clicking the return to home button when accessing a sub account from a parent', async () => {
+  it('should navigate back to the dashboard when clicking the return to home button', async () => {
     const { getByText, fixture, routerSpy } = await setup();
 
     const button = getByText('Return to home');
     fireEvent.click(button);
     fixture.detectChanges();
 
-    expect(routerSpy).toHaveBeenCalledWith(['/workplace', '1234-5678'], { fragment: 'training-and-qualifications' });
+    expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'training-and-qualifications' });
   });
 
   describe('sort', () => {

--- a/frontend/src/app/features/training-and-qualifications/expiring-soon-training/expiring-soon-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/expiring-soon-training/expiring-soon-training.component.spec.ts
@@ -272,25 +272,14 @@ describe('ExpiringSoonTrainingComponent', () => {
     expect(tableRow4CategoryCell.getAttribute('class')).not.toContain('asc-table__cell-no-border__bottom-row');
   });
 
-  it('should navigate back to the dashboard when clicking the return to home button in a parent or stand alone account', async () => {
-    const { getByText, component, fixture, routerSpy } = await setup();
-
-    component.primaryWorkplaceUid = '1234-5678';
-    const button = getByText('Return to home');
-    fireEvent.click(button);
-    fixture.detectChanges();
-
-    expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'training-and-qualifications' });
-  });
-
-  it('should navigate back to the workplace page when clicking the return to home button when accessing a sub account from a parent', async () => {
+  it('should navigate back to the dashboard when clicking the return to home button', async () => {
     const { getByText, fixture, routerSpy } = await setup();
 
     const button = getByText('Return to home');
     fireEvent.click(button);
     fixture.detectChanges();
 
-    expect(routerSpy).toHaveBeenCalledWith(['/workplace', '1234-5678'], { fragment: 'training-and-qualifications' });
+    expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'training-and-qualifications' });
   });
 
   describe('sort', () => {

--- a/frontend/src/app/features/workers/total-staff-change/total-staff-change.component.ts
+++ b/frontend/src/app/features/workers/total-staff-change/total-staff-change.component.ts
@@ -42,12 +42,7 @@ export class TotalStaffChangeComponent implements OnInit, OnDestroy, AfterViewIn
 
   ngOnInit() {
     this.workplace = this.route.parent.snapshot.data.establishment;
-    const primaryWorkplaceUid = this.establishmentService.primaryWorkplace.uid;
-
-    this.return =
-      this.workplace.uid === primaryWorkplaceUid
-        ? { url: ['/dashboard'], fragment: 'staff-records' }
-        : { url: ['/workplace', this.workplace.uid], fragment: 'staff-records' };
+    this.return = { url: ['/dashboard'], fragment: 'staff-records' };
 
     this.returnToDash = this.workerService.totalStaffReturn;
 

--- a/frontend/src/app/features/workplace/start/start.component.ts
+++ b/frontend/src/app/features/workplace/start/start.component.ts
@@ -13,11 +13,9 @@ import { take } from 'rxjs/operators';
 })
 export class StartComponent implements OnInit, OnDestroy {
   public establishment: Establishment;
-  public primaryWorkplaceUid: string;
   public returnLink: Array<string>;
   public returnUrl: URLStructure;
   private subscriptions: Subscription = new Subscription();
-  private workplaceUid: string;
   private fragment: string;
   public isViewingSubAsParent: boolean;
   public continueUrl: Array<string>;
@@ -36,7 +34,6 @@ export class StartComponent implements OnInit, OnDestroy {
     );
 
     this.fragment = history.state?.navigatedFromFragment;
-    this.setReturnLink();
     this.setBackLink();
     this.setRecuritmentBannerToTrue();
   }
@@ -45,14 +42,9 @@ export class StartComponent implements OnInit, OnDestroy {
     this.subscriptions.unsubscribe();
   }
 
-  public setReturnLink(): void {
-    this.returnLink =
-      this.workplaceUid === this.primaryWorkplaceUid ? ['/dashboard'] : ['/workplace', this.workplaceUid];
-  }
-
   public setBackLink(): void {
     const returnTo = this.fragment ? this.fragment : 'home';
-    this.backService.setBackLink({ url: this.returnLink, fragment: returnTo });
+    this.backService.setBackLink({ url: ['/dashboard'], fragment: returnTo });
   }
 
   public removeAddDetailsBanner(event: Event): void {

--- a/frontend/src/app/shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component.spec.ts
+++ b/frontend/src/app/shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component.spec.ts
@@ -243,23 +243,13 @@ describe('ViewTrainingComponent', () => {
   });
 
   it(`should navigate back to training-and-qualification page`, async () => {
-    const { component, fixture, routerSpy, getByText } = await setup();
+    const { fixture, routerSpy, getByText } = await setup();
 
-    component.primaryWorkplaceUid = 'mocked-uid';
     const returnToHome = getByText('Return to home');
     userEvent.click(returnToHome);
     fixture.detectChanges();
 
     expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'training-and-qualifications' });
-  });
-
-  it(`should navigate back to sub workplace page when clicking the return home button when accessing a sub account from a parent`, async () => {
-    const { routerSpy, getByText } = await setup();
-
-    const returnToHome = getByText('Return to home');
-    userEvent.click(returnToHome);
-
-    expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid'], { fragment: 'training-and-qualifications' });
   });
 
   describe('sort', () => {

--- a/frontend/src/app/shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component.ts
+++ b/frontend/src/app/shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component.ts
@@ -24,7 +24,6 @@ export class ViewTrainingComponent implements OnInit, OnDestroy {
   readonly OK = 'OK';
 
   public workplace: Establishment;
-  public primaryWorkplaceUid: string;
   public category: string;
   public canEditWorker = false;
   public trainingCategoryId: number;
@@ -50,7 +49,6 @@ export class ViewTrainingComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.workplace = this.establishmentService.establishment;
-    this.primaryWorkplaceUid = this.establishmentService.primaryWorkplace.uid;
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
     this.trainingCategoryId = this.route.snapshot.params.categoryId;
     this.setWorkersAndCount();
@@ -135,9 +133,7 @@ export class ViewTrainingComponent implements OnInit, OnDestroy {
   }
 
   public returnToHome(): void {
-    const returnLink =
-      this.workplace.uid === this.primaryWorkplaceUid ? ['/dashboard'] : ['/workplace', this.workplace.uid];
-    this.router.navigate(returnLink, { fragment: 'training-and-qualifications' });
+    this.router.navigate(['/dashboard'], { fragment: 'training-and-qualifications' });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Prevents navigation to workplace tab in sub view on back and submit buttons

#### Work done
- Removed logic for navigating to old workplace view to handle navigating to tab in sub view with subsidiary routing service

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
