### PR TITLE
Feat/1514 download single and multiple training certificates

### DIFF
--- a/backend/migrations/20240912113822-createTableForTrainingCertificates.js
+++ b/backend/migrations/20240912113822-createTableForTrainingCertificates.js
@@ -47,6 +47,10 @@ module.exports = {
           type: Sequelize.DataTypes.DATE,
           allowNull: true,
         },
+        Key: {
+          type: Sequelize.DataTypes.TEXT,
+          allowNull: false,
+        },
       },
       { schema: 'cqc' },
     );

--- a/backend/server/models/trainingCertificates.js
+++ b/backend/server/models/trainingCertificates.js
@@ -38,6 +38,11 @@ module.exports = function (sequelize, DataTypes) {
         allowNull: false,
         field: '"UploadDate"',
       },
+      key: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+        field: '"Key"',
+      },
     },
     {
       tableName: 'TrainingCertificates',
@@ -61,7 +66,7 @@ module.exports = function (sequelize, DataTypes) {
     });
   };
 
-  TrainingCertificates.addCertificate = function ({ trainingRecordId, workerFk, filename, fileId }) {
+  TrainingCertificates.addCertificate = function ({ trainingRecordId, workerFk, filename, fileId, key }) {
     const timeNow = dayjs().format();
 
     return this.create({
@@ -70,6 +75,7 @@ module.exports = function (sequelize, DataTypes) {
       workerTrainingFk: trainingRecordId,
       filename: filename,
       uploadDate: timeNow,
+      key,
     });
   };
 

--- a/backend/server/routes/establishments/workerCertificate/s3.js
+++ b/backend/server/routes/establishments/workerCertificate/s3.js
@@ -1,4 +1,4 @@
-const { PutObjectCommand, S3Client, HeadObjectCommand } = require('@aws-sdk/client-s3');
+const { PutObjectCommand, GetObjectCommand, S3Client, HeadObjectCommand } = require('@aws-sdk/client-s3');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 
 const config = require('../../../config/config');
@@ -25,6 +25,15 @@ function getSignedUrlForUpload({ bucket, key, options }) {
   return getSignedUrl(s3client, putCommand, options);
 }
 
+const getSignedUrlForDownload = ({ bucket, key, options }) => {
+  const s3client = getS3Client();
+  const getCommand = new GetObjectCommand({
+    Bucket: bucket,
+    Key: key,
+  });
+  return getSignedUrl(s3client, getCommand, options);
+};
+
 async function verifyEtag(bucket, key, etag) {
   const s3client = getS3Client();
   const headCommand = new HeadObjectCommand({ Bucket: bucket, Key: key });
@@ -34,4 +43,4 @@ async function verifyEtag(bucket, key, etag) {
   return etagFromS3 === etag;
 }
 
-module.exports = { getS3Client, getSignedUrlForUpload, verifyEtag };
+module.exports = { getS3Client, getSignedUrlForUpload, getSignedUrlForDownload, verifyEtag };

--- a/backend/server/routes/establishments/workerCertificate/s3.js
+++ b/backend/server/routes/establishments/workerCertificate/s3.js
@@ -16,28 +16,27 @@ const getS3Client = () => {
   return new S3Client(clientConfigs);
 };
 
+const s3Client = getS3Client();
+
 function getSignedUrlForUpload({ bucket, key, options }) {
-  const s3client = getS3Client();
   const putCommand = new PutObjectCommand({
     Bucket: bucket,
     Key: key,
   });
-  return getSignedUrl(s3client, putCommand, options);
+  return getSignedUrl(s3Client, putCommand, options);
 }
 
 const getSignedUrlForDownload = ({ bucket, key, options }) => {
-  const s3client = getS3Client();
   const getCommand = new GetObjectCommand({
     Bucket: bucket,
     Key: key,
   });
-  return getSignedUrl(s3client, getCommand, options);
+  return getSignedUrl(s3Client, getCommand, options);
 };
 
 async function verifyEtag(bucket, key, etag) {
-  const s3client = getS3Client();
   const headCommand = new HeadObjectCommand({ Bucket: bucket, Key: key });
-  const response = await s3client.send(headCommand);
+  const response = await s3Client.send(headCommand);
   const etagFromS3 = response.ETag;
 
   return etagFromS3 === etag;

--- a/backend/server/routes/establishments/workerCertificate/trainingCertificate.js
+++ b/backend/server/routes/establishments/workerCertificate/trainingCertificate.js
@@ -13,13 +13,13 @@ const downloadSignedUrlExpire = config.get('workerCertificate.downloadSignedUrlE
 
 const router = express.Router({ mergeParams: true });
 
-const makeFileKey = (establishmentId, fileId) => {
-  return `${establishmentId}/trainingCertificate/${fileId}`;
+const makeFileKey = (establishmentUid, workerId, trainingUid, fileId) => {
+  return `${establishmentUid}/${workerId}/trainingCertificate/${trainingUid}/${fileId}`;
 };
 
 const requestUploadUrl = async (req, res) => {
-  const { establishmentId } = req;
   const { files } = req.body;
+  const { id, workerId, trainingUid } = req.params;
   if (!files || !files.length) {
     return res.status(400).send('Missing `files` param in request body');
   }
@@ -33,13 +33,13 @@ const requestUploadUrl = async (req, res) => {
   for (const file of files) {
     const filename = file.filename;
     const fileId = uuidv4();
-    const fileKey = makeFileKey(establishmentId, fileId);
+    const key = makeFileKey(id, workerId, trainingUid, fileId);
     const signedUrl = await s3.getSignedUrlForUpload({
       bucket: certificateBucket,
-      key: fileKey,
+      key,
       options: { expiresIn: uploadSignedUrlExpire },
     });
-    responsePayload.push({ filename, signedUrl, fileId });
+    responsePayload.push({ filename, signedUrl, fileId, key });
   }
 
   return res.status(200).json({ files: responsePayload });
@@ -73,10 +73,10 @@ const confirmUpload = async (req, res) => {
   }
 
   for (const file of files) {
-    const { filename, fileId } = file;
+    const { filename, fileId, key } = file;
 
     try {
-      await models.trainingCertificates.addCertificate({ trainingRecordId, workerFk, filename, fileId });
+      await models.trainingCertificates.addCertificate({ trainingRecordId, workerFk, filename, fileId, key });
     } catch (err) {
       console.error(err);
       return res.status(500).send('Failed to add records to database');
@@ -89,8 +89,7 @@ const confirmUpload = async (req, res) => {
 const verifyEtagsForAllFiles = async (establishmentId, files) => {
   try {
     for (const file of files) {
-      const fileKey = makeFileKey(establishmentId, file.fileId);
-      const etagMatchS3Record = await s3.verifyEtag(certificateBucket, fileKey, file.etag);
+      const etagMatchS3Record = await s3.verifyEtag(certificateBucket, file.key, file.etag);
       if (!etagMatchS3Record) {
         console.error('Etags in the request does not match the record at AWS bucket');
         return false;
@@ -103,9 +102,33 @@ const verifyEtagsForAllFiles = async (establishmentId, files) => {
   return true;
 };
 
+const getPresignedUrlForCertificateDownload = async (req, res) => {
+  const { filesToDownload } = req.body;
+  const { id, workerId, trainingUid } = req.params;
+
+  if (!filesToDownload || !filesToDownload.length) {
+    return res.status(400).send('No files provided in request body');
+  }
+
+  const responsePayload = [];
+
+  for (const fileUid of filesToDownload) {
+    const signedUrl = await s3.getSignedUrlForDownload({
+      bucket: certificateBucket,
+      key: makeFileKey(id, workerId, trainingUid, fileUid),
+      options: { expiresIn: downloadSignedUrlExpire },
+    });
+    responsePayload.push({ signedUrl });
+  }
+
+  return res.status(200).json({ files: responsePayload });
+};
+
 router.route('/').post(hasPermission('canEditWorker'), requestUploadUrl);
 router.route('/').put(hasPermission('canEditWorker'), confirmUpload);
+router.route('/download').post(hasPermission('canEditWorker'), getPresignedUrlForCertificateDownload);
 
 module.exports = router;
 module.exports.requestUploadUrl = requestUploadUrl;
 module.exports.confirmUpload = confirmUpload;
+module.exports.getPresignedUrlForCertificateDownload = getPresignedUrlForCertificateDownload;

--- a/backend/server/routes/establishments/workerCertificate/trainingCertificate.js
+++ b/backend/server/routes/establishments/workerCertificate/trainingCertificate.js
@@ -112,13 +112,13 @@ const getPresignedUrlForCertificateDownload = async (req, res) => {
 
   const responsePayload = [];
 
-  for (const fileUid of filesToDownload) {
+  for (const file of filesToDownload) {
     const signedUrl = await s3.getSignedUrlForDownload({
       bucket: certificateBucket,
-      key: makeFileKey(id, workerId, trainingUid, fileUid),
+      key: makeFileKey(id, workerId, trainingUid, file.uid),
       options: { expiresIn: downloadSignedUrlExpire },
     });
-    responsePayload.push({ signedUrl });
+    responsePayload.push({ signedUrl, filename: file.filename });
   }
 
   return res.status(200).json({ files: responsePayload });

--- a/backend/server/test/unit/routes/establishments/workerCertificate/trainingCertificate.spec.js
+++ b/backend/server/test/unit/routes/establishments/workerCertificate/trainingCertificate.spec.js
@@ -196,14 +196,16 @@ describe('backend/server/routes/establishments/workerCertificate/trainingCertifi
     const mockSignedUrl = 'http://localhost/mock-download-url';
     let res;
     let mockFileUid;
+    let mockFileName;
 
     beforeEach(() => {
       getSignedUrlForDownloadSpy = sinon.stub(s3, 'getSignedUrlForDownload').returns(mockSignedUrl);
       mockFileUid = 'mockFileUid';
+      mockFileName = 'mockFileName';
       req = httpMocks.createRequest({
         method: 'POST',
         url: `/api/establishment/${user.establishment.uid}/worker/${user.uid}/training/${training.uid}/certificate/download`,
-        body: { filesToDownload: [mockFileUid] },
+        body: { filesToDownload: [{ uid: mockFileUid, filename: mockFileName }] },
         establishmentId: user.establishment.uid,
         params: { id: user.establishment.uid, workerId: user.uid, trainingUid: training.uid },
       });
@@ -216,11 +218,11 @@ describe('backend/server/routes/establishments/workerCertificate/trainingCertifi
       expect(res.statusCode).to.equal(200);
     });
 
-    it('should return an array with signed url for download in response', async () => {
+    it('should return an array with signed url for download and file name in response', async () => {
       await trainingCertificateRoute.getPresignedUrlForCertificateDownload(req, res);
       const actual = await res._getJSONData();
 
-      expect(actual.files).to.deep.equal([{ signedUrl: mockSignedUrl }]);
+      expect(actual.files).to.deep.equal([{ signedUrl: mockSignedUrl, filename: mockFileName }]);
     });
 
     it('should call getSignedUrlForDownload with bucket name from config', async () => {

--- a/frontend/src/app/core/model/training.model.ts
+++ b/frontend/src/app/core/model/training.model.ts
@@ -122,7 +122,7 @@ export interface CertificateSignedUrlRequest {
 }
 
 export interface CertificateSignedUrlResponse {
-  files: { filename: string; fileId: string; signedUrl: string }[];
+  files: { filename: string; fileId: string; signedUrl: string; key: string }[];
 }
 
 export interface S3UploadResponse {
@@ -132,6 +132,7 @@ export interface FileInfoWithETag {
   filename: string;
   fileId: string;
   etag: string;
+  key: string;
 }
 
 export interface ConfirmUploadRequest {

--- a/frontend/src/app/core/model/training.model.ts
+++ b/frontend/src/app/core/model/training.model.ts
@@ -30,6 +30,11 @@ export interface TrainingResponse {
   training: TrainingRecord[];
 }
 
+export interface CertificateDownload {
+  uid: string;
+  filename: string;
+}
+
 export interface TrainingCertificate {
   uid: string;
   filename: string;

--- a/frontend/src/app/core/services/training.service.spec.ts
+++ b/frontend/src/app/core/services/training.service.spec.ts
@@ -218,7 +218,7 @@ describe('TrainingService', () => {
     });
   });
 
-  describe('downloadCertificate', () => {
+  describe('downloadCertificates', () => {
     const mockWorkplaceUid = 'mockWorkplaceUid';
     const mockWorkerUid = 'mockWorkerUid';
     const mockTrainingUid = 'mockTrainingUid';
@@ -228,14 +228,14 @@ describe('TrainingService', () => {
     const certificateDownloadEndpoint = `${environment.appRunnerEndpoint}/api/establishment/${mockWorkplaceUid}/worker/${mockWorkerUid}/training/${mockTrainingUid}/certificate/download`;
 
     it('should make call to expected backend endpoint', async () => {
-      service.downloadCertificate(mockWorkplaceUid, mockWorkerUid, mockTrainingUid, mockFiles).subscribe();
+      service.downloadCertificates(mockWorkplaceUid, mockWorkerUid, mockTrainingUid, mockFiles).subscribe();
 
       const downloadRequest = http.expectOne(certificateDownloadEndpoint);
       expect(downloadRequest.request.method).toBe('POST');
     });
 
     it('should have request body that contains file uid', async () => {
-      service.downloadCertificate(mockWorkplaceUid, mockWorkerUid, mockTrainingUid, mockFiles).subscribe();
+      service.downloadCertificates(mockWorkplaceUid, mockWorkerUid, mockTrainingUid, mockFiles).subscribe();
 
       const downloadRequest = http.expectOne(certificateDownloadEndpoint);
       const expectedRequestBody = { filesToDownload: mockFiles };

--- a/frontend/src/app/core/services/training.service.spec.ts
+++ b/frontend/src/app/core/services/training.service.spec.ts
@@ -223,7 +223,7 @@ describe('TrainingService', () => {
     const mockWorkerUid = 'mockWorkerUid';
     const mockTrainingUid = 'mockTrainingUid';
 
-    const mockFiles = ['mockCertificateUid123'];
+    const mockFiles = [{ uid: 'mockCertificateUid123', filename: 'mockCertificateName' }];
 
     const certificateDownloadEndpoint = `${environment.appRunnerEndpoint}/api/establishment/${mockWorkplaceUid}/worker/${mockWorkerUid}/training/${mockTrainingUid}/certificate/download`;
 
@@ -246,7 +246,7 @@ describe('TrainingService', () => {
 
   describe('triggerCertificateDownloads', () => {
     it('should download certificates by creating and triggering anchor tag, then cleaning DOM', () => {
-      const mockCertificates = [{ signedUrl: 'https://example.com/file1.pdf' }];
+      const mockCertificates = [{ signedUrl: 'https://example.com/file1.pdf', filename: 'file1.pdf' }];
       const mockBlob = new Blob(['file content'], { type: 'application/pdf' });
       const mockBlobUrl = 'blob:http://signed-url-example.com/blob-url';
 
@@ -268,7 +268,7 @@ describe('TrainingService', () => {
       // Assert anchor element has correct attributes
       const createdAnchor = createElementSpy.calls.mostRecent().returnValue as HTMLAnchorElement;
       expect(createdAnchor.href).toBe(mockBlobUrl);
-      expect(createdAnchor.download).toBe('test0');
+      expect(createdAnchor.download).toBe(mockCertificates[0].filename);
 
       // Assert DOM is cleaned up after download
       expect(revokeObjectURLSpy).toHaveBeenCalledWith(mockBlobUrl);

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -185,7 +185,7 @@ export class TrainingService {
     );
   }
 
-  public downloadCertificate(
+  public downloadCertificates(
     workplaceUid: string,
     workerUid: string,
     trainingUid: string,

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
@@ -867,10 +867,10 @@ describe('AddEditTrainingComponent', () => {
         expect(downloadButton).toBeTruthy();
       });
 
-      it('should make call to downloadCertificate with required uids and file uid in array when Download button clicked', async () => {
+      it('should make call to downloadCertificates with required uids and file uid in array when Download button clicked', async () => {
         const { component, fixture, getByTestId, trainingService } = await setup();
 
-        const downloadCertificateSpy = spyOn(trainingService, 'downloadCertificate').and.returnValue(
+        const downloadCertificatesSpy = spyOn(trainingService, 'downloadCertificates').and.returnValue(
           of({ files: ['abc123'] }),
         );
         component.trainingCertificates = [mockTrainingCertificate];
@@ -880,7 +880,7 @@ describe('AddEditTrainingComponent', () => {
         const firstCertDownloadButton = within(certificatesTable).getAllByText('Download')[0];
         firstCertDownloadButton.click();
 
-        expect(downloadCertificateSpy).toHaveBeenCalledWith(
+        expect(downloadCertificatesSpy).toHaveBeenCalledWith(
           component.workplace.uid,
           component.worker.uid,
           component.trainingRecordId,
@@ -888,10 +888,10 @@ describe('AddEditTrainingComponent', () => {
         );
       });
 
-      it('should make call to downloadCertificate with all certificate file uids in array when Download all button clicked', async () => {
+      it('should make call to downloadCertificates with all certificate file uids in array when Download all button clicked', async () => {
         const { component, fixture, getByTestId, trainingService } = await setup();
 
-        const downloadCertificateSpy = spyOn(trainingService, 'downloadCertificate').and.returnValue(
+        const downloadCertificatesSpy = spyOn(trainingService, 'downloadCertificates').and.returnValue(
           of({ files: ['abc123'] }),
         );
         component.trainingCertificates = [mockTrainingCertificate, mockTrainingCertificate2];
@@ -901,7 +901,7 @@ describe('AddEditTrainingComponent', () => {
         const downloadButton = within(certificatesTable).getByText('Download all');
         downloadButton.click();
 
-        expect(downloadCertificateSpy).toHaveBeenCalledWith(
+        expect(downloadCertificatesSpy).toHaveBeenCalledWith(
           component.workplace.uid,
           component.worker.uid,
           component.trainingRecordId,
@@ -915,7 +915,7 @@ describe('AddEditTrainingComponent', () => {
       it('should display singular version of error message when Download fails', async () => {
         const { component, fixture, getByText, getByTestId, trainingService } = await setup();
 
-        spyOn(trainingService, 'downloadCertificate').and.returnValue(of({ files: [] }));
+        spyOn(trainingService, 'downloadCertificates').and.returnValue(of({ files: [] }));
         component.trainingCertificates = [mockTrainingCertificate, mockTrainingCertificate2];
 
         fixture.detectChanges();
@@ -932,7 +932,7 @@ describe('AddEditTrainingComponent', () => {
       it('should display plural version of error message when Download all fails', async () => {
         const { component, fixture, getByText, getByTestId, trainingService } = await setup();
 
-        spyOn(trainingService, 'downloadCertificate').and.returnValue(of({ files: [] }));
+        spyOn(trainingService, 'downloadCertificates').and.returnValue(of({ files: [] }));
         component.trainingCertificates = [mockTrainingCertificate, mockTrainingCertificate2];
 
         fixture.detectChanges();

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
@@ -912,7 +912,7 @@ describe('AddEditTrainingComponent', () => {
         );
       });
 
-      it('should display singular version of error message when Download fails', async () => {
+      it('should display error message when Download fails', async () => {
         const { component, fixture, getByText, getByTestId, trainingService } = await setup();
 
         spyOn(trainingService, 'downloadCertificates').and.returnValue(of({ files: [] }));
@@ -925,11 +925,13 @@ describe('AddEditTrainingComponent', () => {
         downloadButton.click();
         fixture.detectChanges();
 
-        const expectedErrorMessage = getByText('Error downloading the certificate');
+        const expectedErrorMessage = getByText(
+          "There's a problem with this download. Try again later or contact us for help.",
+        );
         expect(expectedErrorMessage).toBeTruthy();
       });
 
-      it('should display plural version of error message when Download all fails', async () => {
+      it('should display error message when Download all fails', async () => {
         const { component, fixture, getByText, getByTestId, trainingService } = await setup();
 
         spyOn(trainingService, 'downloadCertificates').and.returnValue(of({ files: [] }));
@@ -942,7 +944,9 @@ describe('AddEditTrainingComponent', () => {
         downloadAllButton.click();
         fixture.detectChanges();
 
-        const expectedErrorMessage = getByText('Error downloading the certificates');
+        const expectedErrorMessage = getByText(
+          "There's a problem with this download. Try again later or contact us for help.",
+        );
         expect(expectedErrorMessage).toBeTruthy();
       });
     });

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
@@ -884,7 +884,7 @@ describe('AddEditTrainingComponent', () => {
           component.workplace.uid,
           component.worker.uid,
           component.trainingRecordId,
-          [mockTrainingCertificate.uid],
+          [{ uid: mockTrainingCertificate.uid, filename: mockTrainingCertificate.filename }],
         );
       });
 
@@ -905,7 +905,10 @@ describe('AddEditTrainingComponent', () => {
           component.workplace.uid,
           component.worker.uid,
           component.trainingRecordId,
-          [mockTrainingCertificate.uid, mockTrainingCertificate2.uid],
+          [
+            { uid: mockTrainingCertificate.uid, filename: mockTrainingCertificate.filename },
+            { uid: mockTrainingCertificate2.uid, filename: mockTrainingCertificate2.filename },
+          ],
         );
       });
 

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -216,7 +216,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
       .downloadCertificates(this.workplace.uid, this.worker.uid, this.trainingRecordId, filesToDownload)
       .subscribe((res) => {
         if (!res.files || res.files.length == 0) {
-          this.certificateErrors = [`Error downloading the certificate${filesToDownload.length > 1 ? 's' : ''}`];
+          this.certificateErrors = ["There's a problem with this download. Try again later or contact us for help."];
           return;
         }
         this.trainingService.triggerCertificateDownloads(res.files);

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -202,10 +202,11 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
   }
 
   public downloadCertificate(fileIndex: number): void {
+    const filesToDownload = fileIndex
+      ? [this.trainingCertificates[fileIndex].uid]
+      : this.trainingCertificates.map((certificate) => certificate.uid);
     this.trainingService
-      .downloadCertificate(this.workplace.uid, this.worker.uid, this.trainingRecordId, [
-        this.trainingCertificates[fileIndex].uid,
-      ])
+      .downloadCertificate(this.workplace.uid, this.worker.uid, this.trainingRecordId, filesToDownload)
       .subscribe((res) => {
         res.files.forEach((file) => {
           window.open(file.signedUrl, '_blank');

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -25,7 +25,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
   public establishmentUid: string;
   public workerId: string;
   private _filesToUpload: File[];
-  public uploadFilesErrors: string[] | null;
+  public certificateErrors: string[] | null;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -156,11 +156,11 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
   }
 
   private resetUploadFilesError(): void {
-    this.uploadFilesErrors = null;
+    this.certificateErrors = null;
   }
 
   public getUploadComponentAriaDescribedBy(): string {
-    if (this.uploadFilesErrors) {
+    if (this.certificateErrors) {
       return 'uploadCertificate-errors uploadCertificate-aria-text';
     } else if (this.filesToUpload?.length > 0) {
       return 'uploadCertificate-aria-text';
@@ -174,7 +174,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
     const errors = CustomValidators.validateUploadCertificates(newFiles);
 
     if (errors) {
-      this.uploadFilesErrors = errors;
+      this.certificateErrors = errors;
       return;
     }
 
@@ -216,7 +216,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
       .downloadCertificates(this.workplace.uid, this.worker.uid, this.trainingRecordId, filesToDownload)
       .subscribe((res) => {
         if (!res.files || res.files.length == 0) {
-          this.uploadFilesErrors = [`Error downloading the certificate${filesToDownload.length > 1 ? 's' : ''}`];
+          this.certificateErrors = [`Error downloading the certificate${filesToDownload.length > 1 ? 's' : ''}`];
           return;
         }
         this.trainingService.triggerCertificateDownloads(res.files);

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -35,6 +36,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
     protected trainingCategoryService: TrainingCategoryService,
     protected workerService: WorkerService,
     protected alertService: AlertService,
+    protected http: HttpClient,
   ) {
     super(
       formBuilder,
@@ -205,12 +207,11 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
     const filesToDownload = fileIndex
       ? [this.trainingCertificates[fileIndex].uid]
       : this.trainingCertificates.map((certificate) => certificate.uid);
+
     this.trainingService
       .downloadCertificate(this.workplace.uid, this.worker.uid, this.trainingRecordId, filesToDownload)
       .subscribe((res) => {
-        res.files.forEach((file) => {
-          window.open(file.signedUrl, '_blank');
-        });
+        this.trainingService.triggerCertificateDownloads(res.files);
       });
   }
 

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -204,13 +204,18 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
   }
 
   public downloadCertificate(fileIndex: number): void {
-    const filesToDownload = fileIndex
-      ? [this.trainingCertificates[fileIndex].uid]
-      : this.trainingCertificates.map((certificate) => certificate.uid);
+    const filesToDownload =
+      fileIndex != null
+        ? [this.trainingCertificates[fileIndex].uid]
+        : this.trainingCertificates.map((certificate) => certificate.uid);
 
     this.trainingService
       .downloadCertificate(this.workplace.uid, this.worker.uid, this.trainingRecordId, filesToDownload)
       .subscribe((res) => {
+        if (!res.files || res.files.length == 0) {
+          this.uploadFilesErrors = [`Error downloading the certificate${filesToDownload.length > 1 ? 's' : ''}`];
+          return;
+        }
         this.trainingService.triggerCertificateDownloads(res.files);
       });
   }

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -204,7 +204,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
     );
   }
 
-  public downloadCertificate(fileIndex: number): void {
+  public downloadCertificates(fileIndex: number): void {
     const filesToDownload =
       fileIndex != null
         ? [this.formatForCertificateDownload(this.trainingCertificates[fileIndex])]
@@ -213,7 +213,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
           });
 
     this.trainingService
-      .downloadCertificate(this.workplace.uid, this.worker.uid, this.trainingRecordId, filesToDownload)
+      .downloadCertificates(this.workplace.uid, this.worker.uid, this.trainingRecordId, filesToDownload)
       .subscribe((res) => {
         if (!res.files || res.files.length == 0) {
           this.uploadFilesErrors = [`Error downloading the certificate${filesToDownload.length > 1 ? 's' : ''}`];

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -3,6 +3,7 @@ import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DATE_PARSE_FORMAT } from '@core/constants/constants';
+import { CertificateDownload, TrainingCertificate } from '@core/model/training.model';
 import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
@@ -206,8 +207,10 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
   public downloadCertificate(fileIndex: number): void {
     const filesToDownload =
       fileIndex != null
-        ? [this.trainingCertificates[fileIndex].uid]
-        : this.trainingCertificates.map((certificate) => certificate.uid);
+        ? [this.formatForCertificateDownload(this.trainingCertificates[fileIndex])]
+        : this.trainingCertificates.map((certificate) => {
+            return this.formatForCertificateDownload(certificate);
+          });
 
     this.trainingService
       .downloadCertificate(this.workplace.uid, this.worker.uid, this.trainingRecordId, filesToDownload)
@@ -218,6 +221,10 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
         }
         this.trainingService.triggerCertificateDownloads(res.files);
       });
+  }
+
+  private formatForCertificateDownload(certificate: TrainingCertificate): CertificateDownload {
+    return { uid: certificate.uid, filename: certificate.filename };
   }
 
   private onSuccess() {

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -201,7 +201,7 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
     );
   }
 
-  public downloadFile(fileIndex: number): void {
+  public downloadCertificate(fileIndex: number): void {
     this.trainingService
       .downloadCertificate(this.workplace.uid, this.worker.uid, this.trainingRecordId, [
         this.trainingCertificates[fileIndex].uid,

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -5,14 +5,14 @@ import { DATE_PARSE_FORMAT } from '@core/constants/constants';
 import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { TrainingCategoryService } from '@core/services/training-category.service';
 import { TrainingService } from '@core/services/training.service';
 import { WorkerService } from '@core/services/worker.service';
+import { CustomValidators } from '@shared/validators/custom-form-validators';
 import dayjs from 'dayjs';
+import { mergeMap } from 'rxjs/operators';
 
 import { AddEditTrainingDirective } from '../../../shared/directives/add-edit-training/add-edit-training.directive';
-import { TrainingCategoryService } from '@core/services/training-category.service';
-import { mergeMap } from 'rxjs/operators';
-import { CustomValidators } from '@shared/validators/custom-form-validators';
 
 @Component({
   selector: 'app-add-edit-training',
@@ -199,6 +199,18 @@ export class AddEditTrainingComponent extends AddEditTrainingDirective implement
       trainingRecordId,
       this.filesToUpload,
     );
+  }
+
+  public downloadFile(fileIndex: number): void {
+    this.trainingService
+      .downloadCertificate(this.workplace.uid, this.worker.uid, this.trainingRecordId, [
+        this.trainingCertificates[fileIndex].uid,
+      ])
+      .subscribe((res) => {
+        res.files.forEach((file) => {
+          window.open(file.signedUrl, '_blank');
+        });
+      });
   }
 
   private onSuccess() {

--- a/frontend/src/app/shared/components/certifications-table/certifications-table.component.html
+++ b/frontend/src/app/shared/components/certifications-table/certifications-table.component.html
@@ -6,10 +6,13 @@
         <th scope="col" class="govuk-table__header govuk-!-padding-bottom-1">Upload date</th>
         <th scope="col" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-bottom-1">
           <ng-container *ngIf="certificates?.length > 1">
-            <a href="#" class="govuk-link govuk-link--no-visited-state">
+            <a
+              href="#"
+              class="govuk-link govuk-link--no-visited-state"
+              (click)="handleDownloadCertificate($event, null)"
+            >
               <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
                 class="govuk-!-margin-left-1"
-                (click)="handleDownloadCertificate($event, null)"
                 >Download all</span
               ></a
             >
@@ -45,10 +48,9 @@
             {{ certificate.uploadDate | date: "d MMM y, h:mmaaaaa'm'" }}
           </td>
           <td class="govuk-table__cell table__cell-download_button">
-            <a href="#" class="govuk-link govuk-link--no-visited-state">
+            <a href="#" class="govuk-link govuk-link--no-visited-state" (click)="handleDownloadCertificate($event, i)">
               <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
                 class="govuk-!-margin-left-1"
-                (click)="handleDownloadCertificate($event, i)"
                 >Download</span
               >
               <span class="govuk-visually-hidden">the certificate {{ certificate.filename }}</span>

--- a/frontend/src/app/shared/components/certifications-table/certifications-table.component.html
+++ b/frontend/src/app/shared/components/certifications-table/certifications-table.component.html
@@ -9,6 +9,7 @@
             <a href="#" class="govuk-link govuk-link--no-visited-state">
               <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
                 class="govuk-!-margin-left-1"
+                (click)="handleDownloadCertificate($event, null)"
                 >Download all</span
               ></a
             >

--- a/frontend/src/app/shared/components/certifications-table/certifications-table.component.html
+++ b/frontend/src/app/shared/components/certifications-table/certifications-table.component.html
@@ -47,7 +47,7 @@
             <a href="#" class="govuk-link govuk-link--no-visited-state">
               <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
                 class="govuk-!-margin-left-1"
-                (click)="handleDownloadFile($event, i)"
+                (click)="handleDownloadCertificate($event, i)"
                 >Download</span
               >
               <span class="govuk-visually-hidden">the certificate {{ certificate.filename }}</span>

--- a/frontend/src/app/shared/components/certifications-table/certifications-table.component.html
+++ b/frontend/src/app/shared/components/certifications-table/certifications-table.component.html
@@ -47,6 +47,7 @@
             <a href="#" class="govuk-link govuk-link--no-visited-state">
               <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
                 class="govuk-!-margin-left-1"
+                (click)="handleDownloadFile($event, i)"
                 >Download</span
               >
               <span class="govuk-visually-hidden">the certificate {{ certificate.filename }}</span>

--- a/frontend/src/app/shared/components/certifications-table/certifications-table.component.spec.ts
+++ b/frontend/src/app/shared/components/certifications-table/certifications-table.component.spec.ts
@@ -119,12 +119,12 @@ describe('CertificationsTableComponent', () => {
   it('should emit event when download button clicked with index of table row', async () => {
     const { component, getByTestId } = await setup(multipleFiles);
 
-    const fileDownloadEmitSpy = spyOn(component.downloadFile, 'emit');
+    const certificateDownloadEmitSpy = spyOn(component.downloadCertificate, 'emit');
     const certificateRow = getByTestId('certificate-row-0');
     const downloadButton = within(certificateRow).getByText('Download');
     downloadButton.click();
 
-    expect(fileDownloadEmitSpy).toHaveBeenCalledWith(0);
+    expect(certificateDownloadEmitSpy).toHaveBeenCalledWith(0);
   });
 
   describe('Files to upload', () => {

--- a/frontend/src/app/shared/components/certifications-table/certifications-table.component.spec.ts
+++ b/frontend/src/app/shared/components/certifications-table/certifications-table.component.spec.ts
@@ -93,6 +93,17 @@ describe('CertificationsTableComponent', () => {
 
         expect(within(certificationsTableHeader).queryByText('Download all')).toBeFalsy();
       });
+
+      it('should emit download event with no index when download all button clicked', async () => {
+        const { component, getByTestId } = await setup(multipleFiles);
+
+        const downloadCertificateEmitSpy = spyOn(component.downloadCertificate, 'emit');
+        const certificationsTableHeader = getByTestId('certificationsTableHeader');
+        const downloadAllButton = within(certificationsTableHeader).getByText('Download all');
+
+        downloadAllButton.click();
+        expect(downloadCertificateEmitSpy).toHaveBeenCalledWith(null);
+      });
     });
   });
 

--- a/frontend/src/app/shared/components/certifications-table/certifications-table.component.spec.ts
+++ b/frontend/src/app/shared/components/certifications-table/certifications-table.component.spec.ts
@@ -1,8 +1,8 @@
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 
 import { CertificationsTableComponent } from './certifications-table.component';
-import userEvent from '@testing-library/user-event';
 
 describe('CertificationsTableComponent', () => {
   let singleFile = [
@@ -114,6 +114,17 @@ describe('CertificationsTableComponent', () => {
     expect(getByTestId('certificate-row-0')).toBeTruthy();
     expect(getByTestId('certificate-row-1')).toBeTruthy();
     expect(getByTestId('certificate-row-2')).toBeTruthy();
+  });
+
+  it('should emit event when download button clicked with index of table row', async () => {
+    const { component, getByTestId } = await setup(multipleFiles);
+
+    const fileDownloadEmitSpy = spyOn(component.downloadFile, 'emit');
+    const certificateRow = getByTestId('certificate-row-0');
+    const downloadButton = within(certificateRow).getByText('Download');
+    downloadButton.click();
+
+    expect(fileDownloadEmitSpy).toHaveBeenCalledWith(0);
   });
 
   describe('Files to upload', () => {

--- a/frontend/src/app/shared/components/certifications-table/certifications-table.component.ts
+++ b/frontend/src/app/shared/components/certifications-table/certifications-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { TrainingCertificate } from '@core/model/training.model';
 
 @Component({
@@ -10,11 +10,17 @@ export class CertificationsTableComponent implements OnInit {
   @Input() certificates: TrainingCertificate[] = [];
   @Input() filesToUpload: File[] = [];
   @Output() removeFileToUpload = new EventEmitter<number>();
+  @Output() downloadFile = new EventEmitter<number>();
 
   ngOnInit() {}
 
   public handleRemoveUploadFile(event: Event, index: number): void {
     event.preventDefault();
     this.removeFileToUpload.emit(index);
+  }
+
+  public handleDownloadFile(event: Event, index: number): void {
+    event.preventDefault();
+    this.downloadFile.emit(index);
   }
 }

--- a/frontend/src/app/shared/components/certifications-table/certifications-table.component.ts
+++ b/frontend/src/app/shared/components/certifications-table/certifications-table.component.ts
@@ -10,7 +10,7 @@ export class CertificationsTableComponent implements OnInit {
   @Input() certificates: TrainingCertificate[] = [];
   @Input() filesToUpload: File[] = [];
   @Output() removeFileToUpload = new EventEmitter<number>();
-  @Output() downloadFile = new EventEmitter<number>();
+  @Output() downloadCertificate = new EventEmitter<number>();
 
   ngOnInit() {}
 
@@ -19,8 +19,8 @@ export class CertificationsTableComponent implements OnInit {
     this.removeFileToUpload.emit(index);
   }
 
-  public handleDownloadFile(event: Event, index: number): void {
+  public handleDownloadCertificate(event: Event, index: number): void {
     event.preventDefault();
-    this.downloadFile.emit(index);
+    this.downloadCertificate.emit(index);
   }
 }

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -216,6 +216,7 @@
               [certificates]="trainingCertificates"
               [filesToUpload]="filesToUpload"
               (removeFileToUpload)="removeFileToUpload($event)"
+              (downloadFile)="downloadFile($event)"
             ></app-certifications-table>
           </div>
         </div>

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -216,7 +216,7 @@
               [certificates]="trainingCertificates"
               [filesToUpload]="filesToUpload"
               (removeFileToUpload)="removeFileToUpload($event)"
-              (downloadCertificate)="downloadCertificate($event)"
+              (downloadCertificate)="downloadCertificates($event)"
             ></app-certifications-table>
           </div>
         </div>

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -216,7 +216,7 @@
               [certificates]="trainingCertificates"
               [filesToUpload]="filesToUpload"
               (removeFileToUpload)="removeFileToUpload($event)"
-              (downloadFile)="downloadFile($event)"
+              (downloadCertificate)="downloadCertificate($event)"
             ></app-certifications-table>
           </div>
         </div>

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -206,7 +206,7 @@
                   </span>
                 </div>
                 <div id="uploadCertificate-errors">
-                  <app-validation-error-message *ngFor="let errorMessage of uploadFilesErrors" [errorMessage]="errorMessage"/>
+                  <app-validation-error-message *ngFor="let errorMessage of certificateErrors" [errorMessage]="errorMessage"/>
                 </div>
               </fieldset>
             </div>


### PR DESCRIPTION
#### Work done
- Created new API endpoint to return a presigned URL for downloading existing certificates on a training record
- Connected Download and Download all buttons on frontend to new endpoint 
- Updated certificate metadata table to store key as well to make retrieval from S3 easier 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
