### PR TITLE
fix/populate-category-from-training-tab-view

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component.spec.ts
@@ -114,8 +114,7 @@ describe('SelectTrainingCategoryComponent', () => {
   });
 
   it('should show the cancel link', async () => {
-    const { getByText, fixture } = await setup(true);
-    fixture.detectChanges();
+    const { getByText } = await setup(true);
 
     const cancelLink = getByText('Cancel');
 

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component.spec.ts
@@ -22,7 +22,7 @@ import { trainingCategories } from '@core/test-utils/MockTrainingCategoriesServi
 import sinon from 'sinon';
 
 describe('SelectTrainingCategoryComponent', () => {
-  async function setup(prefill = false, qsParamGetMock = sinon.stub()) {
+  async function setup(prefill = false, qsParamGetMock = sinon.fake()) {
     const establishment = establishmentBuilder() as Establishment;
     const worker = workerBuilder();
 
@@ -114,7 +114,8 @@ describe('SelectTrainingCategoryComponent', () => {
   });
 
   it('should show the cancel link', async () => {
-    const { getByText } = await setup(true);
+    const { getByText, fixture } = await setup(true);
+    fixture.detectChanges();
 
     const cancelLink = getByText('Cancel');
 
@@ -172,6 +173,16 @@ describe('SelectTrainingCategoryComponent', () => {
 
   it('should pre-fill when adding a record to a mandatory training category', async () => {
     const qsParamGetMock = sinon.stub().returns(JSON.stringify({ id: 2, category: 'Autism' }));
+
+    const { component, fixture } = await setup(false, qsParamGetMock);
+
+    fixture.detectChanges();
+
+    expect(component.form.value).toEqual({ category: 2 });
+  });
+
+  it('should pre-fill when adding a record to a mandatory training category from the training tab', async () => {
+    const qsParamGetMock = sinon.stub().returns(JSON.stringify({ id: '2', category: 'Autism' }));
 
     const { component, fixture } = await setup(false, qsParamGetMock);
 

--- a/frontend/src/app/shared/directives/select-training-category/select-training-category.directive.ts
+++ b/frontend/src/app/shared/directives/select-training-category/select-training-category.directive.ts
@@ -66,8 +66,9 @@ export class SelectTrainingCategoryDirective implements OnInit, AfterViewInit {
 
     if (this.route.snapshot.queryParamMap.get('trainingCategory')) {
       const mandatoryTrainingCategory = JSON.parse(this.route.snapshot.queryParamMap.get('trainingCategory'));
-      this.form.setValue({ category: mandatoryTrainingCategory.id });
-      this.preFilledId = mandatoryTrainingCategory.id;
+      let categoryId = parseInt(mandatoryTrainingCategory.id, 10);
+      this.form.setValue({ category: categoryId });
+      this.preFilledId = categoryId;
     } else if (selectedCategory) {
       this.form.setValue({ category: selectedCategory?.id });
       this.preFilledId = selectedCategory?.id;


### PR DESCRIPTION
#### Work done
- Add parseInt for string category ids in queryParam

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
