### PR TITLE
Updated download of start in sector to set No to 999 and empty string when unanswered

### DIFF
--- a/backend/server/routes/establishments/bulkUpload/download/workerCSV.js
+++ b/backend/server/routes/establishments/bulkUpload/download/workerCSV.js
@@ -222,7 +222,12 @@ const toCSV = (establishmentId, entity, MAX_QUALIFICATIONS, downloadType) => {
   ); // in UK date format dd/mm/yyyy (Worker stores as YYYY-MM-DD)
 
   // "STARTINSECT"
-  columns.push(entity.SocialCareStartDateValue === 'Yes' ? entity.SocialCareStartDateYear : '');
+  const socialCareStartDateMappings = {
+    Yes: entity.SocialCareStartDateYear,
+    No: '999',
+  };
+
+  columns.push(socialCareStartDateMappings[entity.SocialCareStartDateValue] || '');
 
   // "APPRENTICE"
   let apprenticeship = '';

--- a/backend/server/test/unit/routes/establishments/bulkUpload/download/workerCSV.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/download/workerCSV.spec.js
@@ -392,22 +392,34 @@ describe('workerCSV', () => {
           expect(csvAsArray[getWorkerColumnIndex('STARTDATE')]).to.equal('');
         });
 
-        it('should return the correct code for social care start date', async () => {
-          worker.SocialCareStartDateValue = 'Yes';
-          worker.SocialCareStartDateYear = '1998';
+        describe('Social care start date', () => {
+          it('should return the correct code for social care start date', async () => {
+            worker.SocialCareStartDateValue = 'Yes';
+            worker.SocialCareStartDateYear = '1998';
 
-          const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
-          const csvAsArray = csv.split(',');
+            const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
+            const csvAsArray = csv.split(',');
 
-          expect(csvAsArray[getWorkerColumnIndex('STARTINSECT')]).to.equal(worker.YearArrivedYear);
-        });
-        it('should not return year if the social care start date is no', async () => {
-          worker.SocialCareStartDateValue = 'No';
+            expect(csvAsArray[getWorkerColumnIndex('STARTINSECT')]).to.equal(worker.YearArrivedYear);
+          });
 
-          const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
-          const csvAsArray = csv.split(',');
+          it('should return 999 if the social care start date value is No', async () => {
+            worker.SocialCareStartDateValue = 'No';
 
-          expect(csvAsArray[getWorkerColumnIndex('STARTINSECT')]).to.equal('');
+            const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
+            const csvAsArray = csv.split(',');
+
+            expect(csvAsArray[getWorkerColumnIndex('STARTINSECT')]).to.equal('999');
+          });
+
+          it('should return empty string if the social care start date value is null (question not answered)', async () => {
+            worker.SocialCareStartDateValue = null;
+
+            const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
+            const csvAsArray = csv.split(',');
+
+            expect(csvAsArray[getWorkerColumnIndex('STARTINSECT')]).to.equal('');
+          });
         });
 
         yesNoDontKnow.forEach((value) => {


### PR DESCRIPTION
#### Work done
- Updated download of start in sector to set No to 999 and empty string when unanswered

#### Issue
The STARTINSECT column would be empty for users who had answered No previously, and they would then get a warning when trying to upload if they leave the column blank. This ensures users can differentiate between No and not answering the Start in sector question.

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
