### PR TITLE
Feat/1489 l2cc add reveal to care cert question

### DIFF
--- a/frontend/src/app/features/workers/care-certificate/care-certificate.component.html
+++ b/frontend/src/app/features/workers/care-certificate/care-certificate.component.html
@@ -11,6 +11,21 @@
               Have they completed, started or partially completed their Care Certificate?
             </h1>
           </legend>
+          <div class="govuk-inset-text govuk-!-margin-top-0">
+            The Care Certificate is not the same thing as the Level 2 Adult Social Care Certificate, introduced in 2024.
+          </div>
+          <details class="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">What’s the Care Certificate?</span>
+            </summary>
+            <div class="govuk-details__text">
+              <p>
+                The Care Certificate is an agreed set of standards that define the knowledge, skills and behaviours
+                expected of specific job roles in the health and social care sectors. It’s made up of the 15 standards
+                that should be covered as part of a robust induction programme.
+              </p>
+            </div>
+          </details>
           <div class="govuk-radios">
             <div *ngFor="let answer of answersAvailable; let idx = index" class="govuk-radios__item">
               <input

--- a/frontend/src/app/features/workers/care-certificate/care-certificate.component.html
+++ b/frontend/src/app/features/workers/care-certificate/care-certificate.component.html
@@ -11,7 +11,7 @@
               Have they completed, started or partially completed their Care Certificate?
             </h1>
           </legend>
-          <div class="govuk-inset-text govuk-!-margin-top-0">
+          <div class="govuk-inset-text thin-border govuk-!-margin-top-0">
             The Care Certificate is not the same thing as the Level 2 Adult Social Care Certificate, introduced in 2024.
           </div>
           <details class="govuk-details">

--- a/frontend/src/app/features/workers/care-certificate/care-certificate.component.spec.ts
+++ b/frontend/src/app/features/workers/care-certificate/care-certificate.component.spec.ts
@@ -10,7 +10,7 @@ import { fireEvent, render } from '@testing-library/angular';
 
 import { CareCertificateComponent } from './care-certificate.component';
 
-fdescribe('CareCertificateComponent', () => {
+describe('CareCertificateComponent', () => {
   async function setup(insideFlow = true) {
     const { fixture, getByText, getAllByText, getByLabelText, getByTestId, queryByTestId } = await render(
       CareCertificateComponent,

--- a/frontend/src/app/features/workers/care-certificate/care-certificate.component.spec.ts
+++ b/frontend/src/app/features/workers/care-certificate/care-certificate.component.spec.ts
@@ -10,7 +10,7 @@ import { fireEvent, render } from '@testing-library/angular';
 
 import { CareCertificateComponent } from './care-certificate.component';
 
-describe('CareCertificateComponent', () => {
+fdescribe('CareCertificateComponent', () => {
   async function setup(insideFlow = true) {
     const { fixture, getByText, getAllByText, getByLabelText, getByTestId, queryByTestId } = await render(
       CareCertificateComponent,
@@ -76,6 +76,28 @@ describe('CareCertificateComponent', () => {
     expect(getByLabelText('Yes, completed')).toBeTruthy();
     expect(getByLabelText('Yes, started or partially completed')).toBeTruthy();
     expect(getByLabelText('No')).toBeTruthy();
+  });
+
+  it('should render a inset text to explain Care Certificate is not the same as L2 CC certificate', async () => {
+    const { getByText } = await setup();
+
+    const explanationText = getByText(
+      'The Care Certificate is not the same thing as the Level 2 Adult Social Care Certificate, introduced in 2024.',
+    );
+
+    expect(explanationText).toBeTruthy();
+  });
+
+  it('should render a reveal text about what is the Care Certification', async () => {
+    const { getByText } = await setup();
+
+    const reveal = getByText('What’s the Care Certificate?');
+    const revealText = getByText(
+      'The Care Certificate is an agreed set of standards that define the knowledge, skills and behaviours expected of specific job roles in the health and social care sectors. It’s made up of the 15 standards that should be covered as part of a robust induction programme.',
+    );
+
+    expect(reveal).toBeTruthy();
+    expect(revealText).toBeTruthy();
   });
 
   describe('submit buttons', () => {

--- a/frontend/src/assets/scss/components/_inset-text.scss
+++ b/frontend/src/assets/scss/components/_inset-text.scss
@@ -18,4 +18,9 @@
     border-color: govuk-colour('blue');
     background-color: rgba(govuk-colour('blue'), 0.15);
   }
+
+  &.thin-border {
+    border-width: 5px;
+    padding-left: 20px;
+  }
 }


### PR DESCRIPTION
#### Work done
- Add reveal text and inset text to Care Certificate question page
- Add a custom css class for adjusting `govuk-inset-text` style, to align the grey bar thickness with `.govuk-details__text`

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
