### PR TITLE
Update staff record pages to navigate to dashboard on back/cancel buttons and handle route in sub routing service

### DIFF
--- a/frontend/src/app/features/workers/question/question.component.ts
+++ b/frontend/src/app/features/workers/question/question.component.ts
@@ -135,9 +135,7 @@ export class QuestionComponent implements OnInit, OnDestroy, AfterViewInit {
         break;
 
       case 'exit':
-        const url =
-          this.primaryWorkplace?.uid === this.workplace.uid ? ['/dashboard'] : ['/workplace', this.workplace.uid];
-        this.router.navigate(url, { fragment: 'staff-records' });
+        this.router.navigate(['/dashboard'], { fragment: 'staff-records' });
         break;
 
       case 'return':

--- a/frontend/src/app/features/workers/staff-details/staff-details.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-details/staff-details.component.spec.ts
@@ -375,12 +375,12 @@ describe('StaffDetailsComponent', () => {
       expect(setAddStaffRecordInProgressSpy).toHaveBeenCalledWith(true);
     });
 
-    it('should return the user to the workplace home page when clicking cancel', async () => {
-      const { component, getByText, submitSpy, routerSpy, updateWorkerSpy } = await setup();
+    it('should return the user to the staff records tab when clicking cancel', async () => {
+      const { getByText, submitSpy, routerSpy, updateWorkerSpy } = await setup();
 
       userEvent.click(getByText('Cancel'));
       expect(submitSpy).toHaveBeenCalledWith({ action: 'exit', save: false });
-      expect(routerSpy).toHaveBeenCalledWith(['/workplace', component.workplace.uid], {
+      expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], {
         fragment: 'staff-records',
       });
       expect(updateWorkerSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
#### Work done
- Updated staff record pages to navigate to dashboard on back/cancel buttons and handle route in sub routing service

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
