### PR TITLE
fix/remove-parent-approval-banner-on-navigate

### DIFF
--- a/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
+++ b/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
@@ -1,5 +1,5 @@
 import { HttpResponse } from '@angular/common/http';
-import { Directive, Inject, Input, OnChanges, OnDestroy, OnInit, HostListener } from '@angular/core';
+import { Directive, Inject, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Article } from '@core/model/article.model';
 import { Meta } from '@core/model/benchmarks.model';


### PR DESCRIPTION
#### Work done
- Add functionality to remove parent approved banner on all router events, from the parent home tab, as it was only happening when navigating to tabs

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
