### PR TITLE
Add check to clear selected category at beginning of add training record

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-staff/select-staff.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-staff/select-staff.component.spec.ts
@@ -90,6 +90,7 @@ describe('SelectStaffComponent', () => {
       trainingService,
       'clearUpdatingSelectedStaffForMultipleTraining',
     ).and.callThrough();
+    const clearSelectedTrainingCategorySpy = spyOn(trainingService, 'clearSelectedTrainingCategory').and.callThrough();
 
     return {
       component,
@@ -110,6 +111,7 @@ describe('SelectStaffComponent', () => {
       searchSpy,
       workers,
       clearUpdatingSelectedStaffForMultipleTrainingSpy,
+      clearSelectedTrainingCategorySpy,
     };
   }
 
@@ -598,5 +600,13 @@ describe('SelectStaffComponent', () => {
       expect(trainingSpy).not.toHaveBeenCalled();
       expect(spy.calls.mostRecent().args[0]).toEqual(['../']);
     });
+  });
+
+  it('should call trainingService if there are no selected workers when landing on the page', async () => {
+    const { component, clearSelectedTrainingCategorySpy } = await setup();
+
+    component.ngOnInit();
+
+    expect(clearSelectedTrainingCategorySpy).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-staff/select-staff.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-multiple-training/select-staff/select-staff.component.ts
@@ -72,6 +72,13 @@ export class SelectStaffComponent implements OnInit, AfterViewInit {
   private prefill(): void {
     this.selectedWorkers = this.trainingService.selectedStaff.map((worker) => worker.uid);
     this.updateSelectAllLinks();
+    this.clearSelectedTrainingCategoryOnPageEntry();
+  }
+
+  private clearSelectedTrainingCategoryOnPageEntry() {
+    if (this.selectedWorkers.length === 0) {
+      this.trainingService.clearSelectedTrainingCategory();
+    }
   }
 
   public getPageOfWorkers(): void {

--- a/frontend/src/app/features/workers/select-record-type/select-record-type.component.spec.ts
+++ b/frontend/src/app/features/workers/select-record-type/select-record-type.component.spec.ts
@@ -30,6 +30,8 @@ describe('SelectRecordTypeComponent', () => {
     const injector = getTestBed();
     const router = injector.inject(Router) as Router;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+    const trainingService = injector.inject(TrainingService) as TrainingService;
+    const clearSelectedTrainingCategorySpy = spyOn(trainingService, 'clearSelectedTrainingCategory').and.callThrough();
 
     return {
       component,
@@ -37,6 +39,7 @@ describe('SelectRecordTypeComponent', () => {
       routerSpy,
       getByText,
       getAllByText,
+      clearSelectedTrainingCategorySpy,
     };
   }
 
@@ -62,7 +65,7 @@ describe('SelectRecordTypeComponent', () => {
       fixture.detectChanges();
       const form = component.form;
       expect(form.valid).toBeTruthy();
-      // expect(form.value).toEqual({ selectRecordType: 'Training course' });
+      expect(form.value).toEqual({ selectRecordType: 'Training course' });
     });
 
     it('should not prefill the radio button when navigating from training page', async () => {
@@ -73,5 +76,13 @@ describe('SelectRecordTypeComponent', () => {
       expect(form.invalid).toBeTruthy();
       expect(form.value).toEqual({ selectRecordType: null });
     });
+  });
+
+  it('should call trainingService if there is no trainingOrQualificationPreviouslySelected when landing on the page', async () => {
+    const { component, clearSelectedTrainingCategorySpy } = await setup();
+
+    component.ngOnInit();
+
+    expect(clearSelectedTrainingCategorySpy).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/features/workers/select-record-type/select-record-type.component.ts
+++ b/frontend/src/app/features/workers/select-record-type/select-record-type.component.ts
@@ -57,6 +57,14 @@ export class SelectRecordTypeComponent implements OnInit, AfterViewInit {
     if (this.trainingOrQualificationPreviouslySelected) {
       this.prefill(this.getPrefillValue());
     }
+
+    this.clearSelectedTrainingCategoryOnPageEntry();
+  }
+
+  private clearSelectedTrainingCategoryOnPageEntry() {
+    if (!this.trainingOrQualificationPreviouslySelected || this.trainingOrQualificationPreviouslySelected === 'null') {
+      this.trainingService.clearSelectedTrainingCategory();
+    }
   }
 
   private setupForm(): void {


### PR DESCRIPTION
#### Work done
- When in the middle of adding a training record and you click one of the tabs while in training details, when you go back to the beginning of the journey of adding a single or multiple training record the category is already selected in the select category page. Added a check that at the beginning of both journeys, to make sure the selectedTrainingCategory variable is clear in the training service

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
