### PR TITLE
Add sub postcode to link to parent notification

### DIFF
--- a/backend/server/data/linkToParent.js
+++ b/backend/server/data/linkToParent.js
@@ -131,10 +131,11 @@ exports.updateLinkToParent = async (params) =>
 
 const getNotificationDetailsQuery = `
   select "ApprovalStatus" as "approvalStatus", "PermissionRequest" as "permissionRequest",
-  parent."NameValue" as "parentEstablishmentName", parent."PostCode" as "postCode", sub."Updated" as updated
+  parent."NameValue" as "parentEstablishmentName", parent."PostCode" as "parentPostCode", sub."Updated" as updated, subDetails."PostCode" as "subPostCode"
   from cqc."LinkToParent" as sub
   JOIN cqc."Establishment" as parent on sub."ParentEstablishmentID" =  parent."EstablishmentID"
-  where "LinkToParentUID" = :uid `;
+  JOIN cqc."Establishment" as subDetails on sub."SubEstablishmentID" = subDetails."EstablishmentID"
+  where "LinkToParentUID" = :uid`;
 
 exports.getNotificationDetails = async (params) =>
   db.query(getNotificationDetailsQuery, {

--- a/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
+++ b/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.html
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds notificationTable">
       <div [ngSwitch]="notification.typeContent.approvalStatus">
         <div *ngSwitchCase="'REQUESTED'">
-          <p>{{ notificationRequestedFrom }}, {{ postCode }} want to link to you.</p>
+          <p>{{ notificationRequestedFrom }}, {{ subPostcode }} want to link to you.</p>
         </div>
         <div *ngSwitchCase="'CANCELLED'">
           <p>You have a request from {{ notificationRequestedFrom }} to link to you.</p>
@@ -21,7 +21,7 @@
             </ng-template>
           </ng-container>
           <ng-template #nonWorkplaceRequester>
-            <p>{{ notificationRequestedTo }}, {{ postCode }} has rejected your request to link to them.</p>
+            <p>{{ notificationRequestedTo }}, {{ parentPostcode }} has rejected your request to link to them.</p>
             <h2 class="govuk-heading-s">Reason</h2>
             <ng-container *ngIf="notification.typeContent.rejectionReason; else noReason">
               <p>{{ notification.typeContent.rejectionReason }}</p>
@@ -34,12 +34,12 @@
         <div *ngSwitchCase="'APPROVED'">
           <ng-container *ngIf="isWorkPlaceRequester; else nonWorkplaceRequester">
             <p>
-              You approved a link request from {{ notificationRequestedFrom }}, {{ postCode }}, on
+              You approved a link request from {{ notificationRequestedFrom }}, {{ subPostcode }}, on
               {{ notification.typeContent.updated | longDate }}.
             </p>
           </ng-container>
           <ng-template #nonWorkplaceRequester>
-            <p>Your request to link to {{ notificationRequestedTo }}, {{ postCode }}, has been approved.</p>
+            <p>Your request to link to {{ notificationRequestedTo }}, {{ parentPostcode }}, has been approved.</p>
           </ng-template>
         </div>
         <div *ngSwitchDefault></div>

--- a/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.spec.ts
+++ b/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.spec.ts
@@ -1,18 +1,17 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { getTestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AlertService } from '@core/services/alert.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WindowRef } from '@core/services/window.ref';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { NotificationTypePipe } from '@shared/pipes/notification-type.pipe';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 import { Observable } from 'rxjs';
-import { BreadcrumbService } from '@core/services/breadcrumb.service';
-import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 
 import { NotificationLinkToParentComponent } from './notification-link-to-parent.component';
 
@@ -25,7 +24,8 @@ describe('NotificationLinkToParentComponent', () => {
         parentEstablishmentId: 137,
         parentEstablishmentName: 'Test Parent',
         permissionRequest: permissionRequest,
-        postCode: 'postalcode',
+        parentPostCode: 'postalcode',
+        subPostCode: 'ABC123',
         rejectionReason: rejectionReason,
         requestorName: 'Test sub',
         subEstablishmentId: 312,
@@ -103,7 +103,7 @@ describe('NotificationLinkToParentComponent', () => {
       const { component, getByText } = await setup('REQUESTED');
 
       const subName = component.notification.typeContent.subEstablishmentName;
-      const subPostCode = component.notification.typeContent.postCode;
+      const subPostCode = component.notification.typeContent.subPostCode;
 
       const linkToParentRequestText = getByText(`${subName}, ${subPostCode} want to link to you.`);
 
@@ -166,7 +166,7 @@ describe('NotificationLinkToParentComponent', () => {
         fixture.detectChanges();
 
         const parentName = component.notification.typeContent.parentEstablishmentName;
-        const parentPostCode = component.notification.typeContent.postCode;
+        const parentPostCode = component.notification.typeContent.parentPostCode;
 
         const rejectedText = getByText(`${parentName}, ${parentPostCode} has rejected your request to link to them.`);
         const rejectedReasonText = getByText(component.notification.typeContent.rejectionReason);
@@ -182,7 +182,7 @@ describe('NotificationLinkToParentComponent', () => {
         fixture.detectChanges();
 
         const parentName = component.notification.typeContent.parentEstablishmentName;
-        const parentPostCode = component.notification.typeContent.postCode;
+        const parentPostCode = component.notification.typeContent.parentPostCode;
 
         const rejectedText = getByText(`${parentName}, ${parentPostCode} has rejected your request to link to them.`);
         const rejectedReasonText = getByText('No reason provided.');
@@ -198,7 +198,7 @@ describe('NotificationLinkToParentComponent', () => {
       const { component, getByText } = await setup();
 
       const parentName = component.notification.typeContent.parentEstablishmentName;
-      const parentPostCode = component.notification.typeContent.postCode;
+      const parentPostCode = component.notification.typeContent.parentPostCode;
 
       const parentNameAndPostCodeText = `Your request to link to ${parentName}, ${parentPostCode}, has been approved.`;
 
@@ -206,16 +206,18 @@ describe('NotificationLinkToParentComponent', () => {
     });
 
     it('should show the sub name and postcode in the parent notification', async () => {
-      const { component, fixture } = await setup();
+      const { component, fixture, getByText } = await setup();
 
       const subName = component.notification.typeContent.subEstablishmentName;
-      const subPostCode = component.notification.typeContent.postCode;
+      const subPostCode = component.notification.typeContent.subPostCode;
       const approvalDate = '14 December 2023 at 5:23pm';
 
       component.isWorkPlaceRequester = true;
       fixture.detectChanges();
 
-      const parentApprovedRequestLinkText = `You approved a link request from ${subName}, ${subPostCode}, on ${approvalDate}.`;
+      const parentApprovedRequestLinkText = getByText(
+        `You approved a link request from ${subName}, ${subPostCode}, on ${approvalDate}.`,
+      );
 
       expect(parentApprovedRequestLinkText).toBeTruthy();
     });

--- a/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
+++ b/frontend/src/app/features/notifications/notification-link-to-parent/notification-link-to-parent.component.ts
@@ -32,7 +32,8 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
   public notificationRequestedFrom: string;
   public notificationRequestedTo: string;
   public requestorName: string;
-  public postCode: string;
+  public subPostcode: string;
+  public parentPostcode: string;
   public notificationRequestedFromUid: string;
 
   constructor(
@@ -54,7 +55,8 @@ export class NotificationLinkToParentComponent implements OnInit, OnDestroy {
     this.notificationRequestedFrom = this.notification.typeContent.subEstablishmentName;
     this.notificationRequestedFromUid = this.notification.typeContent.subEstablishmentUid;
     this.requestorName = this.notification.typeContent.requestorName;
-    this.postCode = this.notification.typeContent.postCode;
+    this.parentPostcode = this.notification.typeContent.parentPostCode;
+    this.subPostcode = this.notification.typeContent.subPostCode;
     this.isWorkPlaceRequester = this.workplace.name === this.notificationRequestedTo;
   }
 


### PR DESCRIPTION
#### Work done
- Added retrieving sub postcode to the notification details database call
- Pass in parent or sub postcode to notification message depending on notification type

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
