### PR TITLE
fix/ir-existing-workers-clear-q1-on-q2-cancel

### DIFF
--- a/frontend/src/app/core/services/international-recruitment.service.ts
+++ b/frontend/src/app/core/services/international-recruitment.service.ts
@@ -11,7 +11,7 @@ export interface internationalRecruitmentWorkersResponse {
   name: string;
   nationality: string;
   britishCitizenship: string;
-  healthAndCareVisaValue: string;
+  healthAndCareVisa: string;
 }
 
 @Injectable()

--- a/frontend/src/app/core/test-utils/MockInternationalRecruitmentService.ts
+++ b/frontend/src/app/core/test-utils/MockInternationalRecruitmentService.ts
@@ -9,7 +9,8 @@ export const internationalRecruitmentWorkers = () => [
     name: 'Joy Wood',
     nationality: 'Other',
     britishCitizenship: 'No',
-    healthAndCareVisaValue: 'Yes',
+    healthAndCareVisa: 'Yes',
+    //healthAndCareVisaValue: 'Yes',
   },
   {
     uid: 'a432',

--- a/frontend/src/app/core/test-utils/MockInternationalRecruitmentService.ts
+++ b/frontend/src/app/core/test-utils/MockInternationalRecruitmentService.ts
@@ -10,7 +10,6 @@ export const internationalRecruitmentWorkers = () => [
     nationality: 'Other',
     britishCitizenship: 'No',
     healthAndCareVisa: 'Yes',
-    //healthAndCareVisaValue: 'Yes',
   },
   {
     uid: 'a432',

--- a/frontend/src/app/features/workplace/health-and-care-visa-existing-workers/health-and-care-visa-existing-workers.component.ts
+++ b/frontend/src/app/features/workplace/health-and-care-visa-existing-workers/health-and-care-visa-existing-workers.component.ts
@@ -10,6 +10,7 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { PreviousRouteService } from '@core/services/previous-route.service';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -41,6 +42,7 @@ export class HealthAndCareVisaExistingWorkers implements OnInit, OnDestroy {
   public updatedWorkers: any = [];
   public workersHealthAndCareVisaAnswersToSave = [];
   @ViewChild('formEl') formEl: ElementRef;
+  public isFromOutsideOrInsideUKPage: boolean;
 
   constructor(
     private formBuilder: UntypedFormBuilder,
@@ -51,6 +53,7 @@ export class HealthAndCareVisaExistingWorkers implements OnInit, OnDestroy {
     private permissionsService: PermissionsService,
     private internationalRecruitmentService: InternationalRecruitmentService,
     private alertService: AlertService,
+    private previousRouteService: PreviousRouteService,
   ) {
     this.form = this.formBuilder.group({
       healthAndCareVisaRadioList: this.formBuilder.group({}),
@@ -72,6 +75,14 @@ export class HealthAndCareVisaExistingWorkers implements OnInit, OnDestroy {
 
   get healthAndCareVisaRadioListValues(): AbstractControl[] {
     return Object.values(this.healthAndCareVisaRadioList.controls);
+  }
+
+  public checkPreviousRoute(): boolean {
+    const previousPageUrl = this.previousRouteService.getPreviousUrl();
+    if (previousPageUrl.includes('employed-from-outside-or-inside-uk')) {
+      return true;
+    }
+    return false;
   }
 
   initialiseForm(): void {
@@ -119,18 +130,22 @@ export class HealthAndCareVisaExistingWorkers implements OnInit, OnDestroy {
   }
 
   prefillForm(): void {
-    const updatedWorkersResponse = this.internationalRecruitmentService.getInternationalRecruitmentWorkerAnswers();
-    if (
-      updatedWorkersResponse?.workplaceUid === this.workplaceUid &&
-      updatedWorkersResponse?.healthAndCareVisaWorkerAnswers
-    ) {
-      this.updatedWorkers = updatedWorkersResponse.healthAndCareVisaWorkerAnswers;
+    this.isFromOutsideOrInsideUKPage = this.checkPreviousRoute();
+    if (this.isFromOutsideOrInsideUKPage) {
+      const updatedWorkersResponse = this.internationalRecruitmentService.getInternationalRecruitmentWorkerAnswers();
 
-      for (let worker of this.updatedWorkers) {
-        if (this.healthAndCareVisaRadioList.controls[worker.uid]) {
-          this.healthAndCareVisaRadioList.controls[worker.uid].setValue({
-            healthAndCareVisa: worker.healthAndCareVisa,
-          });
+      if (
+        updatedWorkersResponse?.workplaceUid === this.workplaceUid &&
+        updatedWorkersResponse?.healthAndCareVisaWorkerAnswers
+      ) {
+        this.updatedWorkers = updatedWorkersResponse.healthAndCareVisaWorkerAnswers;
+
+        for (let worker of this.updatedWorkers) {
+          if (this.healthAndCareVisaRadioList.controls[worker.uid]) {
+            this.healthAndCareVisaRadioList.controls[worker.uid].setValue({
+              healthAndCareVisa: worker.healthAndCareVisa,
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
#### Work done
- Add condition in health-and-care-visa-existing-workers to check if previous page is outside-or-inside-uk-existing-worker before prefill

#### Reason
If you had gone to health-and-care-visa-existing-workers then outside or inside UK existing workers pages but either clicked cancel or one of the tabs on outside or inside UK existing worker page, when you go back to health-and-care-visa-existing-workers, it was prefilling when it should not

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
