### PR TITLE
Only give canDeleteEstablishment permission when viewing sub as parent

### DIFF
--- a/backend/server/test/unit/utils/security/permissions.spec.js
+++ b/backend/server/test/unit/utils/security/permissions.spec.js
@@ -167,8 +167,19 @@ describe('permissions', () => {
         expect(returnedPermissions).not.to.include('canDeleteEstablishment');
       });
 
-      it('should return canDeleteEstablishment permission when isSubsidiary', async () => {
+      it('should not return canDeleteEstablishment permission when subsidiary logged in', async () => {
         req.establishment.isSubsidiary = true;
+        req.isParent = false;
+
+        const returnedPermissions = await getPermissions(req);
+
+        expect(returnedPermissions).not.to.include('canDeleteEstablishment');
+      });
+
+      it('should return canDeleteEstablishment permission when parent owner viewing subsidiary establishment', async () => {
+        req.establishment.isSubsidiary = true;
+        req.isParent = true;
+        req.parentIsOwner = true;
 
         const returnedPermissions = await getPermissions(req);
 

--- a/backend/server/utils/security/permissions.js
+++ b/backend/server/utils/security/permissions.js
@@ -126,7 +126,7 @@ const dataPermissionWorkplaceAndStaff = (establishmentAndUserInfo) => [
 const getAdditionalEditPermissions = (estabType, establishmentAndUserInfo, isLoggedInAsParent) => {
   const additionalPermissions = [
     _canAddEstablishment(estabType),
-    _canDeleteEstablishment(estabType),
+    _canDeleteEstablishment(estabType, isLoggedInAsParent),
     _canLinkToParent(isLoggedInAsParent, establishmentAndUserInfo),
     _canRemoveParentAssociation(isLoggedInAsParent, establishmentAndUserInfo),
     _canDownloadWdfReport(isLoggedInAsParent),
@@ -169,7 +169,8 @@ const _isRegulatedAndHasServiceWithBenchmarksData = (establishmentAndUserInfo) =
 
 const _canAddEstablishment = (estabType) => (estabType === 'Parent' ? 'canAddEstablishment' : undefined);
 
-const _canDeleteEstablishment = (estabType) => (estabType === 'Subsidiary' ? 'canDeleteEstablishment' : undefined);
+const _canDeleteEstablishment = (estabType, isLoggedInAsParent) =>
+  isLoggedInAsParent && estabType === 'Subsidiary' ? 'canDeleteEstablishment' : undefined;
 
 const _canLinkToParent = (isLoggedInAsParent, establishmentAndUserInfo) =>
   _isStandaloneAndNoRequestToBecomeParent(isLoggedInAsParent, establishmentAndUserInfo) ? 'canLinkToParent' : undefined;


### PR DESCRIPTION
Subs which owned their own data could see the Delete workplace link, this was due to subsidiaries incorrectly being given the canDeleteEstablishment permission which was probably filtered out in the front end in the old version of the dashboard.

#### Work done
- Changed it so canDeleteEstablishment is only given for a subsidiary when request is made by parent which owns data

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
