### PR TITLE
amend materialized view WorkerQualificationStats and WorkerTrainingStats to not filter out Archived workers

### DIFF
--- a/backend/migrations/20240909153100-fixQualificationStatsViewForAnalysisFiles.js
+++ b/backend/migrations/20240909153100-fixQualificationStatsViewForAnalysisFiles.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query('DROP MATERIALIZED VIEW IF EXISTS cqc."WorkerQualificationStats"');
+    await queryInterface.sequelize.query(
+      `CREATE MATERIALIZED VIEW cqc."WorkerQualificationStats" AS (
+        SELECT wt."WorkerFK",
+        wt."QualificationsFK",
+        wt."Year",
+        count(*) AS total_quals
+       FROM cqc."Worker" w
+         JOIN cqc."WorkerQualifications" wt ON wt."WorkerFK" = w."ID"
+      GROUP BY wt."WorkerFK", ROLLUP(wt."QualificationsFK", wt."Year")
+      );`,
+    );
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS workerqualificationstats_worker_qualification_idx ON cqc."WorkerQualificationStats" ("WorkerFK", "QualificationsFK")',
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query('DROP MATERIALIZED VIEW IF EXISTS cqc."WorkerQualificationStats"');
+    await queryInterface.sequelize.query(
+      `CREATE MATERIALIZED VIEW cqc."WorkerQualificationStats" AS (
+        SELECT wt."WorkerFK",
+        wt."QualificationsFK",
+        wt."Year",
+        count(*) AS total_quals
+       FROM cqc."Worker" w
+         JOIN cqc."WorkerQualifications" wt ON wt."WorkerFK" = w."ID"
+      WHERE w."Archived" = false
+      GROUP BY wt."WorkerFK", ROLLUP(wt."QualificationsFK", wt."Year")
+      );`,
+    );
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS workerqualificationstats_worker_qualification_idx ON cqc."WorkerQualificationStats" ("WorkerFK", "QualificationsFK")',
+    );
+  },
+};

--- a/backend/migrations/20240909153600-fixWorkerTrainingStatsViewForAnalysisFiles.js
+++ b/backend/migrations/20240909153600-fixWorkerTrainingStatsViewForAnalysisFiles.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query('DROP MATERIALIZED VIEW IF EXISTS cqc."WorkerTrainingStats"');
+    await queryInterface.sequelize.query(
+      `CREATE MATERIALIZED VIEW cqc."WorkerTrainingStats" AS (
+      SELECT wt."WorkerFK",
+        wt."CategoryFK",
+        count(*) AS total_training,
+        count(*) FILTER (WHERE wt."Accredited" = 'Yes'::cqc."WorkerTrainingAccreditation") AS total_accredited_yes,
+        count(*) FILTER (WHERE wt."Accredited" = 'No'::cqc."WorkerTrainingAccreditation") AS total_accredited_no,
+        count(*) FILTER (WHERE wt."Accredited" = 'Don''t know'::cqc."WorkerTrainingAccreditation") AS total_accredited_unknown,
+        to_char(max(wt."Completed")::timestamp with time zone, 'DD/MM/YYYY'::text) AS latest_training_date
+      FROM cqc."Worker" w
+      JOIN cqc."WorkerTraining" wt ON wt."WorkerFK" = w."ID"
+      GROUP BY wt."WorkerFK", ROLLUP(wt."CategoryFK")
+  );`,
+    );
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS workertrainingstats_worker_category_idx ON cqc."WorkerTrainingStats" ("WorkerFK", "CategoryFK")',
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query('DROP MATERIALIZED VIEW "cqc"."WorkerTrainingStats"');
+    await queryInterface.sequelize.query(
+      `CREATE MATERIALIZED VIEW cqc."WorkerTrainingStats" AS (
+      SELECT wt."WorkerFK",
+        wt."CategoryFK",
+        count(*) AS total_training,
+        count(*) FILTER (WHERE wt."Accredited" = 'Yes'::cqc."WorkerTrainingAccreditation") AS total_accredited_yes,
+        count(*) FILTER (WHERE wt."Accredited" = 'No'::cqc."WorkerTrainingAccreditation") AS total_accredited_no,
+        count(*) FILTER (WHERE wt."Accredited" = 'Don''t know'::cqc."WorkerTrainingAccreditation") AS total_accredited_unknown,
+        to_char(max(wt."Completed")::timestamp with time zone, 'DD/MM/YYYY'::text) AS latest_training_date
+      FROM cqc."Worker" w
+      JOIN cqc."WorkerTraining" wt ON wt."WorkerFK" = w."ID"
+      WHERE w."Archived" = false
+      GROUP BY wt."WorkerFK", ROLLUP(wt."CategoryFK")
+  );`,
+    );
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS workertrainingstats_worker_category_idx ON cqc."WorkerTrainingStats" ("WorkerFK", "CategoryFK")',
+    );
+  },
+};


### PR DESCRIPTION
#### Work done
- Add migrations to correct the materialised view WorkerQualificationStats and WorkerTrainingStats, so that Archived worker will be included. This is to allow Analysis file to generate the leavers report correctly.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
