### PR TITLE
Don't navigate when tab is set on page load in sub view

### DIFF
--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
@@ -154,15 +154,15 @@ describe('NewTabsComponent', () => {
 
     it('should navigate to the sub tab url when tab clicked in sub view', async () => {
       const { getByTestId, parentSubsidiaryViewService, routerSpy } = await setup();
-      const subId = 'abcde123';
+      const subUid = 'abcde123';
 
       spyOn(parentSubsidiaryViewService, 'getViewingSubAsParent').and.returnValue(true);
-      spyOn(parentSubsidiaryViewService, 'getSubsidiaryUid').and.returnValue(subId);
+      spyOn(parentSubsidiaryViewService, 'getSubsidiaryUid').and.returnValue(subUid);
 
       const tAndQTab = getByTestId('tab_training-and-qualifications');
       fireEvent.click(tAndQTab);
 
-      expect(routerSpy).toHaveBeenCalledWith([`/subsidiary/${subId}/training-and-qualifications`]);
+      expect(routerSpy).toHaveBeenCalledWith([`/subsidiary/${subUid}/training-and-qualifications`]);
     });
   });
 
@@ -290,6 +290,47 @@ describe('NewTabsComponent', () => {
       const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
 
       expect(result).toBeFalsy();
+    });
+  });
+
+  describe('selectTab', () => {
+    it('should navigate when in sub view and isOnPageLoad is passed in as false', async () => {
+      const { component, routerSpy, parentSubsidiaryViewService } = await setup(true, []);
+
+      const index = 1;
+      const subUid = 'abcde123';
+      spyOn(parentSubsidiaryViewService, 'getViewingSubAsParent').and.returnValue(true);
+      spyOn(parentSubsidiaryViewService, 'getSubsidiaryUid').and.returnValue(subUid);
+
+      component.selectTab(new Event(null), index, true, true, false);
+
+      expect(routerSpy).toHaveBeenCalledWith([`/subsidiary/${subUid}/${component.tabs[index].slug}`]);
+    });
+
+    it('should not navigate when isOnPageLoad is passed in as true in sub view', async () => {
+      const { component, routerSpy, parentSubsidiaryViewService } = await setup(true, []);
+
+      const index = 1;
+      const subUid = 'abcde123';
+      spyOn(parentSubsidiaryViewService, 'getViewingSubAsParent').and.returnValue(true);
+      spyOn(parentSubsidiaryViewService, 'getSubsidiaryUid').and.returnValue(subUid);
+
+      component.selectTab(new Event(null), index, true, true, true);
+
+      expect(routerSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not navigate when isOnPageLoad is passed in as false but not in sub view', async () => {
+      const { component, routerSpy, parentSubsidiaryViewService } = await setup(true, []);
+
+      const index = 1;
+      const subUid = 'abcde123';
+      spyOn(parentSubsidiaryViewService, 'getViewingSubAsParent').and.returnValue(false);
+      spyOn(parentSubsidiaryViewService, 'getSubsidiaryUid').and.returnValue(subUid);
+
+      component.selectTab(new Event(null), index, true, true, false);
+
+      expect(routerSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.ts
@@ -64,13 +64,13 @@ export class NewTabsComponent implements OnInit, OnDestroy {
     if (hash) {
       const activeTab = this.tabs.findIndex((tab) => tab.slug === hash);
       if (activeTab) {
-        this.selectTab(null, activeTab, false, false);
+        this.selectTab(null, activeTab, false, false, true);
       }
     }
     const activeTabs = this.tabs.filter((tab) => tab.active);
 
     if (activeTabs.length === 0) {
-      this.selectTab(null, 0, false, false);
+      this.selectTab(null, 0, false, false, true);
     }
   }
 
@@ -133,7 +133,7 @@ export class NewTabsComponent implements OnInit, OnDestroy {
     }
   }
 
-  public selectTab(event: Event, index: number, focus: boolean = true, clicked = true): void {
+  public selectTab(event: Event, index: number, focus: boolean = true, clicked = true, isOnPageLoad = false): void {
     event?.preventDefault();
 
     this.clickEvent = clicked;
@@ -143,7 +143,7 @@ export class NewTabsComponent implements OnInit, OnDestroy {
     this.selectedTabClick.emit({ tabSlug: tab.slug });
     this.tabsService.selectedTab = tab.slug;
 
-    if (this.parentSubsidiaryViewService.getViewingSubAsParent()) {
+    if (!isOnPageLoad && this.parentSubsidiaryViewService.getViewingSubAsParent()) {
       let subsidiaryUid: string = this.parentSubsidiaryViewService.getSubsidiaryUid();
       this.router.navigate([`/subsidiary/${subsidiaryUid}/${tab.slug}`]);
     }


### PR DESCRIPTION
Moving navigation out of the event listener for setting the tab allowed the setting of tab without navigating so that tabs can be set as you press the back button. However, this meant that navigation was running on page load in the sub view. This PR resolves that issue.

#### Work done
- Added check for setting tab on page load to stop navigation back to home tab on refresh

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
