### PR TITLE
Fix: 1453 Summary panel

### DIFF
--- a/backend/server/routes/missingCqcProviderLocations/index.js
+++ b/backend/server/routes/missingCqcProviderLocations/index.js
@@ -19,6 +19,9 @@ const missingCqcProviderLocations = async (req, res) => {
   };
 
   try {
+    const childWorkplaces = await models.establishment.getChildWorkplaces(establishmentUid, itemsPerPage, pageIndex);
+    result.childWorkplacesCount = await childWorkplaces.rows.length;
+
     if (establishmentId) {
       const parentApproval = await models.Approvals.findbyEstablishmentId(establishmentId, 'BecomeAParent', 'Approved');
 
@@ -28,10 +31,6 @@ const missingCqcProviderLocations = async (req, res) => {
 
     if (locationId) {
       let CQCProviderData = await CQCDataAPI.getCQCProviderData(locationId);
-
-      const childWorkplaces = await models.establishment.getChildWorkplaces(establishmentUid, itemsPerPage, pageIndex);
-
-      result.childWorkplacesCount = await childWorkplaces.rows.length;
 
       const childWorkplacesLocationIds = await getChildWorkplacesLocationIds(childWorkplaces.rows);
 


### PR DESCRIPTION
#### Work done
- Ensure that number of child workplaces is always returned from missingCqcProviderLocations by moving setting outside of check for location ID

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
