### PR TITLE
Hotfix: NI number returned in BU worker validation 

### DIFF
--- a/backend/server/routes/establishments/bulkUpload/validate/workers/validateWorkerUnderNationalInsuranceMaximum.js
+++ b/backend/server/routes/establishments/bulkUpload/validate/workers/validateWorkerUnderNationalInsuranceMaximum.js
@@ -40,7 +40,7 @@ const exceedsNationalInsuranceMaximum = (thisWorker) => {
     source: thisWorker.localId,
     column: 'NINUMBER',
     worker: thisWorker.uniqueWorkerId,
-    name: thisWorker.niNumber,
+    name: thisWorker.localId,
   };
 };
 

--- a/backend/server/test/unit/routes/establishments/bulkUpload/validate/workers/validateWorkerUnderNationalInsuranceMaximum.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/validate/workers/validateWorkerUnderNationalInsuranceMaximum.spec.js
@@ -1,47 +1,86 @@
 const expect = require('chai').expect;
 const {
   worksOverNationalInsuranceMaximum,
+  validateWorkerUnderNationalInsuranceMaximum,
 } = require('../../../../../../../routes/establishments/bulkUpload/validate/workers/validateWorkerUnderNationalInsuranceMaximum');
 
-describe('worksOverNationalInsuranceMaximum', () => {
-  const worker = { niNumber: 'ABC', hours: { contractedHours: 35 } };
+describe('validateWorkerUnderNationalInsuranceMaximum', () => {
+  it('should add error when two occurences of worker(same NINO) with hours above NI maximum', () => {
+    const worker = {
+      hours: { contractedHours: 35 },
+      niNumber: 'ABC',
+      lineNumber: 2,
+      localId: 'A123456',
+      uniqueWorkerId: 'Martin',
+    };
+    const workers = [worker, { hours: { contractedHours: 41 }, niNumber: 'ABC' }];
+    const csvWorkerSchemaErrors = [];
 
-  it('should return false when only one occurence of worker with hours below NI maximum', async () => {
-    const workers = [{ niNumber: 'ABC', hours: { contractedHours: 35 } }];
+    validateWorkerUnderNationalInsuranceMaximum(worker, workers, csvWorkerSchemaErrors);
 
-    expect(worksOverNationalInsuranceMaximum(worker, workers)).to.be.false;
+    expect(csvWorkerSchemaErrors[0]).to.deep.equal({
+      origin: 'Workers',
+      lineNumber: worker.lineNumber,
+      errCode: 5570,
+      errType: 'NI_WORKER_DUPLICATE_ERROR',
+      error: 'NINUMBER is already associated with another full time worker record',
+      source: worker.localId,
+      column: 'NINUMBER',
+      worker: worker.uniqueWorkerId,
+      name: worker.localId,
+    });
   });
 
-  it('should return true when only one occurence of worker with hours above NI maximum', async () => {
-    const workers = [{ hours: { averageHours: 68 }, niNumber: 'ABC' }];
+  it('should not modify csvWorkerSchemaErrors when hours are below NI maximum', () => {
+    const worker = { niNumber: 'ABC', hours: { contractedHours: 35 } };
+    const workers = [worker];
+    const csvWorkerSchemaErrors = [];
 
-    expect(worksOverNationalInsuranceMaximum(worker, workers)).to.be.true;
+    validateWorkerUnderNationalInsuranceMaximum(worker, workers, csvWorkerSchemaErrors);
+
+    expect(csvWorkerSchemaErrors).to.deep.equal([]);
   });
 
-  it('should return false when two occurences of worker(same NINO) with hours below NI maximum', async () => {
-    const workers = [
-      { hours: { contractedHours: 35 }, niNumber: 'ABC' },
-      { hours: { contractedHours: 45 }, niNumber: 'DifferentNINO' },
-      { hours: { contractedHours: 13 }, niNumber: 'ABC' },
-    ];
+  describe('worksOverNationalInsuranceMaximum', () => {
+    const worker = { niNumber: 'ABC', hours: { contractedHours: 35 } };
 
-    expect(worksOverNationalInsuranceMaximum(worker, workers)).to.be.false;
-  });
+    it('should return false when only one occurence of worker with hours below NI maximum', async () => {
+      const workers = [{ niNumber: 'ABC', hours: { contractedHours: 35 } }];
 
-  it('should return true when two occurences of worker(same NINO) with hours above NI maximum', async () => {
-    const workers = [
-      { hours: { contractedHours: 35 }, niNumber: 'ABC' },
-      { hours: { contractedHours: 41 }, niNumber: 'ABC' },
-    ];
+      expect(worksOverNationalInsuranceMaximum(worker, workers)).to.be.false;
+    });
 
-    expect(worksOverNationalInsuranceMaximum(worker, workers)).to.be.true;
-  });
+    it('should return true when only one occurence of worker with hours above NI maximum', async () => {
+      const workers = [{ hours: { averageHours: 68 }, niNumber: 'ABC' }];
 
-  it('should return false when workers have NINO undefined with hours above NI maximum', async () => {
-    const workerNoNi = { hours: { contractedHours: 35 } };
+      expect(worksOverNationalInsuranceMaximum(worker, workers)).to.be.true;
+    });
 
-    const workers = [{ hours: { contractedHours: 35 } }, { hours: { contractedHours: 41 } }];
+    it('should return false when two occurences of worker(same NINO) with hours below NI maximum', async () => {
+      const workers = [
+        { hours: { contractedHours: 35 }, niNumber: 'ABC' },
+        { hours: { contractedHours: 45 }, niNumber: 'DifferentNINO' },
+        { hours: { contractedHours: 13 }, niNumber: 'ABC' },
+      ];
 
-    expect(worksOverNationalInsuranceMaximum(workerNoNi, workers)).to.be.false;
+      expect(worksOverNationalInsuranceMaximum(worker, workers)).to.be.false;
+    });
+
+    it('should return true when two occurences of worker(same NINO) with hours above NI maximum', async () => {
+      const workers = [
+        { hours: { contractedHours: 35 }, niNumber: 'ABC' },
+        { hours: { contractedHours: 41 }, niNumber: 'ABC' },
+      ];
+
+      expect(worksOverNationalInsuranceMaximum(worker, workers)).to.be.true;
+    });
+
+    it('should return false when workers have NINO undefined with hours above NI maximum', async () => {
+      const workerNoNi = { hours: { contractedHours: 35 } };
+
+      const workers = [{ hours: { contractedHours: 35 } }, { hours: { contractedHours: 41 } }];
+
+      expect(worksOverNationalInsuranceMaximum(workerNoNi, workers)).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
#### Issue
One bulk upload validation function was returning a NI number for a validation error message instead of the workplace ID

#### Work done
- Updated NI maximum working hours validation in bulk upload to return local ID instead of NI number

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
