### PR TITLE
Feat/1442 international recruitment edit page

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -90,6 +90,7 @@ import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { RankingsResolver } from '@core/resolvers/rankings.resolver';
 import { UsefulLinkPayResolver } from '@core/resolvers/useful-link-pay.resolver';
 import { UsefulLinkRecruitmentResolver } from '@core/resolvers/useful-link-recruitment.resolver';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 @NgModule({
   declarations: [
@@ -177,6 +178,7 @@ import { UsefulLinkRecruitmentResolver } from '@core/resolvers/useful-link-recru
     TrainingService,
     WindowRef,
     WorkerService,
+    InternationalRecruitmentService,
     { provide: WindowToken, useFactory: windowProvider },
     {
       provide: HTTP_INTERCEPTORS,

--- a/frontend/src/app/core/services/international-recruitment.service.spec.ts
+++ b/frontend/src/app/core/services/international-recruitment.service.spec.ts
@@ -23,23 +23,23 @@ describe('InternationalRecruitmentService', () => {
 
   describe('employed from outside or inside UK values', () => {
     it('should convert the yes value', () => {
-      worker.employedFromOutsideUk = 'Yes';
-      expect(service.convertEmployedFromOutsideUkValue(worker)).toBe('Outside the UK');
+      const employedFromOutsideUk = 'Yes';
+      expect(service.convertEmployedFromOutsideUkValue(employedFromOutsideUk)).toBe('Outside the UK');
     });
 
     it('should convert the no value', () => {
-      worker.employedFromOutsideUk = 'No';
-      expect(service.convertEmployedFromOutsideUkValue(worker)).toBe('Inside the UK');
+      const employedFromOutsideUk = 'No';
+      expect(service.convertEmployedFromOutsideUkValue(employedFromOutsideUk)).toBe('Inside the UK');
     });
 
     it("should convert the don't know value", () => {
-      worker.employedFromOutsideUk = "Don't know";
-      expect(service.convertEmployedFromOutsideUkValue(worker)).toBe('Not known');
+      const employedFromOutsideUk = "Don't know";
+      expect(service.convertEmployedFromOutsideUkValue(employedFromOutsideUk)).toBe('I do not know');
     });
 
     it('should convert the null value', () => {
-      worker.employedFromOutsideUk = null;
-      expect(service.convertEmployedFromOutsideUkValue(worker)).toBe(null);
+      const employedFromOutsideUk = null;
+      expect(service.convertEmployedFromOutsideUkValue(employedFromOutsideUk)).toBe(null);
     });
   });
 

--- a/frontend/src/app/core/services/international-recruitment.service.spec.ts
+++ b/frontend/src/app/core/services/international-recruitment.service.spec.ts
@@ -1,0 +1,114 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { InternationalRecruitmentService } from './international-recruitment.service';
+import { workerBuilder } from '@core/test-utils/MockWorkerService';
+import { Worker } from '@core/model/worker.model';
+
+describe('InternationalRecruitmentService', () => {
+  let service: InternationalRecruitmentService;
+  let worker = workerBuilder() as Worker;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [InternationalRecruitmentService],
+    });
+    service = TestBed.inject(InternationalRecruitmentService);
+  });
+
+  it('should create the service', async () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('employed from outside or inside UK values', () => {
+    it('should convert the yes value', () => {
+      worker.employedFromOutsideUk = 'Yes';
+      expect(service.convertEmployedFromOutsideUkValue(worker)).toBe('Outside the UK');
+    });
+
+    it('should convert the no value', () => {
+      worker.employedFromOutsideUk = 'No';
+      expect(service.convertEmployedFromOutsideUkValue(worker)).toBe('Inside the UK');
+    });
+
+    it("should convert the don't know value", () => {
+      worker.employedFromOutsideUk = "Don't know";
+      expect(service.convertEmployedFromOutsideUkValue(worker)).toBe('Not known');
+    });
+
+    it('should convert the null value', () => {
+      worker.employedFromOutsideUk = null;
+      expect(service.convertEmployedFromOutsideUkValue(worker)).toBe(null);
+    });
+  });
+
+  describe('show international recruitment questions', () => {
+    describe('nationality is other', () => {
+      it('should return true if British citizenship is no', () => {
+        worker.nationality.value = 'Other';
+        worker.britishCitizenship = 'No';
+
+        expect(service.shouldSeeInternationalRecruitmentQuestions(worker)).toBe(true);
+      });
+
+      it("should return true if British citizenship is Don't know", () => {
+        worker.nationality.value = 'Other';
+        worker.britishCitizenship = "Don't know";
+
+        expect(service.shouldSeeInternationalRecruitmentQuestions(worker)).toBe(true);
+      });
+
+      it('should return true if British citizenship is null', () => {
+        worker.nationality.value = 'Other';
+        worker.britishCitizenship = null;
+
+        expect(service.shouldSeeInternationalRecruitmentQuestions(worker)).toBe(true);
+      });
+    });
+
+    describe("nationality is Don't know", () => {
+      it('should return true if British citizenship is no', () => {
+        worker.nationality.value = "Don't know";
+        worker.britishCitizenship = 'No';
+
+        expect(service.shouldSeeInternationalRecruitmentQuestions(worker)).toBe(true);
+      });
+
+      it('should return false if British citizenship is not known', () => {
+        worker.nationality.value = "Don't know";
+        worker.britishCitizenship = "Don't know";
+
+        expect(service.shouldSeeInternationalRecruitmentQuestions(worker)).toBe(false);
+      });
+
+      it('should return false if British citizenship is null', () => {
+        worker.nationality.value = "Don't know";
+        worker.britishCitizenship = null;
+
+        expect(service.shouldSeeInternationalRecruitmentQuestions(worker)).toBe(false);
+      });
+
+      it('should return false if British citizenship is yes', () => {
+        worker.nationality.value = "Don't know";
+        worker.britishCitizenship = 'Yes';
+
+        expect(service.shouldSeeInternationalRecruitmentQuestions(worker)).toBe(false);
+      });
+    });
+
+    it('should return false if nationality is British', () => {
+      worker.nationality.value = 'British';
+      worker.britishCitizenship = null;
+
+      expect(service.shouldSeeInternationalRecruitmentQuestions(worker)).toBe(false);
+    });
+
+    it('should return false if nationality is null', () => {
+      worker.nationality.value = null;
+      worker.britishCitizenship = null;
+
+      expect(service.shouldSeeInternationalRecruitmentQuestions(worker)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/app/core/services/international-recruitment.service.spec.ts
+++ b/frontend/src/app/core/services/international-recruitment.service.spec.ts
@@ -7,7 +7,7 @@ import { Worker } from '@core/model/worker.model';
 
 describe('InternationalRecruitmentService', () => {
   let service: InternationalRecruitmentService;
-  let worker = workerBuilder() as Worker;
+  let worker: Worker;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -15,31 +15,32 @@ describe('InternationalRecruitmentService', () => {
       providers: [InternationalRecruitmentService],
     });
     service = TestBed.inject(InternationalRecruitmentService);
+    worker = workerBuilder() as Worker;
   });
 
   it('should create the service', async () => {
     expect(service).toBeTruthy();
   });
 
-  describe('employed from outside or inside UK values', () => {
-    it('should convert the yes value', () => {
+  describe('employed from outside or inside UK values for staff record', () => {
+    it('should map the yes value', () => {
       const employedFromOutsideUk = 'Yes';
-      expect(service.convertEmployedFromOutsideUkValue(employedFromOutsideUk)).toBe('Outside the UK');
+      expect(service.getEmployedFromOutsideUkStaffRecordValue(employedFromOutsideUk)).toBe('From outside the UK');
     });
 
-    it('should convert the no value', () => {
+    it('should map the no value', () => {
       const employedFromOutsideUk = 'No';
-      expect(service.convertEmployedFromOutsideUkValue(employedFromOutsideUk)).toBe('Inside the UK');
+      expect(service.getEmployedFromOutsideUkStaffRecordValue(employedFromOutsideUk)).toBe('From inside the UK');
     });
 
-    it("should convert the don't know value", () => {
+    it("should map the don't know value", () => {
       const employedFromOutsideUk = "Don't know";
-      expect(service.convertEmployedFromOutsideUkValue(employedFromOutsideUk)).toBe('I do not know');
+      expect(service.getEmployedFromOutsideUkStaffRecordValue(employedFromOutsideUk)).toBe('Not known');
     });
 
-    it('should convert the null value', () => {
+    it('should map the null value', () => {
       const employedFromOutsideUk = null;
-      expect(service.convertEmployedFromOutsideUkValue(employedFromOutsideUk)).toBe(null);
+      expect(service.getEmployedFromOutsideUkStaffRecordValue(employedFromOutsideUk)).toBe(null);
     });
   });
 

--- a/frontend/src/app/core/services/international-recruitment.service.ts
+++ b/frontend/src/app/core/services/international-recruitment.service.ts
@@ -5,14 +5,48 @@ import { Worker } from '@core/model/worker.model';
 export class InternationalRecruitmentService {
   constructor() {}
 
-  public convertEmployedFromOutsideUkValue(employedFromOutsideUk) {
-    return employedFromOutsideUk === 'Yes'
-      ? 'Outside the UK'
-      : employedFromOutsideUk === 'No'
-      ? 'Inside the UK'
-      : employedFromOutsideUk === "Don't know"
-      ? 'I do not know'
-      : null;
+  private _employedFromOutsideUkMappings = {
+    Yes: {
+      databaseValue: 'Yes',
+      questionValues: {
+        tag: 'Outside the UK',
+        value: 'Yes',
+      },
+      staffRecordValue: 'From outside the UK',
+    },
+    No: {
+      databaseValue: 'No',
+      questionValues: {
+        tag: 'Inside the UK',
+        value: 'No',
+      },
+      staffRecordValue: 'From inside the UK',
+    },
+    "Don't know": {
+      databaseValue: "Don't know",
+      questionValues: {
+        tag: 'I do not know',
+        value: "Don't know",
+      },
+      staffRecordValue: 'Not known',
+    },
+    null: {
+      staffRecordValue: null,
+    },
+  };
+
+  private _employedFromOutsideUkAnswers = [
+    this._employedFromOutsideUkMappings['Yes'].questionValues,
+    this._employedFromOutsideUkMappings['No'].questionValues,
+    this._employedFromOutsideUkMappings[`Don't know`].questionValues,
+  ];
+
+  public getEmployedFromOutsideUkAnswers() {
+    return this._employedFromOutsideUkAnswers;
+  }
+
+  public getEmployedFromOutsideUkStaffRecordValue(employedFromOutsideUkDbValue) {
+    return this._employedFromOutsideUkMappings[employedFromOutsideUkDbValue]?.staffRecordValue;
   }
 
   public shouldSeeInternationalRecruitmentQuestions(worker: Worker) {

--- a/frontend/src/app/core/services/international-recruitment.service.ts
+++ b/frontend/src/app/core/services/international-recruitment.service.ts
@@ -12,7 +12,7 @@ export class InternationalRecruitmentService {
       ? 'Inside the UK'
       : employedFromOutsideUk === "Don't know"
       ? 'I do not know'
-      : employedFromOutsideUk;
+      : null;
   }
 
   public shouldSeeInternationalRecruitmentQuestions(worker: Worker) {

--- a/frontend/src/app/core/services/international-recruitment.service.ts
+++ b/frontend/src/app/core/services/international-recruitment.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { Worker } from '@core/model/worker.model';
+
+@Injectable()
+export class InternationalRecruitmentService {
+  constructor() {}
+
+  public convertEmployedFromOutsideUkValue(worker: Worker) {
+    return worker.employedFromOutsideUk === 'Yes'
+      ? 'Outside the UK'
+      : worker.employedFromOutsideUk === 'No'
+      ? 'Inside the UK'
+      : worker.employedFromOutsideUk === "Don't know"
+      ? 'Not known'
+      : null;
+  }
+
+  public shouldSeeInternationalRecruitmentQuestions(worker: Worker) {
+    return (
+      this._isWorkerFromOtherNationWithUnknownCitizenship(worker) ||
+      this._isWorkerWithoutBritishCitizenshipAndUnknownNationality(worker)
+    );
+  }
+
+  private _isWorkerFromOtherNationWithUnknownCitizenship(worker) {
+    return worker.nationality?.value === 'Other' && ['No', "Don't know", null].includes(worker.britishCitizenship);
+  }
+
+  private _isWorkerWithoutBritishCitizenshipAndUnknownNationality(worker) {
+    return worker.nationality?.value === "Don't know" && worker.britishCitizenship === 'No';
+  }
+}

--- a/frontend/src/app/core/services/international-recruitment.service.ts
+++ b/frontend/src/app/core/services/international-recruitment.service.ts
@@ -5,14 +5,14 @@ import { Worker } from '@core/model/worker.model';
 export class InternationalRecruitmentService {
   constructor() {}
 
-  public convertEmployedFromOutsideUkValue(worker: Worker) {
-    return worker.employedFromOutsideUk === 'Yes'
+  public convertEmployedFromOutsideUkValue(employedFromOutsideUk) {
+    return employedFromOutsideUk === 'Yes'
       ? 'Outside the UK'
-      : worker.employedFromOutsideUk === 'No'
+      : employedFromOutsideUk === 'No'
       ? 'Inside the UK'
-      : worker.employedFromOutsideUk === "Don't know"
-      ? 'Not known'
-      : null;
+      : employedFromOutsideUk === "Don't know"
+      ? 'I do not know'
+      : employedFromOutsideUk;
   }
 
   public shouldSeeInternationalRecruitmentQuestions(worker: Worker) {

--- a/frontend/src/app/core/services/international-recruitment.service.ts
+++ b/frontend/src/app/core/services/international-recruitment.service.ts
@@ -30,9 +30,6 @@ export class InternationalRecruitmentService {
       },
       staffRecordValue: 'Not known',
     },
-    null: {
-      staffRecordValue: null,
-    },
   };
 
   private _employedFromOutsideUkAnswers = [
@@ -46,7 +43,7 @@ export class InternationalRecruitmentService {
   }
 
   public getEmployedFromOutsideUkStaffRecordValue(employedFromOutsideUkDbValue) {
-    return this._employedFromOutsideUkMappings[employedFromOutsideUkDbValue]?.staffRecordValue;
+    return this._employedFromOutsideUkMappings[employedFromOutsideUkDbValue]?.staffRecordValue || null;
   }
 
   public shouldSeeInternationalRecruitmentQuestions(worker: Worker) {

--- a/frontend/src/app/core/test-utils/MockWorkerService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkerService.ts
@@ -61,6 +61,8 @@ export const workerBuilder = build('Worker', {
     countryOfBirth: {
       value: 'United Kingdom',
     },
+    nationality: { value: null },
+    britishCitizenship: null,
   },
 });
 

--- a/frontend/src/app/features/workers/employed-from-outside-uk/employed-from-outside-uk.component.spec.ts
+++ b/frontend/src/app/features/workers/employed-from-outside-uk/employed-from-outside-uk.component.spec.ts
@@ -9,6 +9,7 @@ import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
 import { EmployedFromOutsideUkComponent } from './employed-from-outside-uk.component';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 describe('EmployedFromOutsideUkComponent', () => {
   async function setup(insideFlow = true) {
@@ -18,6 +19,7 @@ describe('EmployedFromOutsideUkComponent', () => {
         imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
         providers: [
           UntypedFormBuilder,
+          InternationalRecruitmentService,
           {
             provide: WorkerService,
             useClass: MockWorkerServiceWithUpdateWorker,

--- a/frontend/src/app/features/workers/employed-from-outside-uk/employed-from-outside-uk.component.ts
+++ b/frontend/src/app/features/workers/employed-from-outside-uk/employed-from-outside-uk.component.ts
@@ -14,11 +14,7 @@ import { InternationalRecruitmentService } from '@core/services/international-re
   templateUrl: './employed-from-outside-uk.component.html',
 })
 export class EmployedFromOutsideUkComponent extends QuestionComponent {
-  public answersAvailable = [
-    { tag: this.internationalRecruitmentService.convertEmployedFromOutsideUkValue('Yes'), value: 'Yes' },
-    { tag: this.internationalRecruitmentService.convertEmployedFromOutsideUkValue('No'), value: 'No' },
-    { tag: this.internationalRecruitmentService.convertEmployedFromOutsideUkValue(`Don't know`), value: `Don't know` },
-  ];
+  public answersAvailable = this.internationalRecruitmentService.getEmployedFromOutsideUkAnswers();
 
   constructor(
     protected formBuilder: UntypedFormBuilder,

--- a/frontend/src/app/features/workers/employed-from-outside-uk/employed-from-outside-uk.component.ts
+++ b/frontend/src/app/features/workers/employed-from-outside-uk/employed-from-outside-uk.component.ts
@@ -7,6 +7,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkerService } from '@core/services/worker.service';
 
 import { QuestionComponent } from '../question/question.component';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 @Component({
   selector: 'app-employed-from-outside-uk',
@@ -14,9 +15,9 @@ import { QuestionComponent } from '../question/question.component';
 })
 export class EmployedFromOutsideUkComponent extends QuestionComponent {
   public answersAvailable = [
-    { tag: 'Outside the UK', value: 'Yes' },
-    { tag: 'Inside the UK', value: 'No' },
-    { tag: 'I do not know', value: `Don't know` },
+    { tag: this.internationalRecruitmentService.convertEmployedFromOutsideUkValue('Yes'), value: 'Yes' },
+    { tag: this.internationalRecruitmentService.convertEmployedFromOutsideUkValue('No'), value: 'No' },
+    { tag: this.internationalRecruitmentService.convertEmployedFromOutsideUkValue(`Don't know`), value: `Don't know` },
   ];
 
   constructor(
@@ -27,6 +28,7 @@ export class EmployedFromOutsideUkComponent extends QuestionComponent {
     protected errorSummaryService: ErrorSummaryService,
     protected workerService: WorkerService,
     protected establishmentService: EstablishmentService,
+    public internationalRecruitmentService: InternationalRecruitmentService,
   ) {
     super(formBuilder, router, route, backLinkService, errorSummaryService, workerService, establishmentService);
 

--- a/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
+++ b/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
@@ -22,6 +22,7 @@ import { render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
 import { MandatoryDetailsComponent } from './mandatory-details.component';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 describe('MandatoryDetailsComponent', () => {
   const setup = async (canEditWorker = true, primaryUid = 123) => {
@@ -37,6 +38,7 @@ describe('MandatoryDetailsComponent', () => {
         ProgressBarComponent,
       ],
       providers: [
+        InternationalRecruitmentService,
         {
           provide: WindowRef,
           useValue: WindowRef,

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -21,6 +21,7 @@ import { fireEvent, render } from '@testing-library/angular';
 
 import { WorkersModule } from '../workers.module';
 import { StaffRecordComponent } from './staff-record.component';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 describe('StaffRecordComponent', () => {
   async function setup(isParent = true) {
@@ -31,6 +32,7 @@ describe('StaffRecordComponent', () => {
         AlertService,
         WindowRef,
         DialogService,
+        InternationalRecruitmentService,
         {
           provide: ActivatedRoute,
           useValue: {

--- a/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
@@ -13,6 +13,7 @@ import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
 import { BasicRecordComponent } from './basic-record.component';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 describe('BasicRecordComponent', () => {
   async function setup(mandatoryDetailsPage = false) {
@@ -20,6 +21,7 @@ describe('BasicRecordComponent', () => {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [SummaryRecordChangeComponent],
       providers: [
+        InternationalRecruitmentService,
         {
           provide: PermissionsService,
           useFactory: MockPermissionsService.factory(['canEditWorker']),

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.html
@@ -16,20 +16,20 @@
   </div>
   <div
     class="govuk-summary-list__row"
-    *ngIf="displayEmployedFromOutSideOrInsideUk"
+    *ngIf="displayEmployedFromOutsideOrInsideUk"
     data-testid="employed-inside-or-outside-section"
   >
     <dt class="govuk-summary-list__key govuk-!-width-one-half govuk-!-padding-right-1">
       Employed from outside or inside the UK
     </dt>
     <dd class="govuk-summary-list__value govuk-!-padding-left-9">
-      {{ (worker.employedFromInsideUk | closedEndedAnswer) || '-' }}
+      {{ displayEmployedFromOutsideOrInsideUkValue | closedEndedAnswer }}
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
       <app-summary-record-change
         [explanationText]="'Employed from outside or inside UK'"
         [link]="getRoutePath('inside-or-outside-of-uk', wdfView)"
-        [hasData]="!!worker.employedFromInsideUk"
+        [hasData]="!!worker.employedFromOutsideUk"
         (setReturnClicked)="this.setReturn()"
       ></app-summary-record-change>
     </dd>

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.html
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m">Employment details</h2>
 <dl class="govuk-summary-list asc-summarylist-border-top">
-  <div class="govuk-summary-list__row" data-testid="health-and-care-visa-section">
+  <div class="govuk-summary-list__row" *ngIf="displayHealthAndCareVisa" data-testid="health-and-care-visa-section">
     <dt class="govuk-summary-list__key govuk-!-width-one-half">On a Health and Care Worker visa</dt>
     <dd class="govuk-summary-list__value govuk-!-padding-left-9">
       {{ worker.healthAndCareVisa | closedEndedAnswer }}

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.html
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">Employment details</h2>
 <dl class="govuk-summary-list asc-summarylist-border-top">
   <div class="govuk-summary-list__row" data-testid="health-and-care-visa-section">
-    <dt class="govuk-summary-list__key govuk-!-width-one-half">Health and Care Worker visa</dt>
+    <dt class="govuk-summary-list__key govuk-!-width-one-half">On a Health and Care Worker visa</dt>
     <dd class="govuk-summary-list__value govuk-!-padding-left-9">
       {{ worker.healthAndCareVisa | closedEndedAnswer }}
     </dd>
@@ -10,6 +10,26 @@
         [explanationText]="' Health and Care Worker visa'"
         [link]="getRoutePath('health-and-care-visa', wdfView)"
         [hasData]="!!worker.healthAndCareVisa"
+        (setReturnClicked)="this.setReturn()"
+      ></app-summary-record-change>
+    </dd>
+  </div>
+  <div
+    class="govuk-summary-list__row"
+    *ngIf="displayEmployedFromOutSideOrInsideUk"
+    data-testid="employed-inside-or-outside-section"
+  >
+    <dt class="govuk-summary-list__key govuk-!-width-one-half govuk-!-padding-right-1">
+      Employed from outside or inside the UK
+    </dt>
+    <dd class="govuk-summary-list__value govuk-!-padding-left-9">
+      {{ (worker.employedFromInsideUk | closedEndedAnswer) || '-' }}
+    </dd>
+    <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
+      <app-summary-record-change
+        [explanationText]="'Employed from outside or inside UK'"
+        [link]="getRoutePath('inside-or-outside-of-uk', wdfView)"
+        [hasData]="!!worker.employedFromInsideUk"
         (setReturnClicked)="this.setReturn()"
       ></app-summary-record-change>
     </dd>

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
@@ -13,6 +13,7 @@ import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 
 import { EmploymentComponent } from './employment.component';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 describe('EmploymentComponent', () => {
   async function setup() {
@@ -20,11 +21,13 @@ describe('EmploymentComponent', () => {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [SummaryRecordChangeComponent],
       providers: [
+        InternationalRecruitmentService,
         {
           provide: PermissionsService,
           useFactory: MockPermissionsService.factory(['canEditWorker']),
           deps: [HttpClient],
         },
+        //{ provide: InternationalRecruitmentService },
       ],
       componentProperties: {
         canEditWorker: true,
@@ -54,7 +57,7 @@ describe('EmploymentComponent', () => {
     it('should not show the health and care visa section nationality is not answered', async () => {
       const { fixture, component, queryByTestId } = await setup();
 
-      component.worker.nationality.value = undefined;
+      component.worker.nationality.value = null;
       fixture.detectChanges();
 
       const healthAndCareVisaSection = queryByTestId('health-and-care-visa-section');
@@ -115,7 +118,7 @@ describe('EmploymentComponent', () => {
         const { fixture, component, getByTestId } = await setup();
 
         component.worker.nationality.value = 'Other';
-        component.worker.britishCitizenship = undefined;
+        component.worker.britishCitizenship = null;
         fixture.detectChanges();
 
         const healthAndCareVisaSection = getByTestId('health-and-care-visa-section');
@@ -155,7 +158,7 @@ describe('EmploymentComponent', () => {
         const { fixture, component, queryByTestId } = await setup();
 
         component.worker.nationality.value = "Don't know";
-        component.worker.britishCitizenship = undefined;
+        component.worker.britishCitizenship = null;
 
         fixture.detectChanges();
 
@@ -183,7 +186,7 @@ describe('EmploymentComponent', () => {
 
       component.worker.nationality.value = 'Other';
       component.worker.britishCitizenship = 'No';
-      component.worker.healthAndCareVisa = undefined;
+      component.worker.healthAndCareVisa = null;
       fixture.detectChanges();
 
       const healthAndCareVisaSection = within(getByTestId('health-and-care-visa-section'));
@@ -237,7 +240,7 @@ describe('EmploymentComponent', () => {
 
       component.worker.nationality.value = 'Other';
       component.worker.britishCitizenship = 'No';
-      component.worker.healthAndCareVisa = undefined;
+      component.worker.healthAndCareVisa = null;
       fixture.detectChanges();
 
       const employedInsideTheUKSection = queryByTestId('employed-inside-or-outside-section');
@@ -278,7 +281,7 @@ describe('EmploymentComponent', () => {
         component.worker.nationality.value = 'Other';
         component.worker.britishCitizenship = 'No';
         component.worker.healthAndCareVisa = 'Yes';
-        component.worker.employedFromOutsideUk = undefined;
+        component.worker.employedFromOutsideUk = null;
         fixture.detectChanges();
 
         const employedInsideTheUKSection = within(getByTestId('employed-inside-or-outside-section'));

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
@@ -27,7 +27,6 @@ describe('EmploymentComponent', () => {
           useFactory: MockPermissionsService.factory(['canEditWorker']),
           deps: [HttpClient],
         },
-        //{ provide: InternationalRecruitmentService },
       ],
       componentProperties: {
         canEditWorker: true,

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
@@ -14,7 +14,7 @@ import { render, within } from '@testing-library/angular';
 
 import { EmploymentComponent } from './employment.component';
 
-describe('EmploymentComponent', () => {
+fdescribe('EmploymentComponent', () => {
   async function setup() {
     const { fixture, getByText, getByTestId, queryByTestId } = await render(EmploymentComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
@@ -50,10 +50,139 @@ describe('EmploymentComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  fdescribe('Health and Social Care visa', () => {
+  describe('Health and Social Care visa', () => {
+    it('should not show the health and care visa section nationality is not answered', async () => {
+      const { fixture, component, queryByTestId } = await setup();
+
+      component.worker.nationality.value = undefined;
+      fixture.detectChanges();
+
+      const healthAndCareVisaSection = queryByTestId('health-and-care-visa-section');
+
+      expect(healthAndCareVisaSection).toBeFalsy();
+    });
+
+    it('should not show the health and care visa section if the nationality is British', async () => {
+      const { fixture, component, queryByTestId } = await setup();
+
+      component.worker.nationality.value = 'British';
+      fixture.detectChanges();
+
+      const healthAndCareVisaSection = queryByTestId('health-and-care-visa-section');
+
+      expect(healthAndCareVisaSection).toBeFalsy();
+    });
+
+    describe('nationality is other', () => {
+      it('should not show the health and care visa section if the british citizenship is Yes', async () => {
+        const { fixture, component, queryByTestId } = await setup();
+
+        component.worker.nationality.value = 'Other';
+        component.worker.britishCitizenship = 'Yes';
+
+        fixture.detectChanges();
+
+        const healthAndCareVisaSection = queryByTestId('health-and-care-visa-section');
+
+        expect(healthAndCareVisaSection).toBeFalsy();
+      });
+
+      it('should show the health and care visa section if the british citizenship is No', async () => {
+        const { fixture, component, getByTestId } = await setup();
+
+        component.worker.nationality.value = 'Other';
+        component.worker.britishCitizenship = 'No';
+        fixture.detectChanges();
+
+        const healthAndCareVisaSection = getByTestId('health-and-care-visa-section');
+
+        expect(healthAndCareVisaSection).toBeTruthy();
+      });
+
+      it("should show the health and care visa section if the british citizenship is Don't know", async () => {
+        const { fixture, component, getByTestId } = await setup();
+
+        component.worker.nationality.value = 'Other';
+        component.worker.britishCitizenship = "Don't know";
+        fixture.detectChanges();
+
+        const healthAndCareVisaSection = getByTestId('health-and-care-visa-section');
+
+        expect(healthAndCareVisaSection).toBeTruthy();
+      });
+
+      it('should show the health and care visa section if the british citizenship is not answered', async () => {
+        const { fixture, component, getByTestId } = await setup();
+
+        component.worker.nationality.value = 'Other';
+        component.worker.britishCitizenship = undefined;
+        fixture.detectChanges();
+
+        const healthAndCareVisaSection = getByTestId('health-and-care-visa-section');
+
+        expect(healthAndCareVisaSection).toBeTruthy();
+      });
+    });
+
+    describe('nationality is not known', () => {
+      it('should not show if britishCitizenship is Yes', async () => {
+        const { fixture, component, queryByTestId } = await setup();
+
+        component.worker.nationality.value = "Don't know";
+        component.worker.britishCitizenship = 'Yes';
+
+        fixture.detectChanges();
+
+        const healthAndCareVisaSection = queryByTestId('health-and-care-visa-section');
+
+        expect(healthAndCareVisaSection).toBeFalsy();
+      });
+
+      it('should not show if britishCitizenship is not known', async () => {
+        const { fixture, component, queryByTestId } = await setup();
+
+        component.worker.nationality.value = "Don't know";
+        component.worker.britishCitizenship = "Don't know";
+
+        fixture.detectChanges();
+
+        const healthAndCareVisaSection = queryByTestId('health-and-care-visa-section');
+
+        expect(healthAndCareVisaSection).toBeFalsy();
+      });
+
+      it('should not show if britishCitizenship is not answered', async () => {
+        const { fixture, component, queryByTestId } = await setup();
+
+        component.worker.nationality.value = "Don't know";
+        component.worker.britishCitizenship = undefined;
+
+        fixture.detectChanges();
+
+        const healthAndCareVisaSection = queryByTestId('health-and-care-visa-section');
+
+        expect(healthAndCareVisaSection).toBeFalsy();
+      });
+
+      it('should show if britishCitizenship is No', async () => {
+        const { fixture, component, getByTestId } = await setup();
+
+        component.worker.nationality.value = "Don't know";
+        component.worker.britishCitizenship = 'No';
+
+        fixture.detectChanges();
+
+        const healthAndCareVisaSection = getByTestId('health-and-care-visa-section');
+
+        expect(healthAndCareVisaSection).toBeTruthy();
+      });
+    });
+
     it('should render Add link with the staff-record-summary/health-and-social-care url when health and care visa question not answered', async () => {
       const { fixture, component, getByTestId } = await setup();
 
+      component.worker.nationality.value = 'Other';
+      component.worker.britishCitizenship = 'No';
       component.worker.healthAndCareVisa = undefined;
       fixture.detectChanges();
 
@@ -68,6 +197,8 @@ describe('EmploymentComponent', () => {
     it('should render Yes and a Change link with the staff-record-summary/health-and-social-care url when health and care visa question answered Yes', async () => {
       const { fixture, component, getByTestId } = await setup();
 
+      component.worker.nationality.value = 'Other';
+      component.worker.britishCitizenship = 'No';
       component.worker.healthAndCareVisa = 'Yes';
       fixture.detectChanges();
 
@@ -84,6 +215,8 @@ describe('EmploymentComponent', () => {
     it("should display Not known when health and care visa question answered as Don't know", async () => {
       const { fixture, component, getByTestId } = await setup();
 
+      component.worker.nationality.value = 'Other';
+      component.worker.britishCitizenship = 'No';
       component.worker.healthAndCareVisa = "Don't know";
       fixture.detectChanges();
 
@@ -98,10 +231,12 @@ describe('EmploymentComponent', () => {
     });
   });
 
-  fdescribe('Employed from outside or inside the UK', () => {
+  describe('Employed from outside or inside the UK', () => {
     it('should not display if the health and care visa question is not answered', async () => {
       const { fixture, component, queryByTestId } = await setup();
 
+      component.worker.nationality.value = 'Other';
+      component.worker.britishCitizenship = 'No';
       component.worker.healthAndCareVisa = undefined;
       fixture.detectChanges();
 
@@ -113,6 +248,8 @@ describe('EmploymentComponent', () => {
     it('should not display if the health and care visa question is no', async () => {
       const { fixture, component, queryByTestId } = await setup();
 
+      component.worker.nationality.value = 'Other';
+      component.worker.britishCitizenship = 'No';
       component.worker.healthAndCareVisa = 'No';
       fixture.detectChanges();
 
@@ -124,6 +261,8 @@ describe('EmploymentComponent', () => {
     it("should not display if the health and care visa question is Don't know", async () => {
       const { fixture, component, queryByTestId } = await setup();
 
+      component.worker.nationality.value = 'Other';
+      component.worker.britishCitizenship = 'No';
       component.worker.healthAndCareVisa = "Don't know";
       fixture.detectChanges();
 
@@ -136,6 +275,8 @@ describe('EmploymentComponent', () => {
       xit('should display the Add link when the question is not answered', async () => {
         const { component, fixture, getByTestId } = await setup();
 
+        component.worker.nationality.value = 'Other';
+        component.worker.britishCitizenship = 'No';
         component.worker.healthAndCareVisa = 'Yes';
         //component.worker.employedFromInsideUk = undefined;
         fixture.detectChanges();
@@ -153,6 +294,8 @@ describe('EmploymentComponent', () => {
       xit('should display From outside the UK when the questioned is answered as Outside the UK', async () => {
         const { component, fixture, getByTestId } = await setup();
 
+        component.worker.nationality.value = 'Other';
+        component.worker.britishCitizenship = 'No';
         component.worker.healthAndCareVisa = 'Yes';
         //component.worker.employedFromInsideUk = "Outside the UK";
         fixture.detectChanges();
@@ -170,6 +313,8 @@ describe('EmploymentComponent', () => {
       xit('should display From inside the UK when the questioned is answered as inside the UK', async () => {
         const { component, fixture, getByTestId } = await setup();
 
+        component.worker.nationality.value = 'Other';
+        component.worker.britishCitizenship = 'No';
         component.worker.healthAndCareVisa = 'Yes';
         //component.worker.employedFromInsideUk = "Inside the UK";
         fixture.detectChanges();
@@ -187,6 +332,8 @@ describe('EmploymentComponent', () => {
       xit('should display Not known when the questioned is answered as I do not know', async () => {
         const { component, fixture, getByTestId } = await setup();
 
+        component.worker.nationality.value = 'Other';
+        component.worker.britishCitizenship = 'No';
         component.worker.healthAndCareVisa = 'Yes';
         //component.worker.employedFromInsideUk = "I do not know";
         fixture.detectChanges();

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
@@ -10,13 +10,13 @@ import { MockPermissionsService } from '@core/test-utils/MockPermissionsService'
 import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SummaryRecordChangeComponent } from '@shared/components/summary-record-change/summary-record-change.component';
 import { SharedModule } from '@shared/shared.module';
-import { render, within } from '@testing-library/angular';
+import { queryByTestId, render, within } from '@testing-library/angular';
 
 import { EmploymentComponent } from './employment.component';
 
 describe('EmploymentComponent', () => {
   async function setup() {
-    const { fixture, getByText, getByTestId } = await render(EmploymentComponent, {
+    const { fixture, getByText, getByTestId, queryByTestId } = await render(EmploymentComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [SummaryRecordChangeComponent],
       providers: [
@@ -41,6 +41,7 @@ describe('EmploymentComponent', () => {
       fixture,
       getByText,
       getByTestId,
+      queryByTestId,
     };
   }
 
@@ -49,7 +50,7 @@ describe('EmploymentComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('Health and Social Care visa', () => {
+  fdescribe('Health and Social Care visa', () => {
     it('should render Add link with the staff-record-summary/health-and-social-care url when health and care visa question not answered', async () => {
       const { fixture, component, getByTestId } = await setup();
 
@@ -95,5 +96,118 @@ describe('EmploymentComponent', () => {
         `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/health-and-care-visa`,
       );
     });
+  });
+
+  fdescribe('Employed from outside or inside the UK', () => {
+    it('should not display if the health and care visa question is not answered', async () => {
+      const { fixture, component, queryByTestId } = await setup();
+
+      component.worker.healthAndCareVisa = undefined;
+      fixture.detectChanges();
+
+      const employedInsideTheUKSection = queryByTestId('employed-inside-or-outside-section');
+
+      expect(employedInsideTheUKSection).toBeFalsy();
+    });
+
+    it('should not display if the health and care visa question is no', async () => {
+      const { fixture, component, queryByTestId } = await setup();
+
+      component.worker.healthAndCareVisa = 'No';
+      fixture.detectChanges();
+
+      const employedInsideTheUKSection = queryByTestId('employed-inside-or-outside-section');
+
+      expect(employedInsideTheUKSection).toBeFalsy();
+    });
+
+    it("should not display if the health and care visa question is Don't know", async () => {
+      const { fixture, component, queryByTestId } = await setup();
+
+      component.worker.healthAndCareVisa = "Don't know";
+      fixture.detectChanges();
+
+      const employedInsideTheUKSection = queryByTestId('employed-inside-or-outside-section');
+
+      expect(employedInsideTheUKSection).toBeFalsy();
+    });
+
+    xdescribe('health and care visa question is answered Yes', () => {
+      it('should display the Add link when the question is not answered', async () => {
+        const { component, fixture, getByTestId } = await setup();
+
+        component.worker.healthAndCareVisa = 'Yes';
+        //component.worker.employedFromInsideUk = undefined;
+        fixture.detectChanges();
+
+        const employedInsideTheUKSection = within(getByTestId('employed-inside-or-outside-section'));
+        const notKnownMessage = employedInsideTheUKSection.getByText('Not known');
+        const addLink = employedInsideTheUKSection.getByText('Add');
+
+        expect(notKnownMessage).toBeTruthy();
+        expect(addLink.getAttribute('href')).toBe(
+          `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/inside-or-outside-of-uk`,
+        );
+      });
+
+      it('should display From outside the UK when the questioned is answered as Outside the UK', async () => {
+        const { component, fixture, getByTestId } = await setup();
+
+        component.worker.healthAndCareVisa = 'Yes';
+        //component.worker.employedFromInsideUk = "Outside the UK";
+        fixture.detectChanges();
+
+        const employedInsideTheUKSection = within(getByTestId('employed-inside-or-outside-section'));
+        const outsideTheUKMessage = employedInsideTheUKSection.getByText('From outside the UK');
+        const changeLink = employedInsideTheUKSection.getByText('Change');
+
+        expect(outsideTheUKMessage).toBeTruthy();
+        expect(changeLink.getAttribute('href')).toBe(
+          `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/inside-or-outside-of-uk`,
+        );
+      });
+
+      it('should display From inside the UK when the questioned is answered as inside the UK', async () => {
+        const { component, fixture, getByTestId } = await setup();
+
+        component.worker.healthAndCareVisa = 'Yes';
+        //component.worker.employedFromInsideUk = "Inside the UK";
+        fixture.detectChanges();
+
+        const employedInsideTheUKSection = within(getByTestId('employed-inside-or-outside-section'));
+        const insideTheUKMessage = employedInsideTheUKSection.getByText('From inside the UK');
+        const changeLink = employedInsideTheUKSection.getByText('Change');
+
+        expect(insideTheUKMessage).toBeTruthy();
+        expect(changeLink.getAttribute('href')).toBe(
+          `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/inside-or-outside-of-uk`,
+        );
+      });
+
+      it('should display Not known when the questioned is answered as I do not know', async () => {
+        const { component, fixture, getByTestId } = await setup();
+
+        component.worker.healthAndCareVisa = 'Yes';
+        //component.worker.employedFromInsideUk = "I do not know";
+        fixture.detectChanges();
+
+        const employedInsideTheUKSection = within(getByTestId('employed-inside-or-outside-section'));
+        const notKnownMessage = employedInsideTheUKSection.getByText('Not known');
+        const changeLink = employedInsideTheUKSection.getByText('Change');
+
+        expect(notKnownMessage).toBeTruthy();
+        expect(changeLink.getAttribute('href')).toBe(
+          `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/inside-or-outside-of-uk`,
+        );
+      });
+    });
+
+    //h&s yes and employed is outside - From outside the UK & change link
+    //h&s yes and employed is inside - From inside the UK & change link
+    //h&s yes and employed is unknown - Not known & change link
+    //h&s yes and employed is skipped & change link
+    //shouldn't show row if h&s is no
+    //shouldn't show row if h&s is skipped
+    //shouldn't show row if h&s is not known
   });
 });

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
@@ -10,7 +10,7 @@ import { MockPermissionsService } from '@core/test-utils/MockPermissionsService'
 import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SummaryRecordChangeComponent } from '@shared/components/summary-record-change/summary-record-change.component';
 import { SharedModule } from '@shared/shared.module';
-import { queryByTestId, render, within } from '@testing-library/angular';
+import { render, within } from '@testing-library/angular';
 
 import { EmploymentComponent } from './employment.component';
 
@@ -132,8 +132,8 @@ describe('EmploymentComponent', () => {
       expect(employedInsideTheUKSection).toBeFalsy();
     });
 
-    xdescribe('health and care visa question is answered Yes', () => {
-      it('should display the Add link when the question is not answered', async () => {
+    describe('health and care visa question is answered Yes', () => {
+      xit('should display the Add link when the question is not answered', async () => {
         const { component, fixture, getByTestId } = await setup();
 
         component.worker.healthAndCareVisa = 'Yes';
@@ -150,7 +150,7 @@ describe('EmploymentComponent', () => {
         );
       });
 
-      it('should display From outside the UK when the questioned is answered as Outside the UK', async () => {
+      xit('should display From outside the UK when the questioned is answered as Outside the UK', async () => {
         const { component, fixture, getByTestId } = await setup();
 
         component.worker.healthAndCareVisa = 'Yes';
@@ -167,7 +167,7 @@ describe('EmploymentComponent', () => {
         );
       });
 
-      it('should display From inside the UK when the questioned is answered as inside the UK', async () => {
+      xit('should display From inside the UK when the questioned is answered as inside the UK', async () => {
         const { component, fixture, getByTestId } = await setup();
 
         component.worker.healthAndCareVisa = 'Yes';
@@ -184,7 +184,7 @@ describe('EmploymentComponent', () => {
         );
       });
 
-      it('should display Not known when the questioned is answered as I do not know', async () => {
+      xit('should display Not known when the questioned is answered as I do not know', async () => {
         const { component, fixture, getByTestId } = await setup();
 
         component.worker.healthAndCareVisa = 'Yes';
@@ -201,13 +201,5 @@ describe('EmploymentComponent', () => {
         );
       });
     });
-
-    //h&s yes and employed is outside - From outside the UK & change link
-    //h&s yes and employed is inside - From inside the UK & change link
-    //h&s yes and employed is unknown - Not known & change link
-    //h&s yes and employed is skipped & change link
-    //shouldn't show row if h&s is no
-    //shouldn't show row if h&s is skipped
-    //shouldn't show row if h&s is not known
   });
 });

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.spec.ts
@@ -14,7 +14,7 @@ import { render, within } from '@testing-library/angular';
 
 import { EmploymentComponent } from './employment.component';
 
-fdescribe('EmploymentComponent', () => {
+describe('EmploymentComponent', () => {
   async function setup() {
     const { fixture, getByText, getByTestId, queryByTestId } = await render(EmploymentComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
@@ -272,32 +272,30 @@ fdescribe('EmploymentComponent', () => {
     });
 
     describe('health and care visa question is answered Yes', () => {
-      xit('should display the Add link when the question is not answered', async () => {
+      it('should display the Add link when the question is not answered', async () => {
         const { component, fixture, getByTestId } = await setup();
 
         component.worker.nationality.value = 'Other';
         component.worker.britishCitizenship = 'No';
         component.worker.healthAndCareVisa = 'Yes';
-        //component.worker.employedFromInsideUk = undefined;
+        component.worker.employedFromOutsideUk = undefined;
         fixture.detectChanges();
 
         const employedInsideTheUKSection = within(getByTestId('employed-inside-or-outside-section'));
-        const notKnownMessage = employedInsideTheUKSection.getByText('Not known');
         const addLink = employedInsideTheUKSection.getByText('Add');
 
-        expect(notKnownMessage).toBeTruthy();
         expect(addLink.getAttribute('href')).toBe(
           `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/inside-or-outside-of-uk`,
         );
       });
 
-      xit('should display From outside the UK when the questioned is answered as Outside the UK', async () => {
+      it('should display From outside the UK when the questioned is answered as Outside the UK', async () => {
         const { component, fixture, getByTestId } = await setup();
 
         component.worker.nationality.value = 'Other';
         component.worker.britishCitizenship = 'No';
         component.worker.healthAndCareVisa = 'Yes';
-        //component.worker.employedFromInsideUk = "Outside the UK";
+        component.worker.employedFromOutsideUk = 'Yes';
         fixture.detectChanges();
 
         const employedInsideTheUKSection = within(getByTestId('employed-inside-or-outside-section'));
@@ -310,13 +308,13 @@ fdescribe('EmploymentComponent', () => {
         );
       });
 
-      xit('should display From inside the UK when the questioned is answered as inside the UK', async () => {
+      it('should display From inside the UK when the questioned is answered as inside the UK', async () => {
         const { component, fixture, getByTestId } = await setup();
 
         component.worker.nationality.value = 'Other';
         component.worker.britishCitizenship = 'No';
         component.worker.healthAndCareVisa = 'Yes';
-        //component.worker.employedFromInsideUk = "Inside the UK";
+        component.worker.employedFromOutsideUk = 'No';
         fixture.detectChanges();
 
         const employedInsideTheUKSection = within(getByTestId('employed-inside-or-outside-section'));
@@ -329,13 +327,13 @@ fdescribe('EmploymentComponent', () => {
         );
       });
 
-      xit('should display Not known when the questioned is answered as I do not know', async () => {
+      it('should display Not known when the questioned is answered as I do not know', async () => {
         const { component, fixture, getByTestId } = await setup();
 
         component.worker.nationality.value = 'Other';
         component.worker.britishCitizenship = 'No';
         component.worker.healthAndCareVisa = 'Yes';
-        //component.worker.employedFromInsideUk = "I do not know";
+        component.worker.employedFromOutsideUk = "Don't know";
         fixture.detectChanges();
 
         const employedInsideTheUKSection = within(getByTestId('employed-inside-or-outside-section'));

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
@@ -74,7 +74,17 @@ export class EmploymentComponent extends StaffRecordSummaryComponent {
     }
   }
 
-  get displayEmployedFromOutSideOrInsideUk() {
+  get displayEmployedFromOutsideOrInsideUk() {
     return this.worker.healthAndCareVisa === 'Yes';
+  }
+
+  get displayEmployedFromOutsideOrInsideUkValue() {
+    return this.worker.employedFromOutsideUk === 'Yes'
+      ? 'From outside the UK'
+      : this.worker.employedFromOutsideUk === 'No'
+      ? 'From inside the UK'
+      : this.worker.employedFromOutsideUk === "Don't know"
+      ? 'Not known'
+      : null;
   }
 }

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
@@ -62,6 +62,18 @@ export class EmploymentComponent extends StaffRecordSummaryComponent {
     return dayjs(this.worker.mainJobStartDate).format('D MMMM YYYY');
   }
 
+  get displayHealthAndCareVisa() {
+    if (this.worker.nationality?.value === 'Other') {
+      return (
+        this.worker.britishCitizenship === 'No' ||
+        this.worker.britishCitizenship === "Don't know" ||
+        this.worker.britishCitizenship === undefined
+      );
+    } else if (this.worker.nationality?.value === "Don't know") {
+      return this.worker.britishCitizenship === 'No';
+    }
+  }
+
   get displayEmployedFromOutSideOrInsideUk() {
     return this.worker.healthAndCareVisa === 'Yes';
   }

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
@@ -10,6 +10,7 @@ import dayjs from 'dayjs';
 import isNumber from 'lodash/isNumber';
 
 import { StaffRecordSummaryComponent } from '../staff-record-summary.component';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 @Component({
   selector: 'app-employment',
@@ -27,8 +28,16 @@ export class EmploymentComponent extends StaffRecordSummaryComponent {
     wdfConfirmFieldsService: WdfConfirmFieldsService,
     route: ActivatedRoute,
     ethnicityService: EthnicityService,
+    internationalRecruitmentService: InternationalRecruitmentService,
   ) {
-    super(permissionsService, workerService, wdfConfirmFieldsService, route, ethnicityService);
+    super(
+      permissionsService,
+      workerService,
+      wdfConfirmFieldsService,
+      route,
+      ethnicityService,
+      internationalRecruitmentService,
+    );
   }
 
   isNumber(number: number) {
@@ -63,15 +72,7 @@ export class EmploymentComponent extends StaffRecordSummaryComponent {
   }
 
   get displayHealthAndCareVisa() {
-    if (this.worker.nationality?.value === 'Other') {
-      return (
-        this.worker.britishCitizenship === 'No' ||
-        this.worker.britishCitizenship === "Don't know" ||
-        this.worker.britishCitizenship === undefined
-      );
-    } else if (this.worker.nationality?.value === "Don't know") {
-      return this.worker.britishCitizenship === 'No';
-    }
+    return this.internationalRecruitmentService.shouldSeeInternationalRecruitmentQuestions(this.worker);
   }
 
   get displayEmployedFromOutsideOrInsideUk() {
@@ -79,12 +80,19 @@ export class EmploymentComponent extends StaffRecordSummaryComponent {
   }
 
   get displayEmployedFromOutsideOrInsideUkValue() {
-    return this.worker.employedFromOutsideUk === 'Yes'
-      ? 'From outside the UK'
-      : this.worker.employedFromOutsideUk === 'No'
-      ? 'From inside the UK'
-      : this.worker.employedFromOutsideUk === "Don't know"
-      ? 'Not known'
-      : null;
+    if (this.worker.employedFromOutsideUk === 'Yes' || this.worker.employedFromOutsideUk === 'No') {
+      return (
+        'From ' +
+        this.internationalRecruitmentService
+          .convertEmployedFromOutsideUkValue(this.worker.employedFromOutsideUk)
+          .charAt(0)
+          .toLowerCase() +
+        this.internationalRecruitmentService
+          .convertEmployedFromOutsideUkValue(this.worker.employedFromOutsideUk)
+          .slice(1)
+      );
+    } else {
+      return this.worker.employedFromOutsideUk;
+    }
   }
 }

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
@@ -80,13 +80,8 @@ export class EmploymentComponent extends StaffRecordSummaryComponent {
   }
 
   get displayEmployedFromOutsideOrInsideUkValue() {
-    if (this.worker.employedFromOutsideUk === 'Yes' || this.worker.employedFromOutsideUk === 'No') {
-      let convertedValue = this.internationalRecruitmentService.convertEmployedFromOutsideUkValue(
-        this.worker.employedFromOutsideUk,
-      );
-      return 'From ' + convertedValue.charAt(0).toLowerCase() + convertedValue.slice(1);
-    } else {
-      return this.worker.employedFromOutsideUk;
-    }
+    return this.internationalRecruitmentService.getEmployedFromOutsideUkStaffRecordValue(
+      this.worker.employedFromOutsideUk,
+    );
   }
 }

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
@@ -81,16 +81,10 @@ export class EmploymentComponent extends StaffRecordSummaryComponent {
 
   get displayEmployedFromOutsideOrInsideUkValue() {
     if (this.worker.employedFromOutsideUk === 'Yes' || this.worker.employedFromOutsideUk === 'No') {
-      return (
-        'From ' +
-        this.internationalRecruitmentService
-          .convertEmployedFromOutsideUkValue(this.worker.employedFromOutsideUk)
-          .charAt(0)
-          .toLowerCase() +
-        this.internationalRecruitmentService
-          .convertEmployedFromOutsideUkValue(this.worker.employedFromOutsideUk)
-          .slice(1)
+      let convertedValue = this.internationalRecruitmentService.convertEmployedFromOutsideUkValue(
+        this.worker.employedFromOutsideUk,
       );
+      return 'From ' + convertedValue.charAt(0).toLowerCase() + convertedValue.slice(1);
     } else {
       return this.worker.employedFromOutsideUk;
     }

--- a/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/employment/employment.component.ts
@@ -61,4 +61,8 @@ export class EmploymentComponent extends StaffRecordSummaryComponent {
   get mainStartDate() {
     return dayjs(this.worker.mainJobStartDate).format('D MMMM YYYY');
   }
+
+  get displayEmployedFromOutSideOrInsideUk() {
+    return this.worker.healthAndCareVisa === 'Yes';
+  }
 }

--- a/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
@@ -21,12 +21,14 @@ import { render } from '@testing-library/angular';
 import { of } from 'rxjs';
 
 import { StaffRecordSummaryComponent } from './staff-record-summary.component';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 describe('StaffRecordSummaryComponent', () => {
   const setup = async () => {
     const { fixture, getByText, queryByText, getAllByText } = await render(StaffRecordSummaryComponent, {
       imports: [SharedModule, RouterTestingModule, HttpClientTestingModule, BrowserModule, WdfModule],
       providers: [
+        InternationalRecruitmentService,
         {
           provide: PermissionsService,
           useFactory: MockPermissionsService.factory(['canEditWorker']),

--- a/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
@@ -4,6 +4,7 @@ import { Establishment } from '@core/model/establishment.model';
 import { Ethnicity } from '@core/model/ethnicity.model';
 import { Worker } from '@core/model/worker.model';
 import { EthnicityService } from '@core/services/ethnicity.service';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { WdfConfirmFieldsService } from '@core/services/wdf/wdf-confirm-fields.service';
 import { WorkerService } from '@core/services/worker.service';
@@ -44,6 +45,7 @@ export class StaffRecordSummaryComponent implements OnInit, OnDestroy {
     private wdfConfirmFieldsService: WdfConfirmFieldsService,
     protected route: ActivatedRoute,
     public ethnicityService: EthnicityService,
+    public internationalRecruitmentService: InternationalRecruitmentService,
   ) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
#### Work done
-  Display the health and visa and employed from outside or inside UK questions in the employment details section within the staff record page
- Added International recruitment service to hold the logic for the correct routing for the health and visa and employed from outside or inside UK questions or to show on staff record. Service also used to transform the employed from outside or inside UK values


![Employment details](https://github.com/NMDSdevopsServiceAdm/SopraSteria-SFC/assets/17614754/abb514c8-5de9-4175-8577-4413bdfe4315)

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
