### PR TITLE
Fix/reset health and care when nationality and British citizenship values change

### DIFF
--- a/backend/server/models/classes/worker.js
+++ b/backend/server/models/classes/worker.js
@@ -374,6 +374,18 @@ class Worker extends EntityValidator {
         document.britishCitizenship = null;
       }
 
+      // Remove health and care visa and employed from outside UK if they are British or have a British citizenship
+      if (
+        (document.nationality && document.nationality.value === 'British') ||
+        (document.britishCitizenship && document.britishCitizenship === 'Yes') ||
+        (document.nationality &&
+          document.nationality.value === "Don't know" &&
+          document.britishCitizenship === "Don't know")
+      ) {
+        document.healthAndCareVisa = null;
+        document.employedFromOutsideUk = null;
+      }
+
       // Remove employed from outside UK if they don't have health and care visa
       if (document.healthAndCareVisa && document.healthAndCareVisa !== 'Yes') {
         document.employedFromOutsideUk = null;

--- a/backend/server/models/classes/worker/properties/healthAndCareVisa.js
+++ b/backend/server/models/classes/worker/properties/healthAndCareVisa.js
@@ -14,7 +14,7 @@ exports.HealthAndCareVisaProperty = class HealthAndCareVisaProperty extends Chan
 
   // concrete implementations
   async restoreFromJson(document) {
-    if (document.healthAndCareVisa) {
+    if (document.healthAndCareVisa || document.healthAndCareVisa === null) {
       if (HEALTH_AND_CARE_VISA_TYPE.includes(document.healthAndCareVisa)) {
         this.property = document.healthAndCareVisa;
       } else {

--- a/backend/server/test/unit/models/classes/worker.spec.js
+++ b/backend/server/test/unit/models/classes/worker.spec.js
@@ -283,6 +283,61 @@ describe('Worker Class', () => {
       });
     });
 
+    describe('Resetting healthAndCareVisa', () => {
+      it('should set healthAndCareVisa and employedFromOutsideUk to null when nationality is set to British', async () => {
+        const document = {
+          nationality: {
+            value: 'British',
+          },
+        };
+
+        await worker.load(document);
+
+        expect(document).to.deep.equal({
+          nationality: {
+            value: 'British',
+          },
+          britishCitizenship: null,
+          healthAndCareVisa: null,
+          employedFromOutsideUk: null,
+        });
+      });
+
+      it('should set healthAndCareVisa and employedFromOutsideUk to null when britishCitizenship is set to Yes', async () => {
+        const document = {
+          britishCitizenship: 'Yes',
+        };
+
+        await worker.load(document);
+
+        expect(document).to.deep.equal({
+          britishCitizenship: 'Yes',
+          healthAndCareVisa: null,
+          employedFromOutsideUk: null,
+        });
+      });
+
+      it("should set healthAndCareVisa and employedFromOutsideUk to null when nationality is set to Don't know britishCitizenship is set to Don't know", async () => {
+        const document = {
+          nationality: {
+            value: "Don't know",
+          },
+          britishCitizenship: "Don't know",
+        };
+
+        await worker.load(document);
+
+        expect(document).to.deep.equal({
+          nationality: {
+            value: "Don't know",
+          },
+          britishCitizenship: "Don't know",
+          healthAndCareVisa: null,
+          employedFromOutsideUk: null,
+        });
+      });
+    });
+
     describe('Resetting employedFromOutsideUk', () => {
       it('should set employedFromOutsideUk to null when healthAndCareVisa set to No', async () => {
         const document = {

--- a/frontend/src/app/features/workers/british-citizenship/british-citizenship.component.spec.ts
+++ b/frontend/src/app/features/workers/british-citizenship/british-citizenship.component.spec.ts
@@ -46,8 +46,10 @@ describe('BritishCitizenshipComponent', () => {
 
     const component = fixture.componentInstance;
     const router = injector.inject(Router) as Router;
+    const workerService = injector.inject(WorkerService);
 
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+    const workerServiceSpy = spyOn(workerService, 'updateWorker').and.callThrough();
 
     return {
       component,
@@ -58,6 +60,7 @@ describe('BritishCitizenshipComponent', () => {
       queryByTestId,
       getByLabelText,
       getByTestId,
+      workerServiceSpy,
     };
   }
 
@@ -214,6 +217,44 @@ describe('BritishCitizenshipComponent', () => {
       fireEvent.click(skipButton);
 
       expect(routerSpy).toHaveBeenCalledWith(['/wdf', 'staff-record', workerId]);
+    });
+  });
+
+  describe('onSubmit', () => {
+    it('should update the worker with healthAndCare and employedFromOutsideUk set to null when "Yes" is selected', async () => {
+      const { component, getByLabelText, getByText, fixture, workerServiceSpy } = await setup(false);
+
+      fireEvent.click(getByLabelText('Yes'));
+      fireEvent.click(getByText('Save and return'));
+      fixture.detectChanges();
+
+      const updatedFormData = component.form.value;
+      expect(updatedFormData).toEqual({ britishCitizenship: 'Yes' });
+
+      expect(workerServiceSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, {
+        britishCitizenship: 'Yes',
+        healthAndCareVisa: null,
+        employedFromOutsideUk: null,
+      });
+    });
+
+    it('should update the worker with healthAndCare and employedFromOutsideUk set to null when "Don\'t know" is selected and nationality is set as "Don\'t know" is ', async () => {
+      const { component, getByLabelText, getByText, fixture, workerServiceSpy } = await setup(false);
+
+      component.worker.nationality.value = "Don't know";
+
+      fireEvent.click(getByLabelText('I do not know'));
+      fireEvent.click(getByText('Save and return'));
+      fixture.detectChanges();
+
+      const updatedFormData = component.form.value;
+      expect(updatedFormData).toEqual({ britishCitizenship: "Don't know" });
+
+      expect(workerServiceSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, {
+        britishCitizenship: "Don't know",
+        healthAndCareVisa: null,
+        employedFromOutsideUk: null,
+      });
     });
   });
 });

--- a/frontend/src/app/features/workers/british-citizenship/british-citizenship.component.ts
+++ b/frontend/src/app/features/workers/british-citizenship/british-citizenship.component.ts
@@ -48,9 +48,21 @@ export class BritishCitizenshipComponent extends QuestionComponent {
 
   generateUpdateProps() {
     const { britishCitizenship } = this.form.value;
+
+    let extraFields = {};
+    if (
+      (this.worker && britishCitizenship === 'Yes') ||
+      (this.worker && britishCitizenship === "Don't know" && this.worker.nationality.value === "Don't know")
+    ) {
+      this.worker.healthAndCareVisa = null;
+      this.worker.employedFromOutsideUk = null;
+      extraFields = { healthAndCareVisa: null, employedFromOutsideUk: null };
+    }
+
     return britishCitizenship
       ? {
           britishCitizenship,
+          ...extraFields,
         }
       : null;
   }

--- a/frontend/src/app/features/workers/nationality/nationality.component.spec.ts
+++ b/frontend/src/app/features/workers/nationality/nationality.component.spec.ts
@@ -130,6 +130,9 @@ describe('NationalityComponent', () => {
       expect(submitSpy).toHaveBeenCalledWith({ action: 'continue', save: true });
       expect(workerServiceSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, {
         nationality: { value: 'British' },
+        britishCitizenship: null,
+        healthAndCareVisa: null,
+        employedFromOutsideUk: null,
       });
       expect(routerSpy).toHaveBeenCalledWith([
         '/workplace',
@@ -239,6 +242,9 @@ describe('NationalityComponent', () => {
       expect(submitSpy).toHaveBeenCalledWith({ action: 'continue', save: true });
       expect(workerServiceSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, {
         nationality: { value: 'British' },
+        britishCitizenship: null,
+        healthAndCareVisa: null,
+        employedFromOutsideUk: null,
       });
       expect(routerSpy).toHaveBeenCalledWith([
         '/workplace',
@@ -310,6 +316,9 @@ describe('NationalityComponent', () => {
       expect(submitSpy).toHaveBeenCalledWith({ action: 'continue', save: true });
       expect(workerServiceSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, {
         nationality: { value: 'British' },
+        britishCitizenship: null,
+        healthAndCareVisa: null,
+        employedFromOutsideUk: null,
       });
       expect(routerSpy).toHaveBeenCalledWith(['/wdf', 'staff-record', component.worker.uid]);
     });
@@ -350,6 +359,28 @@ describe('NationalityComponent', () => {
       expect(submitSpy).toHaveBeenCalledWith({ action: 'return', save: false });
       expect(routerSpy).toHaveBeenCalledWith(['/wdf', 'staff-record', component.worker.uid]);
       expect(workerServiceSpy).not.toHaveBeenCalled();
+    });
+
+    it('should update the worker with healthAndCare set to null when "British" is selected', async () => {
+      const { component, getByLabelText, getByText, fixture, submitSpy, workerServiceSpy } = await setup(false);
+
+      fireEvent.click(getByLabelText('British'));
+      fixture.detectChanges();
+      fireEvent.click(getByText('Save'));
+      fixture.detectChanges();
+
+      const updatedFormData = component.form.value;
+      expect(updatedFormData).toEqual({ nationalityKnown: 'British', nationalityName: null });
+      expect(submitSpy).toHaveBeenCalledWith({ action: 'continue', save: true });
+
+      expect(workerServiceSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, {
+        nationality: {
+          value: 'British',
+        },
+        britishCitizenship: null,
+        healthAndCareVisa: null,
+        employedFromOutsideUk: null,
+      });
     });
   });
 

--- a/frontend/src/app/features/workers/nationality/nationality.component.ts
+++ b/frontend/src/app/features/workers/nationality/nationality.component.ts
@@ -92,8 +92,17 @@ export class NationalityComponent extends QuestionComponent {
   generateUpdateProps() {
     const { nationalityName, nationalityKnown } = this.form.controls;
 
+    let extraFields = {};
+
     if (this.worker && nationalityKnown.value === 'British') {
       this.worker.britishCitizenship = null;
+      this.worker.healthAndCareVisa = null;
+      this.worker.employedFromOutsideUk = null;
+      extraFields = {
+        britishCitizenship: null,
+        healthAndCareVisa: null,
+        employedFromOutsideUk: null,
+      };
     }
 
     return nationalityKnown.value
@@ -106,6 +115,7 @@ export class NationalityComponent extends QuestionComponent {
               },
             }),
           },
+          ...extraFields,
         }
       : null;
   }


### PR DESCRIPTION
#### Work done
- Add condition to reset healthAndVisaCare and employedFromOutsideUK when nationality and British citizenship are updated to values that shouldn't show the healthAndVisaCare and employedFromOutsideUK questions.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
