### PR TITLE
Fix/1476 create parent approvals for old parent accounts

### DIFF
--- a/backend/migrations/20240726100029-createParentApprovalForOldParentAccounts.js
+++ b/backend/migrations/20240726100029-createParentApprovalForOldParentAccounts.js
@@ -1,0 +1,54 @@
+'use strict';
+const models = require('../server/models/index');
+
+const dateAccountsCreatedInService = new Date('2019-08-30T00:00:00Z');
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      const parentEstablishmentsWithoutApprovalRecord = await queryInterface.sequelize.query(
+        `
+          SELECT e."EstablishmentID", u."RegistrationID"
+          FROM cqc."Establishment" e
+          LEFT JOIN cqc."Approvals" a ON e."EstablishmentID" = a."EstablishmentID"
+          JOIN cqc."User" u ON e."EstablishmentID" = u."EstablishmentID"
+            WHERE a."EstablishmentID" IS NULL AND e."IsParent" = true
+            AND e."IsRegulated" = true
+            AND e."Archived" = false
+            AND u."IsPrimary" = true;
+        `,
+        { type: Sequelize.QueryTypes.SELECT, transaction },
+      );
+
+      for (const establishment of parentEstablishmentsWithoutApprovalRecord) {
+        await models.Approvals.create(
+          {
+            EstablishmentID: establishment.EstablishmentID,
+            ApprovalType: 'BecomeAParent',
+            UserID: establishment.RegistrationID,
+            Status: 'Approved',
+            createdAt: dateAccountsCreatedInService,
+            updatedAt: dateAccountsCreatedInService,
+          },
+          {
+            transaction,
+            silent: true, // prevents updatedAt being overridden
+          },
+        );
+      }
+    });
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await models.Approvals.destroy(
+        {
+          where: {
+            createdAt: dateAccountsCreatedInService,
+          },
+        },
+        { transaction },
+      );
+    });
+  },
+};

--- a/backend/migrations/20240726100029-createParentApprovalForOldParentAccounts.js
+++ b/backend/migrations/20240726100029-createParentApprovalForOldParentAccounts.js
@@ -15,7 +15,8 @@ module.exports = {
             WHERE a."EstablishmentID" IS NULL AND e."IsParent" = true
             AND e."IsRegulated" = true
             AND e."Archived" = false
-            AND u."IsPrimary" = true;
+            AND u."IsPrimary" = true
+            AND u."Archived" = false;
         `,
         { type: Sequelize.QueryTypes.SELECT, transaction },
       );

--- a/backend/migrations/20240726100029-createParentApprovalForOldParentAccounts.js
+++ b/backend/migrations/20240726100029-createParentApprovalForOldParentAccounts.js
@@ -13,7 +13,6 @@ module.exports = {
           LEFT JOIN cqc."Approvals" a ON e."EstablishmentID" = a."EstablishmentID"
           JOIN cqc."User" u ON e."EstablishmentID" = u."EstablishmentID"
             WHERE a."EstablishmentID" IS NULL AND e."IsParent" = true
-            AND e."IsRegulated" = true
             AND e."Archived" = false
             AND u."IsPrimary" = true
             AND u."Archived" = false;


### PR DESCRIPTION
#### Issue
CQC providers with missing child workplaces should see the '_Have you added all your workplaces?_' message after they have been a parent for more than eight weeks. Investigation found that some old accounts did not have a record for when they became a parent, so this PR adds records for parent approval to these accounts so that they can see these messages.

#### Work done
- Created database migration to add become a parent records to parent workplaces with no approval record

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
