### PR TITLE
Fix/switching to parent on new about the data in sub view

### DIFF
--- a/frontend/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.spec.ts
+++ b/frontend/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 
@@ -10,12 +9,14 @@ import { AboutTheDataLinkComponent } from './about-the-data-link.component';
 
 describe('AboutTheDataLinkComponent', () => {
   const setup = async () => {
+    const workplaceUid = 'mockUid';
+
     const { fixture, getByText, getByTestId, queryByTestId, queryByText } = await render(AboutTheDataLinkComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       providers: [
         {
           provide: EstablishmentService,
-          useClass: MockEstablishmentService,
+          useValue: { establishment: { uid: workplaceUid } },
         },
       ],
       schemas: [],
@@ -31,6 +32,7 @@ describe('AboutTheDataLinkComponent', () => {
       getByTestId,
       queryByTestId,
       queryByText,
+      workplaceUid,
     };
   };
 
@@ -48,11 +50,11 @@ describe('AboutTheDataLinkComponent', () => {
     expect(within(link).getByText('About the data')).toBeTruthy();
   });
 
-  it('should show about the data text', async () => {
-    const { component, getByTestId } = await setup();
+  it('should link to the about the data page', async () => {
+    const { getByTestId, workplaceUid } = await setup();
 
     const link = getByTestId('about-the-data-link');
 
-    expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplaceUid}/data-area/about-the-data`);
+    expect(link.getAttribute('href')).toEqual(`/workplace/${workplaceUid}/data-area/about-the-data`);
   });
 });

--- a/frontend/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.ts
+++ b/frontend/src/app/shared/components/data-area-tab/about-the-data-link/about-the-data-link.component.ts
@@ -11,6 +11,6 @@ export class AboutTheDataLinkComponent implements OnInit {
   constructor(private establishmentService: EstablishmentService) {}
 
   ngOnInit(): void {
-    this.workplaceUid = this.establishmentService ? this.establishmentService.primaryWorkplace.uid : null;
+    this.workplaceUid = this.establishmentService.establishment?.uid;
   }
 }

--- a/frontend/src/app/shared/components/data-area-tab/about-the-data/about-the-data.component.html
+++ b/frontend/src/app/shared/components/data-area-tab/about-the-data/about-the-data.component.html
@@ -68,7 +68,7 @@
     </div>
 
     <div>
-      <button type="submit" class="govuk-button govuk-!-margin-top-6" (click)="returnToHome()">
+      <button type="submit" class="govuk-button govuk-!-margin-top-6" (click)="returnToBenchmarks()">
         Return to benchmarks
       </button>
     </div>

--- a/frontend/src/app/shared/components/data-area-tab/about-the-data/about-the-data.component.spec.ts
+++ b/frontend/src/app/shared/components/data-area-tab/about-the-data/about-the-data.component.spec.ts
@@ -1,23 +1,23 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-
+import { getTestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { MockBenchmarksService } from '@core/test-utils/MockBenchmarkService';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
 import { DataAreaAboutTheDataComponent } from './about-the-data.component';
-import { EstablishmentService } from '@core/services/establishment.service';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { BreadcrumbService } from '@core/services/breadcrumb.service';
-import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
-import { SharedModule } from '@shared/shared.module';
-import { getTestBed } from '@angular/core/testing';
-import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 
 describe('DataAreaAboutTheDataComponent', () => {
   async function setup() {
+    const workplaceName = 'Mock Workplace Name';
+
     const { getByText, getByLabelText, getByTestId, fixture } = await render(DataAreaAboutTheDataComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [],
@@ -31,7 +31,7 @@ describe('DataAreaAboutTheDataComponent', () => {
 
         {
           provide: EstablishmentService,
-          useClass: MockEstablishmentService,
+          useValue: { establishment: { name: workplaceName } },
         },
         {
           provide: ActivatedRoute,
@@ -57,17 +57,19 @@ describe('DataAreaAboutTheDataComponent', () => {
       fixture,
       component,
       routerSpy,
+      workplaceName,
     };
   }
+
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
   });
 
   it('should show the workplace name', async () => {
-    const { component } = await setup();
-    const workplaceName = component.workplace.name;
-    expect(workplaceName).toBeTruthy();
+    const { getByText, workplaceName } = await setup();
+
+    expect(getByText(workplaceName)).toBeTruthy();
   });
 
   it('should show the About the data header', async () => {
@@ -78,7 +80,7 @@ describe('DataAreaAboutTheDataComponent', () => {
   });
 
   it('should navigate to the benchmarks page', async () => {
-    const { component, getByText, routerSpy, fixture } = await setup();
+    const { getByText, routerSpy, fixture } = await setup();
 
     const returnButton = getByText('Return to benchmarks');
 

--- a/frontend/src/app/shared/components/data-area-tab/about-the-data/about-the-data.component.ts
+++ b/frontend/src/app/shared/components/data-area-tab/about-the-data/about-the-data.component.ts
@@ -7,7 +7,6 @@ import { URLStructure } from '@core/model/url.model';
 import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -27,24 +26,20 @@ export class DataAreaAboutTheDataComponent implements OnInit, OnDestroy {
     protected router: Router,
     protected route: ActivatedRoute,
     protected benchmarksService: BenchmarksServiceBase,
-    private permissionsService: PermissionsService,
     private breadcrumbService: BreadcrumbService,
     private establishmentService: EstablishmentService,
   ) {}
 
   ngOnInit(): void {
-    this.workplace = this.establishmentService.primaryWorkplace;
+    this.workplace = this.establishmentService.establishment;
     this.url = this.benchmarksService.returnTo?.url;
     this.fragment = this.benchmarksService.returnTo?.fragment;
-    const workplaceUid = this.workplace ? this.workplace.uid : this.route.snapshot.params.establishmentuid;
-
-    const canViewBenchmarks = this.permissionsService.can(workplaceUid, 'canViewBenchmarks');
 
     this.breadcrumbService.show(JourneyType.BENCHMARKS_TAB);
   }
 
   public returnToHome(): void {
-    const returnLink = this.router.navigate(['/dashboard'], { fragment: 'benchmarks' });
+    this.router.navigate(['/dashboard'], { fragment: 'benchmarks' });
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/shared/components/data-area-tab/about-the-data/about-the-data.component.ts
+++ b/frontend/src/app/shared/components/data-area-tab/about-the-data/about-the-data.component.ts
@@ -1,48 +1,30 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
-import { Meta } from '@core/model/benchmarks.model';
 import { Establishment } from '@core/model/establishment.model';
-import { URLStructure } from '@core/model/url.model';
-import { BenchmarksServiceBase } from '@core/services/benchmarks-base.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-data-area-about-the-data',
   templateUrl: './about-the-data.component.html',
 })
-export class DataAreaAboutTheDataComponent implements OnInit, OnDestroy {
+export class DataAreaAboutTheDataComponent implements OnInit {
   public workplace: Establishment;
 
-  protected subscriptions: Subscription = new Subscription();
-  public meta: Meta;
-  public returnTo: URLStructure;
-  public url: any[];
-  public fragment: string;
-
   constructor(
-    protected router: Router,
-    protected route: ActivatedRoute,
-    protected benchmarksService: BenchmarksServiceBase,
+    private router: Router,
     private breadcrumbService: BreadcrumbService,
     private establishmentService: EstablishmentService,
   ) {}
 
   ngOnInit(): void {
     this.workplace = this.establishmentService.establishment;
-    this.url = this.benchmarksService.returnTo?.url;
-    this.fragment = this.benchmarksService.returnTo?.fragment;
 
     this.breadcrumbService.show(JourneyType.BENCHMARKS_TAB);
   }
 
-  public returnToHome(): void {
+  public returnToBenchmarks(): void {
     this.router.navigate(['/dashboard'], { fragment: 'benchmarks' });
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.unsubscribe();
   }
 }


### PR DESCRIPTION
The link to the data area version of the about the data page was using the primaryWorkplace uid, so after navigating there it was changing the service so that you were viewing the parent but still in sub view which caused strange issues.

#### Work done
- Updated the data area version of About the Data to use establishment instead of primaryWorkplace
- Updated About the Data link to use establishment
- Removed unused code in about the data component

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
