### PR TITLE
Fix/flashing before navigation from view workplaces

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -10,15 +10,20 @@
       else otherView
     "
   >
-    <div *ngIf="parentAccount || parentSubsidiaryViewService.getViewingSubAsParent()">
+    <div *ngIf="parentAccount || viewingSubsidiaryWorkplace">
       <app-navigate-to-workplace-dropdown [maxChildWorkplacesForDropdown]="31"></app-navigate-to-workplace-dropdown>
     </div>
     <app-stand-alone-account
-      *ngIf="!parentSubsidiaryViewService.getViewingSubAsParent()"
+      *ngIf="!viewingSubsidiaryWorkplace"
       [dashboardView]="dashboardView"
+      data-testid="stand-alone-account"
     >
     </app-stand-alone-account>
-    <app-subsidiary-account *ngIf="parentSubsidiaryViewService.getViewingSubAsParent()" [dashboardView]="dashboardView">
+    <app-subsidiary-account
+      *ngIf="viewingSubsidiaryWorkplace"
+      [dashboardView]="dashboardView"
+      data-testid="subsidiary-account"
+    >
     </app-subsidiary-account>
   </ng-container>
   <ng-template #otherView>

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,4 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
 import { NavigationEnd, Router, RouterEvent, RouterModule } from '@angular/router';
@@ -16,17 +17,17 @@ import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubs
 import { MockTabsService } from '@core/test-utils/MockTabsService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
-import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 import { Angulartics2GoogleTagManager } from 'angulartics2/gtm';
 import { of, Subject } from 'rxjs';
 
 import { AppComponent } from './app.component';
 
-fdescribe('AppComponent', () => {
+describe('AppComponent', () => {
   async function setup(navigationUrl = '/') {
-    const { fixture, getByText, getByTestId } = await render(AppComponent, {
-      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+    const { fixture, getByText, queryByTestId } = await render(AppComponent, {
+      imports: [RouterModule, RouterTestingModule, HttpClientTestingModule],
+      schemas: [NO_ERRORS_SCHEMA],
       providers: [
         { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
         {
@@ -75,7 +76,7 @@ fdescribe('AppComponent', () => {
       component,
       fixture,
       getByText,
-      getByTestId,
+      queryByTestId,
     };
   }
 
@@ -84,20 +85,25 @@ fdescribe('AppComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render subsidiary-account ', async () => {
-    const { fixture, getByTestId } = await setup('/subsidiary/subUid/home');
+  it('should render subsidiary-account view when subsidiary page is navigated to', async () => {
+    const { fixture, queryByTestId } = await setup('/subsidiary/subUid/home');
     fixture.detectChanges();
-    const subsidiaryAccountRendered = getByTestId('subsidiary-account');
+
+    const subsidiaryAccountRendered = queryByTestId('subsidiary-account');
+    const standAloneAccountRendered = queryByTestId('stand-alone-account');
 
     expect(subsidiaryAccountRendered).toBeTruthy();
+    expect(standAloneAccountRendered).toBeFalsy();
   });
 
-  it('should set standalone', async () => {
-    const { fixture, getByTestId } = await setup('/');
+  it('should render standalone view when subsidiary not in url', async () => {
+    const { fixture, queryByTestId } = await setup('/');
     fixture.detectChanges();
 
-    const standAloneAccountRendered = getByTestId('stand-alone-account');
+    const standAloneAccountRendered = queryByTestId('stand-alone-account');
+    const subsidiaryAccountRendered = queryByTestId('subsidiary-account');
 
     expect(standAloneAccountRendered).toBeTruthy();
+    expect(subsidiaryAccountRendered).toBeFalsy();
   });
 });

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,37 +1,103 @@
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { NavigationEnd, Router, RouterEvent, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { AlertService } from '@core/services/alert.service';
+import { AuthService } from '@core/services/auth.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { IdleService } from '@core/services/idle.service';
+import { NestedRoutesService } from '@core/services/nested-routes.service';
+import { TabsService } from '@core/services/tabs.service';
+import { WindowRef } from '@core/services/window.ref';
+import { MockAuthService } from '@core/test-utils/MockAuthService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockParentSubsidiaryViewService } from '@core/test-utils/MockParentSubsidiaryViewService';
+import { MockTabsService } from '@core/test-utils/MockTabsService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+import { Angulartics2GoogleTagManager } from 'angulartics2/gtm';
+import { of, Subject } from 'rxjs';
+
 import { AppComponent } from './app.component';
 
-describe('AppComponent', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes([{ path: '', component: AppComponent }])],
-      declarations: [AppComponent],
-    }).compileComponents();
-  }));
+fdescribe('AppComponent', () => {
+  async function setup(navigationUrl = '/') {
+    const { fixture, getByText, getByTestId } = await render(AppComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
+        {
+          provide: EstablishmentService,
+          useValue: {
+            primaryWorkplace: { isParent: true, parentName: null },
+            standAloneAccount: false,
+            getChildWorkplaces() {
+              of({ childWorkplaces: null });
+            },
+          },
+        },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
+        },
+        {
+          provide: TabsService,
+          useClass: MockTabsService,
+        },
+        {
+          provide: ParentSubsidiaryViewService,
+          useClass: MockParentSubsidiaryViewService,
+        },
+        {
+          provide: Angulartics2GoogleTagManager,
+          useValue: {
+            startTracking() {
+              return null;
+            },
+          },
+        },
+        IdleService,
+        Title,
+        NestedRoutesService,
+        WindowRef,
+        AlertService,
+      ],
+    });
 
-  /*
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app).toBeTruthy();
+    const injector = getTestBed();
+    const event = new NavigationEnd(42, navigationUrl, navigationUrl);
+    (injector.inject(Router).events as unknown as Subject<RouterEvent>).next(event);
+    const component = fixture.componentInstance;
+    return {
+      component,
+      fixture,
+      getByText,
+      getByTestId,
+    };
+  }
+
+  it('should render an AppComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
   });
-  */
 
-  /*
-  it(`should have as title 'ng-sfc-v2'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('ng-sfc-v2');
-  });
-  */
-
-  /*
-  it('should render title in a h1 tag', () => {
-    const fixture = TestBed.createComponent(AppComponent);
+  it('should render subsidiary-account ', async () => {
+    const { fixture, getByTestId } = await setup('/subsidiary/subUid/home');
     fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to ng-sfc-v2!');
+    const subsidiaryAccountRendered = getByTestId('subsidiary-account');
+
+    expect(subsidiaryAccountRendered).toBeTruthy();
   });
-  */
+
+  it('should set standalone', async () => {
+    const { fixture, getByTestId } = await setup('/');
+    fixture.detectChanges();
+
+    const standAloneAccountRendered = getByTestId('stand-alone-account');
+
+    expect(standAloneAccountRendered).toBeTruthy();
+  });
 });

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -9,9 +9,9 @@ import { IdleService } from '@core/services/idle.service';
 import { NestedRoutesService } from '@core/services/nested-routes.service';
 import { TabsService } from '@core/services/tabs.service';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Angulartics2GoogleTagManager } from 'angulartics2/gtm';
 import { filter, take, takeWhile } from 'rxjs/operators';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 
 @Component({
   selector: 'app-root',
@@ -27,6 +27,7 @@ export class AppComponent implements OnInit {
   public newDataAreaFlag: boolean;
   public parentAccount: boolean;
   public subsAccount: boolean;
+  public viewingSubsidiaryWorkplace: boolean;
   @ViewChild('top') top: ElementRef;
   @ViewChild('content') content: ElementRef;
 
@@ -68,10 +69,12 @@ export class AppComponent implements OnInit {
         nav.url.includes('dashboard') ||
         nav.url === '/' ||
         this.parentSubsidiaryViewService.getViewingSubAsParentDashboard(nav.url);
+
       if (nav.url === '/') this.tabsService.selectedTab = 'home';
       this.standAloneAccount = this.establishmentService.standAloneAccount;
       this.parentAccount = this.establishmentService.primaryWorkplace?.isParent;
       this.subsAccount = this.establishmentService.primaryWorkplace?.parentName ? true : false;
+      this.viewingSubsidiaryWorkplace = nav.url.includes('subsidiary');
 
       window.scrollTo(0, 0);
       if (document.activeElement && document.activeElement !== document.body) {

--- a/frontend/src/app/core/test-utils/MockFeatureFlagService.ts
+++ b/frontend/src/app/core/test-utils/MockFeatureFlagService.ts
@@ -26,6 +26,12 @@ export class MockFeatureFlagsService extends FeatureFlagsService {
           return resolve(true);
         });
       }
+      if (flagName === 'homePageNewDesignParent') {
+        return new Promise((resolve) => {
+          return resolve(true);
+        });
+      }
+
       return new Promise((resolve) => {
         return resolve(defaultSetting);
       });


### PR DESCRIPTION
#### Work done
- Changed app component to render subsidiary account view based on url instead of getViewingSubAsParent in the parent sub service

#### Why? 
This was causing a reload of components before navigating to sub pages and when navigating away from sub pages, an example of this being the flashing of the first page of workplaces when navigating from the second page of the view my workplaces page. 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
