### PR TITLE
Feat/1543 delete training certificates on deletion of worker

### DIFF
--- a/backend/server/models/classes/worker.js
+++ b/backend/server/models/classes/worker.js
@@ -27,6 +27,8 @@ const WorkerProperties = require('./worker/workerProperties').WorkerPropertyMana
 const JSON_DOCUMENT_TYPE = require('./worker/workerProperties').JSON_DOCUMENT;
 const SEQUELIZE_DOCUMENT_TYPE = require('./worker/workerProperties').SEQUELIZE_DOCUMENT;
 
+const TrainingCertificateRoute = require('../../routes/establishments/workerCertificate/trainingCertificate');
+
 // WDF Calculator
 const WdfCalculator = require('./wdfCalculator').WdfCalculator;
 
@@ -1150,6 +1152,8 @@ class Worker extends EntityValidator {
           // TODO - to be confirmed
         }
 
+        this.deleteAllTrainingCertificatesAssociatedWithWorker();
+
         // always recalculate WDF - if not bulk upload (this._status)
         if (this._status === null) {
           await WdfCalculator.calculate(
@@ -1892,6 +1896,26 @@ class Worker extends EntityValidator {
     } catch (err) {
       console.error('Worker::bulkUpdateLocalIdentifiers error: ', err);
       throw err;
+    }
+  }
+
+  async deleteAllTrainingCertificatesAssociatedWithWorker() {
+    try {
+      const trainingCertificates = await models.trainingCertificates.getAllTrainingCertificateRecordsForWorker(
+        this._id,
+      );
+
+      if (!trainingCertificates.length) return;
+
+      const trainingCertificateUids = trainingCertificates.map((cert) => cert.uid);
+      const filesToDeleteFromS3 = trainingCertificates.map((cert) => {
+        return { Key: cert.key };
+      });
+
+      await models.trainingCertificates.deleteCertificate(trainingCertificateUids);
+      await TrainingCertificateRoute.deleteCertificatesFromS3(filesToDeleteFromS3);
+    } catch (error) {
+      console.log(error);
     }
   }
 }

--- a/backend/server/models/classes/worker.js
+++ b/backend/server/models/classes/worker.js
@@ -1152,7 +1152,7 @@ class Worker extends EntityValidator {
           // TODO - to be confirmed
         }
 
-        this.deleteAllTrainingCertificatesAssociatedWithWorker();
+        this.deleteAllTrainingCertificatesAssociatedWithWorker(thisTransaction);
 
         // always recalculate WDF - if not bulk upload (this._status)
         if (this._status === null) {
@@ -1899,24 +1899,18 @@ class Worker extends EntityValidator {
     }
   }
 
-  async deleteAllTrainingCertificatesAssociatedWithWorker() {
-    try {
-      const trainingCertificates = await models.trainingCertificates.getAllTrainingCertificateRecordsForWorker(
-        this._id,
-      );
+  async deleteAllTrainingCertificatesAssociatedWithWorker(transaction) {
+    const trainingCertificates = await models.trainingCertificates.getAllTrainingCertificateRecordsForWorker(this._id);
 
-      if (!trainingCertificates.length) return;
+    if (!trainingCertificates.length) return;
 
-      const trainingCertificateUids = trainingCertificates.map((cert) => cert.uid);
-      const filesToDeleteFromS3 = trainingCertificates.map((cert) => {
-        return { Key: cert.key };
-      });
+    const trainingCertificateUids = trainingCertificates.map((cert) => cert.uid);
+    const filesToDeleteFromS3 = trainingCertificates.map((cert) => {
+      return { Key: cert.key };
+    });
 
-      await models.trainingCertificates.deleteCertificate(trainingCertificateUids);
-      await TrainingCertificateRoute.deleteCertificatesFromS3(filesToDeleteFromS3);
-    } catch (error) {
-      console.log(error);
-    }
+    await models.trainingCertificates.deleteCertificate(trainingCertificateUids, transaction);
+    await TrainingCertificateRoute.deleteCertificatesFromS3(filesToDeleteFromS3);
   }
 }
 

--- a/backend/server/models/classes/worker.js
+++ b/backend/server/models/classes/worker.js
@@ -1152,7 +1152,7 @@ class Worker extends EntityValidator {
           // TODO - to be confirmed
         }
 
-        this.deleteAllTrainingCertificatesAssociatedWithWorker(thisTransaction);
+        await this.deleteAllTrainingCertificatesAssociatedWithWorker(thisTransaction);
 
         // always recalculate WDF - if not bulk upload (this._status)
         if (this._status === null) {

--- a/backend/server/models/trainingCertificates.js
+++ b/backend/server/models/trainingCertificates.js
@@ -79,11 +79,12 @@ module.exports = function (sequelize, DataTypes) {
     });
   };
 
-  TrainingCertificates.deleteCertificate = async function (uids) {
+  TrainingCertificates.deleteCertificate = async function (uids, transaction = null) {
     return await this.destroy({
       where: {
         uid: uids,
       },
+      ...(transaction ? { transaction } : {}),
     });
   };
 

--- a/backend/server/models/trainingCertificates.js
+++ b/backend/server/models/trainingCertificates.js
@@ -95,5 +95,13 @@ module.exports = function (sequelize, DataTypes) {
     });
   };
 
+  TrainingCertificates.getAllTrainingCertificateRecordsForWorker = async function (workerFk) {
+    return await this.findAll({
+      where: {
+        workerFk,
+      },
+    });
+  };
+
   return TrainingCertificates;
 };

--- a/backend/server/test/unit/models/classes/worker.spec.js
+++ b/backend/server/test/unit/models/classes/worker.spec.js
@@ -2,8 +2,9 @@ const expect = require('chai').expect;
 const { build, fake, oneOf } = require('@jackfranklin/test-data-bot');
 const sinon = require('sinon');
 
+const models = require('../../../../models');
 const Worker = require('../../../../models/classes/worker').Worker;
-const WdfCalculator = require('../../../../models/classes/wdfCalculator');
+const TrainingCertificateRoute = require('../../../../routes/establishments/workerCertificate/trainingCertificate');
 
 const worker = new Worker();
 
@@ -426,6 +427,88 @@ describe('Worker Class', () => {
         username: 'test',
         type: 'wdfEligible',
       });
+    });
+  });
+
+  describe('deleteAllTrainingCertificatesAssociatedWithWorker()', async () => {
+    let mockWorker;
+    const trainingCertificatesReturnedFromDb = () => {
+      return [
+        { uid: 'abc123', key: 'abc123/trainingCertificate/dasdsa12312' },
+        { uid: 'def456', key: 'def456/trainingCertificate/deass12092' },
+        { uid: 'ghi789', key: 'ghi789/trainingCertificate/da1412342' },
+      ];
+    };
+
+    beforeEach(() => {
+      mockWorker = new Worker();
+      mockWorker._id = 12345;
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should call getAllTrainingCertificateRecordsForWorker with worker ID', async () => {
+      const getAllTrainingCertificateRecordsForWorkerSpy = sinon
+        .stub(models.trainingCertificates, 'getAllTrainingCertificateRecordsForWorker')
+        .resolves([]);
+
+      await mockWorker.deleteAllTrainingCertificatesAssociatedWithWorker();
+
+      expect(getAllTrainingCertificateRecordsForWorkerSpy.args[0][0]).to.equal(12345);
+    });
+
+    it('should not make DB or S3 deletion calls if no training certificates found', async () => {
+      const getAllTrainingCertificateRecordsForWorkerSpy = sinon
+        .stub(models.trainingCertificates, 'getAllTrainingCertificateRecordsForWorker')
+        .resolves([]);
+
+      const dbDeleteCertificateSpy = sinon.stub(models.trainingCertificates, 'deleteCertificate');
+      const s3DeleteCertificateSpy = sinon.stub(TrainingCertificateRoute, 'deleteCertificatesFromS3');
+
+      await mockWorker.deleteAllTrainingCertificatesAssociatedWithWorker();
+
+      expect(dbDeleteCertificateSpy.callCount).to.equal(0);
+      expect(s3DeleteCertificateSpy.callCount).to.equal(0);
+    });
+
+    it('should call deleteCertificate on DB model with uids returned from getAllTrainingCertificateRecordsForWorker', async () => {
+      const trainingCertificates = trainingCertificatesReturnedFromDb();
+
+      const getAllTrainingCertificateRecordsForWorkerSpy = sinon
+        .stub(models.trainingCertificates, 'getAllTrainingCertificateRecordsForWorker')
+        .resolves(trainingCertificates);
+
+      const dbDeleteCertificateSpy = sinon.stub(models.trainingCertificates, 'deleteCertificate');
+      sinon.stub(TrainingCertificateRoute, 'deleteCertificatesFromS3');
+
+      await mockWorker.deleteAllTrainingCertificatesAssociatedWithWorker();
+
+      expect(dbDeleteCertificateSpy.args[0][0]).to.deep.equal([
+        trainingCertificates[0].uid,
+        trainingCertificates[1].uid,
+        trainingCertificates[2].uid,
+      ]);
+    });
+
+    it('should call deleteCertificatesFromS3 with keys returned from getAllTrainingCertificateRecordsForWorker', async () => {
+      const trainingCertificates = trainingCertificatesReturnedFromDb();
+
+      const getAllTrainingCertificateRecordsForWorkerSpy = sinon
+        .stub(models.trainingCertificates, 'getAllTrainingCertificateRecordsForWorker')
+        .resolves(trainingCertificates);
+
+      sinon.stub(models.trainingCertificates, 'deleteCertificate');
+      const s3DeleteCertificateSpy = sinon.stub(TrainingCertificateRoute, 'deleteCertificatesFromS3');
+
+      await mockWorker.deleteAllTrainingCertificatesAssociatedWithWorker();
+
+      expect(s3DeleteCertificateSpy.args[0][0]).to.deep.equal([
+        { Key: trainingCertificates[0].key },
+        { Key: trainingCertificates[1].key },
+        { Key: trainingCertificates[2].key },
+      ]);
     });
   });
 });

--- a/backend/server/test/unit/models/classes/worker.spec.js
+++ b/backend/server/test/unit/models/classes/worker.spec.js
@@ -473,7 +473,7 @@ describe('Worker Class', () => {
       expect(s3DeleteCertificateSpy.callCount).to.equal(0);
     });
 
-    it('should call deleteCertificate on DB model with uids returned from getAllTrainingCertificateRecordsForWorker', async () => {
+    it('should call deleteCertificate on DB model with uids returned from getAllTrainingCertificateRecordsForWorker and pass in transaction', async () => {
       const trainingCertificates = trainingCertificatesReturnedFromDb();
 
       const getAllTrainingCertificateRecordsForWorkerSpy = sinon
@@ -482,14 +482,17 @@ describe('Worker Class', () => {
 
       const dbDeleteCertificateSpy = sinon.stub(models.trainingCertificates, 'deleteCertificate');
       sinon.stub(TrainingCertificateRoute, 'deleteCertificatesFromS3');
+      const transaction = await models.sequelize.transaction();
 
-      await mockWorker.deleteAllTrainingCertificatesAssociatedWithWorker();
+      await mockWorker.deleteAllTrainingCertificatesAssociatedWithWorker(transaction);
 
       expect(dbDeleteCertificateSpy.args[0][0]).to.deep.equal([
         trainingCertificates[0].uid,
         trainingCertificates[1].uid,
         trainingCertificates[2].uid,
       ]);
+
+      expect(dbDeleteCertificateSpy.args[0][1]).to.deep.equal(transaction);
     });
 
     it('should call deleteCertificatesFromS3 with keys returned from getAllTrainingCertificateRecordsForWorker', async () => {
@@ -501,8 +504,9 @@ describe('Worker Class', () => {
 
       sinon.stub(models.trainingCertificates, 'deleteCertificate');
       const s3DeleteCertificateSpy = sinon.stub(TrainingCertificateRoute, 'deleteCertificatesFromS3');
+      const transaction = await models.sequelize.transaction();
 
-      await mockWorker.deleteAllTrainingCertificatesAssociatedWithWorker();
+      await mockWorker.deleteAllTrainingCertificatesAssociatedWithWorker(transaction);
 
       expect(s3DeleteCertificateSpy.args[0][0]).to.deep.equal([
         { Key: trainingCertificates[0].key },


### PR DESCRIPTION
#### Work done
- Updated `archive` in  worker model to delete certificates - this removes certificates from the database and S3 on any archive of worker (deletion of worker or workplace in service)

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
