### PR TITLE
Fix/remove wdf report call in nhs api

### DIFF
--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2366,11 +2366,11 @@ module.exports = function (sequelize, DataTypes) {
     'dataOwner',
     'NumberOfStaffValue',
     'parentId',
+    'OverallWdfEligibility',
   ];
 
   Establishment.getNhsBsaApiDataByWorkplaceId = async function (where) {
     return await this.findOne({
-      nhsBsaAttributes,
       as: 'establishment',
 
       where: {
@@ -2383,6 +2383,15 @@ module.exports = function (sequelize, DataTypes) {
           as: 'mainService',
           attributes: ['name', 'category'],
           required: true,
+        },
+        {
+          model: sequelize.models.worker,
+          as: 'workers',
+          attributes: ['WdfEligible', 'LastWdfEligibility'],
+          where: {
+            archived: false,
+          },
+          required: false,
         },
       ],
     });

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2354,25 +2354,9 @@ module.exports = function (sequelize, DataTypes) {
     });
   };
 
-  const nhsBsaAttributes = [
-    'id',
-    'nmdsId',
-    'NameValue',
-    'address1',
-    'locationId',
-    'town',
-    'postcode',
-    'isParent',
-    'dataOwner',
-    'NumberOfStaffValue',
-    'parentId',
-    'OverallWdfEligibility',
-  ];
-
-  Establishment.getNhsBsaApiDataByWorkplaceId = async function (where) {
-    return await this.findOne({
+  const nhsBsaApiQuery = (where) => {
+    return {
       as: 'establishment',
-
       where: {
         archived: false,
         ...where,
@@ -2387,35 +2371,22 @@ module.exports = function (sequelize, DataTypes) {
         {
           model: sequelize.models.worker,
           as: 'workers',
-          attributes: ['WdfEligible', 'LastWdfEligibility'],
+          attributes: ['WdfEligible'],
           where: {
             archived: false,
           },
           required: false,
         },
       ],
-    });
+    };
   };
 
-  Establishment.getNhsBsaApiDataForSubs = async function (establishmentId) {
-    return await this.findAll({
-      nhsBsaAttributes,
-      as: 'establishment',
+  Establishment.getNhsBsaApiDataByWorkplaceId = async function (workplaceId) {
+    return await this.findOne(nhsBsaApiQuery({ nmdsId: workplaceId }));
+  };
 
-      where: {
-        archived: false,
-        parentId: establishmentId,
-      },
-
-      include: [
-        {
-          model: sequelize.models.services,
-          as: 'mainService',
-          attributes: ['name', 'category'],
-          required: true,
-        },
-      ],
-    });
+  Establishment.getNhsBsaApiDataForSubs = async function (parentId) {
+    return await this.findAll(nhsBsaApiQuery({ parentId }));
   };
 
   return Establishment;

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2385,6 +2385,10 @@ module.exports = function (sequelize, DataTypes) {
     return await this.findOne(nhsBsaApiQuery({ nmdsId: workplaceId }));
   };
 
+  Establishment.getNhsBsaApiDataForParent = async function (workplaceId) {
+    return await this.findOne(nhsBsaApiQuery({ id: workplaceId }));
+  };
+
   Establishment.getNhsBsaApiDataForSubs = async function (parentId) {
     return await this.findAll(nhsBsaApiQuery({ parentId }));
   };

--- a/backend/server/routes/nhsBsaApi/workplaceData.js
+++ b/backend/server/routes/nhsBsaApi/workplaceData.js
@@ -10,29 +10,29 @@ const nhsBsaApi = async (req, res) => {
   const workplaceId = req.params.workplaceId;
 
   try {
-    const workplaceDetail = await models.establishment.getNhsBsaApiDataByWorkplaceId(workplaceId);
-    if (!workplaceDetail) return res.status(404).json({ error: 'Can not find this Id.' });
+    const workplace = await models.establishment.getNhsBsaApiDataByWorkplaceId(workplaceId);
+    if (!workplace) return res.status(404).json({ error: 'Cannot find this Id.' });
 
-    const isParent = workplaceDetail.isParent;
-    const establishmentId = workplaceDetail.id;
-    const parentId = workplaceDetail.parentId;
+    const isParent = workplace.isParent;
+    const establishmentId = workplace.id;
+    const parentId = workplace.parentId;
 
     let workplaceData = null;
 
     if (isParent) {
       workplaceData = {
-        isParent: workplaceDetail.isParent,
-        workplaceDetails: await workplaceObject(workplaceDetail),
+        isParent,
+        workplaceDetails: await workplaceObject(workplace),
         subsidiaries: await subsidiariesList(establishmentId),
       };
     } else if (parentId) {
       workplaceData = {
-        workplaceDetails: await workplaceObject(workplaceDetail),
+        workplaceDetails: await workplaceObject(workplace),
         parentWorkplace: await parentWorkplace(parentId),
       };
     } else {
       workplaceData = {
-        workplaceDetails: await workplaceObject(workplaceDetail),
+        workplaceDetails: await workplaceObject(workplace),
       };
     }
 
@@ -84,10 +84,7 @@ const subsidiariesList = async (parentId) => {
 };
 
 const parentWorkplace = async (parentId) => {
-  const where = {
-    id: parentId,
-  };
-  const parentWorkplace = await models.establishment.getNhsBsaApiDataByWorkplaceId(where);
+  const parentWorkplace = await models.establishment.getNhsBsaApiDataForParent(parentId);
 
   return await workplaceObject(parentWorkplace);
 };

--- a/backend/server/routes/nhsBsaApi/workplaceData.js
+++ b/backend/server/routes/nhsBsaApi/workplaceData.js
@@ -9,12 +9,8 @@ const WdfCalculator = require('../../models/classes/wdfCalculator').WdfCalculato
 const nhsBsaApi = async (req, res) => {
   const workplaceId = req.params.workplaceId;
 
-  const where = {
-    nmdsId: workplaceId,
-  };
-
   try {
-    const workplaceDetail = await models.establishment.getNhsBsaApiDataByWorkplaceId(where);
+    const workplaceDetail = await models.establishment.getNhsBsaApiDataByWorkplaceId(workplaceId);
     if (!workplaceDetail) return res.status(404).json({ error: 'Can not find this Id.' });
 
     const isParent = workplaceDetail.isParent;
@@ -76,8 +72,8 @@ const workplaceIsEligible = (workplace) => {
     : false;
 };
 
-const subsidiariesList = async (establishmentId) => {
-  const subs = await models.establishment.getNhsBsaApiDataForSubs(establishmentId);
+const subsidiariesList = async (parentId) => {
+  const subs = await models.establishment.getNhsBsaApiDataForSubs(parentId);
 
   const subsidiaries = await Promise.all(
     subs.map(async (workplace) => {

--- a/backend/server/test/unit/routes/nhsBsaApi/workplaceData.spec.js
+++ b/backend/server/test/unit/routes/nhsBsaApi/workplaceData.spec.js
@@ -83,7 +83,7 @@ describe('server/routes/nhsBsaApi/workplaceData.js', () => {
       });
     });
 
-    it('should return subsidiaries as an array formatted in the same way as a standalone', async () => {
+    it('should return subsidiaries as an array formatted in the same way as a standalone when is parent', async () => {
       result.isParent = true;
 
       sinon.stub(models.establishment, 'getNhsBsaApiDataByWorkplaceId').returns(result);
@@ -92,6 +92,7 @@ describe('server/routes/nhsBsaApi/workplaceData.js', () => {
       await nhsBsaApi(req, res);
       const response = res._getJSONData();
 
+      expect(response.workplaceData.isParent).to.equal(true);
       expect(response.workplaceData.subsidiaries).to.deep.equal([
         {
           workplaceId: 'J1001845',
@@ -109,12 +110,36 @@ describe('server/routes/nhsBsaApi/workplaceData.js', () => {
       ]);
     });
 
+    it('should return parent data formatted in the same way as a standalone when workplace has parent ID', async () => {
+      result.parentId = 'J1001845';
+
+      sinon.stub(models.establishment, 'getNhsBsaApiDataByWorkplaceId').returns(result);
+      sinon.stub(models.establishment, 'getNhsBsaApiDataForParent').returns(result);
+
+      await nhsBsaApi(req, res);
+      const response = res._getJSONData();
+
+      expect(response.workplaceData.parentWorkplace).to.deep.equal({
+        workplaceId: 'J1001845',
+        workplaceName: 'SKILLS FOR CARE',
+        dataOwner: 'Workplace',
+        workplaceAddress: { firstLine: 'WEST GATE', town: 'LEEDS', postCode: 'LS1 2RP' },
+        locationId: null,
+        numberOfWorkplaceStaff: 2,
+        serviceName: 'Domiciliary care services',
+        serviceCategory: 'Adult domiciliary',
+        eligibilityPercentage: 0,
+        eligibilityDate: '2021-05-13T09:27:34.471Z',
+        isEligible: false,
+      });
+    });
+
     it('should return 404 when workplace is not found', async () => {
       sinon.stub(models.establishment, 'getNhsBsaApiDataByWorkplaceId').returns(null);
       await nhsBsaApi(req, res);
 
       expect(res.statusCode).to.deep.equal(404);
-      expect(res._getJSONData()).to.deep.equal({ error: 'Can not find this Id.' });
+      expect(res._getJSONData()).to.deep.equal({ error: 'Cannot find this Id.' });
     });
 
     it('should return 500 when an error is thrown', async () => {


### PR DESCRIPTION
#### Work done
- Changed NHS API endpoint to retrieve all data from Establishment table and add workers to the query
- Refactored database calls to ensure the same data was being returned for all workplace types 

#### Reason
All of the data required for this endpoint is available in the Establishment and Worker tables. By using the *wdfsummaryreport* function, a table was being generated for all workplaces each time the endpoint was hit which seemed fine in staging but could have been a problem when there are large amounts of live data. 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
