### PR TITLE
Spike: Keep training certificates when bulk uploading training

### DIFF
--- a/backend/server/models/classes/training.js
+++ b/backend/server/models/classes/training.js
@@ -118,6 +118,9 @@ class Training extends EntityValidator {
   get uid() {
     return this._uid;
   }
+  set uid(uid) {
+    this._uid = uid;
+  }
   get created() {
     return this._created;
   }
@@ -188,7 +191,7 @@ class Training extends EntityValidator {
 
   // used by save to initialise a new Trainign Record; returns true if having initialised this Training Record
   _initialise() {
-    if (this._uid === null) {
+    if (!this._uid) {
       this._isNew = true;
       this._uid = uuidv4();
 
@@ -382,6 +385,10 @@ class Training extends EntityValidator {
       validatedTrainingRecord.expires = null;
     }
 
+    if (document.uid) {
+      validatedTrainingRecord.uid = document.uid;
+    }
+
     // notes
     if (document.notes) {
       // validate title
@@ -419,6 +426,7 @@ class Training extends EntityValidator {
       if (validatedTrainingRecord !== false) {
         this.category = validatedTrainingRecord.trainingCategory;
         this.title = validatedTrainingRecord.title;
+        this.uid = validatedTrainingRecord.uid;
         this.accredited = validatedTrainingRecord.accredited;
         this.completed = validatedTrainingRecord.completed
           ? validatedTrainingRecord.completed.toJSON().slice(0, 10)

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -1586,7 +1586,7 @@ module.exports = function (sequelize, DataTypes) {
           },
           include: [
             {
-              attributes: ['title', 'completed', 'expires', 'accredited', 'notes'],
+              attributes: ['title', 'completed', 'expires', 'accredited', 'notes', 'uid'],
               model: sequelize.models.workerTraining,
               as: 'workerTraining',
               include: {

--- a/backend/server/routes/establishments/bulkUpload/data/trainingHeaders.js
+++ b/backend/server/routes/establishments/bulkUpload/data/trainingHeaders.js
@@ -1,6 +1,7 @@
 const trainingHeadersAsArray = [
   'LOCALESTID',
   'UNIQUEWORKERID',
+  'TRAININGUID',
   'CATEGORY',
   'DESCRIPTION',
   'DATECOMPLETED',

--- a/backend/server/routes/establishments/bulkUpload/download/trainingCSV.js
+++ b/backend/server/routes/establishments/bulkUpload/download/trainingCSV.js
@@ -2,11 +2,11 @@ const BUDI = require('../../../../models/BulkImport/BUDI').BUDI;
 const { csvQuote } = require('../../../../utils/bulkUploadUtils');
 
 const toCSV = (establishmentId, workerId, entity) => {
-  // ["LOCALESTID","UNIQUEWORKERID","CATEGORY","DESCRIPTION","DATECOMPLETED","EXPIRYDATE","ACCREDITED","NOTES"]
-
+  // ["LOCALESTID","UNIQUEWORKERID","TRAININGUID","CATEGORY","DESCRIPTION","DATECOMPLETED","EXPIRYDATE","ACCREDITED","NOTES"]
   const columns = [
     csvQuote(establishmentId),
     csvQuote(workerId),
+    csvQuote(entity.uid),
     BUDI.trainingCategory(BUDI.FROM_ASC, entity.category.id),
     entity.title ? csvQuote(entity.title) : '',
     convertDateFormatToDayMonthYearWithSlashes(entity.completed),

--- a/backend/server/routes/establishments/bulkUpload/whichFile.js
+++ b/backend/server/routes/establishments/bulkUpload/whichFile.js
@@ -9,8 +9,8 @@ const isWorkerFile = (fileAsString) => {
 };
 
 const isTrainingFile = (fileAsString) => {
-  const contentRegex = /LOCALESTID,UNIQUEWORKERID,CATEGORY,DESCRIPTION,DAT/;
-  return contentRegex.test(fileAsString.substring(0, 50));
+  const contentRegex = /LOCALESTID,UNIQUEWORKERID,TRAININGUID,CATEGORY,DESCRIPTION,DAT/;
+  return contentRegex.test(fileAsString.substring(0, 62));
 };
 
 const getFileType = (fileData) => {

--- a/lambdas/bulkUpload/classes/trainingCSVValidator.js
+++ b/lambdas/bulkUpload/classes/trainingCSVValidator.js
@@ -10,6 +10,7 @@ class TrainingCsvValidator {
     this.validationErrors = [];
     this.localeStId = null;
     this.uniqueWorkerId = null;
+    this.trainingUid = null;
     this.dateCompleted = null;
     this.expiry = null;
     this.description = null;
@@ -66,6 +67,7 @@ class TrainingCsvValidator {
   validate() {
     this._validateLocaleStId();
     this._validateUniqueWorkerId();
+    this._validateTrainingUid();
     this._validateDateCompleted();
     this._validateExpiry();
     this._validateDescription();
@@ -78,6 +80,7 @@ class TrainingCsvValidator {
     return {
       localId: this.localeStId,
       uniqueWorkerId: this.uniqueWorkerId,
+      uid: this.trainingUid ? this.trainingUid : undefined,
       completed: this.dateCompleted ? this.dateCompleted.format('DD/MM/YYYY') : undefined,
       expiry: this.expiry ? this.expiry.format('DD/MM/YYYY') : undefined,
       description: this.description,
@@ -93,6 +96,7 @@ class TrainingCsvValidator {
       trainingCategory: {
         id: this.category,
       },
+      uid: this.trainingUid ? this.trainingUid : undefined,
       completed: this.dateCompleted ? this.dateCompleted.format('YYYY-MM-DD') : undefined,
       expires: this.expiry ? this.expiry.format('YYYY-MM-DD') : undefined,
       title: this.description ? this.description : undefined,
@@ -123,6 +127,14 @@ class TrainingCsvValidator {
       return;
     }
     this._addValidationError('UNIQUE_WORKER_ID_ERROR', errMessage, this.currentLine.UNIQUEWORKERID, 'UNIQUEWORKERID');
+  }
+
+  _validateTrainingUid() {
+    const trainingUid = this.currentLine.TRAININGUID;
+    if (trainingUid) {
+      this.trainingUid = trainingUid;
+      return;
+    }
   }
 
   _validateDateCompleted() {

--- a/lambdas/bulkUpload/serverless.yml
+++ b/lambdas/bulkUpload/serverless.yml
@@ -22,7 +22,7 @@ frameworkVersion: '2'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs18.x
   lambdaHashingVersion: 20201221
   stage: dev
   region: eu-west-2


### PR DESCRIPTION
### Spike Branch
- This is a spike branch to create a proof of concept that we can maintain training certificates when bulk uploading training records. This requires changing the current setup where all training records for workers with training in the BU file are deleted and then the new ones are created.

- We have added code which creates a training uid column in training bulk upload file and update existing records based on uid, if no uid create record

