### PR TITLE
Fix issue of the same file could not be added again after removal

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
@@ -1174,6 +1174,33 @@ describe('AddEditTrainingComponent', () => {
         expect(component.filesToUpload).toHaveSize(1);
         expect(component.filesToUpload[0]).toEqual(mockUploadFile1);
       });
+
+      xit('should allow a file to be added again after removal', async () => {
+        /* TODO: unskip this test when we bump up @testing-library/user-event to >= 14.0.0 in the future
+         *
+         * This test is skipped because the version of @testing-library/user-event we are using
+         * does not handle fileinput.value = '' or fileinput.files = null correctly.
+         */
+        const { component, fixture, getByText, getByTestId, queryByText } = await setup();
+        fixture.autoDetectChanges();
+
+        const fileInput = getByTestId('fileInput') as HTMLInputElement;
+        await userEvent.upload(fileInput, [mockUploadFile1]);
+
+        const certificateRow = getByText(mockUploadFile1.name).parentElement;
+        const removeButton = within(certificateRow).getByText('Remove');
+        await userEvent.click(removeButton);
+
+        expect(queryByText(mockUploadFile1.name)).toBeFalsy();
+        expect(component.filesToUpload).toEqual([]);
+        expect(fileInput.value).toBeFalsy();
+
+        // select the removed file again
+        await userEvent.upload(fileInput, [mockUploadFile1]);
+
+        expect(getByText(mockUploadFile1.name)).toBeTruthy();
+        expect(component.filesToUpload).toEqual([mockUploadFile1]);
+      });
     });
 
     describe('saved files to be removed', () => {

--- a/frontend/src/app/shared/components/select-upload-file/select-upload-file.component.ts
+++ b/frontend/src/app/shared/components/select-upload-file/select-upload-file.component.ts
@@ -25,6 +25,8 @@ export class SelectUploadFileComponent implements OnInit {
     const selectedFiles = Array.from(event.target.files);
     if (selectedFiles?.length) {
       this.selectFiles.emit(selectedFiles);
+
+      event.target.value = '';
     }
   }
 }


### PR DESCRIPTION
#### Work done
- Clear the value of the file input element to allow the same file to be selected again

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
