### PR TITLE
Create migration to ensure workplaces with CQC status change records have parent approval record

### DIFF
--- a/backend/migrations/20240730084222-updateParentApprovalForWorkplacesWithCqcChangeRecord.js
+++ b/backend/migrations/20240730084222-updateParentApprovalForWorkplacesWithCqcChangeRecord.js
@@ -1,0 +1,55 @@
+'use strict';
+const models = require('../server/models/index');
+
+const dateAccountsCreatedInService = new Date('2019-08-30T00:00:00Z');
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      const remainingParentEstablishmentsWithoutApprovalRecord = await queryInterface.sequelize.query(
+        `
+          SELECT e."EstablishmentID", u."RegistrationID"
+          FROM cqc."Establishment" e
+          LEFT JOIN cqc."Approvals" a ON e."EstablishmentID" = a."EstablishmentID"
+          AND a."ApprovalType" = 'BecomeAParent'
+          JOIN cqc."User" u ON e."EstablishmentID" = u."EstablishmentID"
+            WHERE a."EstablishmentID" IS NULL AND e."IsParent" = true
+            AND e."Archived" = false
+            AND u."IsPrimary" = true
+            AND u."Archived" = false;
+        `,
+        { type: Sequelize.QueryTypes.SELECT, transaction },
+      );
+
+      for (const establishment of remainingParentEstablishmentsWithoutApprovalRecord) {
+        await models.Approvals.create(
+          {
+            EstablishmentID: establishment.EstablishmentID,
+            ApprovalType: 'BecomeAParent',
+            UserID: establishment.RegistrationID,
+            Status: 'Approved',
+            createdAt: dateAccountsCreatedInService,
+            updatedAt: dateAccountsCreatedInService,
+          },
+          {
+            transaction,
+            silent: true, // prevents updatedAt being overridden
+          },
+        );
+      }
+    });
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await models.Approvals.destroy(
+        {
+          where: {
+            createdAt: dateAccountsCreatedInService,
+          },
+        },
+        { transaction },
+      );
+    });
+  },
+};


### PR DESCRIPTION
#### Issue
[The previous fix PR](https://github.com/NMDSdevopsServiceAdm/SopraSteria-SFC/pull/6305) created a migration to add become a parent records to parent workplaces with no approval record. This worked on the assumption that these accounts would have no records in the Approvals table. However, workplaces with CQC status change records were not included in the update. This PR ensures those workplaces are also updated.

#### Work done
- Created new migration to ensure workplaces with CQC status change records have parent approval record, by adding check for parent approval type to the previous query.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
