### PR TITLE
Only display text in bulk upload card on parent home page when user does not have bulk upload permission

### DIFF
--- a/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
@@ -27,12 +27,18 @@
     <div class="govuk-grid-column-full govuk-!-padding-left-2 govuk-!-padding-right-2">
       <div class="govuk-grid-column-one-third asc-card-padding">
         <app-card [image]="'/assets/images/bulk-upload.svg'">
-          <a
-            class="govuk-link--no-visited-state govuk-!-font-size-19 govuk-!-font-weight-bold"
-            routerLink="/bulk-upload"
-            href="#"
-            >Bulk upload your data</a
-          >
+          <ng-container *ngIf="canBulkUpload; else noLink">
+            <a
+              class="govuk-link--no-visited-state govuk-!-font-size-19 govuk-!-font-weight-bold"
+              routerLink="/bulk-upload"
+              href="#"
+              data-testid="bulkUploadLink"
+              >Bulk upload your data</a
+            >
+          </ng-container>
+          <ng-template #noLink>
+            <p class="govuk-!-font-size-19 govuk-!-font-weight-bold">Bulk upload your data</p>
+          </ng-template>
           <p class="govuk-!-margin-top-5">
             Add all your workplace data into ASC-WDS without the need to add it manually.
           </p></app-card

--- a/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.spec.ts
@@ -49,6 +49,7 @@ describe('ParentHomeTabComponent', () => {
     establishment = Establishment,
     comparisonDataAvailable = true,
     noOfWorkplaces = 9,
+    permissions = [],
   ) => {
     const { fixture, queryAllByText, getByText, queryByText, getByTestId, queryByTestId } = await render(
       ParentHomeTabComponent,
@@ -62,7 +63,7 @@ describe('ParentHomeTabComponent', () => {
           },
           {
             provide: PermissionsService,
-            useFactory: MockPermissionsService.factory(),
+            useFactory: MockPermissionsService.factory(permissions),
             deps: [HttpClient, Router, UserService],
           },
           {
@@ -104,7 +105,7 @@ describe('ParentHomeTabComponent', () => {
             ? { workplaces: noOfWorkplaces, staff: 4, localAuthority: 'Test LA' }
             : ({ workplaces: 0, staff: 0, localAuthority: 'Test LA' } as Meta),
           canRunLocalAuthorityReport: false,
-          article: {slug: ''}
+          article: { slug: '' },
         },
         schemas: [NO_ERRORS_SCHEMA],
       },
@@ -257,13 +258,24 @@ describe('ParentHomeTabComponent', () => {
       expect(benefitsBundleLink.getAttribute('href')).toBe('/benefits-bundle');
     });
 
-    it('should show a card with a link that takes you to the bulk upload page', async () => {
-      const { getByText } = await setup();
+    it('should show a card with a link to bulk upload page when user has canBulkUpload permission', async () => {
+      const { queryByTestId } = await setup(false, Establishment, true, 9, ['canBulkUpload']);
 
-      const bulkUploadLink = getByText('Bulk upload your data');
+      const bulkUploadLink = queryByTestId('bulkUploadLink');
 
       expect(bulkUploadLink).toBeTruthy();
+      expect(bulkUploadLink.innerHTML).toBe('Bulk upload your data');
       expect(bulkUploadLink.getAttribute('href')).toBe('/bulk-upload');
+    });
+
+    it('should show the bulk upload card without a link when user does not have canBulkUpload permission', async () => {
+      const { getByText, queryByTestId } = await setup();
+
+      const bulkUploadText = getByText('Bulk upload your data');
+      const bulkUploadLink = queryByTestId('bulkUploadLink');
+
+      expect(bulkUploadText).toBeTruthy();
+      expect(bulkUploadLink).toBeFalsy();
     });
 
     it('should show a card with a link that takes you to the wdf page', async () => {


### PR DESCRIPTION
#### Work done
- Changed bulk upload card on parent home page so it doesn't have link for read only users

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
