### PR TITLE
Feat/1465 changes to mandatory information

### DIFF
--- a/frontend/src/app/core/test-utils/MockWorkerService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkerService.ts
@@ -360,6 +360,15 @@ export class MockWorkerServiceWithUpdateWorker extends MockWorkerService {
 }
 
 @Injectable()
+export class MockWorkerServiceWithNoWorker extends MockWorkerService {
+  public get worker() {
+    return null;
+  }
+
+  public worker$ = of(null);
+}
+
+@Injectable()
 export class MockWorkerServiceWithoutReturnUrl extends MockWorkerServiceWithUpdateWorker {
   public static factory(worker: Worker) {
     return (httpClient: HttpClient) => {

--- a/frontend/src/app/core/test-utils/MockWorkerService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkerService.ts
@@ -5,7 +5,7 @@ import { QualificationsByGroup } from '@core/model/qualification.model';
 import { MultipleTrainingResponse, TrainingRecordRequest } from '@core/model/training.model';
 import { URLStructure } from '@core/model/url.model';
 import { Worker, WorkerEditResponse, WorkersResponse } from '@core/model/worker.model';
-import { WorkerService } from '@core/services/worker.service';
+import { NewWorkerMandatoryInfo, WorkerService } from '@core/services/worker.service';
 import { build, fake, oneOf, perBuild, sequence } from '@jackfranklin/test-data-bot';
 import { Observable, of } from 'rxjs';
 
@@ -339,7 +339,7 @@ export class MockWorkerService extends WorkerService {
 
 @Injectable()
 export class MockWorkerServiceWithUpdateWorker extends MockWorkerService {
-  public static factory(worker: Worker) {
+  public static factory(worker: Worker = null) {
     return (httpClient: HttpClient) => {
       const service = new MockWorkerServiceWithUpdateWorker(httpClient);
       if (worker) {
@@ -361,6 +361,15 @@ export class MockWorkerServiceWithUpdateWorker extends MockWorkerService {
 
 @Injectable()
 export class MockWorkerServiceWithNoWorker extends MockWorkerService {
+  public static factory(workerMandatoryInfo: NewWorkerMandatoryInfo = null) {
+    return (httpClient: HttpClient) => {
+      const service = new MockWorkerServiceWithNoWorker(httpClient);
+      if (workerMandatoryInfo) {
+        service.setNewWorkerMandatoryInfo(workerMandatoryInfo.nameOrId, workerMandatoryInfo.contract);
+      }
+      return service;
+    };
+  }
   public get worker() {
     return null;
   }

--- a/frontend/src/app/features/workers/main-job-role/main-job-role.component.spec.ts
+++ b/frontend/src/app/features/workers/main-job-role/main-job-role.component.spec.ts
@@ -1,26 +1,27 @@
-import { render } from '@testing-library/angular';
-import { MainJobRoleComponent } from './main-job-role.component';
-import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
-import { ProgressBarComponent } from '@shared/components/progress-bar/progress-bar.component';
-import { WorkerService } from '@core/services/worker.service';
-import { MockWorkerServiceWithUpdateWorker, workerBuilder } from '@core/test-utils/MockWorkerService';
-import { WindowRef } from '@core/services/window.ref';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { SharedModule } from '@shared/shared.module';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
-import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { HttpClient } from '@angular/common/http';
-import { UserService } from '@core/services/user.service';
-import { MockUserService } from '@core/test-utils/MockUserService';
-import { Roles } from '@core/model/roles.enum';
+import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { Contracts } from '@core/model/contracts.enum';
+import { Roles } from '@core/model/roles.enum';
 import { Worker } from '@core/model/worker.model';
-import userEvent from '@testing-library/user-event';
 import { AlertService } from '@core/services/alert.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { UserService } from '@core/services/user.service';
+import { WindowRef } from '@core/services/window.ref';
+import { WorkerService } from '@core/services/worker.service';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { MockUserService } from '@core/test-utils/MockUserService';
+import { MockWorkerServiceWithUpdateWorker, workerBuilder } from '@core/test-utils/MockWorkerService';
+import { ProgressBarComponent } from '@shared/components/progress-bar/progress-bar.component';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+import { MainJobRoleComponent } from './main-job-role.component';
 
 describe('MainJobRoleComponent', () => {
   async function setup(insideFlow = true, returnToMandatoryDetails = false, addNewWorker = false) {
@@ -428,6 +429,29 @@ describe('MainJobRoleComponent', () => {
         component.worker.uid,
         'mental-health-professional',
       ]);
+    });
+
+    it('should clear the mandatory worker info in the worker service on submit', async () => {
+      const { fixture, getByText, workerService } = await setup();
+
+      const clearWorkerInfoSpy = spyOn(workerService, 'clearNewWorkerMandatoryInfo');
+
+      userEvent.click(getByText('Professional and related roles'));
+      userEvent.click(getByText('Social worker'));
+      userEvent.click(getByText('Save and return'));
+      fixture.detectChanges();
+
+      expect(clearWorkerInfoSpy).toHaveBeenCalled();
+    });
+
+    it('should clear the mandatory worker info in the worker service on click of Cancel', async () => {
+      const { getByText, workerService } = await setup();
+
+      const clearWorkerInfoSpy = spyOn(workerService, 'clearNewWorkerMandatoryInfo');
+
+      userEvent.click(getByText('Cancel'));
+
+      expect(clearWorkerInfoSpy).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/app/features/workers/main-job-role/main-job-role.component.ts
+++ b/frontend/src/app/features/workers/main-job-role/main-job-role.component.ts
@@ -1,14 +1,14 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { QuestionComponent } from '../question/question.component';
-import { Job } from '@core/model/job.model';
 import { UntypedFormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Job } from '@core/model/job.model';
+import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { NewWorkerMandatoryInfo, WorkerService } from '@core/services/worker.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { Contracts } from '@core/model/contracts.enum';
-import { AlertService } from '@core/services/alert.service';
+import { NewWorkerMandatoryInfo, WorkerService } from '@core/services/worker.service';
+
+import { QuestionComponent } from '../question/question.component';
 
 @Component({
   selector: 'app-main-job-role.component',
@@ -157,7 +157,6 @@ export class MainJobRoleComponent extends QuestionComponent implements OnInit, O
     if (this.editFlow) {
       this.next = this.determineConditionalRouting();
     } else {
-      this.workerService.clearNewWorkerMandatoryInfo();
       this.next = this.getRoutePath('mandatory-details');
     }
     !this.editFlow && this.workerService.setAddStaffRecordInProgress(true);
@@ -183,5 +182,10 @@ export class MainJobRoleComponent extends QuestionComponent implements OnInit, O
         ],
       },
     ];
+  }
+
+  public onSubmit(): void {
+    this.workerService.clearNewWorkerMandatoryInfo();
+    super.onSubmit();
   }
 }

--- a/frontend/src/app/features/workers/staff-details/staff-details.component.html
+++ b/frontend/src/app/features/workers/staff-details/staff-details.component.html
@@ -26,56 +26,6 @@
             type="text"
           />
         </div>
-        <div
-          class="govuk-form-group"
-          [class.govuk-form-group--error]="
-            submitted && (form.get('mainJob').invalid || form.get('otherJobRole').invalid)
-          "
-        >
-          <label class="govuk-label" for="mainJob"> Main job role </label>
-          <span *ngIf="submitted && form.get('mainJob').errors" id="mainJob-error" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span>
-            {{ getFormErrorMessage('mainJob', 'required') }}
-          </span>
-          <select
-            class="govuk-select"
-            [class.govuk-select--error]="submitted && form.get('mainJob').invalid"
-            [formControlName]="'mainJob'"
-            id="mainJob"
-            name="mainJob"
-            (change)="selectedJobRole($event.target.value)"
-          >
-            <option [ngValue]="null">Select main job role</option>
-            <option *ngFor="let job of jobsAvailable" [value]="job.id">
-              {{ job.title }}
-            </option>
-          </select>
-
-          <div
-            class="govuk-radios__conditional govuk-!-margin-top-4"
-            [class.govuk-select__conditional--hidden]="!showInputTextforOtherRole"
-          >
-            <label class="govuk-label" for="otherJobRole-conditional"> What is the job role? </label>
-            <span
-              *ngIf="submitted && form.get('otherJobRole').invalid"
-              id="otherJobRole-error"
-              class="govuk-error-message"
-            >
-              <span class="govuk-visually-hidden">Error:</span>
-              {{ getFormErrorMessage('otherJobRole', 'maxlength') }}
-            </span>
-            <input
-              data-testid="other-job-role"
-              class="govuk-input govuk-!-width-two-thirds"
-              [formControlName]="'otherJobRole'"
-              id="otherJobRole-conditional"
-              name="otherJobRole"
-              type="text"
-              aria-describedby="otherJobRole-hint"
-              [class.govuk-select--error]="submitted && form.get('otherJobRole').invalid"
-            />
-          </div>
-        </div>
 
         <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && form.get('contract').invalid">
           <fieldset class="govuk-fieldset">
@@ -121,7 +71,7 @@
   </div>
   <app-submit-button
     [summaryContinue]="summaryContinue"
-    [callToAction]="submitTitle"
+    [callToAction]="'Continue'"
     [recordSummary]="false"
     [canExit]="canExit"
     [return]="editFlow"

--- a/frontend/src/app/features/workers/staff-details/staff-details.component.html
+++ b/frontend/src/app/features/workers/staff-details/staff-details.component.html
@@ -70,7 +70,7 @@
     </div>
   </div>
   <app-submit-button
-    [summaryContinue]="summaryContinue"
+    [summaryContinue]="false"
     [callToAction]="'Continue'"
     [recordSummary]="false"
     [canExit]="canExit"

--- a/frontend/src/app/features/workers/staff-details/staff-details.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-details/staff-details.component.spec.ts
@@ -170,8 +170,15 @@ describe('StaffDetailsComponent', () => {
     });
 
     it(`should navigate to main-job-role page and set mandatory info in worker service after clicking 'Continue' cta button when adding a staff record`, async () => {
-      const { fixture, getByText, getByLabelText, routerSpy, updateWorkerSpy, setNewWorkerMandatoryInfoSpy } =
-        await setup(true, false, true);
+      const {
+        fixture,
+        getByText,
+        getByLabelText,
+        routerSpy,
+        updateWorkerSpy,
+        setNewWorkerMandatoryInfoSpy,
+        submitSpy,
+      } = await setup(true, false, true);
 
       const enteredName = 'Someone';
       userEvent.type(getByLabelText('Name or ID number'), enteredName);
@@ -180,6 +187,7 @@ describe('StaffDetailsComponent', () => {
       fixture.detectChanges();
 
       expect(updateWorkerSpy).not.toHaveBeenCalled();
+      expect(submitSpy).toHaveBeenCalledWith({ action: 'continue', save: true });
       expect(setNewWorkerMandatoryInfoSpy).toHaveBeenCalledWith(enteredName, 'Temporary' as Contracts);
       expect(routerSpy.calls.mostRecent().args[0]).toEqual(['main-job-role']);
     });
@@ -193,21 +201,21 @@ describe('StaffDetailsComponent', () => {
       expect(clearNewWorkerMandatoryInfoSpy).toHaveBeenCalled();
     });
 
-    it(`should show 'Save' and 'Cancel' buttons when not in mandatory details flow or in the staff record flow`, async () => {
+    it(`should show 'Save and return' and 'Cancel' buttons when not in mandatory details flow or in the staff record flow`, async () => {
       const { getByText } = await setup(false, false);
 
-      expect(getByText('Save')).toBeTruthy();
+      expect(getByText('Save and return')).toBeTruthy();
       expect(getByText('Cancel')).toBeTruthy();
     });
 
-    it(`should show 'Save' cta button and 'Cancel' link when editing a staff record outside`, async () => {
+    it(`should show 'Save and return' cta button and 'Cancel' link when editing a staff record outside`, async () => {
       const { getByText } = await setup(false);
 
-      expect(getByText('Save')).toBeTruthy();
+      expect(getByText('Save and return')).toBeTruthy();
       expect(getByText('Cancel')).toBeTruthy();
     });
 
-    it(`should call submit data and navigate to the wdf staff record summary page when 'Save' is clicked in WDF version of the page`, async () => {
+    it(`should call submit data and navigate to the wdf staff record summary page when 'Save and return' is clicked in WDF version of the page`, async () => {
       const { component, router, fixture, getByText, getByLabelText, submitSpy, routerSpy, updateWorkerSpy } =
         await setup(false, false);
       spyOnProperty(router, 'url').and.returnValue('/wdf/staff-record');
@@ -216,7 +224,7 @@ describe('StaffDetailsComponent', () => {
       fixture.detectChanges();
 
       userEvent.click(getByLabelText('Temporary'));
-      userEvent.click(getByText('Save'));
+      userEvent.click(getByText('Save and return'));
       fixture.detectChanges();
 
       const updatedFormData = component.form.value;
@@ -224,7 +232,7 @@ describe('StaffDetailsComponent', () => {
         nameOrId: component.worker.nameOrId,
         contract: 'Temporary',
       });
-      expect(submitSpy).toHaveBeenCalledWith({ action: 'continue', save: true });
+      expect(submitSpy).toHaveBeenCalledWith({ action: 'return', save: true });
       expect(updateWorkerSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, {
         nameOrId: component.worker.nameOrId,
         contract: 'Temporary',
@@ -232,13 +240,13 @@ describe('StaffDetailsComponent', () => {
       expect(routerSpy).toHaveBeenCalledWith(['/wdf', 'staff-record', fixture.componentInstance.worker.uid]);
     });
 
-    it(`should call submit data and navigate to the the staff record summary page when 'Save' is clicked outside of mandatory details flow`, async () => {
+    it(`should call submit data and navigate to the the staff record summary page when 'Save and return' is clicked outside of mandatory details flow`, async () => {
       const { component, fixture, getByText, getByLabelText, submitSpy, routerSpy, updateWorkerSpy } = await setup(
         false,
       );
 
       userEvent.click(getByLabelText('Temporary'));
-      userEvent.click(getByText('Save'));
+      userEvent.click(getByText('Save and return'));
       fixture.detectChanges();
 
       const updatedFormData = component.form.value;
@@ -246,7 +254,7 @@ describe('StaffDetailsComponent', () => {
         nameOrId: component.worker.nameOrId,
         contract: 'Temporary',
       });
-      expect(submitSpy).toHaveBeenCalledWith({ action: 'continue', save: true });
+      expect(submitSpy).toHaveBeenCalledWith({ action: 'return', save: true });
       expect(updateWorkerSpy).toHaveBeenCalledWith(component.workplace.uid, component.worker.uid, {
         nameOrId: component.worker.nameOrId,
         contract: 'Temporary',
@@ -297,7 +305,7 @@ describe('StaffDetailsComponent', () => {
       });
 
       userEvent.click(getByLabelText('Permanent'));
-      userEvent.click(getByText('Save'));
+      userEvent.click(getByText('Save and return'));
       fixture.detectChanges();
 
       expect(alertSpy).not.toHaveBeenCalled();
@@ -318,13 +326,13 @@ describe('StaffDetailsComponent', () => {
       });
 
       userEvent.click(getByLabelText('Permanent'));
-      userEvent.click(getByText('Save'));
+      userEvent.click(getByText('Save and return'));
       fixture.detectChanges();
 
       expect(alertSpy).not.toHaveBeenCalled();
     });
 
-    it('should not call setAddStaffRecordInProgress when clicking save', async () => {
+    it('should not call setAddStaffRecordInProgress when clicking save and return', async () => {
       const { component, fixture, getByText, getByLabelText, workerService, setAddStaffRecordInProgressSpy } =
         await setup(false);
 
@@ -333,7 +341,7 @@ describe('StaffDetailsComponent', () => {
       });
 
       userEvent.click(getByLabelText('Permanent'));
-      userEvent.click(getByText('Save'));
+      userEvent.click(getByText('Save and return'));
       fixture.detectChanges();
       expect(setAddStaffRecordInProgressSpy).not.toHaveBeenCalled();
     });

--- a/frontend/src/app/features/workers/staff-details/staff-details.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-details/staff-details.component.spec.ts
@@ -93,6 +93,7 @@ describe('StaffDetailsComponent', () => {
     const alertSpy = spyOn(alertService, 'addAlert').and.callThrough();
     const setAddStaffRecordInProgressSpy = spyOn(workerService, 'setAddStaffRecordInProgress');
     const setNewWorkerMandatoryInfoSpy = spyOn(workerService, 'setNewWorkerMandatoryInfo').and.callThrough();
+    const clearNewWorkerMandatoryInfoSpy = spyOn(workerService, 'clearNewWorkerMandatoryInfo').and.callThrough();
 
     return {
       component,
@@ -111,6 +112,7 @@ describe('StaffDetailsComponent', () => {
       alertSpy,
       setAddStaffRecordInProgressSpy,
       setNewWorkerMandatoryInfoSpy,
+      clearNewWorkerMandatoryInfoSpy,
     };
   }
 
@@ -173,6 +175,15 @@ describe('StaffDetailsComponent', () => {
       expect(updateWorkerSpy).not.toHaveBeenCalled();
       expect(setNewWorkerMandatoryInfoSpy).toHaveBeenCalledWith(enteredName, 'Temporary' as Contracts);
       expect(routerSpy.calls.mostRecent().args[0]).toEqual(['main-job-role']);
+    });
+
+    it(`should clear mandatory info in worker service after clicking 'Cancel' button when adding a staff record`, async () => {
+      const { fixture, getByText, clearNewWorkerMandatoryInfoSpy } = await setup(true, false, true);
+
+      userEvent.click(getByText('Cancel'));
+      fixture.detectChanges();
+
+      expect(clearNewWorkerMandatoryInfoSpy).toHaveBeenCalled();
     });
 
     it(`should show 'Save' and 'Cancel' buttons when not in mandatory details flow or in the staff record flow`, async () => {

--- a/frontend/src/app/features/workers/staff-details/staff-details.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-details/staff-details.component.spec.ts
@@ -92,6 +92,7 @@ describe('StaffDetailsComponent', () => {
     const submitSpy = spyOn(component, 'setSubmitAction').and.callThrough();
     const alertSpy = spyOn(alertService, 'addAlert').and.callThrough();
     const setAddStaffRecordInProgressSpy = spyOn(workerService, 'setAddStaffRecordInProgress');
+    const setNewWorkerMandatoryInfoSpy = spyOn(workerService, 'setNewWorkerMandatoryInfo').and.callThrough();
 
     return {
       component,
@@ -109,6 +110,7 @@ describe('StaffDetailsComponent', () => {
       submitSpy,
       alertSpy,
       setAddStaffRecordInProgressSpy,
+      setNewWorkerMandatoryInfoSpy,
     };
   }
 
@@ -158,12 +160,9 @@ describe('StaffDetailsComponent', () => {
       expect(getByText('Cancel')).toBeTruthy();
     });
 
-    it(`should navigate to main-job-role page after clicking 'Continue' cta button when adding a staff record`, async () => {
-      const { component, fixture, getByText, getByLabelText, submitSpy, routerSpy, updateWorkerSpy } = await setup(
-        true,
-        false,
-        true,
-      );
+    it(`should navigate to main-job-role page and set mandatory info in worker service after clicking 'Continue' cta button when adding a staff record`, async () => {
+      const { fixture, getByText, getByLabelText, routerSpy, updateWorkerSpy, setNewWorkerMandatoryInfoSpy } =
+        await setup(true, false, true);
 
       const enteredName = 'Someone';
       userEvent.type(getByLabelText('Name or ID number'), enteredName);
@@ -171,13 +170,8 @@ describe('StaffDetailsComponent', () => {
       userEvent.click(getByText('Continue'));
       fixture.detectChanges();
 
-      const updatedFormData = component.form.value;
-      expect(updatedFormData).toEqual({
-        nameOrId: enteredName,
-        contract: 'Temporary',
-      });
-
       expect(updateWorkerSpy).not.toHaveBeenCalled();
+      expect(setNewWorkerMandatoryInfoSpy).toHaveBeenCalledWith(enteredName, 'Temporary' as Contracts);
       expect(routerSpy.calls.mostRecent().args[0]).toEqual(['main-job-role']);
     });
 

--- a/frontend/src/app/features/workers/staff-details/staff-details.component.ts
+++ b/frontend/src/app/features/workers/staff-details/staff-details.component.ts
@@ -28,7 +28,6 @@ export class StaffDetailsComponent extends QuestionComponent implements OnInit, 
   public canExit = true;
   public editFlow: boolean;
   public inMandatoryDetailsFlow: boolean;
-  public summaryContinue: boolean;
   private isAddingNewWorker: boolean;
 
   constructor(
@@ -54,7 +53,6 @@ export class StaffDetailsComponent extends QuestionComponent implements OnInit, 
   init(): void {
     this.inMandatoryDetailsFlow = this.route.parent.snapshot.url[0].path === 'mandatory-details';
     this.isAddingNewWorker = !this.worker;
-    this.summaryContinue = !this.insideFlow && !this.inMandatoryDetailsFlow;
 
     this.prefillFormIfExistingWorkerOrInfoSetInWorkerService();
     this.getReturnPath();

--- a/frontend/src/app/features/workers/staff-details/staff-details.component.ts
+++ b/frontend/src/app/features/workers/staff-details/staff-details.component.ts
@@ -56,9 +56,7 @@ export class StaffDetailsComponent extends QuestionComponent implements OnInit, 
     this.isAddingNewWorker = !this.worker;
     this.summaryContinue = !this.insideFlow && !this.inMandatoryDetailsFlow;
 
-    if (this.worker) {
-      this.prefillForm();
-    }
+    this.prefillFormIfExistingWorkerOrInfoSetInWorkerService();
     this.getReturnPath();
     this.editFlow = this.inMandatoryDetailsFlow || this.wdfEditPageFlag || !this.insideFlow;
   }
@@ -95,11 +93,14 @@ export class StaffDetailsComponent extends QuestionComponent implements OnInit, 
     };
   }
 
-  prefillForm(): void {
-    this.form.patchValue({
-      nameOrId: this.worker.nameOrId,
-      contract: this.worker.contract,
-    });
+  prefillFormIfExistingWorkerOrInfoSetInWorkerService(): void {
+    const worker = this.worker || this.workerService.newWorkerMandatoryInfo;
+    if (worker) {
+      this.form.patchValue({
+        nameOrId: worker.nameOrId,
+        contract: worker.contract,
+      });
+    }
   }
 
   private getReturnPath() {
@@ -111,6 +112,7 @@ export class StaffDetailsComponent extends QuestionComponent implements OnInit, 
 
   public onSubmit(): void {
     if (!this.submitAction.save) {
+      this.workerService.clearNewWorkerMandatoryInfo();
       this.navigate();
       return;
     }


### PR DESCRIPTION
#### Work done
- Removed main job role content from first mandatory staff details page
- Added logic to the page to prefill the mandatory worker data for a new staff record when navigating back to the page
- Added logic to clear the new worker mandatory data in the worker service on exit of page/submission on main job role page to prevent prefilling form after having left and come back to the Add staff record flow 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
