### PR TITLE
Fix/use prov id for missing cqc subs check

### DIFF
--- a/backend/server/routes/missingCqcProviderLocations/index.js
+++ b/backend/server/routes/missingCqcProviderLocations/index.js
@@ -6,7 +6,7 @@ const models = require('../../models');
 const Authorization = require('../../utils/security/isAuthenticated');
 
 const missingCqcProviderLocations = async (req, res) => {
-  const locationId = req.query.locationId;
+  const provId = req.query.provId;
   const establishmentUid = req.query.establishmentUid;
   const establishmentId = req.query.establishmentId;
   let weeksSinceParentApproval = null;
@@ -27,8 +27,8 @@ const missingCqcProviderLocations = async (req, res) => {
       result.weeksSinceParentApproval = weeksSinceParentApproval;
     }
 
-    if (locationId) {
-      let CQCProviderData = await CQCDataAPI.getCQCProviderData(locationId);
+    if (provId && provId != 'null' && weeksSinceParentApproval) {
+      let CQCProviderData = await CQCDataAPI.getCQCProviderData(provId);
 
       const childWorkplacesLocationIds = await getChildWorkplacesLocationIds(childWorkplaces.rows);
 

--- a/backend/server/test/unit/routes/missingCqcProviderLocations/index.spec.js
+++ b/backend/server/test/unit/routes/missingCqcProviderLocations/index.spec.js
@@ -15,7 +15,7 @@ const {
 
 describe('server/routes/establishments/missingCqcProviderLocations', async () => {
   describe('get missingCqcProviderLocations', async () => {
-    const locationId = '1-2003';
+    const provId = '1-2003';
     const cqcLocationIds = ['1-12427547986', '1-2043158439', '1-5310224737'];
 
     let request;
@@ -23,7 +23,7 @@ describe('server/routes/establishments/missingCqcProviderLocations', async () =>
     beforeEach(() => {
       sinon.stub(CQCDataAPI, 'getCQCProviderData').callsFake(async (locationProviderId) => {
         return {
-          providerId: locationId,
+          providerId: provId,
           locationIds: cqcLocationIds,
         };
       });
@@ -33,7 +33,7 @@ describe('server/routes/establishments/missingCqcProviderLocations', async () =>
         url: `/api/missingCqcProviderLocations`,
         params: {},
         query: {
-          locationId: locationId,
+          provId: provId,
           establishmentUid: 'some-uuid',
           establishmentId: 2,
         },
@@ -104,7 +104,7 @@ describe('server/routes/establishments/missingCqcProviderLocations', async () =>
       expect(res.statusCode).to.deep.equal(200);
     });
 
-    it('should return childWorkplaceCount and parent approval info with empty fields for CQC when no locationId', async () => {
+    it('should return childWorkplaceCount and parent approval info with empty fields for CQC when no provId in query', async () => {
       sinon.stub(models.Approvals, 'findbyEstablishmentId').returns({
         updatedAt: moment(moment().subtract(21, 'days')),
       });
@@ -121,7 +121,7 @@ describe('server/routes/establishments/missingCqcProviderLocations', async () =>
         childWorkplacesCount: 3,
       };
 
-      request.query.locationId = null;
+      request.query.provId = null;
 
       const req = httpMocks.createRequest(request);
       const res = httpMocks.createResponse();
@@ -192,7 +192,7 @@ describe('server/routes/establishments/missingCqcProviderLocations', async () =>
         method: 'GET',
         url: `/api/missingCqcProviderLocations`,
         query: {
-          locationId: '1-locationId',
+          provId: '1-provId',
           establishmentUid: 'some-uuid',
           establishmentId: 2,
         },

--- a/frontend/src/app/core/model/establishment.model.ts
+++ b/frontend/src/app/core/model/establishment.model.ts
@@ -160,6 +160,7 @@ export interface Establishment {
   careWorkersCashLoyaltyForFirstTwoYears?: string;
   sickPay?: string;
   isParentApprovedBannerViewed?: boolean;
+  provId?: string;
 }
 
 export interface UpdateJobsRequest {

--- a/frontend/src/app/core/resolvers/getMissingCqcLocations/getMissingCqcLocations.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/getMissingCqcLocations/getMissingCqcLocations.resolver.spec.ts
@@ -1,13 +1,18 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { of } from 'rxjs';
 
 import { GetMissingCqcLocationsResolver } from './getMissingCqcLocations.resolver';
 
 describe('GetMissingCqcLocationsResolver', () => {
+  const mockWorkplace = {
+    provId: '1-11111111',
+    uid: '98a83eef-e1e1-49f3-89c5-b1287a3cc8de',
+    id: 1234,
+  };
+
   const setup = () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
@@ -15,16 +20,19 @@ describe('GetMissingCqcLocationsResolver', () => {
         GetMissingCqcLocationsResolver,
         {
           provide: EstablishmentService,
-          useClass: MockEstablishmentService,
+          useValue: {
+            primaryWorkplace: mockWorkplace,
+            async getMissingCqcLocations() {
+              of(null);
+            },
+          },
         },
       ],
     });
     const resolver = TestBed.inject(GetMissingCqcLocationsResolver);
-    const route = TestBed.inject(ActivatedRoute);
-
     const establishmentService = TestBed.inject(EstablishmentService);
 
-    return { resolver, route, establishmentService };
+    return { resolver, establishmentService };
   };
 
   it('should be created', async () => {
@@ -33,14 +41,14 @@ describe('GetMissingCqcLocationsResolver', () => {
   });
 
   it('should call getMissingCqcLocations', async () => {
-    const { resolver, route, establishmentService } = await setup();
-    const getMissingCqcLocationsSpy = spyOn(establishmentService, 'getMissingCqcLocations').and.callThrough();
-    resolver.resolve(route.snapshot);
+    const { resolver, establishmentService } = await setup();
+    const getMissingCqcLocationsSpy = spyOn(establishmentService, 'getMissingCqcLocations').and.returnValue(of(null));
+    resolver.resolve();
 
     expect(getMissingCqcLocationsSpy).toHaveBeenCalledWith({
-      locationId: '1-11111111',
-      uid: '98a83eef-e1e1-49f3-89c5-b1287a3cc8de',
-      id: 0,
+      provId: mockWorkplace.provId,
+      uid: mockWorkplace.uid,
+      id: mockWorkplace.id,
     });
   });
 });

--- a/frontend/src/app/core/resolvers/getMissingCqcLocations/getMissingCqcLocations.resolver.ts
+++ b/frontend/src/app/core/resolvers/getMissingCqcLocations/getMissingCqcLocations.resolver.ts
@@ -1,18 +1,18 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { Resolve } from '@angular/router';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class GetMissingCqcLocationsResolver implements Resolve<any> {
   constructor(private establishmentService: EstablishmentService) {}
 
-  resolve(route: ActivatedRouteSnapshot) {
-    const { locationId, uid, id } = this.establishmentService.primaryWorkplace;
+  resolve() {
+    const { provId, uid, id } = this.establishmentService.primaryWorkplace;
     return this.establishmentService
       .getMissingCqcLocations({
-        locationId,
+        provId,
         uid,
         id,
       })

--- a/frontend/src/app/core/services/establishment.service.ts
+++ b/frontend/src/app/core/services/establishment.service.ts
@@ -470,7 +470,7 @@ export class EstablishmentService {
   public getMissingCqcLocations(requestParams): Observable<any> {
     let params = new HttpParams();
 
-    params = params.set('locationId', `${requestParams.locationId}`);
+    params = params.set('provId', `${requestParams.provId}`);
     params = params.set('establishmentUid', `${requestParams.uid}`);
     params = params.set('establishmentId', `${requestParams.id}`);
 

--- a/frontend/src/app/core/test-utils/MockEstablishmentService.ts
+++ b/frontend/src/app/core/test-utils/MockEstablishmentService.ts
@@ -242,6 +242,7 @@ export class MockEstablishmentService extends EstablishmentService {
       updatedBy: '',
       vacancies: undefined,
       locationId: '1-11111111',
+      provId: '1-21232433',
     };
   }
 

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
@@ -37,7 +37,7 @@
       </p>
 
       <p>
-        <a href="https://www.cqc.org.uk/provider/{{ locationId }}" class="govuk-link--no-visited-state" target="_blank"
+        <a href="https://www.cqc.org.uk/provider/{{ providerId }}" class="govuk-link--no-visited-state" target="_blank"
           >Please check your CQC workplaces</a
         >
         and then add any you want to include in ASC-WDS.

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
@@ -290,6 +290,14 @@ describe('ViewMyWorkplacesComponent', () => {
 
       expect(missingCqcWorkplacesMessage.textContent).toContain(component.primaryWorkplace.name);
     });
+
+    it('should show link to CQC provider page with provider ID in url', async () => {
+      const { component, getByText } = await setup(true);
+
+      const cqcLink = getByText('Please check your CQC workplaces');
+
+      expect(cqcLink.getAttribute('href')).toEqual(`https://www.cqc.org.uk/provider/${component.providerId}`);
+    });
   });
 
   it('should show `What you can do as a parent workplace` link', async () => {

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
@@ -30,7 +30,7 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
   public itemsPerPage = 12;
   public currentPageIndex = 0;
   private searchTerm = '';
-  public locationId: string;
+  public providerId: string;
   public showMissingCqcMessage: boolean;
   public missingCqcLocations: any;
 
@@ -58,7 +58,7 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
     this.setupServerErrorsMap();
     this.setSearchIfPrevious();
 
-    this.locationId = this.primaryWorkplace.locationId;
+    this.providerId = this.primaryWorkplace.provId;
 
     this.showMissingCqcMessage = this.route.snapshot.data?.cqcLocations?.showMissingCqcMessage;
   }


### PR DESCRIPTION
#### Issue
The missing CQC locations message in the summary panel and  banner on the view your workplaces page were never displaying, as we were trying to retrieve provider information from CQC using the location ID instead of the provider ID  

#### Work done
- Updated the missing CQC locations banner code to use provider ID instead of location ID

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
