### PR TITLE
Fix: Flickering navigate to workplace dropdown

### DIFF
--- a/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
@@ -68,6 +68,15 @@ describe('SubsidiaryRouterService', () => {
       expect(subViewServiceSpy.clearViewingSubAsParent).toHaveBeenCalled();
       expect(routerSpy).toHaveBeenCalledWith(rootUrl, undefined);
     });
+
+    it('should navigate and not clear sub view if navigation event to /subsidiary (skipped navigate for clean rendering from dropdown)', async () => {
+      const subsidiaryUrlAsString = '/subsidiary';
+      const subsidiaryUrl = subsidiaryUrlAsString as unknown as UrlTree;
+      service.navigateByUrl(subsidiaryUrl);
+
+      expect(subViewServiceSpy.clearViewingSubAsParent).not.toHaveBeenCalled();
+      expect(routerSpy).toHaveBeenCalledWith(subsidiaryUrl, undefined);
+    });
   });
 
   describe('When hitting exit sub view pages', () => {

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -42,7 +42,9 @@ export class SubsidiaryRouterService extends Router {
 
   navigateByUrl(url: UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean> {
     if (!url.root?.children?.primary?.segments) {
-      this.parentSubsidiaryViewService.clearViewingSubAsParent();
+      if (this.isNotNavigateToWorkplaceDropdownSkippedNavigation(url)) {
+        this.parentSubsidiaryViewService.clearViewingSubAsParent();
+      }
       return super.navigateByUrl(url, extras);
     }
 
@@ -77,5 +79,9 @@ export class SubsidiaryRouterService extends Router {
     }
 
     return true;
+  }
+
+  isNotNavigateToWorkplaceDropdownSkippedNavigation(url: UrlTree | string) {
+    return url !== '/subsidiary';
   }
 }


### PR DESCRIPTION
#### Issue
Our fix for going back to the parent view when you click the home banner was to clear the sub view when an empty navigation is called. However, this introduced a flicker of the parent name in the navigate to workplace dropdown as it would momentarily clear the sub view. This is due to the dropdown component navigating to /subsidiary before its proper navigation, which allows a clean render of the sub view. 

#### Work done
- Added logic to stop clearing sub view for case when navigate to workplace dropdown navigates to /subsidiary

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
