### PR TITLE
Add check for article before rendering ASC-WDS news card on parent home page

### DIFF
--- a/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
@@ -111,7 +111,7 @@
           </p></app-card
         >
       </div>
-      <div class="govuk-grid-column-one-third asc-card-padding">
+      <div *ngIf="article" class="govuk-grid-column-one-third asc-card-padding">
         <app-card [image]="'/assets/images/news.svg'">
           <a
             class="govuk-link--no-visited-state govuk-!-font-size-19 govuk-!-font-weight-bold"

--- a/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.spec.ts
@@ -50,6 +50,7 @@ describe('ParentHomeTabComponent', () => {
     comparisonDataAvailable = true,
     noOfWorkplaces = 9,
     permissions = [],
+    canAccessCms = true,
   ) => {
     const { fixture, queryAllByText, getByText, queryByText, getByTestId, queryByTestId } = await render(
       ParentHomeTabComponent,
@@ -76,8 +77,8 @@ describe('ParentHomeTabComponent', () => {
             useValue: {
               snapshot: {
                 data: {
-                  articleList,
-                  articles,
+                  articleList: canAccessCms ? articleList : null,
+                  articles: canAccessCms ? articles : null,
                   workers: {
                     workersCreatedDate: [],
                     workerCount: 0,
@@ -303,6 +304,14 @@ describe('ParentHomeTabComponent', () => {
 
       expect(ascWdsNewsLink).toBeTruthy();
       expect(ascWdsNewsLink.getAttribute('href')).toContain(articleList.data[0].slug);
+    });
+
+    it('should not show an ASC-WDS news card when user cannot access CMS', async () => {
+      const { queryByText } = await setup(false, Establishment, true, 9, [], false);
+
+      const ascWdsNewsLink = queryByText('ASC-WDS news');
+
+      expect(ascWdsNewsLink).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
#### Work done
- Added check for article object before rendering ASC-WDS news card on parent home page to ensure failure of CMS doesn't break parent home page

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
