### PR TITLE
Fix/1477 cqc workplace questions in sub navigate to parent

### DIFF
--- a/frontend/src/app/features/workplace/regulated-by-cqc/regulated-by-cqc.component.spec.ts
+++ b/frontend/src/app/features/workplace/regulated-by-cqc/regulated-by-cqc.component.spec.ts
@@ -1,0 +1,43 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { LocationService } from '@core/services/location.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { RegulatedByCqcComponent } from './regulated-by-cqc.component';
+
+describe('RegulatedByCqcComponent', () => {
+  const workplaceUid = 'abc131355543435';
+
+  async function setup() {
+    const { fixture, getByText } = await render(RegulatedByCqcComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+      providers: [
+        UntypedFormBuilder,
+        {
+          provide: EstablishmentService,
+          useValue: {
+            establishment: { uid: workplaceUid },
+          },
+        },
+        LocationService,
+      ],
+    });
+
+    const component = fixture.componentInstance;
+
+    return {
+      component,
+      fixture,
+      getByText,
+    };
+  }
+
+  it('should render a RegulatedByCqcComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/features/workplace/regulated-by-cqc/regulated-by-cqc.component.ts
+++ b/frontend/src/app/features/workplace/regulated-by-cqc/regulated-by-cqc.component.ts
@@ -30,7 +30,7 @@ export class RegulatedByCqcComponent extends RegulatedByCQCDirective {
   }
 
   protected init() {
-    this.flow = `workplace/${this.establishmentService.establishmentId}`;
+    this.flow = `workplace/${this.establishmentService.establishment.uid}`;
     this.isCQCLocationUpdate = true;
     this.setBackLink();
     this.validateLocationChange();

--- a/frontend/src/app/features/workplace/select-main-service/select-main-service-cqc.component.ts
+++ b/frontend/src/app/features/workplace/select-main-service/select-main-service-cqc.component.ts
@@ -36,8 +36,6 @@ export class SelectMainServiceCqcComponent extends Question {
         ],
       },
     ];
-
-    this.form.get('cqc'); // If it's stupid but it works, it isn't stupid.
   }
 
   public onSubmit(): void {
@@ -51,7 +49,7 @@ export class SelectMainServiceCqcComponent extends Question {
 
     if (this.form.valid) {
       this.establishmentService.mainServiceCQC = this.form.get('cqc').value;
-      this.router.navigate(['/workplace', this.establishmentService.establishmentId, 'main-service']);
+      this.router.navigate(['/workplace', this.establishment.uid, 'main-service']);
     } else {
       this.errorSummaryService.scrollToErrorSummary();
     }

--- a/frontend/src/app/features/workplace/select-main-service/select-main-service.component.spec.ts
+++ b/frontend/src/app/features/workplace/select-main-service/select-main-service.component.spec.ts
@@ -10,7 +10,7 @@ import { render } from '@testing-library/angular';
 
 describe('SelectMainServiceComponent', () => {
   async function setup() {
-    const component = await render(SelectMainServiceComponent, {
+    const { fixture, getByText } = await render(SelectMainServiceComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
         {
@@ -20,8 +20,11 @@ describe('SelectMainServiceComponent', () => {
       ],
     });
 
+    const component = fixture.componentInstance;
+
     return {
       component,
+      getByText,
     };
   }
 
@@ -32,7 +35,14 @@ describe('SelectMainServiceComponent', () => {
   });
 
   it('should render a subheading of Services', async () => {
-    const { component } = await setup();
-    expect(component.getByText('Services')).toBeTruthy();
+    const { getByText } = await setup();
+    expect(getByText('Services')).toBeTruthy();
+  });
+
+  it('should have cancel link with href back to dashboard', async () => {
+    const { getByText } = await setup();
+
+    const cancelLink = getByText('Cancel');
+    expect(cancelLink.getAttribute('href')).toEqual('/dashboard');
   });
 });

--- a/frontend/src/app/features/workplace/select-main-service/select-main-service.component.ts
+++ b/frontend/src/app/features/workplace/select-main-service/select-main-service.component.ts
@@ -31,6 +31,7 @@ export class SelectMainServiceComponent extends SelectMainServiceDirective {
     this.workplace = this.establishmentService.establishment;
     this.selectedMainService = this.workplace.mainService;
     this.isWorkPlaceUpdate = true;
+    this.flow = 'dashboard';
   }
 
   protected getServiceCategories() {

--- a/frontend/src/app/features/workplace/select-workplace/select-workplace.component.spec.ts
+++ b/frontend/src/app/features/workplace/select-workplace/select-workplace.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed, TestBed } from '@angular/core/testing';
-import { UntypedFormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BackService } from '@core/services/back.service';
@@ -134,12 +134,9 @@ describe('SelectWorkplaceComponent', () => {
       const continueButton = getByText('Save and return');
       fireEvent.click(continueButton);
 
-      expect(spy).toHaveBeenCalledWith(
-        [`workplace/${component.establishmentService.establishmentId}`, 'cannot-create-account'],
-        {
-          state: { returnTo: `workplace/${component.establishmentService.establishmentId}/select-workplace` },
-        },
-      );
+      expect(spy).toHaveBeenCalledWith([`workplace/${component.workplace.uid}`, 'cannot-create-account'], {
+        state: { returnTo: `workplace/${component.workplace.uid}/select-workplace` },
+      });
     });
 
     it('should navigate to the back to the workplace page when workplace selected and the establishment does not already exists in the service', async () => {
@@ -188,7 +185,7 @@ describe('SelectWorkplaceComponent', () => {
       component.setBackLink();
 
       expect(backLinkSpy).toHaveBeenCalledWith({
-        url: [`workplace/${component.establishmentService.establishmentId}/regulated-by-cqc`],
+        url: [`workplace/${component.workplace.uid}/regulated-by-cqc`],
       });
     });
   });

--- a/frontend/src/app/features/workplace/select-workplace/select-workplace.component.ts
+++ b/frontend/src/app/features/workplace/select-workplace/select-workplace.component.ts
@@ -31,8 +31,8 @@ export class SelectWorkplaceComponent extends SelectWorkplaceDirective {
   }
 
   protected init(): void {
-    this.flow = `workplace/${this.establishmentService.establishmentId}`;
     this.workplace = this.establishmentService.establishment;
+    this.flow = `workplace/${this.workplace.uid}`;
     this.back = `${this.flow}/regulated-by-cqc`;
     !this.locationAddresses && this.redirect();
     this.isCQCLocationUpdate = true;

--- a/frontend/src/app/features/workplace/workplace-not-found/workplace-not-found.component.spec.ts
+++ b/frontend/src/app/features/workplace/workplace-not-found/workplace-not-found.component.spec.ts
@@ -1,0 +1,51 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { LocationService } from '@core/services/location.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { WorkplaceNotFoundComponent } from './workplace-not-found.component';
+
+describe('WorkplaceNotFoundComponent', () => {
+  const workplaceUid = 'abc131355543435';
+
+  async function setup() {
+    const { fixture, getByText } = await render(WorkplaceNotFoundComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+      providers: [
+        UntypedFormBuilder,
+        {
+          provide: EstablishmentService,
+          useValue: {
+            establishment: { uid: workplaceUid },
+          },
+        },
+        LocationService,
+      ],
+    });
+
+    const component = fixture.componentInstance;
+
+    return {
+      component,
+      fixture,
+      getByText,
+    };
+  }
+
+  it('should render a WorkplaceNotFoundComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should show a go back link with workplace uid in url', async () => {
+    const { getByText } = await setup();
+
+    const link = getByText('go back and try again');
+
+    expect(link.getAttribute('href')).toEqual(`/workplace/${workplaceUid}/regulated-by-cqc`);
+  });
+});

--- a/frontend/src/app/features/workplace/workplace-not-found/workplace-not-found.component.ts
+++ b/frontend/src/app/features/workplace/workplace-not-found/workplace-not-found.component.ts
@@ -23,13 +23,13 @@ export class WorkplaceNotFoundComponent extends WorkplaceNotFound {
     protected locationService: LocationService,
     protected router: Router,
     protected backService: BackService,
-    private establishmentService: EstablishmentService
+    private establishmentService: EstablishmentService,
   ) {
     super(formBuilder, backService, errorSummaryService, locationService, router);
   }
   protected init(): void {
-    this.flow = `workplace/${this.establishmentService.establishmentId}`;
     this.workplace = this.establishmentService.establishment;
+    this.flow = `workplace/${this.workplace.uid}`;
     this.setBackLink();
   }
 


### PR DESCRIPTION
#### Issue
Users were being taken back to the parent view on certain CQC/workplace details pages after clicking Continue to navigate to the next page. This was due to the uid of the primary workplace being set in the URL for the pages you navigate to, instead of the uid of the workplace the user is currently viewing.

#### Work done
- Updated pages to use the uid of the current workplace for setting URLs of pages to navigate to
  - Workplace not found page
  - New main service regulated by CQC
  - Select workplace
  - Postcode/location ID entry page for CQC regulated workplaces 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
