### PR TITLE
Revert changes to set tab in parent/standalone view

### DIFF
--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
@@ -261,12 +261,12 @@ describe('NewTabsComponent', () => {
     });
   });
 
-  describe('getTabSlugFromNavigationEvent', async () => {
+  describe('getTabSlugFromSubsidiaryUrl', async () => {
     it(`should return correct tab when third section of url is the tab slug`, async () => {
       const { component } = await setup(true, []);
       component.tabs.forEach((tab) => {
         const url = `/subsidiary/test-uid/${tab.slug}`;
-        const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
+        const result = component.getTabSlugFromSubsidiaryUrl(new NavigationEnd(0, url, url));
 
         expect(result).toEqual(tab);
       });
@@ -275,7 +275,7 @@ describe('NewTabsComponent', () => {
     it('should return nothing when no tab slug in the navigation event url', async () => {
       const { component } = await setup(true, []);
 
-      const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, 'test-url.com', 'test-url.com'));
+      const result = component.getTabSlugFromSubsidiaryUrl(new NavigationEnd(0, 'test-url.com', 'test-url.com'));
 
       expect(result).toBeFalsy();
     });
@@ -283,7 +283,7 @@ describe('NewTabsComponent', () => {
     it('should return nothing when workplace in url but in wrong section', async () => {
       const { component } = await setup(true, []);
       const url = '/subsidiary/workplace/test-uid/main-service-cqc';
-      const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
+      const result = component.getTabSlugFromSubsidiaryUrl(new NavigationEnd(0, url, url));
 
       expect(result).toBeFalsy();
     });
@@ -291,7 +291,37 @@ describe('NewTabsComponent', () => {
     it('should return nothing when url has fewer than 3 sections', async () => {
       const { component } = await setup(true, []);
       const url = '/subsidiary/benefits-bundle';
-      const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
+      const result = component.getTabSlugFromSubsidiaryUrl(new NavigationEnd(0, url, url));
+
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe('getTabSlugFromMainDashboardUrl', async () => {
+    it(`should return tab slug when slug is in list of tabs`, async () => {
+      const { component } = await setup(true, []);
+      component.tabs.forEach((tab) => {
+        const url = `/dashboard#${tab.slug}`;
+        const result = component.getTabSlugFromMainDashboardUrl(new NavigationEnd(0, url, url));
+
+        expect(result).toEqual(tab.slug);
+      });
+    });
+
+    it('should return nothing when unexpected tab slug in the navigation event url', async () => {
+      const { component } = await setup(true, []);
+
+      const url = `/dashboard#invalidSlug`;
+      const result = component.getTabSlugFromMainDashboardUrl(new NavigationEnd(0, url, url));
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return nothing when main url is not dashboard', async () => {
+      const { component } = await setup(true, []);
+
+      const url = `/invalidUrl#home`;
+      const result = component.getTabSlugFromMainDashboardUrl(new NavigationEnd(0, url, url));
 
       expect(result).toBeFalsy();
     });

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
@@ -261,12 +261,12 @@ describe('NewTabsComponent', () => {
     });
   });
 
-  describe('getTabSlugFromSubsidiaryUrl', async () => {
+  describe('getTabSlugFromNavigationEvent', async () => {
     it(`should return correct tab when third section of url is the tab slug`, async () => {
       const { component } = await setup(true, []);
       component.tabs.forEach((tab) => {
         const url = `/subsidiary/test-uid/${tab.slug}`;
-        const result = component.getTabSlugFromSubsidiaryUrl(new NavigationEnd(0, url, url));
+        const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
 
         expect(result).toEqual(tab);
       });
@@ -275,7 +275,7 @@ describe('NewTabsComponent', () => {
     it('should return nothing when no tab slug in the navigation event url', async () => {
       const { component } = await setup(true, []);
 
-      const result = component.getTabSlugFromSubsidiaryUrl(new NavigationEnd(0, 'test-url.com', 'test-url.com'));
+      const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, 'test-url.com', 'test-url.com'));
 
       expect(result).toBeFalsy();
     });
@@ -283,7 +283,7 @@ describe('NewTabsComponent', () => {
     it('should return nothing when workplace in url but in wrong section', async () => {
       const { component } = await setup(true, []);
       const url = '/subsidiary/workplace/test-uid/main-service-cqc';
-      const result = component.getTabSlugFromSubsidiaryUrl(new NavigationEnd(0, url, url));
+      const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
 
       expect(result).toBeFalsy();
     });
@@ -291,37 +291,7 @@ describe('NewTabsComponent', () => {
     it('should return nothing when url has fewer than 3 sections', async () => {
       const { component } = await setup(true, []);
       const url = '/subsidiary/benefits-bundle';
-      const result = component.getTabSlugFromSubsidiaryUrl(new NavigationEnd(0, url, url));
-
-      expect(result).toBeFalsy();
-    });
-  });
-
-  describe('getTabSlugFromMainDashboardUrl', async () => {
-    it(`should return tab slug when slug is in list of tabs`, async () => {
-      const { component } = await setup(true, []);
-      component.tabs.forEach((tab) => {
-        const url = `/dashboard#${tab.slug}`;
-        const result = component.getTabSlugFromMainDashboardUrl(new NavigationEnd(0, url, url));
-
-        expect(result).toEqual(tab.slug);
-      });
-    });
-
-    it('should return nothing when unexpected tab slug in the navigation event url', async () => {
-      const { component } = await setup(true, []);
-
-      const url = `/dashboard#invalidSlug`;
-      const result = component.getTabSlugFromMainDashboardUrl(new NavigationEnd(0, url, url));
-
-      expect(result).toBeFalsy();
-    });
-
-    it('should return nothing when main url is not dashboard', async () => {
-      const { component } = await setup(true, []);
-
-      const url = `/invalidUrl#home`;
-      const result = component.getTabSlugFromMainDashboardUrl(new NavigationEnd(0, url, url));
+      const result = component.getTabSlugFromNavigationEvent(new NavigationEnd(0, url, url));
 
       expect(result).toBeFalsy();
     });

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.ts
@@ -37,24 +37,52 @@ export class NewTabsComponent implements OnInit, OnDestroy {
 
     this.selectedTabSubscription();
     this.setTabOnInit();
-    this.trackRouterEventsToSetTabInSubView();
+    this.trackRouterEventsToSetTab();
   }
 
-  private trackRouterEventsToSetTabInSubView(): void {
+  private trackRouterEventsToSetTab(): void {
     this.subscriptions.add(
       this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe((route: NavigationEnd) => {
         if (this.isParentViewingSub) {
-          const tabInUrl = this.getTabSlugFromNavigationEvent(route);
+          const tabInUrl = this.getTabSlugFromSubsidiaryUrl(route);
 
           if (tabInUrl) {
             this.tabsService.selectedTab = tabInUrl.slug;
+          }
+        } else {
+          const tabInUrl = this.getTabSlugFromMainDashboardUrl(route);
+          console.log('tabInUrl: ', tabInUrl);
+          console.log('this.tabs[this.currentTab]: ', this.tabs[this.currentTab]);
+
+          if (tabInUrl && this.tabs[this.currentTab].slug !== tabInUrl) {
+            this.tabsService.selectedTab = tabInUrl;
           }
         }
       }),
     );
   }
 
-  public getTabSlugFromNavigationEvent(route: NavigationEnd) {
+  public getTabSlugFromMainDashboardUrl(route: NavigationEnd): string {
+    const url = route.urlAfterRedirects;
+    console.log('****************  INSIDE getTabSlugFromMainDashboardUrl ************************');
+    console.log('url: ', url);
+    const hashIndex = url.indexOf('#');
+    console.log('hashIndex: ', hashIndex);
+    if (hashIndex !== -1 && hashIndex < url.length - 1) {
+      const urlWithoutFragment = url.substring(0, hashIndex);
+      if (!urlWithoutFragment.includes('dashboard')) return null;
+      console.log('urlWithoutFragment: ', urlWithoutFragment);
+
+      const tabSlug = url.substring(hashIndex + 1);
+      console.log('tabSlug: ', tabSlug);
+      console.log('****************  END OF getTabSlugFromMainDashboardUrl ************************');
+
+      return this.tabs.find((tab) => tab.slug === tabSlug) ? tabSlug : null;
+    }
+    return null;
+  }
+
+  public getTabSlugFromSubsidiaryUrl(route: NavigationEnd) {
     const urlArray = route.urlAfterRedirects.split('/').filter((section) => section.length > 0);
     if (urlArray.length > 2) {
       return this.tabs.find((tab) => urlArray[2] === tab.slug);

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.ts
@@ -37,43 +37,24 @@ export class NewTabsComponent implements OnInit, OnDestroy {
 
     this.selectedTabSubscription();
     this.setTabOnInit();
-    this.trackRouterEventsToSetTab();
+    this.trackRouterEventsToSetTabInSubView();
   }
 
-  private trackRouterEventsToSetTab(): void {
+  private trackRouterEventsToSetTabInSubView(): void {
     this.subscriptions.add(
       this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe((route: NavigationEnd) => {
         if (this.isParentViewingSub) {
-          const tabInUrl = this.getTabSlugFromSubsidiaryUrl(route);
+          const tabInUrl = this.getTabSlugFromNavigationEvent(route);
 
           if (tabInUrl) {
             this.tabsService.selectedTab = tabInUrl.slug;
-          }
-        } else {
-          const tabInUrl = this.getTabSlugFromMainDashboardUrl(route);
-          if (tabInUrl && this.tabs[this.currentTab].slug !== tabInUrl) {
-            this.tabsService.selectedTab = tabInUrl;
           }
         }
       }),
     );
   }
 
-  public getTabSlugFromMainDashboardUrl(route: NavigationEnd): string {
-    const url = route.urlAfterRedirects;
-
-    const hashIndex = url.indexOf('#');
-    if (hashIndex !== -1 && hashIndex < url.length - 1) {
-      const urlWithoutFragment = url.substring(0, hashIndex);
-      if (!urlWithoutFragment.includes('dashboard')) return null;
-
-      const tabSlug = url.substring(hashIndex + 1);
-      return this.tabs.find((tab) => tab.slug === tabSlug) ? tabSlug : null;
-    }
-    return null;
-  }
-
-  public getTabSlugFromSubsidiaryUrl(route: NavigationEnd) {
+  public getTabSlugFromNavigationEvent(route: NavigationEnd) {
     const urlArray = route.urlAfterRedirects.split('/').filter((section) => section.length > 0);
     if (urlArray.length > 2) {
       return this.tabs.find((tab) => urlArray[2] === tab.slug);


### PR DESCRIPTION
#### Work done
- Reverted changes for setting tabs in the parent/standalone view

#### Reason
Due to the way tabs are set in the parent/stand alone view, when working on the International Recruitment tickets, it was difficult to get the back links to go back to the home page and they were instead going to staff records. I made a change to track setting tab in a similar way to the sub view, which worked locally but completely prevented navigation away from the dashboard in our staging environment. This PR reverts the change, fixing navigation but reintroducing the issue of the back links in parent view going to Staff records instead of the Home tab. 

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
