### PR TITLE
1481 training add multiple records summary

### DIFF
--- a/frontend/src/app/core/model/training.model.ts
+++ b/frontend/src/app/core/model/training.model.ts
@@ -9,6 +9,10 @@ export interface TrainingCategoryResponse {
   trainingCategories: TrainingCategory[];
 }
 
+export interface SelectedTraining extends Omit<TrainingRecordRequest, 'trainingCategory'> {
+  trainingCategory: TrainingCategory;
+}
+
 export interface TrainingRecordRequest {
   trainingCategory: {
     id: number;

--- a/frontend/src/app/core/services/training.service.spec.ts
+++ b/frontend/src/app/core/services/training.service.spec.ts
@@ -48,34 +48,40 @@ describe('TrainingService', () => {
     });
   });
 
-  describe('trainingCategorySelectedForTrainingRecord', () => {
-    it('should return the training category selected for training record', () => {
-      service.setTrainingCategorySelectedForTrainingRecord({
+  describe('setSelectedTrainingCategory', () => {
+    it('should update the training category selected for training record', () => {
+      service.setSelectedTrainingCategory({
         id: 1,
         category: 'Activity provision, wellbeing',
         seq: 0,
         trainingCategoryGroup: 'Care skills and knowledge',
       });
 
-      expect(service.getTrainingCategorySelectedForTrainingRecord()).toEqual({
-        id: 1,
-        category: 'Activity provision, wellbeing',
-        seq: 0,
-        trainingCategoryGroup: 'Care skills and knowledge',
-      });
+      expect(service.selectedTraining).toEqual(
+        jasmine.objectContaining({
+          trainingCategory: {
+            id: 1,
+            category: 'Activity provision, wellbeing',
+            seq: 0,
+            trainingCategoryGroup: 'Care skills and knowledge',
+          },
+        }),
+      );
     });
+  });
 
-    it('should clear trainingCategorySelectedForTrainingRecord', () => {
-      service.setTrainingCategorySelectedForTrainingRecord({
+  describe('clearSelectedTrainingCategory', () => {
+    it('should clear the training category selected for training record', () => {
+      service.setSelectedTrainingCategory({
         id: 1,
         category: 'Activity provision, wellbeing',
         seq: 0,
         trainingCategoryGroup: 'Care skills and knowledge',
       });
 
-      service.clearTrainingCategorySelectedForTrainingRecord();
+      service.clearSelectedTrainingCategory();
 
-      expect(service.getTrainingCategorySelectedForTrainingRecord()).toBeNull();
+      expect(service.selectedTraining.trainingCategory).toBeNull();
     });
   });
 

--- a/frontend/src/app/core/services/training.service.spec.ts
+++ b/frontend/src/app/core/services/training.service.spec.ts
@@ -57,16 +57,12 @@ describe('TrainingService', () => {
         trainingCategoryGroup: 'Care skills and knowledge',
       });
 
-      expect(service.selectedTraining).toEqual(
-        jasmine.objectContaining({
-          trainingCategory: {
-            id: 1,
-            category: 'Activity provision, wellbeing',
-            seq: 0,
-            trainingCategoryGroup: 'Care skills and knowledge',
-          },
-        }),
-      );
+      expect(service.selectedTraining.trainingCategory).toEqual({
+        id: 1,
+        category: 'Activity provision, wellbeing',
+        seq: 0,
+        trainingCategoryGroup: 'Care skills and knowledge',
+      });
     });
   });
 

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -15,7 +15,6 @@ export class TrainingService {
   public selectedStaff: Worker[] = [];
   public addMultipleTrainingInProgress$ = new BehaviorSubject<boolean>(false);
   private _trainingOrQualificationPreviouslySelected: string = null;
-  private _trainingCategorySelectedForTrainingRecord: TrainingCategory = null;
   public updatingSelectedStaffForMultipleTraining: boolean = null;
 
   constructor(private http: HttpClient) {}
@@ -94,17 +93,23 @@ export class TrainingService {
   }
 
   public getTrainingCategorySelectedForTrainingRecord(): TrainingCategory {
-    return this._trainingCategorySelectedForTrainingRecord;
+    return this.selectedTraining?.trainingCategory ?? null;
   }
 
   public setTrainingCategorySelectedForTrainingRecord(trainingCategory: TrainingCategory) {
     if (trainingCategory) {
-      this._trainingCategorySelectedForTrainingRecord = trainingCategory;
+      if (this.selectedTraining) {
+        this.selectedTraining.trainingCategory = trainingCategory;
+      } else {
+        this.selectedTraining = { trainingCategory };
+      }
     }
   }
 
   public clearTrainingCategorySelectedForTrainingRecord(): void {
-    this._trainingCategorySelectedForTrainingRecord = null;
+    if ('trainingCategory' in this.selectedTraining) {
+      this.selectedTraining.trainingCategory = null;
+    }
   }
 
   public setUpdatingSelectedStaffForMultipleTraining(value: boolean): void {

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -107,7 +107,7 @@ export class TrainingService {
   }
 
   public clearTrainingCategorySelectedForTrainingRecord(): void {
-    if ('trainingCategory' in this.selectedTraining) {
+    if (this?.selectedTraining?.trainingCategory) {
       this.selectedTraining.trainingCategory = null;
     }
   }

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -1,7 +1,12 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Params } from '@angular/router';
-import { allMandatoryTrainingCategories, TrainingCategory, TrainingCategoryResponse } from '@core/model/training.model';
+import {
+  allMandatoryTrainingCategories,
+  TrainingCategory,
+  TrainingCategoryResponse,
+  SelectedTraining,
+} from '@core/model/training.model';
 import { Worker } from '@core/model/worker.model';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -11,7 +16,7 @@ import { environment } from 'src/environments/environment';
   providedIn: 'root',
 })
 export class TrainingService {
-  public selectedTraining = null;
+  protected _selectedTraining = null;
   public selectedStaff: Worker[] = [];
   public addMultipleTrainingInProgress$ = new BehaviorSubject<boolean>(false);
   private _trainingOrQualificationPreviouslySelected: string = null;
@@ -51,12 +56,18 @@ export class TrainingService {
     this.selectedStaff = [];
   }
 
-  public updateSelectedTraining(formValue): void {
-    this.selectedTraining = formValue;
+  public get selectedTraining(): SelectedTraining {
+    return this._selectedTraining;
+  }
+
+  public set selectedTraining(selectedTraining: SelectedTraining) {
+    if (selectedTraining) {
+      this._selectedTraining = selectedTraining;
+    }
   }
 
   public resetSelectedTraining(): void {
-    this.selectedTraining = null;
+    this._selectedTraining = null;
   }
 
   //get all mandatory training
@@ -89,26 +100,22 @@ export class TrainingService {
     this.addMultipleTrainingInProgress$.next(false);
     this.resetSelectedStaff();
     this.resetSelectedTraining();
-    this.clearTrainingCategorySelectedForTrainingRecord();
+    this.clearSelectedTrainingCategory();
   }
 
-  public getTrainingCategorySelectedForTrainingRecord(): TrainingCategory {
-    return this.selectedTraining?.trainingCategory ?? null;
-  }
-
-  public setTrainingCategorySelectedForTrainingRecord(trainingCategory: TrainingCategory) {
+  public setSelectedTrainingCategory(trainingCategory: TrainingCategory) {
     if (trainingCategory) {
-      if (this.selectedTraining) {
-        this.selectedTraining.trainingCategory = trainingCategory;
+      if (this._selectedTraining) {
+        this._selectedTraining.trainingCategory = trainingCategory;
       } else {
-        this.selectedTraining = { trainingCategory };
+        this._selectedTraining = { trainingCategory };
       }
     }
   }
 
-  public clearTrainingCategorySelectedForTrainingRecord(): void {
-    if (this?.selectedTraining?.trainingCategory) {
-      this.selectedTraining.trainingCategory = null;
+  public clearSelectedTrainingCategory(): void {
+    if (this?._selectedTraining?.trainingCategory) {
+      this._selectedTraining.trainingCategory = null;
     }
   }
 

--- a/frontend/src/app/core/test-utils/MockTrainingService.ts
+++ b/frontend/src/app/core/test-utils/MockTrainingService.ts
@@ -31,7 +31,6 @@ export class MockTrainingService extends TrainingService {
     this._mockTrainingOrQualificationPreviouslySelected = value;
   }
 
-  public selectedTraining = null;
   getCategories(): Observable<TrainingCategory[]> {
     return of([
       { id: 1, seq: 10, category: 'Activity provision/Well-being', trainingCategoryGroup: 'Care skills and knowledge' },
@@ -72,20 +71,12 @@ export class MockTrainingService extends TrainingService {
   public deleteCategoryById(establishmentId, categoryId) {
     return of({});
   }
-
-  public getTrainingCategorySelectedForTrainingRecord(): any {
-    return this._mockTrainingCategorySelectedForTrainingRecord;
-  }
-
-  public clearTrainingCategorySelectedForTrainingRecord(): void {
-    this._mockTrainingCategorySelectedForTrainingRecord = null;
-  }
 }
 
 @Injectable()
 export class MockTrainingServiceWithPreselectedStaff extends MockTrainingService {
   public selectedStaff = workers;
-  public selectedTraining = {
+  protected _selectedTraining = {
     accredited: 'Yes',
     trainingCategory: { id: 1, seq: 3, category: 'Category' },
     completed: '2020-01-01',
@@ -102,7 +93,7 @@ export class MockTrainingServiceWithPreselectedStaff extends MockTrainingService
     return (http: HttpClient) => {
       const service = new MockTrainingServiceWithPreselectedStaff(http);
       if (incompleteTraining) {
-        service.selectedTraining = { ...service.selectedTraining, completed: null, expires: null, notes: null };
+        service._selectedTraining = { ...service._selectedTraining, completed: null, expires: null, notes: null };
       }
       return service;
     };

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
@@ -131,9 +131,12 @@ describe('AddEditTrainingComponent', () => {
     it('should show the training category displayed as text with a change link when there is a training category present and update the form value', async () => {
       const { component, fixture, getByText, getByTestId, queryByTestId, trainingService } = await setup(null);
 
-      const trainingServiceSpy = spyOn(trainingService, 'getTrainingCategorySelectedForTrainingRecord').and.returnValue(
-        { id: 1, seq: 20, category: 'Autism', trainingCategoryGroup: 'Specific conditions and disabilities' },
-      );
+      trainingService.setSelectedTrainingCategory({
+        id: 1,
+        seq: 20,
+        category: 'Autism',
+        trainingCategoryGroup: 'Specific conditions and disabilities',
+      });
 
       component.ngOnInit();
       fixture.detectChanges();
@@ -151,7 +154,6 @@ describe('AddEditTrainingComponent', () => {
       expect(getByText('Autism')).toBeTruthy();
       expect(form.value).toEqual(expectedFormValue);
       expect(getByTestId('changeTrainingCategoryLink')).toBeTruthy();
-      expect(trainingServiceSpy).toHaveBeenCalled();
     });
   });
 
@@ -383,11 +385,9 @@ describe('AddEditTrainingComponent', () => {
     });
 
     it('should reset the training category selected for training record in the service on submit', async () => {
-      const { component, fixture, getByText, getByTestId, getByLabelText, trainingService, routerSpy } = await setup(
-        null,
-      );
+      const { component, fixture, getByText, getByLabelText, trainingService, routerSpy } = await setup(null);
 
-      spyOn(trainingService, 'getTrainingCategorySelectedForTrainingRecord').and.returnValue({
+      trainingService.setSelectedTrainingCategory({
         id: 2,
         seq: 20,
         category: 'Autism',
@@ -402,11 +402,13 @@ describe('AddEditTrainingComponent', () => {
       userEvent.type(getByLabelText('Training name'), 'Some training');
       userEvent.click(getByLabelText('No'));
 
-      const trainingServiceSpy = spyOn(trainingService, 'clearTrainingCategorySelectedForTrainingRecord');
+      const trainingServiceSpy = spyOn(trainingService, 'clearSelectedTrainingCategory').and.callThrough();
       fireEvent.click(getByText('Save record'));
 
       expect(routerSpy).toHaveBeenCalledWith(['/goToPreviousUrl']);
       expect(trainingServiceSpy).toHaveBeenCalled();
+
+      expect(trainingService.selectedTraining.trainingCategory).toBeNull();
     });
   });
 

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -142,7 +142,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
   }
 
   private onSuccess() {
-    this.trainingService.clearTrainingCategorySelectedForTrainingRecord();
+    this.trainingService.clearSelectedTrainingCategory();
     const message = this.trainingRecordId ? 'Training record updated' : 'Training record added';
 
     this.router.navigate(this.previousUrl).then(() => {

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component.spec.ts
@@ -130,7 +130,7 @@ describe('SelectTrainingCategoryComponent', () => {
   it('should call the training service and navigate to the details page', async () => {
     const { component, getByText, routerSpy, trainingService } = await setup(true);
 
-    const trainingServiceSpy = spyOn(trainingService, 'setTrainingCategorySelectedForTrainingRecord').and.callThrough();
+    const trainingServiceSpy = spyOn(trainingService, 'setSelectedTrainingCategory').and.callThrough();
 
     const openAllLinkLink = getByText('Show all categories');
     fireEvent.click(openAllLinkLink);

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component.ts
@@ -35,7 +35,7 @@ export class SelectTrainingCategoryComponent extends SelectTrainingCategoryDirec
   }
 
   protected submit(selectedCategory): void {
-    this.trainingService.setTrainingCategorySelectedForTrainingRecord(selectedCategory);
+    this.trainingService.setSelectedTrainingCategory(selectedCategory);
     this.router.navigate([
       `workplace/${this.establishmentUid}/training-and-qualifications-record/${this.workerId}/add-training/details`,
     ]);
@@ -43,7 +43,7 @@ export class SelectTrainingCategoryComponent extends SelectTrainingCategoryDirec
 
   public onCancel(event: any) {
     event.preventDefault();
-    this.trainingService.clearTrainingCategorySelectedForTrainingRecord();
+    this.trainingService.clearSelectedTrainingCategory();
     this.router.navigate(['/dashboard'], { fragment: 'training-and-qualifications' });
   }
 

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.html
@@ -57,6 +57,14 @@
             <ng-container *ngIf="i === 0">
               <dd class="govuk-summary-list__actions">
                 <app-summary-record-change
+                  [link]="getRoutePath('select-training-category')"
+                  [hasData]="true"
+                ></app-summary-record-change>
+              </dd>
+            </ng-container>
+            <ng-container *ngIf="i === 1">
+              <dd class="govuk-summary-list__actions">
+                <app-summary-record-change
                   [link]="getRoutePath('training-details')"
                   [hasData]="true"
                 ></app-summary-record-change>

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.html
@@ -43,11 +43,11 @@
     <div class="govuk-grid-row govuk-!-margin-left-0 govuk-!-margin-right-0">
       <h2 class="govuk-heading-m">Training record details</h2>
       <dl
-        class="govuk-summary-list govuk-summary-list--no-border asc-summarylist-border-top asc-summarylist-border-bottom govuk-!-width-full"
+        class="govuk-summary-list govuk-summary-list asc-summarylist-border-top asc-summarylist-border-bottom govuk-!-width-full"
         data-testid="trainingRecordDetails"
       >
         <ng-container *ngFor="let record of trainingRecords; index as i">
-          <div class="govuk-summary-list__row">
+          <div class="govuk-summary-list__row" [class]="{ 'govuk-summary-list__row--no-border': i > 0 }">
             <dt class="govuk-summary-list__key">
               {{ record.key }}
             </dt>

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.spec.ts
@@ -144,8 +144,8 @@ describe('MultipleTrainingDetailsComponent', () => {
       const { getByTestId } = await setup();
 
       const trainingRecordDetails = getByTestId('trainingRecordDetails');
-      const trainingNameRow = within(trainingRecordDetails).getByText('Training category').parentElement;
-      const changeLink = within(trainingNameRow).getByText('Change');
+      const trainingCategoryRow = within(trainingRecordDetails).getByText('Training category').parentElement;
+      const changeLink = within(trainingCategoryRow).getByText('Change');
 
       expect(changeLink.getAttribute('href')).toEqual(
         '/workplace/98a83eef-e1e1-49f3-89c5-b1287a3cc8de/add-multiple-training/confirm-training/select-training-category',

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.spec.ts
@@ -140,11 +140,24 @@ describe('MultipleTrainingDetailsComponent', () => {
       expect(within(trainingRecordDetails).getByText('No notes added')).toBeTruthy();
     });
 
-    it('should display a change link with the correct href', async () => {
+    it('should display a change link with the correct href at Training category row which navigate to select training category page', async () => {
       const { getByTestId } = await setup();
 
       const trainingRecordDetails = getByTestId('trainingRecordDetails');
-      const changeLink = within(trainingRecordDetails).getByText('Change');
+      const trainingNameRow = within(trainingRecordDetails).getByText('Training category').parentElement;
+      const changeLink = within(trainingNameRow).getByText('Change');
+
+      expect(changeLink.getAttribute('href')).toEqual(
+        '/workplace/98a83eef-e1e1-49f3-89c5-b1287a3cc8de/add-multiple-training/confirm-training/select-training-category',
+      );
+    });
+
+    it('should display a change link with the correct href at Training name row which navigate to training detail page', async () => {
+      const { getByTestId } = await setup();
+
+      const trainingRecordDetails = getByTestId('trainingRecordDetails');
+      const trainingNameRow = within(trainingRecordDetails).getByText('Training name').parentElement;
+      const changeLink = within(trainingNameRow).getByText('Change');
 
       expect(changeLink.getAttribute('href')).toEqual(
         '/workplace/98a83eef-e1e1-49f3-89c5-b1287a3cc8de/add-multiple-training/confirm-training/training-details',

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.ts
@@ -40,7 +40,6 @@ export class ConfirmMultipleTrainingComponent implements OnInit {
 
   private convertTrainingRecord(): void {
     const training = this.trainingService.selectedTraining;
-
     this.trainingRecords = [
       { key: 'Training category', value: training.trainingCategory.category },
       { key: 'Training name', value: training.title ? training.title : '-' },

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/confirm-multiple-training/confirm-multiple-training.component.ts
@@ -40,6 +40,7 @@ export class ConfirmMultipleTrainingComponent implements OnInit {
 
   private convertTrainingRecord(): void {
     const training = this.trainingService.selectedTraining;
+
     this.trainingRecords = [
       { key: 'Training category', value: training.trainingCategory.category },
       { key: 'Training name', value: training.title ? training.title : '-' },

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.spec.ts
@@ -21,7 +21,7 @@ import { Establishment } from '@core/model/establishment.model';
 import { trainingCategories } from '@core/test-utils/MockTrainingCategoriesService';
 
 describe('SelectTrainingCategoryMultipleComponent', () => {
-  async function setup(prefill = false) {
+  async function setup(prefill = false, accessedFromSummary = false) {
     const establishment = establishmentBuilder() as Establishment;
     const { fixture, getByText, getAllByText, getByTestId } = await render(SelectTrainingCategoryMultipleComponent, {
       imports: [HttpClientTestingModule, SharedModule, RouterModule, RouterTestingModule, AddMultipleTrainingModule],
@@ -46,6 +46,9 @@ describe('SelectTrainingCategoryMultipleComponent', () => {
               data: {
                 establishment: establishment,
                 trainingCategories: trainingCategories,
+              },
+              parent: {
+                url: [{ path: accessedFromSummary ? 'confirm-training' : 'select-staff' }],
               },
             },
           },
@@ -95,10 +98,18 @@ describe('SelectTrainingCategoryMultipleComponent', () => {
     expect(heading).toBeTruthy();
   });
 
-  it('should show the continue button', async () => {
+  it('should show the continue button when it is not accessed from the confirm training page', async () => {
     const { getByText } = await setup(true);
 
     const button = getByText('Continue');
+
+    expect(button).toBeTruthy();
+  });
+
+  it('should show the save and return button when it is accessed from the confirm training page', async () => {
+    const { getByText } = await setup(true, true);
+
+    const button = getByText('Save and return');
 
     expect(button).toBeTruthy();
   });
@@ -146,7 +157,7 @@ describe('SelectTrainingCategoryMultipleComponent', () => {
     ]);
   });
 
-  it('should call the training service and navigate to the details page', async () => {
+  it('should call the training service and navigate to the details page when it is not accessed from the confirm training page', async () => {
     const { component, getByText, routerSpy, trainingService } = await setup(true);
 
     const trainingServiceSpy = spyOn(trainingService, 'setTrainingCategorySelectedForTrainingRecord').and.callThrough();
@@ -171,6 +182,34 @@ describe('SelectTrainingCategoryMultipleComponent', () => {
       component.establishmentUid,
       'add-multiple-training',
       'training-details',
+    ]);
+  });
+
+  it('should navigate back to the confirm training page when it is accessed from the confirm training page', async () => {
+    const { component, getByText, routerSpy, trainingService } = await setup(true, true);
+
+    const trainingServiceSpy = spyOn(trainingService, 'setTrainingCategorySelectedForTrainingRecord').and.callThrough();
+
+    const openAllLinkLink = getByText('Show all categories');
+    fireEvent.click(openAllLinkLink);
+
+    const wellbeingCategory = getByText('Activity provision/Well-being');
+    fireEvent.click(wellbeingCategory);
+
+    const saveAndReturnButton = getByText('Save and return');
+    fireEvent.click(saveAndReturnButton);
+
+    expect(trainingServiceSpy).toHaveBeenCalledWith({
+      id: 1,
+      seq: 10,
+      category: 'Activity provision/Well-being',
+      trainingCategoryGroup: 'Care skills and knowledge',
+    });
+    expect(routerSpy).toHaveBeenCalledWith([
+      'workplace',
+      component.establishmentUid,
+      'add-multiple-training',
+      'confirm-training',
     ]);
   });
 

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.spec.ts
@@ -160,7 +160,7 @@ describe('SelectTrainingCategoryMultipleComponent', () => {
   it('should call the training service and navigate to the details page when it is not accessed from the confirm training page', async () => {
     const { component, getByText, routerSpy, trainingService } = await setup(true);
 
-    const trainingServiceSpy = spyOn(trainingService, 'setTrainingCategorySelectedForTrainingRecord').and.callThrough();
+    const trainingServiceSpy = spyOn(trainingService, 'setSelectedTrainingCategory').and.callThrough();
 
     const openAllLinkLink = getByText('Show all categories');
     fireEvent.click(openAllLinkLink);
@@ -188,7 +188,7 @@ describe('SelectTrainingCategoryMultipleComponent', () => {
   it('should navigate back to the confirm training page when it is accessed from the confirm training page', async () => {
     const { component, getByText, routerSpy, trainingService } = await setup(true, true);
 
-    const trainingServiceSpy = spyOn(trainingService, 'setTrainingCategorySelectedForTrainingRecord').and.callThrough();
+    const trainingServiceSpy = spyOn(trainingService, 'setSelectedTrainingCategory').and.callThrough();
 
     const openAllLinkLink = getByText('Show all categories');
     fireEvent.click(openAllLinkLink);

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.ts
@@ -14,6 +14,7 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 export class SelectTrainingCategoryMultipleComponent extends SelectTrainingCategoryDirective implements OnInit {
   public selectedStaff = [];
   public accessedFromSummary = false;
+  submitButtonText: string;
 
   constructor(
     protected formBuilder: FormBuilder,

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.ts
@@ -30,6 +30,8 @@ export class SelectTrainingCategoryMultipleComponent extends SelectTrainingCateg
 
   init(): void {
     this.checkForSelectedStaff();
+    this.accessedFromSummary = this.route.snapshot.parent.url[0].path.includes('confirm-training');
+    this.submitButtonText = this.accessedFromSummary ? 'Save and return' : 'Continue';
   }
 
   public checkForSelectedStaff(): void {

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-training-category-multiple/select-training-category-multiple.component.ts
@@ -59,7 +59,7 @@ export class SelectTrainingCategoryMultipleComponent extends SelectTrainingCateg
   }
 
   protected submit(selectedCategory): void {
-    this.trainingService.setTrainingCategorySelectedForTrainingRecord(selectedCategory);
+    this.trainingService.setSelectedTrainingCategory(selectedCategory);
     const nextRoute = this.getNextRoute();
     this.trainingService.addMultipleTrainingInProgress$.next(true);
     this.router.navigate(['workplace', this.establishmentUid, 'add-multiple-training', nextRoute]);

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/training-details/training-details.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/training-details/training-details.component.spec.ts
@@ -81,7 +81,7 @@ describe('MultipleTrainingDetailsComponent', () => {
     const spy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
     const workerSpy = spyOn(workerService, 'createMultipleTrainingRecords').and.callThrough();
     const trainingSpy = spyOn(trainingService, 'resetState').and.callThrough();
-    const updateSelectedTrainingSpy = spyOn(trainingService, 'updateSelectedTraining');
+    const setSelectedTrainingSpy = spyOnProperty(trainingService, 'selectedTraining', 'set');
     const setUpdatingSelectedStaffForMultipleTrainingSpy = spyOn(
       trainingService,
       'setUpdatingSelectedStaffForMultipleTraining',
@@ -98,7 +98,7 @@ describe('MultipleTrainingDetailsComponent', () => {
       workerSpy,
       trainingService,
       trainingSpy,
-      updateSelectedTrainingSpy,
+      setSelectedTrainingSpy,
       setUpdatingSelectedStaffForMultipleTrainingSpy,
       queryByTestId,
     };
@@ -133,8 +133,7 @@ describe('MultipleTrainingDetailsComponent', () => {
   });
 
   it('should store the selected training in training service and navigate to the next page when filling out the form and clicking continue', async () => {
-    const { component, getByText, getByLabelText, getByTestId, fixture, updateSelectedTrainingSpy, spy } =
-      await setup();
+    const { component, getByText, getByLabelText, getByTestId, fixture, setSelectedTrainingSpy, spy } = await setup();
 
     component.trainingCategory = {
       id: component.categories[0].id,
@@ -159,7 +158,7 @@ describe('MultipleTrainingDetailsComponent', () => {
     fixture.detectChanges();
 
     expect(component.form.valid).toBeTruthy();
-    expect(updateSelectedTrainingSpy).toHaveBeenCalledWith({
+    expect(setSelectedTrainingSpy).toHaveBeenCalledWith({
       trainingCategory: component.categories[0],
       title: 'Training',
       accredited: 'Yes',
@@ -176,7 +175,7 @@ describe('MultipleTrainingDetailsComponent', () => {
   });
 
   it('should navigate to the confirm training page when page has been accessed from that page and pressing Save and return', async () => {
-    const { component, fixture, getByText, updateSelectedTrainingSpy, spy } = await setup(true, true);
+    const { component, fixture, getByText, setSelectedTrainingSpy, spy } = await setup(true, true);
 
     component.trainingCategory = {
       id: component.categories[0].id,
@@ -187,7 +186,7 @@ describe('MultipleTrainingDetailsComponent', () => {
     fireEvent.click(button);
     fixture.detectChanges();
 
-    expect(updateSelectedTrainingSpy).toHaveBeenCalledWith({
+    expect(setSelectedTrainingSpy).toHaveBeenCalledWith({
       trainingCategory: component.categories[0],
       title: 'Title',
       accredited: 'Yes',

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/training-details/training-details.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/training-details/training-details.component.spec.ts
@@ -29,7 +29,7 @@ describe('MultipleTrainingDetailsComponent', () => {
     isPrimaryWorkplace = true,
     qsParamGetMock = sinon.fake(),
   ) {
-    const { fixture, getByText, getAllByText, getByTestId, getByLabelText } = await render(
+    const { fixture, getByText, getAllByText, getByTestId, getByLabelText, queryByTestId } = await render(
       MultipleTrainingDetailsComponent,
       {
         imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, AddMultipleTrainingModule],
@@ -100,6 +100,7 @@ describe('MultipleTrainingDetailsComponent', () => {
       trainingSpy,
       updateSelectedTrainingSpy,
       setUpdatingSelectedStaffForMultipleTrainingSpy,
+      queryByTestId,
     };
   }
 
@@ -371,7 +372,7 @@ describe('MultipleTrainingDetailsComponent', () => {
       expect(changeStaffSelectedLink).toBeTruthy();
     });
 
-    it('should display a change link for training category selected', async () => {
+    it('should display a change link for training category selected if not accessed from summary page', async () => {
       const { component, fixture, getByTestId } = await setup(false, true);
 
       component.trainingCategory = {
@@ -387,6 +388,16 @@ describe('MultipleTrainingDetailsComponent', () => {
 
       expect(trainingCategoryDisplay).toBeTruthy();
       expect(changeTrainingCaegorySelectedLink).toBeTruthy();
+    });
+
+    it('should not display the number of staff and training category if accessed from summary page', async () => {
+      const { queryByTestId } = await setup(true, true);
+
+      const numberOfStaffSelected = queryByTestId('numberOfStaffSelected');
+      const trainingCategoryDisplay = queryByTestId('trainingCategoryDisplay');
+
+      expect(numberOfStaffSelected).toBeFalsy();
+      expect(trainingCategoryDisplay).toBeFalsy();
     });
 
     it('should call setIsSelectStaffChange when change is clicked for staff', async () => {

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/training-details/training-details.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/training-details/training-details.component.ts
@@ -17,6 +17,7 @@ import { TrainingCategoryService } from '@core/services/training-category.servic
 })
 export class MultipleTrainingDetailsComponent extends AddEditTrainingDirective implements OnInit, AfterViewInit {
   public showWorkerCount = true;
+  public showCategory = true;
   public workerCount: number = this.trainingService.selectedStaff.length;
   private accessedFromSummary = false;
   public category: string;
@@ -54,6 +55,8 @@ export class MultipleTrainingDetailsComponent extends AddEditTrainingDirective i
     if (this.trainingCategory) {
       this.category = this.trainingCategory.category;
     }
+
+    this.checkAccessFromSummaryAndHideElements();
   }
 
   protected setSection(): void {
@@ -94,6 +97,13 @@ export class MultipleTrainingDetailsComponent extends AddEditTrainingDirective i
 
   protected setButtonText(): void {
     this.buttonText = this.accessedFromSummary ? 'Save and return' : 'Continue';
+  }
+
+  protected checkAccessFromSummaryAndHideElements(): void {
+    if (this.accessedFromSummary) {
+      this.showWorkerCount = false;
+      this.showCategory = false;
+    }
   }
 
   protected submit(record: TrainingRecordRequest): void {

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/training-details/training-details.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/training-details/training-details.component.ts
@@ -108,7 +108,7 @@ export class MultipleTrainingDetailsComponent extends AddEditTrainingDirective i
 
   protected submit(record: TrainingRecordRequest): void {
     const trainingCategory = this.categories.find((category) => category.id === record.trainingCategory.id);
-    this.trainingService.updateSelectedTraining({ ...record, trainingCategory });
+    this.trainingService.selectedTraining = { ...record, trainingCategory };
     this.router.navigate(['workplace', this.workplace.uid, 'add-multiple-training', 'confirm-training']);
   }
 

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -34,7 +34,7 @@
         </div>
 
         <ng-container *ngIf="multipleTrainingDetails; else singleRecord">
-          <div class="govuk-body" data-testid="trainingCategoryDisplay">
+          <div *ngIf="showCategory" class="govuk-body" data-testid="trainingCategoryDisplay">
             <span class="govuk-util__block govuk-!-font-weight-bold">Training category</span>
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-three-quarters">

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -38,6 +38,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
   public section: string;
   public buttonText: string;
   public showWorkerCount = false;
+  public showCategory: boolean;
   public remainingCharacterCount: number = this.notesMaxLength;
   public notesValue = '';
   public showChangeLink: boolean = false;

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.directive.ts
@@ -76,7 +76,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
   }
 
   public checkForCategoryId(): void {
-    const selectedCategory = this.trainingService.getTrainingCategorySelectedForTrainingRecord();
+    const selectedCategory = this.trainingService.selectedTraining?.trainingCategory;
     if (selectedCategory) {
       this.trainingCategory = { id: selectedCategory.id, category: selectedCategory.category };
       this.showChangeLink = true;
@@ -284,7 +284,7 @@ export class AddEditTrainingDirective implements OnInit, AfterViewInit {
 
   public onCancel(event: Event): void {
     event.preventDefault();
-    this.trainingService.clearTrainingCategorySelectedForTrainingRecord();
+    this.trainingService.clearSelectedTrainingCategory();
     if (this.previousUrl?.length) {
       this.router.navigate(this.previousUrl);
     } else {

--- a/frontend/src/app/shared/directives/select-training-category/select-training-category.component.html
+++ b/frontend/src/app/shared/directives/select-training-category/select-training-category.component.html
@@ -36,7 +36,9 @@
     </div>
   </div>
   <div class="govuk-button-group">
-    <button type="submit" class="govuk-button govuk-!-margin-right-9" data-module="govuk-button">Continue</button>
+    <button type="submit" class="govuk-button govuk-!-margin-right-9" data-module="govuk-button">
+      {{ submitButtonText }}
+    </button>
     <a
       role="button"
       href="#"

--- a/frontend/src/app/shared/directives/select-training-category/select-training-category.directive.ts
+++ b/frontend/src/app/shared/directives/select-training-category/select-training-category.directive.ts
@@ -36,6 +36,8 @@ export class SelectTrainingCategoryDirective implements OnInit, AfterViewInit {
     'Specific conditions and disabilities': "'dementia care', 'Oliver McGowan Mandatory Training'",
     'Staff development': "'communication', 'equality and diversity'",
   };
+  accessedFromSummary: boolean;
+  submitButtonText: string;
 
   constructor(
     protected formBuilder: FormBuilder,
@@ -55,7 +57,8 @@ export class SelectTrainingCategoryDirective implements OnInit, AfterViewInit {
     this.getCategories();
     this.setupForm();
     this.prefillForm();
-
+    this.accessedFromSummary = this.route.snapshot.parent.url[0].path.includes('confirm-training');
+    this.submitButtonText = this.accessedFromSummary ? 'Save and return' : 'Continue';
     this.setupFormErrorsMap();
   }
 

--- a/frontend/src/app/shared/directives/select-training-category/select-training-category.directive.ts
+++ b/frontend/src/app/shared/directives/select-training-category/select-training-category.directive.ts
@@ -36,8 +36,7 @@ export class SelectTrainingCategoryDirective implements OnInit, AfterViewInit {
     'Specific conditions and disabilities': "'dementia care', 'Oliver McGowan Mandatory Training'",
     'Staff development': "'communication', 'equality and diversity'",
   };
-  accessedFromSummary: boolean;
-  submitButtonText: string;
+  submitButtonText: string = 'Continue';
 
   constructor(
     protected formBuilder: FormBuilder,
@@ -57,8 +56,6 @@ export class SelectTrainingCategoryDirective implements OnInit, AfterViewInit {
     this.getCategories();
     this.setupForm();
     this.prefillForm();
-    this.accessedFromSummary = this.route.snapshot.parent.url[0].path.includes('confirm-training');
-    this.submitButtonText = this.accessedFromSummary ? 'Save and return' : 'Continue';
     this.setupFormErrorsMap();
   }
 

--- a/frontend/src/app/shared/directives/select-training-category/select-training-category.directive.ts
+++ b/frontend/src/app/shared/directives/select-training-category/select-training-category.directive.ts
@@ -62,9 +62,9 @@ export class SelectTrainingCategoryDirective implements OnInit, AfterViewInit {
   protected init(): void {}
 
   protected prefillForm(): void {
-    let selectedCategory = this.trainingService.getTrainingCategorySelectedForTrainingRecord();
+    let selectedCategory = this.trainingService.selectedTraining?.trainingCategory;
 
-    if (selectedCategory !== null) {
+    if (selectedCategory) {
       this.form.setValue({ category: selectedCategory?.id });
       this.preFilledId = selectedCategory?.id;
       this.form.get('category').updateValueAndValidity();


### PR DESCRIPTION
#### Work done
- Add a change link beside Training category, which returns to category selection page
- Hide Number of Staff/Training Category fields in training detail page if accessed from summary page

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
