### PR TITLE
Add tracking of navigation events to tabs component to set tab after clicking browser back button

### DIFF
--- a/frontend/src/app/core/services/breadcrumb.service.ts
+++ b/frontend/src/app/core/services/breadcrumb.service.ts
@@ -137,8 +137,8 @@ export class BreadcrumbService {
   public getPath(url: string, segments: UrlSegment[]) {
     const path = this.getParts(url).map((part, index) => {
       if (this.isParameter(part)) {
-        if (part === ':establishmentuid' && segments[index].path === 'workplace') {
-          return segments[index + 1].path;
+        if (part === ':establishmentuid' && segments[index]?.path === 'workplace') {
+          return segments[index + 1]?.path;
         }
         return segments[index] ? segments[index].path : part;
       }

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
@@ -2,7 +2,7 @@ import { Location } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TabsService } from '@core/services/tabs.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
@@ -254,6 +254,42 @@ describe('NewTabsComponent', () => {
       const { component } = await setup(true, urlSegments);
       const returned = component.getTabSlugInSubView();
       expect(returned).toEqual('training-and-qualifications');
+    });
+  });
+
+  describe('getTabSlugFromNavigationEvent', async () => {
+    it(`should return correct tab when third section of url is the tab slug`, async () => {
+      const { component } = await setup(true, []);
+      component.tabs.forEach((tab) => {
+        const url = `/subsidiary/test-uid/${tab.slug}`;
+        const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
+
+        expect(result).toEqual(tab);
+      });
+    });
+
+    it('should return nothing when no tab slug in the navigation event url', async () => {
+      const { component } = await setup(true, []);
+
+      const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, 'test-url.com', 'test-url.com'));
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return nothing when workplace in url but in wrong section', async () => {
+      const { component } = await setup(true, []);
+      const url = '/subsidiary/workplace/test-uid/main-service-cqc';
+      const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return nothing when url has fewer than 3 sections', async () => {
+      const { component } = await setup(true, []);
+      const url = '/subsidiary/benefits-bundle';
+      const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
+
+      expect(result).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
#### Work done
- Added tracking of navigation events to tabs component to set tab after clicking browser back button

#### Note
Once work is done to stop using fragments in parent/stand alone view, we should hopefully be able to use this way of setting tabs across the service and wouldn't need to set tabs as we navigate 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
