### PR TITLE
Feat/1529 qualification summary page

### DIFF
--- a/frontend/src/app/core/model/qualification.model.ts
+++ b/frontend/src/app/core/model/qualification.model.ts
@@ -1,4 +1,4 @@
-import { Certificate } from './trainingAndQualifications.model';
+import { Certificate, CertificateDownload } from './trainingAndQualifications.model';
 
 export enum QualificationType {
   NVQ = 'NVQ',
@@ -88,3 +88,17 @@ export interface BasicQualificationRecord {
 }
 
 export interface QualificationCertificate extends Certificate {}
+
+export interface QualificationCertificateDownloadEvent {
+  recordType: 'qualification';
+  recordUid: string;
+  qualificationType: QualificationType;
+  filesToDownload: CertificateDownload[];
+}
+
+export interface QualificationCertificateUploadEvent {
+  recordType: 'qualification';
+  recordUid: string;
+  qualificationType: QualificationType;
+  files: File[];
+}

--- a/frontend/src/app/core/model/qualification.model.ts
+++ b/frontend/src/app/core/model/qualification.model.ts
@@ -84,6 +84,7 @@ export interface BasicQualificationRecord {
   title: string;
   uid: string;
   year: number;
+  qualificationCertificates: QualificationCertificate[];
 }
 
 export interface QualificationCertificate extends Certificate {}

--- a/frontend/src/app/core/model/training.model.ts
+++ b/frontend/src/app/core/model/training.model.ts
@@ -38,11 +38,6 @@ export interface TrainingResponse {
   training: TrainingRecord[];
 }
 
-export interface CertificateUpload {
-  files: File[];
-  trainingRecord: TrainingRecord;
-}
-
 export interface TrainingCertificateDownloadEvent {
   recordType: 'training';
   recordUid: string;

--- a/frontend/src/app/core/model/training.model.ts
+++ b/frontend/src/app/core/model/training.model.ts
@@ -1,4 +1,4 @@
-import { Certificate } from './trainingAndQualifications.model';
+import { Certificate, CertificateDownload } from './trainingAndQualifications.model';
 
 export interface TrainingCategory {
   id: number;
@@ -38,14 +38,23 @@ export interface TrainingResponse {
   training: TrainingRecord[];
 }
 
-export interface CertificateDownload {
-  uid: string;
-  filename: string;
-}
-
 export interface CertificateUpload {
   files: File[];
   trainingRecord: TrainingRecord;
+}
+
+export interface TrainingCertificateDownloadEvent {
+  recordType: 'training';
+  recordUid: string;
+  categoryName: string;
+  filesToDownload: CertificateDownload[];
+}
+
+export interface TrainingCertificateUploadEvent {
+  recordType: 'training';
+  recordUid: string;
+  categoryName: string;
+  files: File[];
 }
 
 export interface TrainingCertificate extends Certificate {}

--- a/frontend/src/app/core/model/trainingAndQualifications.model.ts
+++ b/frontend/src/app/core/model/trainingAndQualifications.model.ts
@@ -1,5 +1,9 @@
-import { QualificationsByGroup, QualificationCertificate } from './qualification.model';
-import { TrainingRecords, TrainingCertificate } from './training.model';
+import {
+  QualificationsByGroup,
+  QualificationCertificateDownloadEvent,
+  QualificationCertificateUploadEvent,
+} from './qualification.model';
+import { TrainingRecords, TrainingCertificateDownloadEvent, TrainingCertificateUploadEvent } from './training.model';
 
 export interface TrainingAndQualificationRecords {
   qualifications: QualificationsByGroup;
@@ -20,3 +24,12 @@ export interface Certificate {
   filename: string;
   uploadDate: string;
 }
+
+export interface CertificateDownload {
+  uid: string;
+  filename: string;
+}
+
+export type CertificateDownloadEvent = TrainingCertificateDownloadEvent | QualificationCertificateDownloadEvent;
+
+export type CertificateUploadEvent = TrainingCertificateUploadEvent | QualificationCertificateUploadEvent;

--- a/frontend/src/app/core/services/certificate.service.ts
+++ b/frontend/src/app/core/services/certificate.service.ts
@@ -5,7 +5,6 @@ import { environment } from 'src/environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
-  CertificateDownload,
   ConfirmUploadRequest,
   DownloadCertificateSignedUrlResponse,
   FileInfoWithETag,
@@ -13,7 +12,7 @@ import {
   UploadCertificateSignedUrlRequest,
   UploadCertificateSignedUrlResponse,
 } from '@core/model/training.model';
-import { Certificate } from '@core/model/trainingAndQualifications.model';
+import { Certificate, CertificateDownload } from '@core/model/trainingAndQualifications.model';
 
 @Injectable({
   providedIn: 'root',

--- a/frontend/src/app/core/test-utils/MockWorkerService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkerService.ts
@@ -2,7 +2,11 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Params } from '@angular/router';
 import { QualificationsByGroup, QualificationType } from '@core/model/qualification.model';
-import { CreateTrainingRecordResponse, MultipleTrainingResponse, TrainingRecordRequest } from '@core/model/training.model';
+import {
+  CreateTrainingRecordResponse,
+  MultipleTrainingResponse,
+  TrainingRecordRequest,
+} from '@core/model/training.model';
 import { URLStructure } from '@core/model/url.model';
 import { Worker, WorkerEditResponse, WorkersResponse } from '@core/model/worker.model';
 import { NewWorkerMandatoryInfo, WorkerService } from '@core/services/worker.service';
@@ -213,6 +217,7 @@ export const qualificationsByGroup = {
           notes: 'This is a test note for the first row in the Health group',
           title: 'Health qualification',
           uid: 'firstHealthQualUid',
+          qualificationCertificates: [],
         },
       ],
     },
@@ -224,12 +229,14 @@ export const qualificationsByGroup = {
           notes: 'Test notes needed',
           title: 'Cert qualification',
           uid: 'firstCertificateUid',
+          qualificationCertificates: [],
         },
         {
           year: 2012,
           notes: 'These are some more notes in the second row of the cert table',
           title: 'Another name for qual',
           uid: 'secondCertificateUid',
+          qualificationCertificates: [],
         },
       ],
     },

--- a/frontend/src/app/core/test-utils/MockWorkerService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkerService.ts
@@ -205,24 +205,24 @@ export const AllWorkers = [
 
 export const getAllWorkersResponse = { workers: AllWorkers, workerCount: AllWorkers.length };
 
-export const qualificationsByGroup = {
+export const qualificationsByGroup = Object.freeze({
   count: 3,
   lastUpdated: new Date('2020-01-02'),
   groups: [
     {
-      group: 'Health',
+      group: QualificationType.Award,
       records: [
         {
           year: 2020,
-          notes: 'This is a test note for the first row in the Health group',
-          title: 'Health qualification',
-          uid: 'firstHealthQualUid',
+          notes: 'This is a test note for the first row in the Award group',
+          title: 'Award qualification',
+          uid: 'firstAwardQualUid',
           qualificationCertificates: [],
         },
       ],
     },
     {
-      group: 'Certificate',
+      group: QualificationType.Certificate,
       records: [
         {
           year: 2021,
@@ -241,7 +241,7 @@ export const qualificationsByGroup = {
       ],
     },
   ],
-} as QualificationsByGroup;
+}) as QualificationsByGroup;
 
 export const mockAvailableQualifications: AvailableQualificationsResponse[] = [
   {

--- a/frontend/src/app/features/training-and-qualifications/add-edit-qualification/add-edit-qualification.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-qualification/add-edit-qualification.component.ts
@@ -16,8 +16,7 @@ import {
   QualificationResponse,
   QualificationType,
 } from '@core/model/qualification.model';
-import { CertificateDownload } from '@core/model/training.model';
-import { Certificate } from '@core/model/trainingAndQualifications.model';
+import { Certificate, CertificateDownload } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
 import { BackLinkService } from '@core/services/backLink.service';
 import { QualificationCertificateService } from '@core/services/certificate.service';

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.ts
@@ -3,7 +3,8 @@ import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DATE_PARSE_FORMAT } from '@core/constants/constants';
-import { CertificateDownload, TrainingCertificate } from '@core/model/training.model';
+import { TrainingCertificate } from '@core/model/training.model';
+import { CertificateDownload } from '@core/model/trainingAndQualifications.model';
 import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { TrainingCertificateService } from '@core/services/certificate.service';
@@ -11,11 +12,10 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { TrainingCategoryService } from '@core/services/training-category.service';
 import { TrainingService } from '@core/services/training.service';
 import { WorkerService } from '@core/services/worker.service';
+import { AddEditTrainingDirective } from '@shared/directives/add-edit-training/add-edit-training.directive';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
 import dayjs from 'dayjs';
 import { mergeMap } from 'rxjs/operators';
-
-import { AddEditTrainingDirective } from '../../../shared/directives/add-edit-training/add-edit-training.directive';
 
 @Component({
   selector: 'app-add-edit-training',

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
@@ -53,7 +53,7 @@
                   </a>
                 </span>
                 <span *ngIf="qualificationRecord.qualificationCertificates?.length > 1">
-                  <a [routerLink]="['../training', qualificationRecord.uid]" class="govuk-link govuk-link--no-visited-state">
+                  <a [routerLink]="['../qualification', qualificationRecord.uid]" class="govuk-link govuk-link--no-visited-state">
                     Select a download
                   </a>
                 </span>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
@@ -2,9 +2,13 @@
   <div class="govuk-grid-column-full">
     <ng-container *ngIf="qualificationsByGroup.count > 0; else noQualifications">
       <h1 class="govuk-heading-l govuk-!-font-size-27">Qualifications</h1>
-      <div *ngFor="let qualificationGroup of qualificationsByGroup.groups">
+      <div *ngFor="let qualificationGroup of qualificationsByGroup.groups" [attr.data-testid]="qualificationGroup.group + '-section'">
+        <label class="govuk-!-margin-bottom-2 govuk-heading-m" >{{ qualificationGroup.group }}</label>
+        <span aria-live="polite">
+          <app-validation-error-message *ngIf="certificateErrors?.[qualificationGroup.group]" [errorMessage]="certificateErrors[qualificationGroup.group]" />
+        </span>
         <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m">
+          <caption class="govuk-visually-hidden">
             {{
               qualificationGroup.group
             }}

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
@@ -11,12 +11,15 @@
           </caption>
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header" scope="col" style="width: 30%">Certificate name</th>
-              <th scope="col" class="govuk-table__header" scope="col" style="width: 16.5%">Year achieved</th>
+              <th scope="col" class="govuk-table__header" scope="col" style="width: 43.5%">
+                {{ qualificationType.group }} name
+              </th>
+              <th scope="col" class="govuk-table__header" scope="col" style="width: 37.5%">Year achieved</th>
+              <th scope="col" class="govuk-table__header" scope="col" style="width: 19%">Certificate</th>
             </tr>
           </thead>
           <tbody class="govuk-table__body">
-            <tr class="govuk-table__row" *ngFor="let qualificationRecord of qualificationType.records">
+            <tr class="govuk-table__row" [attr.data-testid]="qualificationRecord.uid" *ngFor="let qualificationRecord of qualificationType.records">
               <td class="govuk-table__cell">
                 <ng-container *ngIf="canEditWorker; else viewOnly">
                   <a
@@ -33,6 +36,31 @@
                 </ng-template>
               </td>
               <td class="govuk-table__cell">{{ qualificationRecord?.year ? qualificationRecord.year : '-' }}</td>
+              <td class="govuk-table__cell">
+                <span *ngIf="qualificationRecord.qualificationCertificates?.length == 1">
+                  <a
+                    href="#"
+                    class="govuk-link govuk-link--no-visited-state"
+                    (click)="handleDownloadCertificate($event, qualificationRecord)"
+                  >
+                    <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
+                      class="govuk-!-margin-left-1"
+                      >Download</span
+                    >
+                    <span class="govuk-visually-hidden"
+                      >the certificate {{ qualificationRecord.qualificationCertificates[0].filename }}</span
+                    >
+                  </a>
+                </span>
+                <span *ngIf="qualificationRecord.qualificationCertificates?.length > 1">
+                  <a [routerLink]="['../training', qualificationRecord.uid]" class="govuk-link govuk-link--no-visited-state">
+                    Select a download
+                  </a>
+                </span>
+                <span *ngIf="qualificationRecord.qualificationCertificates?.length === 0">
+                  <app-select-upload-file accept=".pdf" buttonText="Upload file" buttonClasses="govuk-!-margin-bottom-0 govuk-!-padding-top-1 govuk-!-padding-bottom-1" (selectFiles)="handleUploadCertificate($event, qualificationRecord)" />
+                </span>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
@@ -2,24 +2,24 @@
   <div class="govuk-grid-column-full">
     <ng-container *ngIf="qualificationsByGroup.count > 0; else noQualifications">
       <h1 class="govuk-heading-l govuk-!-font-size-27">Qualifications</h1>
-      <div *ngFor="let qualificationType of qualificationsByGroup.groups">
+      <div *ngFor="let qualificationGroup of qualificationsByGroup.groups">
         <table class="govuk-table">
           <caption class="govuk-table__caption govuk-table__caption--m">
             {{
-              qualificationType.group
+              qualificationGroup.group
             }}
           </caption>
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th scope="col" class="govuk-table__header" scope="col" style="width: 43.5%">
-                {{ qualificationType.group }} name
+                {{ qualificationGroup.group }} name
               </th>
               <th scope="col" class="govuk-table__header" scope="col" style="width: 37.5%">Year achieved</th>
               <th scope="col" class="govuk-table__header" scope="col" style="width: 19%">Certificate</th>
             </tr>
           </thead>
           <tbody class="govuk-table__body">
-            <tr class="govuk-table__row" [attr.data-testid]="qualificationRecord.uid" *ngFor="let qualificationRecord of qualificationType.records">
+            <tr class="govuk-table__row" [attr.data-testid]="qualificationRecord.uid" *ngFor="let qualificationRecord of qualificationGroup.records">
               <td class="govuk-table__cell">
                 <ng-container *ngIf="canEditWorker; else viewOnly">
                   <a
@@ -41,7 +41,7 @@
                   <a
                     href="#"
                     class="govuk-link govuk-link--no-visited-state"
-                    (click)="handleDownloadCertificate($event, qualificationRecord)"
+                    (click)="handleDownloadCertificate($event, qualificationGroup, qualificationRecord)"
                   >
                     <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
                       class="govuk-!-margin-left-1"
@@ -58,7 +58,7 @@
                   </a>
                 </span>
                 <span *ngIf="qualificationRecord.qualificationCertificates?.length === 0">
-                  <app-select-upload-file accept=".pdf" buttonText="Upload file" buttonClasses="govuk-!-margin-bottom-0 govuk-!-padding-top-1 govuk-!-padding-bottom-1" (selectFiles)="handleUploadCertificate($event, qualificationRecord)" />
+                  <app-select-upload-file accept=".pdf" buttonText="Upload file" buttonClasses="govuk-!-margin-bottom-0 govuk-!-padding-top-1 govuk-!-padding-bottom-1" (selectFiles)="handleUploadCertificate($event, qualificationGroup, qualificationRecord)" />
                 </span>
               </td>
             </tr>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
@@ -5,6 +5,7 @@ import {
   QualificationCertificateUploadEvent,
   BasicQualificationRecord,
   QualificationType,
+  QualificationGroup,
 } from '@core/model/qualification.model';
 
 @Component({
@@ -19,13 +20,38 @@ export class NewQualificationsComponent {
   @Output() public uploadFile = new EventEmitter<QualificationCertificateUploadEvent>();
   @ViewChild('content') public content: ElementRef;
 
-  public handleDownloadCertificate(event: Event, qualificationRecord: BasicQualificationRecord) {
+  public handleDownloadCertificate(
+    event: Event,
+    qualificationGroup: QualificationGroup,
+    qualificationRecord: BasicQualificationRecord,
+  ) {
     event.preventDefault();
+
+    const filesToDownload = [
+      {
+        uid: qualificationRecord.qualificationCertificates[0].uid,
+        filename: qualificationRecord.qualificationCertificates[0].filename,
+      },
+    ];
+
     this.downloadFile.emit({
       recordType: 'qualification',
       recordUid: qualificationRecord.uid,
-      qualificationType: 'Awards' as QualificationType,
-      filesToDownload: qualificationRecord.qualificationCertificates,
+      qualificationType: qualificationGroup.group as QualificationType,
+      filesToDownload,
+    });
+  }
+
+  public handleUploadCertificate(
+    files: File[],
+    qualificationGroup: QualificationGroup,
+    qualificationRecord: BasicQualificationRecord,
+  ) {
+    this.uploadFile.emit({
+      recordType: 'qualification',
+      recordUid: qualificationRecord.uid,
+      qualificationType: qualificationGroup.group as QualificationType,
+      files,
     });
   }
 }

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
@@ -1,5 +1,7 @@
-import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { QualificationsByGroup } from '@core/model/qualification.model';
+import { BasicQualificationRecord } from '../../../../core/model/qualification.model';
+import { CertificateUpload } from '@core/model/training.model';
 
 @Component({
   selector: 'app-new-qualifications',
@@ -8,5 +10,8 @@ import { QualificationsByGroup } from '@core/model/qualification.model';
 export class NewQualificationsComponent {
   @Input() qualificationsByGroup: QualificationsByGroup;
   @Input() canEditWorker: boolean;
+  @Input() public certificateErrors: Record<string, string> = {};
+  @Output() public downloadFile = new EventEmitter<BasicQualificationRecord>();
+  @Output() public uploadFile = new EventEmitter<CertificateUpload>();
   @ViewChild('content') public content: ElementRef;
 }

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.ts
@@ -1,7 +1,11 @@
 import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { QualificationsByGroup } from '@core/model/qualification.model';
-import { BasicQualificationRecord } from '../../../../core/model/qualification.model';
-import { CertificateUpload } from '@core/model/training.model';
+import {
+  QualificationsByGroup,
+  QualificationCertificateDownloadEvent,
+  QualificationCertificateUploadEvent,
+  BasicQualificationRecord,
+  QualificationType,
+} from '@core/model/qualification.model';
 
 @Component({
   selector: 'app-new-qualifications',
@@ -11,7 +15,17 @@ export class NewQualificationsComponent {
   @Input() qualificationsByGroup: QualificationsByGroup;
   @Input() canEditWorker: boolean;
   @Input() public certificateErrors: Record<string, string> = {};
-  @Output() public downloadFile = new EventEmitter<BasicQualificationRecord>();
-  @Output() public uploadFile = new EventEmitter<CertificateUpload>();
+  @Output() public downloadFile = new EventEmitter<QualificationCertificateDownloadEvent>();
+  @Output() public uploadFile = new EventEmitter<QualificationCertificateUploadEvent>();
   @ViewChild('content') public content: ElementRef;
+
+  public handleDownloadCertificate(event: Event, qualificationRecord: BasicQualificationRecord) {
+    event.preventDefault();
+    this.downloadFile.emit({
+      recordType: 'qualification',
+      recordUid: qualificationRecord.uid,
+      qualificationType: 'Awards' as QualificationType,
+      filesToDownload: qualificationRecord.qualificationCertificates,
+    });
+  }
 }

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
@@ -49,9 +49,9 @@ describe('NewQualificationsComponent', () => {
     const { getByText } = await setup();
 
     qualificationsByGroup.groups.forEach((qualificationGroup) => {
-      const typeName = qualificationGroup.group;
-      expect(getByText(`${typeName} name`)).toBeTruthy();
-      const tableHeaders = getByText(`${typeName} name`).parentElement;
+      const type = qualificationGroup.group;
+      expect(getByText(`${type} name`)).toBeTruthy();
+      const tableHeaders = getByText(`${type} name`).parentElement;
       expect(within(tableHeaders).getByText('Year achieved')).toBeTruthy;
       expect(within(tableHeaders).getByText('Certificate')).toBeTruthy;
     });

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
@@ -9,15 +9,16 @@ import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 
 import { NewQualificationsComponent } from './new-qualifications.component';
+import userEvent from '@testing-library/user-event';
 
-fdescribe('NewQualificationsComponent', () => {
+describe('NewQualificationsComponent', () => {
   async function setup(override: any = {}) {
     const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(NewQualificationsComponent, {
       imports: [SharedModule, RouterTestingModule, HttpClientTestingModule],
       providers: [],
       componentProperties: {
         canEditWorker: true,
-        qualificationsByGroup,
+        qualificationsByGroup: cloneDeep(qualificationsByGroup),
         ...override,
       },
     });
@@ -174,7 +175,7 @@ fdescribe('NewQualificationsComponent', () => {
     });
   });
 
-  fdescribe('Qualification certificates', () => {
+  describe('Qualification certificates', () => {
     const setupWithCertificates = async (certificates: Certificate[]) => {
       const qualificationsWithCertificate = cloneDeep(qualificationsByGroup);
       qualificationsWithCertificate.groups[0].records[0].qualificationCertificates = certificates;
@@ -190,7 +191,18 @@ fdescribe('NewQualificationsComponent', () => {
       expect(within(recordRow).getByText('Download')).toBeTruthy();
     });
 
-    it('should trigger download file emitter when Download link is clicked', async () => {});
+    it('should trigger download file emitter when Download link is clicked', async () => {
+      const { getByTestId, component } = await setupWithCertificates([
+        { uid: 'certificate1uid', filename: 'Health 2024.pdf', uploadDate: '20240101T123456Z' },
+      ]);
+      const downloadFileSpy = spyOn(component.downloadFile, 'emit');
+
+      const recordRow = getByTestId('firstHealthQualUid');
+      userEvent.click(within(recordRow).getByText('Download'));
+
+      expect(downloadFileSpy).toHaveBeenCalled();
+      // TODO: assert about argument
+    });
 
     it('should display Select a download link when training record has more than one certificate associated with it', async () => {
       const { getByTestId } = await setupWithCertificates([

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
@@ -202,7 +202,16 @@ fdescribe('NewQualificationsComponent', () => {
       expect(within(recordRow).getByText('Select a download')).toBeTruthy();
     });
 
-    it('should have href of training record on Select a download link');
+    it('should have href of training record on Select a download link', async () => {
+      const { getByTestId } = await setupWithCertificates([
+        { uid: 'certificate1uid', filename: 'Health 2023.pdf', uploadDate: '20230101T123456Z' },
+        { uid: 'certificate2uid', filename: 'Health 2024.pdf', uploadDate: '20240101T234516Z' },
+      ]);
+
+      const recordRow = getByTestId('firstHealthQualUid');
+      const selectADownloadLink = within(recordRow).getByText('Select a download');
+      expect(selectADownloadLink.getAttribute('href')).toEqual(`/qualification/firstHealthQualUid`);
+    });
 
     it('should display Upload file button when training record has no certificates associated with it', async () => {
       const { getByTestId } = await setupWithCertificates([]);

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
@@ -261,5 +261,17 @@ describe('NewQualificationsComponent', () => {
 
       expect(uploadFileSpy).toHaveBeenCalledWith(expectedUploadEvent);
     });
+
+    it('should display an error message above the category when download certificate fails', async () => {
+      const certificateErrors = {
+        Award: "There's a problem with this download. Try again later or contact us for help.",
+      };
+      const { getByTestId } = await setup({ certificateErrors });
+
+      const awardSection = getByTestId('Award-section');
+      expect(
+        within(awardSection).getByText("There's a problem with this download. Try again later or contact us for help."),
+      ).toBeTruthy();
+    });
   });
 });

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
@@ -16,7 +16,7 @@ import {
   QualificationType,
 } from '@core/model/qualification.model';
 
-fdescribe('NewQualificationsComponent', () => {
+describe('NewQualificationsComponent', () => {
   async function setup(override: any = {}) {
     const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(NewQualificationsComponent, {
       imports: [SharedModule, RouterTestingModule, HttpClientTestingModule],

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -235,6 +235,8 @@
     *ngIf="currentFragment === fragmentsObject.allRecords || currentFragment === fragmentsObject.qualifications"
     [canEditWorker]="canEditWorker"
     [qualificationsByGroup]="qualificationsByGroup"
+    (downloadFile)="downloadCertificate($event)"
+    (uploadFile)="uploadCertificate($event)"
   >
   </app-new-qualifications>
 </div>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -215,8 +215,8 @@
     [canEditWorker]="canEditWorker"
     [setReturnRoute]="setReturnRoute"
     [missingMandatoryTraining]="missingMandatoryTraining.length > 0"
-    (downloadFile)="downloadTrainingCertificate($event)"
-    (uploadFile)="uploadTrainingCertificate($event)"
+    (downloadFile)="downloadCertificate($event)"
+    (uploadFile)="uploadCertificate($event)"
     [certificateErrors]="certificateErrors"
   >
   </app-new-training>
@@ -226,8 +226,8 @@
     [trainingType]="'Non-mandatory training'"
     [canEditWorker]="canEditWorker"
     [setReturnRoute]="setReturnRoute"
-    (downloadFile)="downloadTrainingCertificate($event)"
-    (uploadFile)="uploadTrainingCertificate($event)"
+    (downloadFile)="downloadCertificate($event)"
+    (uploadFile)="uploadCertificate($event)"
     [certificateErrors]="certificateErrors"
   >
   </app-new-training>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -237,6 +237,7 @@
     [qualificationsByGroup]="qualificationsByGroup"
     (downloadFile)="downloadCertificate($event)"
     (uploadFile)="uploadCertificate($event)"
+    [certificateErrors]="certificateErrors"
   >
   </app-new-qualifications>
 </div>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -114,7 +114,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
     ],
   };
 
-  interface SetupProps {
+  interface SetupOptions {
     otherJob: boolean;
     careCert: boolean;
     mandatoryTraining: TrainingRecordCategory[];
@@ -122,7 +122,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
     isOwnWorkplace: boolean;
     qualifications: QualificationsByGroup;
   }
-  const defaultProps: SetupProps = {
+  const defaults: SetupOptions = {
     otherJob: false,
     careCert: true,
     mandatoryTraining: [],
@@ -131,10 +131,10 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
     qualifications: { count: 0, groups: [], lastUpdated: qualificationsByGroup.lastUpdated },
   };
 
-  async function setup(props: Partial<SetupProps> = {}) {
+  async function setup(options: Partial<SetupOptions> = {}) {
     const { otherJob, careCert, mandatoryTraining, fragment, isOwnWorkplace, qualifications } = {
-      ...defaultProps,
-      ...props,
+      ...defaults,
+      ...options,
     };
 
     const { fixture, getByText, getAllByText, queryByText, getByTestId } = await render(
@@ -661,9 +661,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
 
     describe('mandatory training tab', async () => {
       it('should show the Mandatory training tab as active when on training record page with fragment mandatory-training', async () => {
-        const { getByTestId } = await setup({
-          fragment: 'mandatory-training',
-        });
+        const { getByTestId } = await setup({ fragment: 'mandatory-training' });
 
         expect(getByTestId('allRecordsTab').getAttribute('class')).not.toContain('asc-tabs__list-item--active');
         expect(getByTestId('allRecordsTabLink').getAttribute('class')).not.toContain('asc-tabs__link--active');

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -30,7 +30,7 @@ import { TrainingAndQualificationRecords } from '@core/model/trainingAndQualific
 import { TrainingCertificateService } from '@core/services/certificate.service';
 import { MockTrainingCertificateService } from '@core/test-utils/MockCertificationService';
 
-describe('NewTrainingAndQualificationsRecordComponent', () => {
+fdescribe('NewTrainingAndQualificationsRecordComponent', () => {
   const workplace = establishmentBuilder() as Establishment;
 
   const yesterday = new Date();

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -4,7 +4,7 @@ import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { TrainingCertificateService, QualificationCertificateService } from '@core/services/certificate.service';
 import { Establishment, mandatoryTraining } from '@core/model/establishment.model';
 import { QualificationsByGroup } from '@core/model/qualification.model';
-import { CertificateUpload, TrainingRecord, TrainingRecordCategory } from '@core/model/training.model';
+import { TrainingRecordCategory } from '@core/model/training.model';
 import {
   CertificateDownloadEvent,
   CertificateUploadEvent,
@@ -117,13 +117,13 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.worker = this.route.snapshot.data.worker;
     this.qualificationsByGroup = this.route.snapshot.data.trainingAndQualificationRecords.qualifications;
 
-    // add mock data for checking appearance
-    if (!this.qualificationsByGroup?.groups?.[0]?.records?.[0]?.qualificationCertificates) {
-      this.qualificationsByGroup.groups[0].records[0].qualificationCertificates = [
-        { uid: '1', filename: 'cert.pdf', uploadDate: '20240101' },
-        { uid: '2', filename: 'cert.pdf', uploadDate: '20240101' },
-      ];
-    }
+    // mock data for checking appearance
+    // if (!this.qualificationsByGroup?.groups?.[0]?.records?.[0]?.qualificationCertificates) {
+    //   this.qualificationsByGroup.groups[0].records[0].qualificationCertificates = [
+    //     { uid: '1', filename: 'cert.pdf', uploadDate: '20240101' },
+    //     { uid: '2', filename: 'cert.pdf', uploadDate: '20240101' },
+    //   ];
+    // }
 
     this.trainingRecords = this.route.snapshot.data.trainingAndQualificationRecords.training;
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
@@ -392,7 +392,7 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     const subscription = service.addCertificates(this.workplace.uid, this.worker.uid, recordUid, files).subscribe(
       () => {
         this.certificateErrors = {};
-        this.refreshTraining().then(() => {
+        this.refreshTrainingAndQualificationRecords().then(() => {
           this.alertService.addAlert({
             type: 'success',
             message: 'Certificate uploaded',
@@ -408,11 +408,12 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.subscriptions.add(subscription);
   }
 
-  private async refreshTraining() {
+  private async refreshTrainingAndQualificationRecords() {
     const updatedData: TrainingAndQualificationRecords = await this.workerService
       .getAllTrainingAndQualificationRecords(this.workplace.uid, this.worker.uid)
       .toPromise();
     this.trainingRecords = updatedData.training;
+    this.qualificationsByGroup = updatedData.qualifications;
     this.setTraining();
   }
 }

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -118,11 +118,15 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.qualificationsByGroup = this.route.snapshot.data.trainingAndQualificationRecords.qualifications;
 
     // mock data for checking appearance
-    // if (!this.qualificationsByGroup?.groups?.[0]?.records?.[0]?.qualificationCertificates) {
-    //   this.qualificationsByGroup.groups[0].records[0].qualificationCertificates = [
-    //     { uid: '1', filename: 'cert.pdf', uploadDate: '20240101' },
-    //     { uid: '2', filename: 'cert.pdf', uploadDate: '20240101' },
-    //   ];
+    // for (const group of this.qualificationsByGroup.groups) {
+    //   for (const record of group.records) {
+    //     if (!record.qualificationCertificates) {
+    //       record.qualificationCertificates = [
+    //         { uid: '1', filename: 'cert.pdf', uploadDate: '20240101' },
+    //         { uid: '2', filename: 'cert.pdf', uploadDate: '20240101' },
+    //       ];
+    //     }
+    //   }
     // }
 
     this.trainingRecords = this.route.snapshot.data.trainingAndQualificationRecords.training;
@@ -360,20 +364,22 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
   }
 
   public downloadCertificate(event: CertificateDownloadEvent) {
-    const service = this.getCertificateService(event);
+    const certificateService = this.getCertificateService(event);
     const { recordUid, filesToDownload: files } = event;
 
-    const subscription = service.downloadCertificates(this.workplace.uid, this.worker.uid, recordUid, files).subscribe(
-      () => {
-        this.certificateErrors = {};
-      },
-      (_error) => {
-        const categoryName = event.recordType === 'training' ? event.categoryName : event.qualificationType;
-        this.certificateErrors = {
-          [categoryName]: "There's a problem with this download. Try again later or contact us for help.",
-        };
-      },
-    );
+    const subscription = certificateService
+      .downloadCertificates(this.workplace.uid, this.worker.uid, recordUid, files)
+      .subscribe(
+        () => {
+          this.certificateErrors = {};
+        },
+        (_error) => {
+          const categoryName = event.recordType === 'training' ? event.categoryName : event.qualificationType;
+          this.certificateErrors = {
+            [categoryName]: "There's a problem with this download. Try again later or contact us for help.",
+          };
+        },
+      );
     this.subscriptions.add(subscription);
   }
 
@@ -387,24 +393,26 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
       return;
     }
 
-    const service = this.getCertificateService(event);
+    const certificateService = this.getCertificateService(event);
 
-    const subscription = service.addCertificates(this.workplace.uid, this.worker.uid, recordUid, files).subscribe(
-      () => {
-        this.certificateErrors = {};
-        this.refreshTrainingAndQualificationRecords().then(() => {
-          this.alertService.addAlert({
-            type: 'success',
-            message: 'Certificate uploaded',
+    const subscription = certificateService
+      .addCertificates(this.workplace.uid, this.worker.uid, recordUid, files)
+      .subscribe(
+        () => {
+          this.certificateErrors = {};
+          this.refreshTrainingAndQualificationRecords().then(() => {
+            this.alertService.addAlert({
+              type: 'success',
+              message: 'Certificate uploaded',
+            });
           });
-        });
-      },
-      (_error) => {
-        this.certificateErrors = {
-          [categoryName]: "There's a problem with this upload. Try again later or contact us for help.",
-        };
-      },
-    );
+        },
+        (_error) => {
+          this.certificateErrors = {
+            [categoryName]: "There's a problem with this upload. Try again later or contact us for help.",
+          };
+        },
+      );
     this.subscriptions.add(subscription);
   }
 

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -112,6 +112,14 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.workplace = this.route.parent.snapshot.data.establishment;
     this.worker = this.route.snapshot.data.worker;
     this.qualificationsByGroup = this.route.snapshot.data.trainingAndQualificationRecords.qualifications;
+
+    // add mock data for checking appearance
+    if (!this.qualificationsByGroup?.groups?.[0]?.records?.[0]?.qualificationCertificates) {
+      this.qualificationsByGroup.groups[0].records[0].qualificationCertificates = [
+        { uid: '1', filename: 'cert.pdf', uploadDate: '20240101' },
+      ];
+    }
+
     this.trainingRecords = this.route.snapshot.data.trainingAndQualificationRecords.training;
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
     this.canViewWorker = this.permissionsService.can(this.workplace.uid, 'canViewWorker');

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -363,7 +363,7 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     const service = this.getCertificateService(event);
     const { recordUid, filesToDownload: files } = event;
 
-    service.downloadCertificates(this.workplace.uid, this.worker.uid, recordUid, files).subscribe(
+    const subscription = service.downloadCertificates(this.workplace.uid, this.worker.uid, recordUid, files).subscribe(
       () => {
         this.certificateErrors = {};
       },
@@ -374,6 +374,7 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
         };
       },
     );
+    this.subscriptions.add(subscription);
   }
 
   public uploadCertificate(event: CertificateUploadEvent) {
@@ -388,7 +389,7 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
 
     const service = this.getCertificateService(event);
 
-    service.addCertificates(this.workplace.uid, this.worker.uid, recordUid, files).subscribe(
+    const subscription = service.addCertificates(this.workplace.uid, this.worker.uid, recordUid, files).subscribe(
       () => {
         this.certificateErrors = {};
         this.refreshTraining().then(() => {
@@ -404,6 +405,7 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
         };
       },
     );
+    this.subscriptions.add(subscription);
   }
 
   private async refreshTraining() {

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -117,18 +117,6 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.worker = this.route.snapshot.data.worker;
     this.qualificationsByGroup = this.route.snapshot.data.trainingAndQualificationRecords.qualifications;
 
-    // mock data for checking appearance
-    // for (const group of this.qualificationsByGroup.groups) {
-    //   for (const record of group.records) {
-    //     if (!record.qualificationCertificates) {
-    //       record.qualificationCertificates = [
-    //         { uid: '1', filename: 'cert.pdf', uploadDate: '20240101' },
-    //         { uid: '2', filename: 'cert.pdf', uploadDate: '20240101' },
-    //       ];
-    //     }
-    //   }
-    // }
-
     this.trainingRecords = this.route.snapshot.data.trainingAndQualificationRecords.training;
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
     this.canViewWorker = this.permissionsService.can(this.workplace.uid, 'canViewWorker');

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.html
@@ -1,14 +1,14 @@
 <div class="govuk-grid-row" #content>
   <div class="govuk-grid-column-full">
-    <ng-container *ngIf="trainingCategoryToDisplay.length > 0; else noTraining">
+    <ng-container *ngIf="trainingCategories.length > 0; else noTraining">
       <h1 class="govuk-heading-l govuk-!-font-size-27">{{ trainingType }}</h1>
-      <div *ngFor="let trainingCategory of trainingCategoryToDisplay" [attr.data-testid]="trainingCategory.category + '-section'">
+      <div *ngFor="let trainingCategory of trainingCategories" [attr.data-testid]="trainingCategory.category + '-section'">
         <label
           [attr.data-testid]="'category-' + trainingCategory.category"
           class="govuk-!-margin-bottom-2 govuk-heading-m"
         >{{ trainingCategory.category }}</label>
         <span aria-live="polite">
-          <app-validation-error-message *ngIf="trainingCategory.error" [errorMessage]="trainingCategory.error" />
+          <app-validation-error-message *ngIf="certificateErrors?.[trainingCategory.category]" [errorMessage]="certificateErrors?.[trainingCategory.category]" />
         </span>
         <table class="govuk-table govuk-!-margin-bottom-7">
           <caption

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.spec.ts
@@ -215,7 +215,6 @@ describe('NewTrainingComponent', async () => {
       const { component, fixture } = await setup();
 
       component.trainingCategories = [];
-      component.ngOnChanges();
       fixture.detectChanges();
       const noTrainingLink = fixture.debugElement.query(By.css('[data-testid="no-training-link"]')).nativeElement;
 
@@ -240,7 +239,6 @@ describe('NewTrainingComponent', async () => {
       component.trainingCategories = [];
       component.isMandatoryTraining = true;
       component.workplaceUid = '123';
-      component.ngOnChanges();
       fixture.detectChanges();
       const noMandatoryTrainingLink = fixture.debugElement.query(
         By.css('[data-testid="no-mandatory-training-link"]'),
@@ -256,7 +254,6 @@ describe('NewTrainingComponent', async () => {
       component.isMandatoryTraining = true;
       component.workplaceUid = '123';
       component.canEditWorker = false;
-      component.ngOnChanges();
       fixture.detectChanges();
       const noMandatoryTrainingLink = fixture.debugElement.query(By.css('[data-testid="no-mandatory-training-link"]'));
 
@@ -269,7 +266,6 @@ describe('NewTrainingComponent', async () => {
       component.isMandatoryTraining = true;
       component.workplaceUid = '123';
       component.missingMandatoryTraining = false;
-      component.ngOnChanges();
       fixture.detectChanges();
       const mandatoryTrainingMissingLink = fixture.debugElement.query(
         By.css('[data-testid="no-mandatory-training-link"]'),
@@ -289,7 +285,6 @@ describe('NewTrainingComponent', async () => {
       component.isMandatoryTraining = true;
       component.workplaceUid = '123';
       component.missingMandatoryTraining = true;
-      component.ngOnChanges();
       fixture.detectChanges();
       const mandatoryTrainingMissingLink = fixture.debugElement.query(
         By.css('[data-testid="mandatory-training-missing-link"]'),

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.spec.ts
@@ -6,6 +6,7 @@ import { render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
 import { NewTrainingComponent } from './new-training.component';
+import { TrainingCertificateDownloadEvent, TrainingCertificateUploadEvent } from '@core/model/training.model';
 
 describe('NewTrainingComponent', async () => {
   const trainingCategories = [
@@ -270,9 +271,13 @@ describe('NewTrainingComponent', async () => {
       component.missingMandatoryTraining = false;
       component.ngOnChanges();
       fixture.detectChanges();
-      const mandatoryTrainingMissingLink = fixture.debugElement.query(By.css('[data-testid="no-mandatory-training-link"]'));
+      const mandatoryTrainingMissingLink = fixture.debugElement.query(
+        By.css('[data-testid="no-mandatory-training-link"]'),
+      );
       const messageText = 'No mandatory training has been added for this job role yet.';
-      const mandatoryTrainingMessage = fixture.debugElement.query(debugElement => debugElement.nativeElement.textContent === messageText);
+      const mandatoryTrainingMessage = fixture.debugElement.query(
+        (debugElement) => debugElement.nativeElement.textContent === messageText,
+      );
 
       expect(mandatoryTrainingMessage).toBeTruthy();
       expect(mandatoryTrainingMissingLink).toBeTruthy();
@@ -286,9 +291,13 @@ describe('NewTrainingComponent', async () => {
       component.missingMandatoryTraining = true;
       component.ngOnChanges();
       fixture.detectChanges();
-      const mandatoryTrainingMissingLink = fixture.debugElement.query(By.css('[data-testid="mandatory-training-missing-link"]'));
+      const mandatoryTrainingMissingLink = fixture.debugElement.query(
+        By.css('[data-testid="mandatory-training-missing-link"]'),
+      );
       const messageText = 'No mandatory training records have been added for this person yet.';
-      const mandatoryTrainingMessage = fixture.debugElement.query(debugElement => debugElement.nativeElement.textContent === messageText);
+      const mandatoryTrainingMessage = fixture.debugElement.query(
+        (debugElement) => debugElement.nativeElement.textContent === messageText,
+      );
 
       expect(mandatoryTrainingMessage).toBeTruthy();
       expect(mandatoryTrainingMissingLink).toBeTruthy();
@@ -412,8 +421,14 @@ describe('NewTrainingComponent', async () => {
 
       userEvent.click(downloadLink);
       const expectedTrainingRecord = component.trainingCategories[0].trainingRecords[0];
+      const expectedDownloadEvent: TrainingCertificateDownloadEvent = {
+        recordType: 'training',
+        recordUid: expectedTrainingRecord.uid,
+        categoryName: expectedTrainingRecord.trainingCategory.category,
+        filesToDownload: expectedTrainingRecord.trainingCertificates,
+      };
 
-      expect(downloadFileSpy).toHaveBeenCalledOnceWith(expectedTrainingRecord);
+      expect(downloadFileSpy).toHaveBeenCalledOnceWith(expectedDownloadEvent);
     });
 
     it('should display Select a download link when training record has more than one certificate associated with it', async () => {
@@ -485,10 +500,15 @@ describe('NewTrainingComponent', async () => {
 
       userEvent.upload(fileInput, [mockUploadFile]);
 
-      expect(uploadFileSpy).toHaveBeenCalledWith({
+      const expectedTrainingRecord = component.trainingCategories[0].trainingRecords[0];
+      const expectedUploadEvent: TrainingCertificateUploadEvent = {
+        recordType: 'training',
+        recordUid: expectedTrainingRecord.uid,
+        categoryName: expectedTrainingRecord.trainingCategory.category,
         files: [mockUploadFile],
-        trainingRecord: component.trainingCategories[0].trainingRecords[0],
-      });
+      };
+
+      expect(uploadFileSpy).toHaveBeenCalledWith(expectedUploadEvent);
     });
 
     it('should display an error message above the category when download certificate fails', async () => {

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.ts
@@ -13,7 +13,7 @@ import { TrainingStatusService } from '@core/services/trainingStatus.service';
   templateUrl: './new-training.component.html',
   styleUrls: ['./new-training.component.scss'],
 })
-export class NewTrainingComponent implements OnChanges {
+export class NewTrainingComponent {
   @Input() public trainingCategories: TrainingRecordCategory[];
   @Input() public isMandatoryTraining = false;
   @Input() public trainingType: string;
@@ -33,11 +33,6 @@ export class NewTrainingComponent implements OnChanges {
 
   ngOnInit(): void {
     this.workplaceUid = this.route.snapshot.params.establishmentuid;
-    this.addErrorsToTrainingCategories();
-  }
-
-  ngOnChanges(): void {
-    this.addErrorsToTrainingCategories();
   }
 
   handleDownloadCertificate(event: Event, trainingRecord: TrainingRecord) {
@@ -56,17 +51,6 @@ export class NewTrainingComponent implements OnChanges {
       recordUid: trainingRecord.uid,
       categoryName: trainingRecord.trainingCategory.category,
       files,
-    });
-  }
-
-  addErrorsToTrainingCategories() {
-    this.trainingCategoryToDisplay = this.trainingCategories.map((trainingCategory) => {
-      if (this.certificateErrors && trainingCategory.category in this.certificateErrors) {
-        const errorMessage = this.certificateErrors[trainingCategory.category];
-        return { ...trainingCategory, error: errorMessage };
-      } else {
-        return trainingCategory;
-      }
     });
   }
 }

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.ts
@@ -1,6 +1,11 @@
 import { Component, ElementRef, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { CertificateUpload, TrainingRecord, TrainingRecordCategory } from '@core/model/training.model';
+import {
+  TrainingCertificateUploadEvent,
+  TrainingCertificateDownloadEvent,
+  TrainingRecord,
+  TrainingRecordCategory,
+} from '@core/model/training.model';
 import { TrainingStatusService } from '@core/services/trainingStatus.service';
 
 @Component({
@@ -16,8 +21,8 @@ export class NewTrainingComponent implements OnChanges {
   @Input() public canEditWorker: boolean;
   @Input() public missingMandatoryTraining = false;
   @Input() public certificateErrors: Record<string, string> = {};
-  @Output() public downloadFile = new EventEmitter<TrainingRecord>();
-  @Output() public uploadFile = new EventEmitter<CertificateUpload>();
+  @Output() public downloadFile = new EventEmitter<TrainingCertificateDownloadEvent>();
+  @Output() public uploadFile = new EventEmitter<TrainingCertificateUploadEvent>();
 
   public trainingCategoryToDisplay: (TrainingRecordCategory & { error?: string })[];
 
@@ -37,11 +42,21 @@ export class NewTrainingComponent implements OnChanges {
 
   handleDownloadCertificate(event: Event, trainingRecord: TrainingRecord) {
     event.preventDefault();
-    this.downloadFile.emit(trainingRecord);
+    this.downloadFile.emit({
+      recordType: 'training',
+      recordUid: trainingRecord.uid,
+      categoryName: trainingRecord.trainingCategory.category,
+      filesToDownload: trainingRecord.trainingCertificates,
+    });
   }
 
   handleUploadCertificate(files: File[], trainingRecord: TrainingRecord) {
-    this.uploadFile.emit({ files, trainingRecord });
+    this.uploadFile.emit({
+      recordType: 'training',
+      recordUid: trainingRecord.uid,
+      categoryName: trainingRecord.trainingCategory.category,
+      files,
+    });
   }
 
   addErrorsToTrainingCategories() {


### PR DESCRIPTION
#### Work done
- Add a certificate column to new-qualification component, with functionality for certificate upload, download and the related error msgs
- Amend table header from "Certificate name" to "(qualification type) name"
- Refactor new-training component, simplifying the way to show error messages

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
