### PR TITLE
Fix/navigate to workplace dropdown issues

### DIFF
--- a/frontend/src/app/core/services/establishment.service.ts
+++ b/frontend/src/app/core/services/establishment.service.ts
@@ -79,7 +79,7 @@ export class EstablishmentService {
   private _employerTypeHasValue: boolean = null;
   private _inStaffRecruitmentFlow: boolean;
   private _standAloneAccount$: boolean;
-  private _childWorkplacesChanged$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  private _checkForChildWorkplaceChanges$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   constructor(private http: HttpClient) {}
 
@@ -105,12 +105,12 @@ export class EstablishmentService {
     this._standAloneAccount$ = value;
   }
 
-  public get childWorkplacesChanged$(): Observable<boolean> {
-    return this._childWorkplacesChanged$.asObservable();
+  public get checkForChildWorkplaceChanges$(): Observable<boolean> {
+    return this._checkForChildWorkplaceChanges$.asObservable();
   }
 
-  public setChildWorkplacesChanged(value: boolean) {
-    this._childWorkplacesChanged$.next(value);
+  public setCheckForChildWorkplaceChanges(value: boolean) {
+    this._checkForChildWorkplaceChanges$.next(value);
   }
 
   public setEmployerTypeHasValue(hasValue: boolean) {

--- a/frontend/src/app/core/services/establishment.service.ts
+++ b/frontend/src/app/core/services/establishment.service.ts
@@ -79,7 +79,7 @@ export class EstablishmentService {
   private _employerTypeHasValue: boolean = null;
   private _inStaffRecruitmentFlow: boolean;
   private _standAloneAccount$: boolean;
-  private _workplaceDeleted$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  private _childWorkplacesChanged$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   constructor(private http: HttpClient) {}
 
@@ -105,12 +105,12 @@ export class EstablishmentService {
     this._standAloneAccount$ = value;
   }
 
-  public get workplaceDeleted$(): Observable<boolean> {
-    return this._workplaceDeleted$.asObservable();
+  public get childWorkplacesChanged$(): Observable<boolean> {
+    return this._childWorkplacesChanged$.asObservable();
   }
 
-  public setWorkplaceDeleted(value: boolean) {
-    this._workplaceDeleted$.next(value);
+  public setChildWorkplacesChanged(value: boolean) {
+    this._childWorkplacesChanged$.next(value);
   }
 
   public setEmployerTypeHasValue(hasValue: boolean) {

--- a/frontend/src/app/core/test-utils/MockEstablishmentService.ts
+++ b/frontend/src/app/core/test-utils/MockEstablishmentService.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Establishment, mandatoryTraining, UpdateJobsRequest, ChangeOwner } from '@core/model/establishment.model';
+import { ChangeOwner, Establishment, mandatoryTraining, UpdateJobsRequest } from '@core/model/establishment.model';
 import { GetChildWorkplacesResponse } from '@core/model/my-workplaces.model';
 import { ServiceGroup } from '@core/model/services.model';
 import { URLStructure } from '@core/model/url.model';
@@ -97,6 +97,11 @@ export const establishmentWithWdfBuilder = () => {
 export class MockEstablishmentService extends EstablishmentService {
   public shareWith: any = { cqc: null, localAuthorities: null };
   private returnToUrl = true;
+  private childWorkplaces = {
+    childWorkplaces: [subsid1, subsid2, subsid3],
+    count: 3,
+    activeWorkplaceCount: 2,
+  };
   public establishmentObj = {
     address: 'mock establishment address',
     capacities: [],
@@ -139,13 +144,17 @@ export class MockEstablishmentService extends EstablishmentService {
     careWorkersLeaveDaysPerYear: '35',
   };
 
-  public static factory(shareWith: any, returnToUrl = true, estObj: any = {}) {
+  public static factory(shareWith: any, returnToUrl = true, estObj: any = {}, childWorkplaces: any = null) {
     return (http: HttpClient) => {
       const service = new MockEstablishmentService(http);
       if (shareWith) {
         service.setShareWith(shareWith);
       }
       service.returnToUrl = returnToUrl;
+
+      if (childWorkplaces) {
+        service.childWorkplaces = { childWorkplaces, count: childWorkplaces.length, activeWorkplaceCount: 1 };
+      }
 
       if (estObj) {
         Object.keys(estObj).forEach((key) => {
@@ -249,11 +258,7 @@ export class MockEstablishmentService extends EstablishmentService {
   }
 
   public getChildWorkplaces(establishmentUid: string): Observable<GetChildWorkplacesResponse> {
-    return of({
-      childWorkplaces: [subsid1, subsid2, subsid3],
-      count: 3,
-      activeWorkplaceCount: 2,
-    } as GetChildWorkplacesResponse);
+    return of(this.childWorkplaces as GetChildWorkplacesResponse);
   }
 
   public changeOwnership(establishmentId, data: ChangeOwner): Observable<Establishment> {

--- a/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.spec.ts
+++ b/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.spec.ts
@@ -200,9 +200,10 @@ describe('DragAndDropFilesListComponent', () => {
     const getEstablishmentSpy = spyOn(establishmentService, 'getEstablishment').and.callFake(() => of(workplace));
     const setWorkplaceSpy = spyOn(establishmentService, 'setWorkplace').and.callFake(() => {});
     const setPrimaryWorkplaceSpy = spyOn(establishmentService, 'setPrimaryWorkplace').and.callFake(() => {});
-    const setChildWorkplacesChangedSpy = spyOn(establishmentService, 'setChildWorkplacesChanged').and.callFake(
-      () => {},
-    );
+    const setCheckForChildWorkplaceChangesSpy = spyOn(
+      establishmentService,
+      'setCheckForChildWorkplaceChanges',
+    ).and.callFake(() => {});
 
     const dummyFiles = [WorkerFile, TrainingFile, EstablishmentFile];
     component.uploadedFiles = dummyFiles as ValidatedFile[];
@@ -215,7 +216,7 @@ describe('DragAndDropFilesListComponent', () => {
     expect(getEstablishmentSpy).toHaveBeenCalledWith('98a83eef-e1e1-49f3-89c5-b1287a3cc8de');
     expect(setWorkplaceSpy).toHaveBeenCalledWith(workplace);
     expect(setPrimaryWorkplaceSpy).toHaveBeenCalledWith(workplace);
-    expect(setChildWorkplacesChangedSpy).toHaveBeenCalledWith(true);
+    expect(setCheckForChildWorkplaceChangesSpy).toHaveBeenCalledWith(true);
   });
 
   describe('DownloadContent', () => {

--- a/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.spec.ts
+++ b/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.spec.ts
@@ -4,6 +4,7 @@ import { getTestBed, TestBed } from '@angular/core/testing';
 import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BulkUploadFileType, ValidatedFile } from '@core/model/bulk-upload.model';
+import { Establishment } from '@core/model/establishment.model';
 import { BulkUploadService } from '@core/services/bulk-upload.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -16,15 +17,15 @@ import {
   TrainingFile,
   WorkerFile,
 } from '@core/test-utils/MockBulkUploadService';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { BulkUploadModule } from '@features/bulk-upload/bulk-upload.module';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { of } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 import { DragAndDropFilesListComponent } from './drag-and-drop-files-list.component';
-import { environment } from 'src/environments/environment';
 
 describe('DragAndDropFilesListComponent', () => {
   const setup = async () => {
@@ -192,6 +193,31 @@ describe('DragAndDropFilesListComponent', () => {
     expect(bulkUploadCompleteSpy).toHaveBeenCalledWith('98a83eef-e1e1-49f3-89c5-b1287a3cc8de');
   });
 
+  it('sets state in the establishment service when upload successfully completed', async () => {
+    const { component, fixture, getByText, bulkUploadService, establishmentService } = await setup();
+    const workplace = establishmentBuilder() as Establishment;
+    spyOn(bulkUploadService, 'complete').and.callFake(() => of({}));
+    const getEstablishmentSpy = spyOn(establishmentService, 'getEstablishment').and.callFake(() => of(workplace));
+    const setWorkplaceSpy = spyOn(establishmentService, 'setWorkplace').and.callFake(() => {});
+    const setPrimaryWorkplaceSpy = spyOn(establishmentService, 'setPrimaryWorkplace').and.callFake(() => {});
+    const setChildWorkplacesChangedSpy = spyOn(establishmentService, 'setChildWorkplacesChanged').and.callFake(
+      () => {},
+    );
+
+    const dummyFiles = [WorkerFile, TrainingFile, EstablishmentFile];
+    component.uploadedFiles = dummyFiles as ValidatedFile[];
+    component.validationComplete = true;
+    fixture.detectChanges();
+
+    const button = getByText('Complete the upload');
+    fireEvent.click(button);
+
+    expect(getEstablishmentSpy).toHaveBeenCalledWith('98a83eef-e1e1-49f3-89c5-b1287a3cc8de');
+    expect(setWorkplaceSpy).toHaveBeenCalledWith(workplace);
+    expect(setPrimaryWorkplaceSpy).toHaveBeenCalledWith(workplace);
+    expect(setChildWorkplacesChangedSpy).toHaveBeenCalledWith(true);
+  });
+
   describe('DownloadContent', () => {
     it('should call getUploadedFileFromS3 with the StaffSanitise file type when the staff link is clicked and sanitise is true', async () => {
       const { component, fixture, bulkUploadServiceSpy, getByText, establishmentService } = await setup();
@@ -348,7 +374,9 @@ describe('DragAndDropFilesListComponent', () => {
       component.deleteFile(event, filenameToDelete);
       fixture.detectChanges();
 
-      http.expectOne(`${environment.appRunnerEndpoint}/api/establishment/${establishmentId}/bulkupload/delete/${filenameToDelete}`);
+      http.expectOne(
+        `${environment.appRunnerEndpoint}/api/establishment/${establishmentId}/bulkupload/delete/${filenameToDelete}`,
+      );
     });
 
     it('should should show validation as not complete after deleting a file and clear error message', async () => {

--- a/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.ts
+++ b/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.ts
@@ -179,7 +179,7 @@ export class DragAndDropFilesListComponent implements OnInit, OnDestroy {
           return (
             this.establishmentService.setWorkplace(workplace),
             this.establishmentService.setPrimaryWorkplace(workplace),
-            this.establishmentService.setChildWorkplacesChanged(true)
+            this.establishmentService.setCheckForChildWorkplaceChanges(true)
           );
         }),
       )

--- a/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.ts
+++ b/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.ts
@@ -177,7 +177,9 @@ export class DragAndDropFilesListComponent implements OnInit, OnDestroy {
       .pipe(
         tap((workplace) => {
           return (
-            this.establishmentService.setWorkplace(workplace), this.establishmentService.setPrimaryWorkplace(workplace)
+            this.establishmentService.setWorkplace(workplace),
+            this.establishmentService.setPrimaryWorkplace(workplace),
+            this.establishmentService.setChildWorkplacesChanged(true)
           );
         }),
       )

--- a/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.spec.ts
@@ -1,26 +1,26 @@
-import { fireEvent, within, render } from '@testing-library/angular';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { BreadcrumbService } from '@core/services/breadcrumb.service';
-import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
-import { getTestBed } from '@angular/core/testing';
-import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
-import { SharedModule } from '@shared/shared.module';
-import { WindowRef } from '@core/services/window.ref';
-import { AlertService } from '@core/services/alert.service';
-import { of, throwError } from 'rxjs';
-import { EstablishmentService } from '@core/services/establishment.service';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Roles } from '@core/model/roles.enum';
-import { UserService } from '@core/services/user.service';
-import { MockUserService } from '@core/test-utils/MockUserService';
+import { AlertService } from '@core/services/alert.service';
 import { AuthService } from '@core/services/auth.service';
-import { MockAuthService } from '@core/test-utils/MockAuthService';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
+import { UserService } from '@core/services/user.service';
+import { WindowRef } from '@core/services/window.ref';
+import { MockAuthService } from '@core/test-utils/MockAuthService';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockUserService } from '@core/test-utils/MockUserService';
+import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render, within } from '@testing-library/angular';
+import { of, throwError } from 'rxjs';
 
 import { DeleteWorkplaceComponent } from './delete-workplace.component';
 
@@ -251,7 +251,7 @@ describe('DeleteWorkplaceComponent', async () => {
 
     spyOn(establishmentService, 'deleteWorkplace').and.returnValue(of({}));
     spyOn(parentSubsidiaryViewService, 'getViewingSubAsParent').and.returnValue(true);
-    const setWorkplaceDeletedSpy = spyOn(establishmentService, 'setWorkplaceDeleted').and.callThrough();
+    const setChildWorkplacesChangedSpy = spyOn(establishmentService, 'setChildWorkplacesChanged').and.callThrough();
     component.ngOnInit();
     fixture.detectChanges();
 
@@ -261,7 +261,7 @@ describe('DeleteWorkplaceComponent', async () => {
     fireEvent.click(yesRadioButton);
     fireEvent.click(continueButton);
 
-    expect(setWorkplaceDeletedSpy).toHaveBeenCalledWith(true);
+    expect(setChildWorkplacesChangedSpy).toHaveBeenCalledWith(true);
     expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'view-all-workplaces']);
   });
 

--- a/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.spec.ts
@@ -251,7 +251,10 @@ describe('DeleteWorkplaceComponent', async () => {
 
     spyOn(establishmentService, 'deleteWorkplace').and.returnValue(of({}));
     spyOn(parentSubsidiaryViewService, 'getViewingSubAsParent').and.returnValue(true);
-    const setChildWorkplacesChangedSpy = spyOn(establishmentService, 'setChildWorkplacesChanged').and.callThrough();
+    const setCheckForChildWorkplaceChangesSpy = spyOn(
+      establishmentService,
+      'setCheckForChildWorkplaceChanges',
+    ).and.callThrough();
     component.ngOnInit();
     fixture.detectChanges();
 
@@ -261,7 +264,7 @@ describe('DeleteWorkplaceComponent', async () => {
     fireEvent.click(yesRadioButton);
     fireEvent.click(continueButton);
 
-    expect(setChildWorkplacesChangedSpy).toHaveBeenCalledWith(true);
+    expect(setCheckForChildWorkplaceChangesSpy).toHaveBeenCalledWith(true);
     expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'view-all-workplaces']);
   });
 

--- a/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.ts
+++ b/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { ErrorDefinition, ErrorDetails } from '@core/model/errorSummary.model';
 import { Establishment } from '@core/model/establishment.model';
+import { UserDetails } from '@core/model/userDetails.model';
 import { AlertService } from '@core/services/alert.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
@@ -11,7 +12,6 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { isAdminRole } from '@core/utils/check-role-util';
-import { UserDetails } from '@core/model/userDetails.model';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Subscription } from 'rxjs';
 
@@ -121,7 +121,7 @@ export class DeleteWorkplaceComponent implements OnInit, AfterViewInit, OnDestro
         () => {
           if (this.isParentSubsidiaryView) {
             this.parentSubsidiaryViewService.clearViewingSubAsParent();
-            this.establishmentService.setWorkplaceDeleted(true);
+            this.establishmentService.setChildWorkplacesChanged(true);
 
             this.router.navigate(['/workplace', 'view-all-workplaces']);
             this.displaySuccessfullyDeletedAlert();

--- a/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.ts
+++ b/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.ts
@@ -121,7 +121,7 @@ export class DeleteWorkplaceComponent implements OnInit, AfterViewInit, OnDestro
         () => {
           if (this.isParentSubsidiaryView) {
             this.parentSubsidiaryViewService.clearViewingSubAsParent();
-            this.establishmentService.setChildWorkplacesChanged(true);
+            this.establishmentService.setCheckForChildWorkplaceChanges(true);
 
             this.router.navigate(['/workplace', 'view-all-workplaces']);
             this.displaySuccessfullyDeletedAlert();

--- a/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
+++ b/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
@@ -102,6 +102,7 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
                         this.permissionsService.setPermissions(this.workplace.uid, hasPermission.permissions);
                         this.establishmentService.setState(workplace);
                         this.establishmentService.setPrimaryWorkplace(workplace);
+                        this.establishmentService.setChildWorkplacesChanged(true);
                         this.router.navigate(['/dashboard']);
                       }
                     });

--- a/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
+++ b/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
@@ -102,7 +102,7 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
                         this.permissionsService.setPermissions(this.workplace.uid, hasPermission.permissions);
                         this.establishmentService.setState(workplace);
                         this.establishmentService.setPrimaryWorkplace(workplace);
-                        this.establishmentService.setChildWorkplacesChanged(true);
+                        this.establishmentService.setCheckForChildWorkplaceChanges(true);
                         this.router.navigate(['/dashboard']);
                       }
                     });

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
@@ -49,6 +49,7 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
     this.breadcrumbService.show(JourneyType.ALL_WORKPLACES);
     this.canAddEstablishment = this.permissionsService.can(this.primaryWorkplace.uid, 'canAddEstablishment');
 
+    this.establishmentService.setChildWorkplacesChanged(true);
     const childWorkplaces = this.route.snapshot.data.childWorkplaces;
     this.totalWorkplaceCount = childWorkplaces.count;
     this.activeWorkplaceCount = childWorkplaces.activeWorkplaceCount;

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
@@ -49,7 +49,7 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
     this.breadcrumbService.show(JourneyType.ALL_WORKPLACES);
     this.canAddEstablishment = this.permissionsService.can(this.primaryWorkplace.uid, 'canAddEstablishment');
 
-    this.establishmentService.setChildWorkplacesChanged(true);
+    this.establishmentService.setCheckForChildWorkplaceChanges(true);
     const childWorkplaces = this.route.snapshot.data.childWorkplaces;
     this.totalWorkplaceCount = childWorkplaces.count;
     this.activeWorkplaceCount = childWorkplaces.activeWorkplaceCount;

--- a/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.html
+++ b/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.html
@@ -1,5 +1,8 @@
 <div
-  *ngIf="parentSubsidiaryViewService.getViewingSubAsParent() || childWorkplaces?.length < maxChildWorkplacesForDropdown"
+  *ngIf="
+    parentSubsidiaryViewService.getViewingSubAsParent() ||
+    (childWorkplaces?.length > 0 && childWorkplaces?.length < maxChildWorkplacesForDropdown)
+  "
   class="asc-navigate-to-workplace-dropdown-container govuk-!-padding-bottom-1"
   id="navigateToWorkplaceContainer"
 >

--- a/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.spec.ts
+++ b/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.spec.ts
@@ -11,13 +11,13 @@ import { fireEvent, render } from '@testing-library/angular';
 import { NavigateToWorkplaceDropdownComponent } from './navigate-to-workplace-dropdown.component';
 
 describe('NavigateToWorkplaceDropdownComponent', () => {
-  const setup = async (maxChildWorkplacesForDropdown = 5, inSubView = true) => {
+  const setup = async (maxChildWorkplacesForDropdown = 5, inSubView = true, childWorkplaces = null) => {
     const { fixture, getByText, getByLabelText } = await render(NavigateToWorkplaceDropdownComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule],
       providers: [
         {
           provide: EstablishmentService,
-          useClass: MockEstablishmentService,
+          useFactory: MockEstablishmentService.factory(null, true, null, childWorkplaces),
         },
       ],
       componentProperties: {
@@ -54,6 +54,14 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
 
   it('should not display anything when more child workplaces than maxChildWorkplacesForDropdown but not in sub view', async () => {
     const { fixture } = await setup(3, false);
+    fixture.detectChanges();
+    const navigateToWorkplaceContainer = fixture.nativeElement.querySelector('#navigateToWorkplaceContainer');
+
+    expect(navigateToWorkplaceContainer).toBeFalsy();
+  });
+
+  it('should not display anything when no child workplaces', async () => {
+    const { fixture } = await setup(31, false, []);
     fixture.detectChanges();
     const navigateToWorkplaceContainer = fixture.nativeElement.querySelector('#navigateToWorkplaceContainer');
 

--- a/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.ts
+++ b/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.ts
@@ -17,7 +17,7 @@ export class NavigateToWorkplaceDropdownComponent implements OnInit {
   public parentWorkplace: Establishment;
   public childWorkplaces: Workplace[];
   public currentWorkplace: string;
-  @Input() maxChildWorkplacesForDropdown: Number;
+  @Input() maxChildWorkplacesForDropdown: number;
 
   constructor(
     private router: Router,

--- a/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.ts
+++ b/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.ts
@@ -30,10 +30,10 @@ export class NavigateToWorkplaceDropdownComponent implements OnInit {
     this.initialiseComponent();
 
     this.subscriptions.add(
-      this.establishmentService.workplaceDeleted$.subscribe((workplaceHasBeenDeleted) => {
+      this.establishmentService.childWorkplacesChanged$.subscribe((workplaceHasBeenDeleted) => {
         if (workplaceHasBeenDeleted) {
           this.initialiseComponent();
-          this.establishmentService.setWorkplaceDeleted(false);
+          this.establishmentService.setChildWorkplacesChanged(false);
         }
       }),
     );

--- a/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.ts
+++ b/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.ts
@@ -30,10 +30,10 @@ export class NavigateToWorkplaceDropdownComponent implements OnInit {
     this.initialiseComponent();
 
     this.subscriptions.add(
-      this.establishmentService.childWorkplacesChanged$.subscribe((workplaceHasBeenDeleted) => {
+      this.establishmentService.checkForChildWorkplaceChanges$.subscribe((workplaceHasBeenDeleted) => {
         if (workplaceHasBeenDeleted) {
           this.initialiseComponent();
-          this.establishmentService.setChildWorkplacesChanged(false);
+          this.establishmentService.setCheckForChildWorkplaceChanges(false);
         }
       }),
     );


### PR DESCRIPTION
#### Work done
- Generalised the workplaceDeleted field in the establishment service to be used for any case where you need to check for updates to child workplaces
- Added setting of check to approving a parent request, bulk uploading and navigating to the view all workplaces page
- Stopped rendering of navigate to workplace dropdown when parent with no child workplaces 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
