### PR TITLE
Update the NHS API endpoints to use existing rate limiting config

### DIFF
--- a/backend/server/routes/nhsBsaApi/apiDocs.js
+++ b/backend/server/routes/nhsBsaApi/apiDocs.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const fs = require('fs');
 const path = require('path');
-const { authLimiter } = require('../../utils/middleware/rateLimitingNHSBSAAPI');
+const { authLimiter } = require('../../utils/middleware/rateLimiting');
 
 const nhsBsaApiDocumentation = (req, res) => {
   try {

--- a/backend/server/routes/nhsBsaApi/workplaceData.js
+++ b/backend/server/routes/nhsBsaApi/workplaceData.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const models = require('../../models');
 const authorization = require('../../utils/middleware/isNHSBSAAuthenticated');
-const { authLimiter } = require('../../utils/middleware/rateLimitingNHSBSAAPI');
+const { authLimiter } = require('../../utils/middleware/rateLimiting');
 // WDF effective date
 const WdfCalculator = require('../../models/classes/wdfCalculator').WdfCalculator;
 


### PR DESCRIPTION
#### Issue
There were issues with throttling errors when making requests to the NHS BSA API. This PR sets the same rate limiting config for those endpoints as the rest of the service to stop the throttling and give us time to investigate whether rate limiting is still working correctly since the migration to AWS.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
