### PR TITLE
fix/menu-button-in-header

### DIFF
--- a/frontend/src/app/core/components/header/header.component.html
+++ b/frontend/src/app/core/components/header/header.component.html
@@ -8,7 +8,7 @@
       <button
         (click)="toggleMenu()"
         type="button"
-        class="govuk-header__menu-button"
+        class="govuk-header__menu-button menu-button"
         aria-controls="navigation"
         aria-label="Show or hide Top Level Navigation"
       >

--- a/frontend/src/app/core/components/header/header.component.scss
+++ b/frontend/src/app/core/components/header/header.component.scss
@@ -17,3 +17,9 @@ li {
 header {
   border-top: 30px $govuk-link-colour solid;
 }
+
+header .menu-button {
+  @media only screen and (min-width: 769px) {
+    visibility: hidden;
+  }
+}


### PR DESCRIPTION
#### Work done
The menu button for the top navigation in header has been appearing in larger screens, in the top right hand corner. This seems to have been introduced following the design system update on this branch.
<img width="1504" alt="Header before" src="https://github.com/user-attachments/assets/fe82b8ad-b7c2-4689-a473-4a9967b791b2">

Added a styling change so this is only showing the header menu button on small screens
<img width="752" alt="Header after with small screen" src="https://github.com/user-attachments/assets/17420378-fc2f-44cb-bfa8-891ee02e2d89">
<img width="1489" alt="Header after" src="https://github.com/user-attachments/assets/5d5d65b7-52ab-4ef6-9d4b-581a051fe676">



#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
