### PR TITLE
fix/1500-seeing-service-capacity-when-it-is-not-applicable

### DIFF
--- a/frontend/src/app/core/test-utils/MockEstablishmentService.ts
+++ b/frontend/src/app/core/test-utils/MockEstablishmentService.ts
@@ -409,3 +409,52 @@ export class MockEstablishmentServiceCheckCQCDetails extends MockEstablishmentSe
     return this.cqcDetailsBanner;
   }
 }
+
+@Injectable()
+export class MockEstablishmentServiceCapacity extends MockEstablishmentService {
+  private questionsAvailable;
+
+  public static factory(hasQuestions = false) {
+    return (httpClient: HttpClient) => {
+      const service = new MockEstablishmentServiceCapacity(httpClient);
+      service.questionsAvailable = hasQuestions;
+      return service;
+    };
+  }
+
+  public getCapacity(establishmentId: any, all: boolean): Observable<any> {
+    if (this.questionsAvailable) {
+      return of({
+        allServiceCapacities: [
+          {
+            service: 'Main Service: Some kind of service',
+            questions: [
+              { question: 'How many places do you have at the moment?', questionId: 101, seq: 1 },
+              { question: 'Number of those places being used?', questionId: 107, seq: 2 },
+            ],
+          },
+          {
+            service: 'Adult: Residential care',
+            questions: [
+              { question: 'How many beds do you have?', questionId: 102, seq: 1 },
+              { question: 'How many of those beds are being used?', questionId: 105, seq: 2 },
+            ],
+          },
+          {
+            service: 'Domiciliary: Home services',
+            questions: [{ question: 'Number of people receiving care at the moment', questionId: 109, seq: 1 }],
+          },
+          {
+            service: 'Extra Care: Housing services',
+            questions: [{ question: 'Number of people using the service at the moment', questionId: 111, seq: 1 }],
+          },
+        ],
+        mainService: { id: 100, name: 'Some kind of service' },
+      });
+    } else {
+      return of({
+        allServiceCapacities: [],
+      });
+    }
+  }
+}

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -218,7 +218,11 @@
         ></app-summary-record-change>
       </dd>
     </div>
-    <div *ngIf="!workplace.showAddWorkplaceDetailsBanner" class="govuk-summary-list__row" data-testid="serviceCapacity">
+    <div
+      *ngIf="!workplace.showAddWorkplaceDetailsBanner && hasCapacity"
+      class="govuk-summary-list__row"
+      data-testid="serviceCapacity"
+    >
       <dt class="govuk-summary-list__key">Service capacity</dt>
       <dd class="govuk-summary-list__value">
         <app-summary-record-value>

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -10,7 +10,10 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { MockCqcStatusChangeService } from '@core/test-utils/MockCqcStatusChangeService';
-import { establishmentWithShareWith, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import {
+  establishmentWithShareWith,
+  MockEstablishmentServiceCapacity,
+} from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
@@ -18,7 +21,11 @@ import { fireEvent, render, within } from '@testing-library/angular';
 import { NewWorkplaceSummaryComponent } from './workplace-summary.component';
 
 describe('NewWorkplaceSummaryComponent', () => {
-  const setup = async (shareWith = null, permissions = ['canEditEstablishment'] as PermissionType[]) => {
+  const setup = async (
+    shareWith = null,
+    permissions = ['canEditEstablishment'] as PermissionType[],
+    hasQuestions = true,
+  ) => {
     const { fixture, getByText, queryByText, getByTestId, queryByTestId } = await render(NewWorkplaceSummaryComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
@@ -29,7 +36,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         },
         {
           provide: EstablishmentService,
-          useClass: MockEstablishmentService,
+          useFactory: MockEstablishmentServiceCapacity.factory(hasQuestions),
         },
         {
           provide: CqcStatusChangeService,
@@ -616,11 +623,35 @@ describe('NewWorkplaceSummaryComponent', () => {
     });
 
     describe('Service capacity', () => {
-      it('should show dash and have Add information button on when capacities is an empty array', async () => {
+      it('should not show if there are no allServiceCapacities and showAddWorkplaceDetailsBanner is false', async () => {
+        const { component, fixture, queryByTestId } = await setup(null, ['canEditEstablishment'], false);
+
+        component.workplace.showAddWorkplaceDetailsBanner = false;
+
+        fixture.detectChanges();
+
+        const serviceCapacityRow = queryByTestId('serviceCapacity');
+
+        expect(serviceCapacityRow).toBeFalsy();
+      });
+
+      it('should not show if there are no allServiceCapacities and showAddWorkplaceDetailsBanner is false', async () => {
+        const { component, fixture, queryByTestId } = await setup(null, ['canEditEstablishment'], false);
+
+        component.workplace.showAddWorkplaceDetailsBanner = false;
+
+        fixture.detectChanges();
+
+        const serviceCapacityRow = queryByTestId('serviceCapacity');
+
+        expect(serviceCapacityRow).toBeFalsy();
+      });
+
+      it('should show dash and have Add information button if there are allServiceCapacities and showAddWorkplaceDetailsBanner is false', async () => {
         const { component, fixture } = await setup();
 
-        component.workplace.capacities = [];
-        component.canEditEstablishment = true;
+        component.workplace.showAddWorkplaceDetailsBanner = false;
+
         fixture.detectChanges();
 
         const serviceCapacityRow = within(document.body).queryByTestId('serviceCapacity');
@@ -629,6 +660,18 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/capacity-of-services`);
         expect(within(serviceCapacityRow).queryByText('-')).toBeTruthy();
+      });
+
+      it('should not show if there are allServiceCapacities and showAddWorkplaceDetailsBanner is true', async () => {
+        const { component, fixture, queryByTestId } = await setup();
+
+        component.workplace.showAddWorkplaceDetailsBanner = true;
+
+        fixture.detectChanges();
+
+        const serviceCapacityRow = queryByTestId('serviceCapacity');
+
+        expect(serviceCapacityRow).toBeFalsy();
       });
 
       it('should show service capacity and have Change link when capacity array is not emtpy', async () => {


### PR DESCRIPTION
#### Work done
- Extend condition to show service capacity on workplace summary so it only shows if for the correct services 

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
