### PR TITLE
Added Health and care visa and Inside or outside UK questions to WDF routing

### DIFF
--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
@@ -4,48 +4,34 @@ import { CheckPermissionsGuard } from '@core/guards/permissions/check-permission
 import { HasPermissionsGuard } from '@core/guards/permissions/has-permissions/has-permissions.guard';
 import { WorkerResolver } from '@core/resolvers/worker.resolver';
 import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
-import {
-  AdultSocialCareStartedComponent,
-} from '@features/workers/adult-social-care-started/adult-social-care-started.component';
-import {
-  ApprenticeshipTrainingComponent,
-} from '@features/workers/apprenticeship-training/apprenticeship-training.component';
+import { AdultSocialCareStartedComponent } from '@features/workers/adult-social-care-started/adult-social-care-started.component';
+import { ApprenticeshipTrainingComponent } from '@features/workers/apprenticeship-training/apprenticeship-training.component';
 import { AverageWeeklyHoursComponent } from '@features/workers/average-weekly-hours/average-weekly-hours.component';
 import { BritishCitizenshipComponent } from '@features/workers/british-citizenship/british-citizenship.component';
 import { CareCertificateComponent } from '@features/workers/care-certificate/care-certificate.component';
-import {
-  ContractWithZeroHoursComponent,
-} from '@features/workers/contract-with-zero-hours/contract-with-zero-hours.component';
+import { ContractWithZeroHoursComponent } from '@features/workers/contract-with-zero-hours/contract-with-zero-hours.component';
 import { CountryOfBirthComponent } from '@features/workers/country-of-birth/country-of-birth.component';
 import { DateOfBirthComponent } from '@features/workers/date-of-birth/date-of-birth.component';
 import { DaysOfSicknessComponent } from '@features/workers/days-of-sickness/days-of-sickness.component';
 import { DisabilityComponent } from '@features/workers/disability/disability.component';
+import { EmployedFromOutsideUkComponent } from '@features/workers/employed-from-outside-uk/employed-from-outside-uk.component';
 import { EthnicityComponent } from '@features/workers/ethnicity/ethnicity.component';
 import { GenderComponent } from '@features/workers/gender/gender.component';
+import { HealthAndCareVisaComponent } from '@features/workers/health-and-care-visa/health-and-care-visa.component';
 import { HomePostcodeComponent } from '@features/workers/home-postcode/home-postcode.component';
 import { MainJobStartDateComponent } from '@features/workers/main-job-start-date/main-job-start-date.component';
-import {
-  MentalHealthProfessionalComponent,
-} from '@features/workers/mental-health-professional/mental-health-professional.component';
-import {
-  NationalInsuranceNumberComponent,
-} from '@features/workers/national-insurance-number/national-insurance-number.component';
+import { MentalHealthProfessionalComponent } from '@features/workers/mental-health-professional/mental-health-professional.component';
+import { NationalInsuranceNumberComponent } from '@features/workers/national-insurance-number/national-insurance-number.component';
 import { NationalityComponent } from '@features/workers/nationality/nationality.component';
 import { NursingCategoryComponent } from '@features/workers/nursing-category/nursing-category.component';
 import { NursingSpecialismComponent } from '@features/workers/nursing-specialism/nursing-specialism.component';
-import {
-  OtherQualificationsLevelComponent,
-} from '@features/workers/other-qualifications-level/other-qualifications-level.component';
+import { OtherQualificationsLevelComponent } from '@features/workers/other-qualifications-level/other-qualifications-level.component';
 import { OtherQualificationsComponent } from '@features/workers/other-qualifications/other-qualifications.component';
 import { RecruitedFromComponent } from '@features/workers/recruited-from/recruited-from.component';
 import { SalaryComponent } from '@features/workers/salary/salary.component';
 import { SelectRecordTypeComponent } from '@features/workers/select-record-type/select-record-type.component';
-import {
-  SocialCareQualificationLevelComponent,
-} from '@features/workers/social-care-qualification-level/social-care-qualification-level.component';
-import {
-  SocialCareQualificationComponent,
-} from '@features/workers/social-care-qualification/social-care-qualification.component';
+import { SocialCareQualificationLevelComponent } from '@features/workers/social-care-qualification-level/social-care-qualification-level.component';
+import { SocialCareQualificationComponent } from '@features/workers/social-care-qualification/social-care-qualification.component';
 import { StaffDetailsComponent } from '@features/workers/staff-details/staff-details.component';
 import { WeeklyContractedHoursComponent } from '@features/workers/weekly-contracted-hours/weekly-contracted-hours.component';
 import { YearArrivedUkComponent } from '@features/workers/year-arrived-uk/year-arrived-uk.component';
@@ -168,6 +154,16 @@ const routes: Routes = [
         path: 'recruited-from',
         component: RecruitedFromComponent,
         data: { title: 'Recruited From' },
+      },
+      {
+        path: 'health-and-care-visa',
+        component: HealthAndCareVisaComponent,
+        data: { title: 'Health and Care Visa' },
+      },
+      {
+        path: 'inside-or-outside-of-uk',
+        component: EmployedFromOutsideUkComponent,
+        data: { title: 'Inside or Outside UK' },
       },
       {
         path: 'adult-social-care-started',
@@ -347,6 +343,16 @@ const routes: Routes = [
                 path: 'recruited-from',
                 component: RecruitedFromComponent,
                 data: { title: 'Recruited From' },
+              },
+              {
+                path: 'health-and-care-visa',
+                component: HealthAndCareVisaComponent,
+                data: { title: 'Health and Care Visa' },
+              },
+              {
+                path: 'inside-or-outside-of-uk',
+                component: EmployedFromOutsideUkComponent,
+                data: { title: 'Inside or Outside UK' },
               },
               {
                 path: 'adult-social-care-started',


### PR DESCRIPTION
#### Work done
- Added health and care visa and Employed inside or outside the UK pages to the WDF view

#### Issue
The health and care visa pages were not added to the WDF routing, so although you could see them on the staff summary page in WDF, clicking the Change link would take the user to the Page not found page.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
