### PR TITLE
Fix/exit sub view when header link clicked

### DIFF
--- a/frontend/src/app/features/public/public-page/public-page.component.html
+++ b/frontend/src/app/features/public/public-page/public-page.component.html
@@ -6,7 +6,7 @@
       role="button"
       draggable="false"
       class="govuk-button govuk-!-margin-top-3"
-      [routerLink]="['/']"
+      [routerLink]="['/dashboard']"
     >
       Return to home
     </a>

--- a/frontend/src/app/features/public/public-page/public-page.component.spec.ts
+++ b/frontend/src/app/features/public/public-page/public-page.component.spec.ts
@@ -38,6 +38,7 @@ describe('PublicPageComponent', () => {
     });
 
     const component = fixture.componentInstance;
+
     return {
       component,
       fixture,
@@ -61,13 +62,23 @@ describe('PublicPageComponent', () => {
     expect(getByText(pages.data[0].content)).toBeTruthy();
   });
 
-  it('should not display return to home button when returnToHomeButton set to false in routing', async () => {
-    const { queryByText } = await setup();
-    expect(queryByText('Return to home')).toBeFalsy();
-  });
+  describe('Return to home button', async () => {
+    it('should not display when returnToHomeButton set to false in routing', async () => {
+      const { queryByText } = await setup();
+      expect(queryByText('Return to home')).toBeFalsy();
+    });
 
-  it('should display return to home button when returnToHomeButton set to true in routing', async () => {
-    const { queryByText } = await setup(true);
-    expect(queryByText('Return to home')).toBeTruthy();
+    it('should display when returnToHomeButton set to true in routing', async () => {
+      const { queryByText } = await setup(true);
+      expect(queryByText('Return to home')).toBeTruthy();
+    });
+
+    it('should have href for dashboard', async () => {
+      const { queryByText } = await setup(true);
+
+      const returnToHomeButton = queryByText('Return to home');
+
+      expect(returnToHomeButton.getAttribute('href')).toBe('/dashboard');
+    });
   });
 });

--- a/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
@@ -51,12 +51,22 @@ describe('SubsidiaryRouterService', () => {
       expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
     });
 
-    it('should just navigate if unexpected format of url tree', async () => {
+    it('should clear sub view and navigate if unexpected format of url tree', async () => {
       const urlAsString = 'urlasstring.com/test';
       const unexpectedUrlTree = urlAsString as unknown as UrlTree;
       service.navigateByUrl(unexpectedUrlTree);
 
+      expect(subViewServiceSpy.clearViewingSubAsParent).toHaveBeenCalled();
       expect(routerSpy).toHaveBeenCalledWith(urlAsString, undefined);
+    });
+
+    it('should clear sub view and navigate if navigation event to root', async () => {
+      const rootUrl = service.createUrlTree(['/']);
+
+      service.navigateByUrl(rootUrl);
+
+      expect(subViewServiceSpy.clearViewingSubAsParent).toHaveBeenCalled();
+      expect(routerSpy).toHaveBeenCalledWith(rootUrl, undefined);
     });
   });
 

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -42,6 +42,7 @@ export class SubsidiaryRouterService extends Router {
 
   navigateByUrl(url: UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean> {
     if (!url.root?.children?.primary?.segments) {
+      this.parentSubsidiaryViewService.clearViewingSubAsParent();
       return super.navigateByUrl(url, extras);
     }
 


### PR DESCRIPTION
#### Issue
Clicking header link from sub view would keep sub dashboard with parent data, causing unexpected behaviour

#### Work done
- Updated subsidiary router service to clear sub view when navigation event to root for case when header link clicked
- Updated public page component to navigate to dashboard instead of root to prevent exit from sub view

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
