### PR TITLE
Fix: NHS API always return isEligible as boolean

### DIFF
--- a/backend/server/routes/nhsBsaApi/workplaceData.js
+++ b/backend/server/routes/nhsBsaApi/workplaceData.js
@@ -51,7 +51,7 @@ const nhsBsaApi = async (req, res) => {
 };
 
 const workplaceObject = async (workplace) => {
-  const wdfEligible = await wdfData(workplace.id);
+  const wdfEligible = await wdfData(workplace.id, WdfCalculator.effectiveDate);
 
   return {
     workplaceId: workplace.nmdsId,
@@ -90,15 +90,16 @@ const parentWorkplace = async (parentId) => {
   return await workplaceObject(parentWorkplace);
 };
 
-const wdfData = async (workplaceId) => {
-  const effectiveFrom = WdfCalculator.effectiveDate;
-
-  const reportData = await models.sequelize.query(`select * from cqc.wdfsummaryreport(:givenEffectiveDate)`, {
-    replacements: {
-      givenEffectiveDate: effectiveFrom,
+const wdfData = async (workplaceId, effectiveFrom) => {
+  const reportData = await models.sequelize.query(
+    `SELECT * FROM cqc.wdfsummaryreport(:givenEffectiveDate) WHERE "EstablishmentID" = '${workplaceId}'`,
+    {
+      replacements: {
+        givenEffectiveDate: effectiveFrom,
+      },
+      type: models.sequelize.QueryTypes.SELECT,
     },
-    type: models.sequelize.QueryTypes.SELECT,
-  });
+  );
 
   const wdfMeeting = reportData.find((workplace) => workplace.EstablishmentID === workplaceId);
   if (wdfMeeting) {
@@ -109,7 +110,7 @@ const wdfData = async (workplaceId) => {
       eligibilityPercentage: percentageEligibleWorkers,
       eligibilityDate: wdfMeeting.OverallWdfEligibility,
       isEligible:
-        wdfMeeting.OverallWdfEligibility && wdfMeeting.OverallWdfEligibility.getTime() > WdfCalculator.effectiveTime,
+        wdfMeeting.OverallWdfEligibility && wdfMeeting.OverallWdfEligibility.getTime() > effectiveFrom ? true : false,
     };
   }
 };

--- a/backend/server/test/unit/routes/nhsBsaApi/workplaceData.spec.js
+++ b/backend/server/test/unit/routes/nhsBsaApi/workplaceData.spec.js
@@ -98,18 +98,6 @@ describe('server/routes/nhsBsaApi/workplaceData.js', () => {
       ]);
     });
 
-    it('should return WDF eligibility of a workplace', async () => {
-      const establishmentId = result.id;
-
-      const wdf = await wdfData(establishmentId);
-
-      expect(wdf).to.deep.equal({
-        eligibilityPercentage: 0,
-        eligibilityDate: new Date('2021-05-13T09:27:34.471Z'),
-        isEligible: false,
-      });
-    });
-
     it('should return 404 when workplace is not found', async () => {
       sinon.stub(models.establishment, 'getNhsBsaApiDataByWorkplaceId').returns(null);
       await nhsBsaApi(req, res);
@@ -123,6 +111,86 @@ describe('server/routes/nhsBsaApi/workplaceData.js', () => {
       await nhsBsaApi(req, res);
 
       expect(res.statusCode).to.deep.equal(500);
+    });
+  });
+
+  describe('wdfData', () => {
+    const establishmentId = 'A1234567';
+
+    const returnData = (WorkerCompletedCount = 1, WorkerCount = 4, OverallWdfEligibility = null) => {
+      return [
+        {
+          EstablishmentID: establishmentId,
+          WorkerCompletedCount,
+          WorkerCount,
+          OverallWdfEligibility,
+        },
+      ];
+    };
+
+    it('should return isEligible as false when no date returned for OverallWdfEligibility', async () => {
+      sinon.stub(models.sequelize, 'query').returns(returnData(1, 4, null));
+      const effectiveTime = new Date('2022-05-13T09:27:34.471Z').getTime();
+      const wdf = await wdfData(establishmentId, effectiveTime);
+
+      expect(wdf.isEligible).to.equal(false);
+      expect(wdf.eligibilityDate).to.equal(null);
+    });
+
+    it('should return isEligible as false when date returned for OverallWdfEligibility is before effectiveTime', async () => {
+      const OverallWdfEligibility = new Date('2022-03-13T09:27:34.471Z');
+      const effectiveTime = new Date('2022-05-13T09:27:34.471Z').getTime();
+      sinon.stub(models.sequelize, 'query').returns(returnData(1, 4, OverallWdfEligibility));
+
+      const wdf = await wdfData(establishmentId, effectiveTime);
+
+      expect(wdf.isEligible).to.equal(false);
+      expect(wdf.eligibilityDate).to.equal(OverallWdfEligibility);
+    });
+
+    it('should return isEligible as true when date returned for OverallWdfEligibility is after effectiveTime', async () => {
+      const OverallWdfEligibility = new Date('2022-07-13T09:27:34.471Z');
+      const effectiveTime = new Date('2022-06-13T09:27:34.471Z').getTime();
+      sinon.stub(models.sequelize, 'query').returns(returnData(4, 4, OverallWdfEligibility));
+
+      const wdf = await wdfData(establishmentId, effectiveTime);
+
+      expect(wdf.isEligible).to.equal(true);
+      expect(wdf.eligibilityDate).to.equal(OverallWdfEligibility);
+    });
+
+    describe('eligibilityPercentage', () => {
+      it('should set percentage to 25 when 1 out of 4 workers completed', async () => {
+        sinon.stub(models.sequelize, 'query').returns(returnData(1, 4));
+
+        const wdf = await wdfData(establishmentId);
+
+        expect(wdf.eligibilityPercentage).to.equal(25);
+      });
+
+      it('should set percentage to 50 when 5 out of 10 workers completed', async () => {
+        sinon.stub(models.sequelize, 'query').returns(returnData(5, 10));
+
+        const wdf = await wdfData(establishmentId);
+
+        expect(wdf.eligibilityPercentage).to.equal(50);
+      });
+
+      it('should set percentage to 0 when worker count is 0', async () => {
+        sinon.stub(models.sequelize, 'query').returns(returnData(0, 0));
+
+        const wdf = await wdfData(establishmentId);
+
+        expect(wdf.eligibilityPercentage).to.equal(0);
+      });
+
+      it('should set percentage to 100 when worker count is 9 and completed is 9', async () => {
+        sinon.stub(models.sequelize, 'query').returns(returnData(9, 9));
+
+        const wdf = await wdfData(establishmentId);
+
+        expect(wdf.eligibilityPercentage).to.equal(100);
+      });
     });
   });
 });


### PR DESCRIPTION
#### Work done
- Updated workplaceData to always return isEligible as boolean
- Updated WDF database call to only return required workplace

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
