### PR TITLE
add a h2 subheading for certificates

### DIFF
--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -186,6 +186,7 @@
               class="govuk-form-group govuk-!-margin-bottom-4"
               data-testid="uploadCertificate"
             >
+            <h2 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2"> Certificates </h2>
               <fieldset class="govuk-fieldset" aria-describedby="uploadCertificate-hint" role="group">
                 <label class="govuk-label govuk-!-font-weight-bold" for="uploadCertificate">
                   Upload a certificate


### PR DESCRIPTION
#### Work done
- Add a subheading to upload certificates section

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change

![image](https://github.com/user-attachments/assets/0951b2ca-51b2-40fa-b301-c3c49cde115e)
