### PR TITLE
1466 job roles changes to the main record summay page

### DIFF
--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
@@ -59,7 +59,7 @@ const routes: Routes = [
   },
   {
     path: 'staff-record/:id',
-    resolve: { worker: WorkerResolver, establishment: WorkplaceResolver, jobs: JobsResolver },
+    resolve: { worker: WorkerResolver, establishment: WorkplaceResolver },
     children: [
       {
         path: '',
@@ -75,6 +75,7 @@ const routes: Routes = [
         path: 'main-job-role',
         component: MainJobRoleComponent,
         data: { title: 'Main Job Role' },
+        resolve: { jobs: JobsResolver },
       },
       {
         path: 'main-job-start-date',
@@ -241,7 +242,7 @@ const routes: Routes = [
           },
           {
             path: 'staff-record/:id',
-            resolve: { worker: WorkerResolver, establishment: WorkplaceResolver, jobs: JobsResolver },
+            resolve: { worker: WorkerResolver, establishment: WorkplaceResolver },
             canActivate: [HasPermissionsGuard],
             data: { permissions: ['canViewWdfReport'], title: 'Staff Record Summary' },
             children: [
@@ -259,6 +260,7 @@ const routes: Routes = [
                 path: 'main-job-role',
                 component: MainJobRoleComponent,
                 data: { title: 'Main Job Role' },
+                resolve: { jobs: JobsResolver },
               },
               {
                 path: 'main-job-start-date',

--- a/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
+++ b/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
@@ -18,7 +18,7 @@ import { BasicRecordComponent } from '@shared/components/staff-record-summary/ba
 import { SummaryRecordChangeComponent } from '@shared/components/summary-record-change/summary-record-change.component';
 import { SummaryRecordValueComponent } from '@shared/components/summary-record-value/summary-record-value.component';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
 import { MandatoryDetailsComponent } from './mandatory-details.component';
@@ -111,21 +111,48 @@ describe('MandatoryDetailsComponent', () => {
     expect(getByText(expectedWorker.contract));
   });
 
-  it('should take you to the staff-details page when change link is clicked', async () => {
-    const { component, getByText } = await setup();
+  describe('edit name/id and contract', () => {
+    it('should take you to the staff-details page when change link is clicked', async () => {
+      const { component, getByText, getByTestId } = await setup();
 
-    const worker = component.worker;
-    const changeLink = getByText('Change');
+      const worker = component.worker;
 
-    expect(changeLink.getAttribute('href')).toBe(
-      `/workplace/${123}/staff-record/${worker.uid}/mandatory-details/staff-details`,
-    );
+      const nameSection = within(getByTestId('name-and-contract-section'));
+      const changeLink = nameSection.getByText('Change');
+
+      expect(changeLink.getAttribute('href')).toBe(
+        `/workplace/${123}/staff-record/${worker.uid}/mandatory-details/staff-details`,
+      );
+    });
+
+    it('should not show the change link if the user does not have edit permissions', async () => {
+      const { queryByText, getByTestId } = await setup(false);
+
+      const nameSection = within(getByTestId('name-and-contract-section'));
+      expect(nameSection.queryByText('Change')).toBeFalsy();
+    });
   });
 
-  it('should not show the change link if the user does not have edit permissions', async () => {
-    const { queryByText } = await setup(false);
+  describe('main job role', () => {
+    it('should take you to the main-job-role page when change link is clicked', async () => {
+      const { component, getByText, getByTestId } = await setup();
 
-    expect(queryByText('Change')).toBeFalsy();
+      const worker = component.worker;
+
+      const mainJobRoleSection = within(getByTestId('main-job-role-section'));
+      const changeLink = mainJobRoleSection.getByText('Change');
+
+      expect(changeLink.getAttribute('href')).toBe(
+        `/workplace/${123}/staff-record/${worker.uid}/mandatory-details/main-job-role`,
+      );
+    });
+
+    it('should not show the change link if the user does not have edit permissions', async () => {
+      const { queryByText, getByTestId } = await setup(false);
+
+      const mainJobRoleSection = within(getByTestId('main-job-role-section'));
+      expect(mainJobRoleSection.queryByText('Change')).toBeFalsy();
+    });
   });
 
   it('should submit and navigate to date of birth page when add details button clicked', async () => {

--- a/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
@@ -1,5 +1,8 @@
 <h2 class="govuk-heading-m">{{ basicTitle }}</h2>
-<dl class="govuk-summary-list govuk-summary-list--no-border asc-summarylist-border-top asc-summarylist-border-bottom">
+<dl
+  class="govuk-summary-list govuk-summary-list--no-border asc-summarylist-border-top govuk-!-margin-bottom-0"
+  data-testid="name-section"
+>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key govuk-!-padding-right-0 govuk-!-width-one-half">Name or ID number</dt>
     <dd class="govuk-summary-list__value" [ngClass]="{ 'govuk-!-padding-left-9': !mandatoryDetailsPage }">
@@ -11,35 +14,6 @@
         [link]="mandatoryDetailsPage ? getMandatoryDetailsRoute() : getRoutePath('staff-details', wdfView)"
         [hasData]="true"
       ></app-summary-record-change>
-    </dd>
-  </div>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Main job role</dt>
-    <dd class="govuk-summary-list__value" [ngClass]="{ 'govuk-!-padding-left-9': !mandatoryDetailsPage }">
-      <app-summary-record-value
-        [wdfView]="wdfView"
-        [wdfValue]="worker.wdf?.mainJob"
-        [overallWdfEligibility]="overallWdfEligibility"
-      >
-        <ng-container *ngIf="worker.mainJob.other; else title">
-          <span>{{ worker.mainJob.other }}</span>
-        </ng-container>
-        <ng-template #title>
-          <span>{{ worker.mainJob.title }}</span>
-        </ng-template>
-      </app-summary-record-value>
-      <app-wdf-field-confirmation
-        *ngIf="
-          canEditWorker &&
-          wdfView &&
-          worker.wdf?.mainJob.isEligible === 'Yes' &&
-          !worker.wdf?.mainJob.updatedSinceEffectiveDate
-        "
-        [changeLink]="getRoutePath('staff-details',wdfView)"
-        (fieldConfirmation)="this.confirmField('mainJob')"
-        [workerUid]="worker.uid"
-      ></app-wdf-field-confirmation>
     </dd>
   </div>
 
@@ -63,10 +37,48 @@
           worker.wdf?.contract.isEligible === 'Yes' &&
           !worker.wdf?.contract.updatedSinceEffectiveDate
         "
-        [changeLink]="getRoutePath('staff-details',wdfView)"
+        [changeLink]="getRoutePath('staff-details', wdfView)"
         (fieldConfirmation)="this.confirmField('contract')"
         [workerUid]="worker.uid"
       ></app-wdf-field-confirmation>
+    </dd>
+  </div>
+</dl>
+
+<dl class="govuk-summary-list asc-summarylist-border-top asc-summarylist-border-bottom">
+  <div class="govuk-summary-list__row" data-testid="main-job-role-section">
+    <dt class="govuk-summary-list__key govuk-!-padding-right-0 govuk-!-width-one-half">Main job role</dt>
+    <dd class="govuk-summary-list__value" [ngClass]="{ 'govuk-!-padding-left-9': !mandatoryDetailsPage }">
+      <app-summary-record-value
+        [wdfView]="wdfView"
+        [wdfValue]="worker.wdf?.mainJob"
+        [overallWdfEligibility]="overallWdfEligibility"
+      >
+        <ng-container *ngIf="worker.mainJob.other; else title">
+          <span>{{ worker.mainJob.other }}</span>
+        </ng-container>
+        <ng-template #title>
+          <span>{{ worker.mainJob.title }}</span>
+        </ng-template>
+      </app-summary-record-value>
+      <app-wdf-field-confirmation
+        *ngIf="
+          canEditWorker &&
+          wdfView &&
+          worker.wdf?.mainJob.isEligible === 'Yes' &&
+          !worker.wdf?.mainJob.updatedSinceEffectiveDate
+        "
+        [changeLink]="getRoutePath('main-job-role', wdfView)"
+        (fieldConfirmation)="this.confirmField('mainJob')"
+        [workerUid]="worker.uid"
+      ></app-wdf-field-confirmation>
+    </dd>
+    <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
+      <app-summary-record-change
+        [explanationText]="' basic record details'"
+        [link]="mandatoryDetailsPage ? getMandatoryDetailsRoute() : getRoutePath('main-job-role', wdfView)"
+        [hasData]="true"
+      ></app-summary-record-change>
     </dd>
   </div>
 </dl>

--- a/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">{{ basicTitle }}</h2>
 <dl
   class="govuk-summary-list govuk-summary-list--no-border asc-summarylist-border-top govuk-!-margin-bottom-0"
-  data-testid="name-section"
+  data-testid="name-and-contract-section"
 >
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key govuk-!-padding-right-0 govuk-!-width-one-half">Name or ID number</dt>
@@ -11,7 +11,9 @@
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
       <app-summary-record-change
         [explanationText]="' basic record details'"
-        [link]="mandatoryDetailsPage ? getMandatoryDetailsRoute() : getRoutePath('staff-details', wdfView)"
+        [link]="
+          mandatoryDetailsPage ? getMandatoryDetailsRoute('staff-details') : getRoutePath('staff-details', wdfView)
+        "
         [hasData]="true"
       ></app-summary-record-change>
     </dd>
@@ -76,7 +78,9 @@
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
       <app-summary-record-change
         [explanationText]="' basic record details'"
-        [link]="mandatoryDetailsPage ? getMandatoryDetailsRoute() : getRoutePath('main-job-role', wdfView)"
+        [link]="
+          mandatoryDetailsPage ? getMandatoryDetailsRoute('main-job-role') : getRoutePath('main-job-role', wdfView)
+        "
         [hasData]="true"
       ></app-summary-record-change>
     </dd>

--- a/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
@@ -15,7 +15,7 @@ import { render, within } from '@testing-library/angular';
 import { BasicRecordComponent } from './basic-record.component';
 import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
-fdescribe('BasicRecordComponent', () => {
+describe('BasicRecordComponent', () => {
   async function setup(mandatoryDetailsPage = false) {
     const { fixture, getByText, getByTestId } = await render(BasicRecordComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
@@ -54,7 +54,7 @@ fdescribe('BasicRecordComponent', () => {
   it('should render the change link with the staff-record-summary/staff-details url when not on the mandatory details page', async () => {
     const { component, getByText, getByTestId } = await setup();
 
-    const nameSection = within(getByTestId('name-section'));
+    const nameSection = within(getByTestId('name-and-contract-section'));
     const changeLink = nameSection.getByText('Change');
 
     expect(changeLink.getAttribute('href')).toBe(
@@ -76,7 +76,7 @@ fdescribe('BasicRecordComponent', () => {
   it('should render the change link with the mandatory-details/staff-details url when on the mandatory details page', async () => {
     const { component, getByText, getByTestId } = await setup(true);
 
-    const nameSection = within(getByTestId('name-section'));
+    const nameSection = within(getByTestId('name-and-contract-section'));
     const changeLink = nameSection.getByText('Change');
 
     expect(changeLink.getAttribute('href')).toBe(
@@ -84,15 +84,14 @@ fdescribe('BasicRecordComponent', () => {
     );
   });
 
-  // to fix
-  // it('should render the change link with the mandatory-details/main-job-role url when on the mandatory details page', async () => {
-  //   const { component, getByText, getByTestId } = await setup(true);
+  it('should render the change link with the mandatory-details/main-job-role url when on the mandatory details page', async () => {
+    const { component, getByText, getByTestId } = await setup(true);
 
-  //   const mainJobRoleSection = within(getByTestId('main-job-role-section'));
-  //   const changeLink = mainJobRoleSection.getByText('Change');
+    const mainJobRoleSection = within(getByTestId('main-job-role-section'));
+    const changeLink = mainJobRoleSection.getByText('Change');
 
-  //   expect(changeLink.getAttribute('href')).toBe(
-  //     `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/mandatory-details/main-job-role`,
-  //   );
-  // });
+    expect(changeLink.getAttribute('href')).toBe(
+      `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/mandatory-details/main-job-role`,
+    );
+  });
 });

--- a/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
@@ -10,14 +10,14 @@ import { MockPermissionsService } from '@core/test-utils/MockPermissionsService'
 import { workerWithWdf } from '@core/test-utils/MockWorkerService';
 import { SummaryRecordChangeComponent } from '@shared/components/summary-record-change/summary-record-change.component';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { render, within } from '@testing-library/angular';
 
 import { BasicRecordComponent } from './basic-record.component';
 import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
-describe('BasicRecordComponent', () => {
+fdescribe('BasicRecordComponent', () => {
   async function setup(mandatoryDetailsPage = false) {
-    const { fixture, getByText } = await render(BasicRecordComponent, {
+    const { fixture, getByText, getByTestId } = await render(BasicRecordComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [SummaryRecordChangeComponent],
       providers: [
@@ -42,6 +42,7 @@ describe('BasicRecordComponent', () => {
       component,
       fixture,
       getByText,
+      getByTestId,
     };
   }
 
@@ -51,18 +52,47 @@ describe('BasicRecordComponent', () => {
   });
 
   it('should render the change link with the staff-record-summary/staff-details url when not on the mandatory details page', async () => {
-    const { component, getByText } = await setup();
+    const { component, getByText, getByTestId } = await setup();
 
-    expect(getByText('Change').getAttribute('href')).toBe(
+    const nameSection = within(getByTestId('name-section'));
+    const changeLink = nameSection.getByText('Change');
+
+    expect(changeLink.getAttribute('href')).toBe(
       `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/staff-details`,
     );
   });
 
-  it('should render the change link with the mandatory-details/staff-details url when on the mandatory details page', async () => {
-    const { component, getByText } = await setup(true);
+  it('should render the change link with the staff-record-summary/main-job-role url when not on the mandatory details page', async () => {
+    const { component, getByText, getByTestId } = await setup();
 
-    expect(getByText('Change').getAttribute('href')).toBe(
+    const mainJobRoleSection = within(getByTestId('main-job-role-section'));
+    const changeLink = mainJobRoleSection.getByText('Change');
+
+    expect(changeLink.getAttribute('href')).toBe(
+      `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/main-job-role`,
+    );
+  });
+
+  it('should render the change link with the mandatory-details/staff-details url when on the mandatory details page', async () => {
+    const { component, getByText, getByTestId } = await setup(true);
+
+    const nameSection = within(getByTestId('name-section'));
+    const changeLink = nameSection.getByText('Change');
+
+    expect(changeLink.getAttribute('href')).toBe(
       `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/mandatory-details/staff-details`,
     );
   });
+
+  // to fix
+  // it('should render the change link with the mandatory-details/main-job-role url when on the mandatory details page', async () => {
+  //   const { component, getByText, getByTestId } = await setup(true);
+
+  //   const mainJobRoleSection = within(getByTestId('main-job-role-section'));
+  //   const changeLink = mainJobRoleSection.getByText('Change');
+
+  //   expect(changeLink.getAttribute('href')).toBe(
+  //     `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/mandatory-details/main-job-role`,
+  //   );
+  // });
 });

--- a/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.ts
@@ -13,7 +13,9 @@ export class BasicRecordComponent extends StaffRecordSummaryComponent {
   @Input() public canEditWorker: boolean;
   @Input() public mandatoryDetailsPage = false;
 
-  public getMandatoryDetailsRoute(): Array<string> {
-    return ['/workplace', this.workplaceUid, 'staff-record', this.worker.uid, 'mandatory-details', 'staff-details'];
+  public getMandatoryDetailsRoute(path: string): Array<string> {
+    if (path) {
+      return ['/workplace', this.workplaceUid, 'staff-record', this.worker.uid, 'mandatory-details', path];
+    }
   }
 }


### PR DESCRIPTION
#### Work done
- Move main job role in basic record and add a change link to navigate to the new main job role page
- Moved jobs resolver in wdf routing to stop causing issues viewing that route

<img width="1490" alt="staff summary" src="https://github.com/user-attachments/assets/bbc14717-a482-4412-ae83-38e1246a9d31">

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
