### PR TITLE
1471-training-changes-to-the-main-add-a-training-record-page-after-selecting-category

### DIFF
--- a/frontend/src/app/core/services/training.service.spec.ts
+++ b/frontend/src/app/core/services/training.service.spec.ts
@@ -4,7 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import { TrainingService } from './training.service';
 import { environment } from 'src/environments/environment';
 
-fdescribe('TrainingService', () => {
+describe('TrainingService', () => {
   let service: TrainingService;
   let http: HttpTestingController;
 
@@ -48,12 +48,32 @@ fdescribe('TrainingService', () => {
     });
   });
 
-  it('should return the training category selected for training record', () => {
-    service.setTrainingCategorySelectedForTrainingRecord({ id: 1, label: 'Activity provision, wellbeing' });
+  describe('trainingCategorySelectedForTrainingRecord', () => {
+    it('should not set trainingCategorySelectedForTrainingRecord if the incorrect object is sent', () => {
+      service.setTrainingCategorySelectedForTrainingRecord({ record: 'type' });
 
-    expect(service.getTrainingCategorySelectedForTrainingRecord()).toEqual({
-      id: 1,
-      category: 'Activity provision, wellbeing',
+      expect(service.getTrainingCategorySelectedForTrainingRecord()).toBeNull();
+    });
+
+    it('should return the training category selected for training record', () => {
+      service.setTrainingCategorySelectedForTrainingRecord({
+        category: { id: 1, label: 'Activity provision, wellbeing' },
+      });
+
+      expect(service.getTrainingCategorySelectedForTrainingRecord()).toEqual({
+        id: 1,
+        category: 'Activity provision, wellbeing',
+      });
+    });
+
+    it('should clear trainingCategorySelectedForTrainingRecord', () => {
+      service.setTrainingCategorySelectedForTrainingRecord({
+        category: { id: 1, label: 'Activity provision, wellbeing' },
+      });
+
+      service.clearTrainingCategorySelectedForTrainingRecord();
+
+      expect(service.getTrainingCategorySelectedForTrainingRecord()).toBeNull();
     });
   });
 });

--- a/frontend/src/app/core/services/training.service.spec.ts
+++ b/frontend/src/app/core/services/training.service.spec.ts
@@ -49,12 +49,6 @@ describe('TrainingService', () => {
   });
 
   describe('trainingCategorySelectedForTrainingRecord', () => {
-    it('should not set trainingCategorySelectedForTrainingRecord if the incorrect object is sent', () => {
-      service.setTrainingCategorySelectedForTrainingRecord({ record: 'type' });
-
-      expect(service.getTrainingCategorySelectedForTrainingRecord()).toBeNull();
-    });
-
     it('should return the training category selected for training record', () => {
       service.setTrainingCategorySelectedForTrainingRecord({
         category: { id: 1, label: 'Activity provision, wellbeing' },

--- a/frontend/src/app/core/services/training.service.spec.ts
+++ b/frontend/src/app/core/services/training.service.spec.ts
@@ -4,7 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import { TrainingService } from './training.service';
 import { environment } from 'src/environments/environment';
 
-describe('TrainingService', () => {
+fdescribe('TrainingService', () => {
   let service: TrainingService;
   let http: HttpTestingController;
 
@@ -49,8 +49,11 @@ describe('TrainingService', () => {
   });
 
   it('should return the training category selected for training record', () => {
-    service.setTrainingCategorySelectedForTrainingRecord({ category: 1 });
+    service.setTrainingCategorySelectedForTrainingRecord({ id: 1, label: 'Activity provision, wellbeing' });
 
-    expect(service.getTrainingCategorySelectedForTrainingRecord()).toEqual({ category: 1 });
+    expect(service.getTrainingCategorySelectedForTrainingRecord()).toEqual({
+      id: 1,
+      category: 'Activity provision, wellbeing',
+    });
   });
 });

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -43,12 +43,6 @@ export class TrainingService {
     );
   }
 
-  getCategoryById(categoryId): Observable<TrainingCategory[]> {
-    return this.http
-      .get<TrainingCategoryResponse>(`${environment.appRunnerEndpoint}/api/trainingCategories/${categoryId}`)
-      .pipe(map((res) => res.trainingCategories));
-  }
-
   public deleteCategoryById(establishmentId, categoryId) {
     return this.http.delete(
       `${environment.appRunnerEndpoint}/api/establishment/${establishmentId}/mandatoryTraining/${categoryId}`,
@@ -107,6 +101,9 @@ export class TrainingService {
     return this._trainingCategorySelectedForTrainingRecord;
   }
   public setTrainingCategorySelectedForTrainingRecord(trainingCategory: any) {
-    this._trainingCategorySelectedForTrainingRecord = { id: trainingCategory.id, category: trainingCategory.label };
+    this._trainingCategorySelectedForTrainingRecord = {
+      id: trainingCategory.category.id,
+      category: trainingCategory.category.label,
+    };
   }
 }

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -15,7 +15,7 @@ export class TrainingService {
   public selectedStaff: Worker[] = [];
   public addMultipleTrainingInProgress$ = new BehaviorSubject<boolean>(false);
   private _trainingOrQualificationPreviouslySelected: string = null;
-  private _trainingCategorySelectedForTrainingRecord: {};
+  private _trainingCategorySelectedForTrainingRecord: any = null;
 
   constructor(private http: HttpClient) {}
 
@@ -106,7 +106,7 @@ export class TrainingService {
   public getTrainingCategorySelectedForTrainingRecord() {
     return this._trainingCategorySelectedForTrainingRecord;
   }
-  public setTrainingCategorySelectedForTrainingRecord(trainingCategoryId: {}) {
-    this._trainingCategorySelectedForTrainingRecord = trainingCategoryId;
+  public setTrainingCategorySelectedForTrainingRecord(trainingCategory: any) {
+    this._trainingCategorySelectedForTrainingRecord = { id: trainingCategory.id, category: trainingCategory.label };
   }
 }

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -7,6 +7,11 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
+interface SelectedTrainingCategory {
+  id: number;
+  category: string;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -15,7 +20,7 @@ export class TrainingService {
   public selectedStaff: Worker[] = [];
   public addMultipleTrainingInProgress$ = new BehaviorSubject<boolean>(false);
   private _trainingOrQualificationPreviouslySelected: string = null;
-  private _trainingCategorySelectedForTrainingRecord: any = null;
+  private _trainingCategorySelectedForTrainingRecord: SelectedTrainingCategory = null;
 
   constructor(private http: HttpClient) {}
 
@@ -97,11 +102,11 @@ export class TrainingService {
     this.resetSelectedTraining();
   }
 
-  public getTrainingCategorySelectedForTrainingRecord(): any {
+  public getTrainingCategorySelectedForTrainingRecord(): SelectedTrainingCategory {
     return this._trainingCategorySelectedForTrainingRecord;
   }
 
-  public setTrainingCategorySelectedForTrainingRecord(trainingCategory: any) {
+  public setTrainingCategorySelectedForTrainingRecord(trainingCategory: any): void {
     if (trainingCategory?.category) {
       this._trainingCategorySelectedForTrainingRecord = {
         id: trainingCategory.category?.id,

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -97,13 +97,20 @@ export class TrainingService {
     this.resetSelectedTraining();
   }
 
-  public getTrainingCategorySelectedForTrainingRecord() {
+  public getTrainingCategorySelectedForTrainingRecord(): any {
     return this._trainingCategorySelectedForTrainingRecord;
   }
+
   public setTrainingCategorySelectedForTrainingRecord(trainingCategory: any) {
-    this._trainingCategorySelectedForTrainingRecord = {
-      id: trainingCategory.category.id,
-      category: trainingCategory.category.label,
-    };
+    if (trainingCategory?.category) {
+      this._trainingCategorySelectedForTrainingRecord = {
+        id: trainingCategory.category?.id,
+        category: trainingCategory.category?.label,
+      };
+    }
+  }
+
+  public clearTrainingCategorySelectedForTrainingRecord(): void {
+    this._trainingCategorySelectedForTrainingRecord = null;
   }
 }

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -7,9 +7,13 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
-interface SelectedTrainingCategory {
+interface Category {
   id: number;
   category: string;
+}
+
+interface SelectedTrainingCategory {
+  category: { id: number; label: string };
 }
 
 @Injectable({
@@ -20,7 +24,7 @@ export class TrainingService {
   public selectedStaff: Worker[] = [];
   public addMultipleTrainingInProgress$ = new BehaviorSubject<boolean>(false);
   private _trainingOrQualificationPreviouslySelected: string = null;
-  private _trainingCategorySelectedForTrainingRecord: SelectedTrainingCategory = null;
+  private _trainingCategorySelectedForTrainingRecord: Category = null;
 
   constructor(private http: HttpClient) {}
 
@@ -102,11 +106,11 @@ export class TrainingService {
     this.resetSelectedTraining();
   }
 
-  public getTrainingCategorySelectedForTrainingRecord(): SelectedTrainingCategory {
+  public getTrainingCategorySelectedForTrainingRecord(): Category {
     return this._trainingCategorySelectedForTrainingRecord;
   }
 
-  public setTrainingCategorySelectedForTrainingRecord(trainingCategory: any): void {
+  public setTrainingCategorySelectedForTrainingRecord(trainingCategory: SelectedTrainingCategory) {
     if (trainingCategory?.category) {
       this._trainingCategorySelectedForTrainingRecord = {
         id: trainingCategory.category?.id,

--- a/frontend/src/app/core/test-utils/MockTrainingService.ts
+++ b/frontend/src/app/core/test-utils/MockTrainingService.ts
@@ -11,6 +11,7 @@ const workers = [workerBuilder(), workerBuilder()];
 export class MockTrainingService extends TrainingService {
   public selectedStaff = [];
   public _mockTrainingOrQualificationPreviouslySelected: string = null;
+  public _mockTrainingCategorySelectedForTrainingRecord: any = null;
 
   public get trainingOrQualificationPreviouslySelected() {
     return null;
@@ -19,6 +20,7 @@ export class MockTrainingService extends TrainingService {
   public set trainingOrQualificationPreviouslySelected(value: string) {
     this._mockTrainingOrQualificationPreviouslySelected = value;
   }
+
   public selectedTraining = null;
   getCategories(): Observable<TrainingCategory[]> {
     return of([
@@ -175,6 +177,14 @@ export class MockTrainingService extends TrainingService {
 
   public deleteCategoryById(establishmentId, categoryId) {
     return of({});
+  }
+
+  public getTrainingCategorySelectedForTrainingRecord(): any {
+    return this._mockTrainingCategorySelectedForTrainingRecord;
+  }
+
+  public clearTrainingCategorySelectedForTrainingRecord(): void {
+    this._mockTrainingCategorySelectedForTrainingRecord = null;
   }
 }
 

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
@@ -18,7 +18,7 @@ import sinon from 'sinon';
 
 import { AddEditTrainingComponent } from './add-edit-training.component';
 
-describe('AddEditTrainingComponent', () => {
+fdescribe('AddEditTrainingComponent', () => {
   async function setup(trainingRecordId = '1', qsParamGetMock = sinon.fake()) {
     const { fixture, getByText, getAllByText, getByTestId, queryByText, queryByTestId, getByLabelText } = await render(
       AddEditTrainingComponent,
@@ -132,6 +132,32 @@ describe('AddEditTrainingComponent', () => {
       expect(getByText('Autism')).toBeTruthy();
       expect(form.value).toEqual(expectedFormValue);
     });
+
+    it('should show the training category displayed as text with a change link when there is a training category present and update the form value', async () => {
+      const qsParamGetMock = sinon.stub();
+      const { component, fixture, getByText, getByTestId, queryByTestId } = await setup(null, qsParamGetMock);
+
+      component.trainingCategory = {
+        category: 'Autism',
+        id: 1,
+      };
+
+      const { form } = component;
+      const expectedFormValue = {
+        title: null,
+        category: 1,
+        accredited: null,
+        completed: { day: null, month: null, year: null },
+        expires: { day: null, month: null, year: null },
+        notes: null,
+      };
+
+      expect(getByTestId('trainingCategoryDisplay')).toBeTruthy();
+      expect(queryByTestId('trainingSelect')).toBeFalsy();
+      expect(getByText('Autism')).toBeTruthy();
+      expect(form.value).toEqual(expectedFormValue);
+      expect(getByTestId('changeTrainingCategoryLink')).toBeTruthy();
+    });
   });
 
   describe('title', () => {
@@ -139,7 +165,7 @@ describe('AddEditTrainingComponent', () => {
       const trainingRecordId = null;
       const { getByText } = await setup(trainingRecordId);
 
-      expect(getByText('Select the category that best matches the training taken')).toBeTruthy();
+      expect(getByText('Add training record details')).toBeTruthy();
     });
 
     it('should render the Training details title, when there is a training record id', async () => {

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
@@ -408,16 +408,12 @@ describe('AddEditTrainingComponent', () => {
       fixture.detectChanges();
 
       component.previousUrl = ['/goToPreviousUrl'];
-      fixture.detectChanges();
 
       userEvent.type(getByLabelText('Training name'), 'Some training');
       userEvent.click(getByLabelText('No'));
 
       const trainingServiceSpy = spyOn(trainingService, 'clearTrainingCategorySelectedForTrainingRecord');
       fireEvent.click(getByText('Save record'));
-      fixture.detectChanges();
-
-      fixture.detectChanges();
 
       expect(routerSpy).toHaveBeenCalledWith(['/goToPreviousUrl']);
       expect(trainingServiceSpy).toHaveBeenCalled();

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -55,7 +55,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
   }
 
   public setTitle(): void {
-    this.title = this.trainingRecordId ? 'Training record details' : 'Select the category that best matches the training taken';
+    this.title = this.trainingRecordId ? 'Training record details' : 'Add training record details';
   }
 
   protected setSectionHeading(): void {

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -17,6 +17,8 @@ import { AddEditTrainingDirective } from '../../../shared/directives/add-edit-tr
 })
 export class AddEditTrainingComponent extends AddEditTrainingDirective implements OnInit, AfterViewInit {
   public category: string;
+  public establishmentUid: string;
+  public workerId: string;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -51,6 +53,16 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
       this.form.patchValue({
         category: this.trainingCategory.id,
       });
+    }
+
+    this.establishmentUid = this.route.snapshot.params?.establishmentuid;
+    this.workerId = this.route.snapshot.params?.id;
+
+    if (!this.trainingCategory) {
+      this.router.navigate([
+        `workplace/${this.establishmentUid}/training-and-qualifications-record/${this.workerId}/add-training`,
+      ]);
+      return;
     }
   }
 
@@ -127,6 +139,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
   }
 
   private onSuccess() {
+    this.trainingService.clearTrainingCategorySelectedForTrainingRecord();
     const message = this.trainingRecordId ? 'Training record updated' : 'Training record added';
 
     this.router.navigate(this.previousUrl).then(() => {

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -43,7 +43,7 @@
               <a
                 *ngIf="showChangeLink"
                 data-testid="changeTrainingCategoryLink"
-                class="govuk-link--no-visited-state govuk-!-margin-left-8"
+                class="govuk-link--no-visited-state govuk-!-margin-left-4"
                 [routerLink]="['..']"
                 >Change</a
               >

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -43,7 +43,7 @@
               <a
                 *ngIf="showChangeLink"
                 data-testid="changeTrainingCategoryLink"
-                class="govuk-link govuk-!-margin-left-4"
+                class="govuk-link--no-visited-state govuk-!-margin-left-8"
                 [routerLink]="['..']"
                 >Change</a
               >

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -38,7 +38,16 @@
         <ng-template #noDropdown>
           <p class="govuk-body govuk-!-margin-bottom-6" data-testid="trainingCategoryDisplay">
             <span class="govuk-util__block"><b>Training category</b></span>
-            <span class="govuk-util__block govuk-!-margin-top-2">{{ category }}</span>
+            <span class="govuk-util__block govuk-!-margin-top-2"
+              >{{ category }}
+              <a
+                *ngIf="showChangeLink"
+                data-testid="changeTrainingCategoryLink"
+                class="govuk-link govuk-!-margin-left-4"
+                [routerLink]="['..']"
+                >Change</a
+              >
+            </span>
           </p>
         </ng-template>
 
@@ -151,7 +160,7 @@
             }"
             aria-live="polite"
           >
-            <noscript> You can enter up to {{ notesMaxLength }} characters  </noscript>
+            <noscript> You can enter up to {{ notesMaxLength }} characters </noscript>
             <ng-container>
               You have {{ remainingCharacterCount | absoluteNumber | number }}
               {{

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -39,7 +39,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
   public showWorkerCount = false;
   public remainingCharacterCount: number = this.notesMaxLength;
   public notesValue = '';
-  public showChangeLink: boolean;
+  public showChangeLink: boolean = false;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -71,17 +71,15 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
     this.errorSummaryService.formEl$.next(this.formEl);
   }
 
-  public checkForCategoryId() {
-    console.log(this.trainingService.getTrainingCategorySelectedForTrainingRecord());
-    console.log(this.route.snapshot.queryParamMap);
-    //const selectedCategoryId = this.trainingService.getTrainingCategorySelectedForTrainingRecord();
+  public checkForCategoryId(): void {
+    const selectedCategoryId = this.trainingService.getTrainingCategorySelectedForTrainingRecord();
+
     if (this.route.snapshot.queryParamMap.get('trainingCategory')) {
       this.trainingCategory = JSON.parse(this.route.snapshot.queryParamMap.get('trainingCategory'));
+    } else if (selectedCategoryId) {
+      this.trainingCategory = selectedCategoryId;
+      this.showChangeLink = true;
     }
-    // else {
-    //   this.trainingCategory = { id: 1, category: 'Activity provision, wellbeing' };
-    //   this.showChangeLink = true;
-    // }
   }
 
   public handleOnInput(event: Event) {

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -39,6 +39,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
   public showWorkerCount = false;
   public remainingCharacterCount: number = this.notesMaxLength;
   public notesValue = '';
+  public showChangeLink: boolean;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -53,9 +54,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
 
   ngOnInit(): void {
     this.workplace = this.route.parent.snapshot.data.establishment;
-    if (this.route.snapshot.queryParamMap.get('trainingCategory')) {
-      this.trainingCategory = JSON.parse(this.route.snapshot.queryParamMap.get('trainingCategory'));
-    }
+    this.checkForCategoryId();
     this.previousUrl = [localStorage.getItem('previousUrl')];
     this.setupForm();
     this.init();
@@ -70,6 +69,19 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.errorSummaryService.formEl$.next(this.formEl);
+  }
+
+  public checkForCategoryId() {
+    console.log(this.trainingService.getTrainingCategorySelectedForTrainingRecord());
+    console.log(this.route.snapshot.queryParamMap);
+    //const selectedCategoryId = this.trainingService.getTrainingCategorySelectedForTrainingRecord();
+    if (this.route.snapshot.queryParamMap.get('trainingCategory')) {
+      this.trainingCategory = JSON.parse(this.route.snapshot.queryParamMap.get('trainingCategory'));
+    }
+    // else {
+    //   this.trainingCategory = { id: 1, category: 'Activity provision, wellbeing' };
+    //   this.showChangeLink = true;
+    // }
   }
 
   public handleOnInput(event: Event) {


### PR DESCRIPTION
#### Work done
- Show text of category chosen in previous page of add training record
- Add change link to go back to page to change the chosen category
- Redirects back to category page if there's no category id found in training service for add, or params for edit. This will prevent the page being incorrect, on page refresh

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
