### PR TITLE
Feat/1528 download all training and quals certificates

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
                 "@sentry/node": "^6.13.1",
                 "@sentry/tracing": "^6.13.1",
                 "@types/offscreencanvas": "^2019.7.0",
+                "@zip.js/zip.js": "^2.7.52",
                 "ajv-errors": "^1.0.1",
                 "angulartics2": "^10.0.0",
                 "canvg": "^3.0.7",
@@ -6601,6 +6602,16 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
             "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+        },
+        "node_modules/@zip.js/zip.js": {
+            "version": "2.7.52",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.52.tgz",
+            "integrity": "sha512-+5g7FQswvrCHwYKNMd/KFxZSObctLSsQOgqBSi0LzwHo3li9Eh1w5cF5ndjQw9Zbr3ajVnd2+XyiX85gAetx1Q==",
+            "engines": {
+                "bun": ">=0.7.0",
+                "deno": ">=1.0.0",
+                "node": ">=16.5.0"
+            }
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -31800,6 +31811,11 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
             "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+        },
+        "@zip.js/zip.js": {
+            "version": "2.7.52",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.52.tgz",
+            "integrity": "sha512-+5g7FQswvrCHwYKNMd/KFxZSObctLSsQOgqBSi0LzwHo3li9Eh1w5cF5ndjQw9Zbr3ajVnd2+XyiX85gAetx1Q=="
         },
         "abab": {
             "version": "2.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
         "@sentry/node": "^6.13.1",
         "@sentry/tracing": "^6.13.1",
         "@types/offscreencanvas": "^2019.7.0",
+        "@zip.js/zip.js": "^2.7.52",
         "ajv-errors": "^1.0.1",
         "angulartics2": "^10.0.0",
         "canvg": "^3.0.7",

--- a/frontend/src/app/core/model/qualification.model.ts
+++ b/frontend/src/app/core/model/qualification.model.ts
@@ -35,6 +35,7 @@ export interface QualificationRequest {
 }
 
 export interface QualificationsResponse {
+  workerUid: string;
   count: number;
   lastUpdated?: string;
   qualifications: Qualification[];
@@ -66,6 +67,7 @@ export interface Qualification {
     title?: string;
     group?: string;
   };
+  qualificationCertificates?: QualificationCertificate[];
 }
 
 export interface QualificationsByGroup {

--- a/frontend/src/app/core/model/training.model.ts
+++ b/frontend/src/app/core/model/training.model.ts
@@ -134,29 +134,3 @@ export interface TrainingRecordCategories {
   training: Training[];
   isMandatory: boolean;
 }
-
-export interface UploadCertificateSignedUrlRequest {
-  files: { filename: string }[];
-}
-
-export interface UploadCertificateSignedUrlResponse {
-  files: { filename: string; fileId: string; signedUrl: string; key: string }[];
-}
-
-export interface DownloadCertificateSignedUrlResponse {
-  files: { filename: string; signedUrl: string }[];
-}
-
-export interface S3UploadResponse {
-  headers: { etag: string };
-}
-export interface FileInfoWithETag {
-  filename: string;
-  fileId: string;
-  etag: string;
-  key: string;
-}
-
-export interface ConfirmUploadRequest {
-  files: { filename: string; fileId: string; etag: string }[];
-}

--- a/frontend/src/app/core/model/trainingAndQualifications.model.ts
+++ b/frontend/src/app/core/model/trainingAndQualifications.model.ts
@@ -33,3 +33,29 @@ export interface CertificateDownload {
 export type CertificateDownloadEvent = TrainingCertificateDownloadEvent | QualificationCertificateDownloadEvent;
 
 export type CertificateUploadEvent = TrainingCertificateUploadEvent | QualificationCertificateUploadEvent;
+
+export interface UploadCertificateSignedUrlRequest {
+  files: { filename: string }[];
+}
+
+export interface UploadCertificateSignedUrlResponse {
+  files: { filename: string; fileId: string; signedUrl: string; key: string }[];
+}
+
+export interface DownloadCertificateSignedUrlResponse {
+  files: { filename: string; signedUrl: string }[];
+}
+
+export interface S3UploadResponse {
+  headers: { etag: string };
+}
+export interface FileInfoWithETag {
+  filename: string;
+  fileId: string;
+  etag: string;
+  key: string;
+}
+
+export interface ConfirmUploadRequest {
+  files: { filename: string; fileId: string; etag: string }[];
+}

--- a/frontend/src/app/core/services/certificate.service.spec.ts
+++ b/frontend/src/app/core/services/certificate.service.spec.ts
@@ -1,11 +1,20 @@
+import { toArray } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import {
+  mockQualificationRecordsResponse,
+  mockTrainingRecordsResponse,
+  qualificationUidsWithCerts,
+  qualificationUidsWithoutCerts as qualificationUidsNoCerts,
+  trainingUidsWithCerts,
+  trainingUidsWithoutCerts as trainingUidsNoCerts,
+} from '@core/test-utils/MockCertificationService';
 
 import { QualificationCertificateService, TrainingCertificateService } from './certificate.service';
 
-describe('CertificateService', () => {
+fdescribe('CertificateService', () => {
   const testConfigs = [
     {
       certificateType: 'training',
@@ -214,6 +223,86 @@ describe('CertificateService', () => {
         });
       });
 
+      fdescribe('downloadAllCertificatesAsBlobs', () => {
+        const mockWorkplaceUid = 'mockWorkplaceUid';
+        const mockWorkerUid = 'mockWorkerUid';
+
+        const recordsEndpoint = `${environment.appRunnerEndpoint}/api/establishment/${mockWorkplaceUid}/worker/${mockWorkerUid}/${certificateType}`;
+
+        const mockRecordsResponse =
+          certificateType === 'training' ? mockTrainingRecordsResponse : mockQualificationRecordsResponse;
+        const recordsHavingCertificates =
+          certificateType === 'training' ? trainingUidsWithCerts : qualificationUidsWithCerts;
+        const recordsWithoutCertificates =
+          certificateType === 'training' ? trainingUidsNoCerts : qualificationUidsNoCerts;
+
+        it('should query the backend to get all training / qualification records for the worker', async () => {
+          service.downloadAllCertificatesAsBlobs(mockWorkplaceUid, mockWorkerUid).subscribe();
+
+          http.expectOne(recordsEndpoint);
+        });
+
+        it('should request backend for signedUrls and download every certificates as blobs', async () => {
+          service.downloadAllCertificatesAsBlobs(mockWorkplaceUid, mockWorkerUid).subscribe();
+
+          http.expectOne(recordsEndpoint).flush(mockRecordsResponse);
+
+          recordsHavingCertificates.forEach((recordUid) => {
+            const certificateDownloadEndpoint = `${recordsEndpoint}/${recordUid}/certificate/download`;
+            const mockresponse = {
+              files: [
+                { signedUrl: `https://localhost/${recordUid}-1.pdf`, filename: `${recordUid}-1.pdf` },
+                { signedUrl: `https://localhost/${recordUid}-2.pdf`, filename: `${recordUid}-2.pdf` },
+              ],
+            };
+            http.expectOne({ url: certificateDownloadEndpoint, method: 'POST' }).flush(mockresponse);
+
+            http.expectOne(`https://localhost/${recordUid}-1.pdf`).flush(new Blob(['mock blob file']));
+            http.expectOne(`https://localhost/${recordUid}-2.pdf`).flush(new Blob(['mock blob file']));
+          });
+
+          recordsWithoutCertificates.forEach((recordUid) => {
+            const certificateDownloadEndpoint = `${recordsEndpoint}/${recordUid}/certificate/download`;
+            http.expectNone(certificateDownloadEndpoint);
+          });
+        });
+
+        it('should return an observable for every certificates as file blobs', async () => {
+          const returnedObservable = service.downloadAllCertificatesAsBlobs(mockWorkplaceUid, mockWorkerUid);
+          const promise = returnedObservable.pipe(toArray()).toPromise();
+
+          http.expectOne(recordsEndpoint).flush(mockRecordsResponse);
+
+          recordsHavingCertificates.forEach((recordUid) => {
+            const certificateDownloadEndpoint = `${recordsEndpoint}/${recordUid}/certificate/download`;
+            const mockResponse = {
+              files: [
+                { signedUrl: `https://localhost/${recordUid}-1.pdf`, filename: `${recordUid}-1.pdf` },
+                { signedUrl: `https://localhost/${recordUid}-2.pdf`, filename: `${recordUid}-2.pdf` },
+              ],
+            };
+            http.expectOne({ url: certificateDownloadEndpoint, method: 'POST' }).flush(mockResponse);
+
+            http.expectOne(`https://localhost/${recordUid}-1.pdf`).flush(new Blob(['mock blob file']));
+            http.expectOne(`https://localhost/${recordUid}-2.pdf`).flush(new Blob(['mock blob file']));
+          });
+
+          const allFileBlobs = await promise;
+          expect(allFileBlobs.length).toEqual(4);
+
+          for (const recordUid of recordsHavingCertificates) {
+            expect(allFileBlobs).toContain({
+              filename: `${certificateType} certificates/${recordUid}-1.pdf`,
+              fileBlob: jasmine.anything(),
+            });
+            expect(allFileBlobs).toContain({
+              filename: `${certificateType} certificates/${recordUid}-2.pdf`,
+              fileBlob: jasmine.anything(),
+            });
+          }
+        });
+      });
+
       describe('deleteCertificates', () => {
         it('should call the endpoint for deleting training certificates', async () => {
           const mockWorkplaceUid = 'mockWorkplaceUid';
@@ -227,7 +316,7 @@ describe('CertificateService', () => {
             },
           ];
 
-          const deleteCertificatesEndpoint = `${environment.appRunnerEndpoint}/api/establishment/${mockWorkplaceUid}/worker/${mockWorkerUid}/${certificateType}/${mockRecordUid}/certificate/delete`;
+          const deleteCertificatesEndpoint = `${environment.appRunnerEndpoint}/api/establishment/${mockWorkplaceUid}/worker/${mockWorkerUid}/${certificateType}`;
 
           service.deleteCertificates(mockWorkplaceUid, mockWorkerUid, mockRecordUid, mockFilesToDelete).subscribe();
 

--- a/frontend/src/app/core/services/certificate.service.spec.ts
+++ b/frontend/src/app/core/services/certificate.service.spec.ts
@@ -10,11 +10,11 @@ import {
   qualificationUidsWithoutCerts as qualificationUidsNoCerts,
   trainingUidsWithCerts,
   trainingUidsWithoutCerts as trainingUidsNoCerts,
-} from '@core/test-utils/MockCertificationService';
+} from '@core/test-utils/MockCertificateService';
 
 import { QualificationCertificateService, TrainingCertificateService } from './certificate.service';
 
-fdescribe('CertificateService', () => {
+describe('CertificateService', () => {
   const testConfigs = [
     {
       certificateType: 'training',
@@ -223,7 +223,7 @@ fdescribe('CertificateService', () => {
         });
       });
 
-      fdescribe('downloadAllCertificatesAsBlobs', () => {
+      describe('downloadAllCertificatesAsBlobs', () => {
         const mockWorkplaceUid = 'mockWorkplaceUid';
         const mockWorkerUid = 'mockWorkerUid';
 
@@ -316,7 +316,7 @@ fdescribe('CertificateService', () => {
             },
           ];
 
-          const deleteCertificatesEndpoint = `${environment.appRunnerEndpoint}/api/establishment/${mockWorkplaceUid}/worker/${mockWorkerUid}/${certificateType}`;
+          const deleteCertificatesEndpoint = `${environment.appRunnerEndpoint}/api/establishment/${mockWorkplaceUid}/worker/${mockWorkerUid}/${certificateType}/${mockRecordUid}/certificate/delete`;
 
           service.deleteCertificates(mockWorkplaceUid, mockWorkerUid, mockRecordUid, mockFilesToDelete).subscribe();
 

--- a/frontend/src/app/core/services/certificate.service.spec.ts
+++ b/frontend/src/app/core/services/certificate.service.spec.ts
@@ -13,8 +13,9 @@ import {
 } from '@core/test-utils/MockCertificateService';
 
 import { QualificationCertificateService, TrainingCertificateService } from './certificate.service';
+import { mockCertificateFileBlob } from '../test-utils/MockCertificateService';
 
-describe('CertificateService', () => {
+fdescribe('CertificateService', () => {
   const testConfigs = [
     {
       certificateType: 'training',
@@ -283,21 +284,24 @@ describe('CertificateService', () => {
             };
             http.expectOne({ url: certificateDownloadEndpoint, method: 'POST' }).flush(mockResponse);
 
-            http.expectOne(`https://localhost/${recordUid}-1.pdf`).flush(new Blob(['mock blob file']));
-            http.expectOne(`https://localhost/${recordUid}-2.pdf`).flush(new Blob(['mock blob file']));
+            http.expectOne(`https://localhost/${recordUid}-1.pdf`).flush(mockCertificateFileBlob);
+            http.expectOne(`https://localhost/${recordUid}-2.pdf`).flush(mockCertificateFileBlob);
           });
 
           const allFileBlobs = await promise;
           expect(allFileBlobs.length).toEqual(4);
 
+          const expectedFolderName =
+            certificateType === 'training' ? 'Training certificates' : 'Qualification certificates';
+
           for (const recordUid of recordsHavingCertificates) {
             expect(allFileBlobs).toContain({
-              filename: `${certificateType} certificates/${recordUid}-1.pdf`,
-              fileBlob: jasmine.anything(),
+              filename: `${expectedFolderName}/${recordUid}-1.pdf`,
+              fileBlob: mockCertificateFileBlob,
             });
             expect(allFileBlobs).toContain({
-              filename: `${certificateType} certificates/${recordUid}-2.pdf`,
-              fileBlob: jasmine.anything(),
+              filename: `${expectedFolderName}/${recordUid}-2.pdf`,
+              fileBlob: mockCertificateFileBlob,
             });
           }
         });

--- a/frontend/src/app/core/services/certificate.service.spec.ts
+++ b/frontend/src/app/core/services/certificate.service.spec.ts
@@ -15,7 +15,7 @@ import {
 import { QualificationCertificateService, TrainingCertificateService } from './certificate.service';
 import { mockCertificateFileBlob } from '../test-utils/MockCertificateService';
 
-fdescribe('CertificateService', () => {
+describe('CertificateService', () => {
   const testConfigs = [
     {
       certificateType: 'training',

--- a/frontend/src/app/core/services/certificate.service.spec.ts
+++ b/frontend/src/app/core/services/certificate.service.spec.ts
@@ -252,16 +252,17 @@ describe('CertificateService', () => {
             const certificateDownloadEndpoint = `${recordsEndpoint}/${recordUid}/certificate/download`;
             const mockresponse = {
               files: [
-                { signedUrl: `https://localhost/${recordUid}-1.pdf`, filename: `${recordUid}-1.pdf` },
-                { signedUrl: `https://localhost/${recordUid}-2.pdf`, filename: `${recordUid}-2.pdf` },
+                { signedUrl: `https://mocks3endpoint/${recordUid}-1.pdf`, filename: `${recordUid}-1.pdf` },
+                { signedUrl: `https://mocks3endpoint/${recordUid}-2.pdf`, filename: `${recordUid}-2.pdf` },
               ],
             };
             http.expectOne({ url: certificateDownloadEndpoint, method: 'POST' }).flush(mockresponse);
 
-            http.expectOne(`https://localhost/${recordUid}-1.pdf`).flush(new Blob(['mock blob file']));
-            http.expectOne(`https://localhost/${recordUid}-2.pdf`).flush(new Blob(['mock blob file']));
+            http.expectOne(`https://mocks3endpoint/${recordUid}-1.pdf`).flush(mockCertificateFileBlob);
+            http.expectOne(`https://mocks3endpoint/${recordUid}-2.pdf`).flush(mockCertificateFileBlob);
           });
 
+          // should not call certificate download endpoint for records that have no certificates
           recordsWithoutCertificates.forEach((recordUid) => {
             const certificateDownloadEndpoint = `${recordsEndpoint}/${recordUid}/certificate/download`;
             http.expectNone(certificateDownloadEndpoint);
@@ -278,14 +279,14 @@ describe('CertificateService', () => {
             const certificateDownloadEndpoint = `${recordsEndpoint}/${recordUid}/certificate/download`;
             const mockResponse = {
               files: [
-                { signedUrl: `https://localhost/${recordUid}-1.pdf`, filename: `${recordUid}-1.pdf` },
-                { signedUrl: `https://localhost/${recordUid}-2.pdf`, filename: `${recordUid}-2.pdf` },
+                { signedUrl: `https://mocks3endpoint/${recordUid}-1.pdf`, filename: `${recordUid}-1.pdf` },
+                { signedUrl: `https://mocks3endpoint/${recordUid}-2.pdf`, filename: `${recordUid}-2.pdf` },
               ],
             };
             http.expectOne({ url: certificateDownloadEndpoint, method: 'POST' }).flush(mockResponse);
 
-            http.expectOne(`https://localhost/${recordUid}-1.pdf`).flush(mockCertificateFileBlob);
-            http.expectOne(`https://localhost/${recordUid}-2.pdf`).flush(mockCertificateFileBlob);
+            http.expectOne(`https://mocks3endpoint/${recordUid}-1.pdf`).flush(mockCertificateFileBlob);
+            http.expectOne(`https://mocks3endpoint/${recordUid}-2.pdf`).flush(mockCertificateFileBlob);
           });
 
           const allFileBlobs = await promise;

--- a/frontend/src/app/core/services/certificate.service.ts
+++ b/frontend/src/app/core/services/certificate.service.ts
@@ -6,17 +6,15 @@ import { environment } from 'src/environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Qualification, QualificationCertificate, QualificationsResponse } from '@core/model/qualification.model';
+import { TrainingCertificate, TrainingRecord, TrainingResponse } from '@core/model/training.model';
 import {
   ConfirmUploadRequest,
   DownloadCertificateSignedUrlResponse,
   FileInfoWithETag,
   S3UploadResponse,
-  TrainingCertificate,
-  TrainingRecord,
-  TrainingResponse,
   UploadCertificateSignedUrlRequest,
   UploadCertificateSignedUrlResponse,
-} from '@core/model/training.model';
+} from '@core/model/trainingAndQualifications.model';
 import { Certificate, CertificateDownload } from '@core/model/trainingAndQualifications.model';
 import { FileUtil, NamedFileBlob } from '@core/utils/file-util';
 

--- a/frontend/src/app/core/services/certificate.service.ts
+++ b/frontend/src/app/core/services/certificate.service.ts
@@ -1,9 +1,11 @@
+import { capitalize } from 'lodash';
 import { forkJoin, from, Observable } from 'rxjs';
 import { concatMap, filter, map, mergeAll, mergeMap, tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Qualification, QualificationCertificate, QualificationsResponse } from '@core/model/qualification.model';
 import {
   ConfirmUploadRequest,
   DownloadCertificateSignedUrlResponse,
@@ -17,7 +19,6 @@ import {
 } from '@core/model/training.model';
 import { Certificate, CertificateDownload } from '@core/model/trainingAndQualifications.model';
 import { FileUtil, NamedFileBlob } from '@core/utils/file-util';
-import { Qualification, QualificationCertificate, QualificationsResponse } from '@core/model/qualification.model';
 
 @Injectable({
   providedIn: 'root',
@@ -135,7 +136,7 @@ export class BaseCertificateService {
 
   protected addFolderName(file: NamedFileBlob): NamedFileBlob {
     const { filename, fileBlob } = file;
-    return { filename: `${this.recordType} certificates/${filename}`, fileBlob };
+    return { filename: `${capitalize(this.recordType)} certificates/${filename}`, fileBlob };
   }
 
   public downloadCertificatesAsBlobs(
@@ -144,10 +145,6 @@ export class BaseCertificateService {
     recordUid: string,
     filesToDownload: CertificateDownload[],
   ): Observable<NamedFileBlob> {
-    // TODO: Delete this before PR
-    // uncomment this to test frontend without actually downloading from S3
-    // return from(filesToDownload.map((file) => ({ fileBlob: new Blob(['abc']), filename: file.filename })));
-
     return this.getCertificateDownloadUrls(workplaceUid, workerUid, recordUid, filesToDownload).pipe(
       mergeMap((res) => this.downloadBlobsFromBucket(res['files'])),
       mergeAll(),
@@ -166,7 +163,7 @@ export class BaseCertificateService {
     });
   }
 
-  public triggerCertificateDownloads(files: { signedUrl: string; filename: string }[]): Observable<any> {
+  public triggerCertificateDownloads(files: { signedUrl: string; filename: string }[]): Observable<NamedFileBlob> {
     const blobsAndFilenames = this.downloadBlobsFromBucket(files);
 
     return from(blobsAndFilenames).pipe(

--- a/frontend/src/app/core/services/certificate.service.ts
+++ b/frontend/src/app/core/services/certificate.service.ts
@@ -159,7 +159,7 @@ export class BaseCertificateService {
     workerUid: string,
     recordUid: string,
     filesToDownload: CertificateDownload[],
-  ) {
+  ): Observable<DownloadCertificateSignedUrlResponse> {
     const certificateEndpoint = this.certificateEndpoint(workplaceUid, workerUid, recordUid);
     return this.http.post<DownloadCertificateSignedUrlResponse>(`${certificateEndpoint}/download`, {
       files: filesToDownload,

--- a/frontend/src/app/core/services/pdf-training-and-qualification.service.ts
+++ b/frontend/src/app/core/services/pdf-training-and-qualification.service.ts
@@ -133,7 +133,7 @@ export class PdfTrainingAndQualificationService {
       html.append(this.createSpacer(this.width, this.spacing));
     }
   }
-  private async saveHtmlToPdf(filename, doc: jsPDF, html, scale, width, save): Promise<void> {
+  private async saveHtmlToPdf(filename, doc: jsPDF, html: HTMLElement, scale, width, save): Promise<void> {
     const widthHtml = width * scale;
     const x = (doc.internal.pageSize.getWidth() - widthHtml) / 2;
     let y = 0;
@@ -142,6 +142,11 @@ export class PdfTrainingAndQualificationService {
       scale,
       width,
       windowWidth: width,
+      imageTimeout: 0,
+      ignoreElements: (element: HTMLElement) => {
+        // ignore svg as jspdf does not support svg in html and will cause other contents to render incorrectly
+        return element.tagName.toLowerCase() === 'img' && element.getAttribute('src')?.endsWith('.svg');
+      },
     };
 
     await doc.html(html, {

--- a/frontend/src/app/core/services/pdf-training-and-qualification.service.ts
+++ b/frontend/src/app/core/services/pdf-training-and-qualification.service.ts
@@ -142,7 +142,6 @@ export class PdfTrainingAndQualificationService {
       scale,
       width,
       windowWidth: width,
-      imageTimeout: 0,
       ignoreElements: (element: HTMLElement) => {
         // ignore svg as jspdf does not support svg in html and will cause other contents to render incorrectly
         return element.tagName.toLowerCase() === 'img' && element.getAttribute('src')?.endsWith('.svg');

--- a/frontend/src/app/core/test-utils/MockCertificateService.ts
+++ b/frontend/src/app/core/test-utils/MockCertificateService.ts
@@ -25,6 +25,7 @@ const mockTrainingCertA = buildCertificates(1);
 const mockTrainingCertsB = buildCertificates(3);
 const mockQualificationCertsA = buildCertificates(1);
 const mockQualificationCertsB = buildCertificates(3);
+export const mockCertificateFileBlob = new Blob(['mockdata'], { type: 'application/pdf' });
 export const mockTrainingCertificates = [...mockTrainingCertA, ...mockTrainingCertsB];
 export const mockQualificationCertificates = [...mockQualificationCertsA, ...mockQualificationCertsB];
 
@@ -118,9 +119,7 @@ const mockGetCertificateDownloadUrls = (
 };
 
 const mockDownloadBlobsFromBucket = (files: { signedUrl: string; filename: string }[]) => {
-  return files.map((file) =>
-    of({ fileBlob: new Blob(['mockdata'], { type: 'application/pdf' }), filename: file.filename }),
-  );
+  return files.map((file) => of({ fileBlob: mockCertificateFileBlob, filename: file.filename }));
 };
 
 @Injectable()

--- a/frontend/src/app/core/test-utils/MockCertificationService.ts
+++ b/frontend/src/app/core/test-utils/MockCertificationService.ts
@@ -1,8 +1,126 @@
+import { of } from 'rxjs';
+
 import { Injectable } from '@angular/core';
+import { TrainingResponse } from '@core/model/training.model';
 import { QualificationCertificateService, TrainingCertificateService } from '@core/services/certificate.service';
+import { QualificationsResponse } from '@core/model/qualification.model';
+
+const mockWorkplaceUid = 'mockWorkplaceUid';
+const mockWorkerUid = 'mockWorkerUid';
+const mockRecordUid = 'mockRecordUid';
+
+export const mockCertificatesA = [
+  {
+    filename: 'Certificate 2023.pdf',
+    uid: 'uid1',
+    uploadDate: '2024-09-20T08:57:45.000Z',
+  },
+  {
+    filename: 'Certificate 2024.pdf',
+    uid: 'uid2',
+    uploadDate: '2024-09-20T08:57:45.000Z',
+  },
+];
+
+export const mockCertificatesB = [
+  {
+    filename: 'Certificate 2022.pdf',
+    uid: 'uid3',
+    uploadDate: '2024-09-20T08:57:45.000Z',
+  },
+  {
+    filename: 'Certificate 2023.pdf',
+    uid: 'uid4',
+    uploadDate: '2024-09-20T08:57:45.000Z',
+  },
+];
+
+export const mockTrainingRecordsResponse: TrainingResponse = {
+  workerUid: mockWorkerUid,
+  count: 3,
+  lastUpdated: '2024-10-23T09:38:32.990Z',
+  training: [
+    //@ts-ignore
+    {
+      uid: 'uid-missing-mandatory-training',
+      trainingCategory: { id: 11, category: 'Diabetes' },
+      missing: true,
+      created: new Date(),
+      updated: new Date(),
+      updatedBy: 'admin3',
+    },
+    {
+      uid: 'uid-training-with-no-certs',
+      trainingCategory: { id: 7, category: 'Continence care' },
+      trainingCertificates: [],
+      title: 'training with no certs',
+      created: new Date(),
+      updated: new Date(),
+      updatedBy: 'admin3',
+    },
+    {
+      uid: 'uid-training-with-certs',
+      trainingCategory: { id: 1, category: 'Activity provision, wellbeing' },
+      trainingCertificates: mockCertificatesA,
+      title: 'Training with certs',
+      created: new Date(),
+      updated: new Date(),
+      updatedBy: 'admin3',
+    },
+    {
+      uid: 'uid-another-training-with-certs',
+      trainingCategory: { id: 13, category: 'Duty of care' },
+      trainingCertificates: mockCertificatesB,
+      title: 'another training with certs',
+      created: new Date(),
+      updated: new Date(),
+      updatedBy: 'admin3',
+    },
+  ],
+};
+
+export const trainingUidsWithCerts = ['uid-training-with-certs', 'uid-another-training-with-certs'];
+export const trainingUidsWithoutCerts = ['uid-training-with-no-certs', 'uid-missing-mandatory-training'];
+
+export const mockQualificationRecordsResponse: QualificationsResponse = {
+  workerUid: '3fdc3fd9-4030-440c-96b5-716251cc23c8',
+  count: 1,
+  lastUpdated: '2024-10-23T09:38:17.469Z',
+  qualifications: [
+    {
+      id: 1,
+      uid: 'qual-with-no-certs',
+      qualification: {},
+      qualificationCertificates: [],
+    },
+    {
+      id: 2,
+      uid: 'qual-with-some-certs',
+      qualification: {},
+      qualificationCertificates: mockCertificatesA,
+    },
+    {
+      id: 3,
+      uid: 'another-qual-with-some-certs',
+      qualification: {},
+      qualificationCertificates: mockCertificatesB,
+    },
+  ],
+};
+
+export const qualificationUidsWithCerts = ['qual-with-some-certs', 'another-qual-with-some-certs'];
+export const qualificationUidsWithoutCerts = ['qual-with-no-certs'];
 
 @Injectable()
-export class MockTrainingCertificateService extends TrainingCertificateService {}
+export class MockTrainingCertificateService extends TrainingCertificateService {
+  protected getAllRecords(workplaceUid: string, workerUid: string) {
+    return of(mockTrainingRecordsResponse.training);
+  }
+}
 
 @Injectable()
-export class MockQualificationCertificateService extends QualificationCertificateService {}
+export class MockQualificationCertificateService extends QualificationCertificateService {
+  protected getAllRecords(workplaceUid: string, workerUid: string) {
+    return of(mockQualificationRecordsResponse.qualifications);
+  }
+}

--- a/frontend/src/app/core/utils/file-util.spec.ts
+++ b/frontend/src/app/core/utils/file-util.spec.ts
@@ -1,7 +1,7 @@
 import { FileUtil } from './file-util';
 import { BlobReader, ZipReader } from '@zip.js/zip.js';
 
-fdescribe('FileUtil', () => {
+describe('FileUtil', () => {
   describe('zipFilesAsBlob', () => {
     const mockFiles = [
       { filename: 'training/First Aid.pdf', fileBlob: new Blob(['first aid'], { type: 'application/pdf' }) },

--- a/frontend/src/app/core/utils/file-util.spec.ts
+++ b/frontend/src/app/core/utils/file-util.spec.ts
@@ -1,0 +1,75 @@
+import { FileUtil } from './file-util';
+import { BlobReader, ZipReader } from '@zip.js/zip.js';
+
+fdescribe('FileUtil', () => {
+  describe('zipFileBlobs', () => {
+    const mockFiles = [
+      { filename: 'training/First Aid.pdf', blob: new Blob(['first aid'], { type: 'application/pdf' }) },
+      { filename: 'training/First Aid 2024.pdf', blob: new Blob(['First Aid 2024'], { type: 'application/pdf' }) },
+      {
+        filename: 'qualification/Level 2 Care Cert.pdf',
+        blob: new Blob(['Level 2 Care Cert'], { type: 'application/pdf' }),
+      },
+    ];
+
+    it('should zip all given file blobs into one zip file and return as a single file blob', async () => {
+      const zippedBlob = await FileUtil.zipFiles(mockFiles);
+      expect(zippedBlob).toBeInstanceOf(Blob);
+
+      const contentsOfZipFile = await new ZipReader(new BlobReader(zippedBlob)).getEntries();
+      expect(contentsOfZipFile).toHaveSize(mockFiles.length);
+
+      const fileNamesInZipFile = contentsOfZipFile.map((file) => file.filename);
+      mockFiles.forEach((mockfile) => {
+        expect(fileNamesInZipFile).toContain(mockfile.filename);
+      });
+    });
+
+    it('should be able to handle same filenames', async () => {
+      const mockFileWithSameFileNames = [
+        ...mockFiles,
+        { filename: 'training/First Aid.pdf', blob: new Blob(['another first aid'], { type: 'application/pdf' }) },
+        { filename: 'training/First Aid.pdf', blob: new Blob(['3rd first aid'], { type: 'application/pdf' }) },
+      ];
+
+      const zippedBlob = await FileUtil.zipFiles(mockFileWithSameFileNames);
+
+      const contentsOfZipFile = await new ZipReader(new BlobReader(zippedBlob)).getEntries();
+      expect(contentsOfZipFile).toHaveSize(5);
+
+      const fileNamesInZipFile = contentsOfZipFile.map((file) => file.filename);
+      expect(fileNamesInZipFile).toContain('training/First Aid.pdf');
+      expect(fileNamesInZipFile).toContain('training/First Aid (1).pdf');
+      expect(fileNamesInZipFile).toContain('training/First Aid (2).pdf');
+    });
+  });
+
+  describe('triggerSingleFileDownload', () => {
+    it('should download certificates by creating and triggering anchor tag, then cleaning DOM', () => {
+      const mockCertificates = [{ signedUrl: 'https://example.com/file1.pdf', filename: 'file1.pdf' }];
+      const mockBlob = new Blob(['file content'], { type: 'application/pdf' });
+      const mockBlobUrl = 'blob:http://signed-url-example.com/blob-url';
+
+      const createElementSpy = spyOn(document, 'createElement').and.callThrough();
+      const appendChildSpy = spyOn(document.body, 'appendChild').and.callThrough();
+      const removeChildSpy = spyOn(document.body, 'removeChild').and.callThrough();
+      const revokeObjectURLSpy = spyOn(window.URL, 'revokeObjectURL').and.callThrough();
+      spyOn(window.URL, 'createObjectURL').and.returnValue(mockBlobUrl);
+
+      FileUtil.triggerSingleFileDownload(mockBlob, mockCertificates[0].filename);
+
+      // Assert anchor element appended
+      expect(createElementSpy).toHaveBeenCalledWith('a');
+      expect(appendChildSpy).toHaveBeenCalled();
+
+      // Assert anchor element has correct attributes
+      const createdAnchor = createElementSpy.calls.mostRecent().returnValue as HTMLAnchorElement;
+      expect(createdAnchor.href).toBe(mockBlobUrl);
+      expect(createdAnchor.download).toBe(mockCertificates[0].filename);
+
+      // Assert DOM is cleaned up after download
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith(mockBlobUrl);
+      expect(removeChildSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/core/utils/file-util.ts
+++ b/frontend/src/app/core/utils/file-util.ts
@@ -12,7 +12,33 @@ export class FileUtil {
     return filenameMatches && filenameMatches.length > 1 ? filenameMatches[1] : null;
   }
 
-  public static async downloadFilesAsZip(files: NamedFileBlob[], nameOfZippedFile: string) {
+  public static triggerSingleFileDownload(fileBlob: Blob, filename: string): void {
+    const blobUrl = window.URL.createObjectURL(fileBlob);
+    const link = this.createHiddenDownloadLink(blobUrl, filename);
+
+    // Append the link to the body and click to trigger download
+    document.body.appendChild(link);
+    link.click();
+
+    // Remove the link
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(blobUrl);
+  }
+
+  private static createHiddenDownloadLink(blobUrl: string, filename: string): HTMLAnchorElement {
+    const link = document.createElement('a');
+
+    link.href = blobUrl;
+    link.download = filename;
+    link.style.display = 'none';
+    return link;
+  }
+
+  public static async saveFilesAsZip(files: NamedFileBlob[], nameOfZippedFile: string) {
+    if (!files.length) {
+      return;
+    }
+
     const zippedFileAsBlob = await this.zipFilesAsBlob(files);
     this.triggerSingleFileDownload(zippedFileAsBlob, nameOfZippedFile);
   }
@@ -38,43 +64,22 @@ export class FileUtil {
 
   public static makeAnotherFilename(filename: string): string {
     /*
-     * Append a number to filename to avoid filename collision causing error during zip
-     * "filename.pdf" --> "filename (1).pdf"
-     * "filename (1).pdf" --> "filename (2).pdf"
+     * Append a number to filename to avoid duplicated names causing error during zip
+     * examples:
+     *   "filename.pdf" --> "filename (1).pdf"
+     *   "filename (1).pdf" --> "filename (2).pdf"
      */
     const basename = filename.slice(0, filename.lastIndexOf('.'));
     const extname = filename.slice(filename.lastIndexOf('.') + 1);
-    const findNumberInBracket = /\(([0-9]{1,2})\)$/;
+    const numberInBracket = /\(([0-9]{1,2})\)$/;
 
-    const sameFilenameCount = basename.match(findNumberInBracket);
+    const sameFilenameCount = basename.match(numberInBracket);
     if (sameFilenameCount) {
       const newNumber = Number(sameFilenameCount[1]) + 1;
-      const newBasename = basename.replace(findNumberInBracket, `(${newNumber})`);
+      const newBasename = basename.replace(numberInBracket, `(${newNumber})`);
       return `${newBasename}.${extname}`;
     }
 
     return `${basename} (1).${extname}`;
-  }
-
-  public static triggerSingleFileDownload(fileBlob: Blob, filename: string): void {
-    const blobUrl = window.URL.createObjectURL(fileBlob);
-    const link = this.createHiddenDownloadLink(blobUrl, filename);
-
-    // Append the link to the body and click to trigger download
-    document.body.appendChild(link);
-    link.click();
-
-    // Remove the link
-    document.body.removeChild(link);
-    window.URL.revokeObjectURL(blobUrl);
-  }
-
-  private static createHiddenDownloadLink(blobUrl: string, filename: string): HTMLAnchorElement {
-    const link = document.createElement('a');
-
-    link.href = blobUrl;
-    link.download = filename;
-    link.style.display = 'none';
-    return link;
   }
 }

--- a/frontend/src/app/core/utils/file-util.ts
+++ b/frontend/src/app/core/utils/file-util.ts
@@ -1,7 +1,79 @@
+import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js';
+
 export class FileUtil {
   public static getFileName(response) {
     const filenameRegEx = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
     const filenameMatches = response.headers.get('content-disposition').match(filenameRegEx);
     return filenameMatches && filenameMatches.length > 1 ? filenameMatches[1] : null;
+  }
+
+  public static async downloadFilesAsZip(files: { filename: string; blob: Blob }[], nameOfZipFile: string) {
+    // const x = forkJoin(blobsAndFilenames).pipe(
+    //   tap((files) => FileUtil.downloadFilesAsZip(files, 'all-certificates.zip')),
+    // );
+
+    // return x;
+
+    const zippedFileAsBlob = await this.zipFiles(files);
+    this.triggerSingleFileDownload(zippedFileAsBlob, nameOfZipFile);
+  }
+
+  public static async zipFiles(files: Array<{ filename: string; blob: Blob }>): Promise<Blob> {
+    const filenameUsed = new Set();
+
+    const zipWriter = new ZipWriter(new BlobWriter('application/zip'));
+    for (const file of files) {
+      let { filename, blob } = file;
+
+      while (filenameUsed.has(filename)) {
+        filename = this.makeAnotherFilename(filename);
+      }
+      await zipWriter.add(filename, new BlobReader(blob));
+
+      filenameUsed.add(filename);
+    }
+    const zippedFileBlob = await zipWriter.close();
+    return zippedFileBlob;
+  }
+
+  private static makeAnotherFilename(filename: string): string {
+    /*
+      Append a number to filename to avoid filename collision causing error in zip
+      "filename.pdf" --> "filename (1).pdf"
+      "filename (1).pdf" --> "filename (2).pdf"
+    */
+    const basename = filename.slice(0, filename.lastIndexOf('.'));
+    const extname = filename.slice(filename.lastIndexOf('.') + 1);
+
+    const sameFilenameCount = basename.match(/\(([0-9]+)\)$/);
+    if (sameFilenameCount) {
+      const newNumber = Number(sameFilenameCount[1]) + 1;
+      const newBasename = basename.replace(/(\([0-9]+\))$/, `(${newNumber})`);
+      return `${newBasename}.${extname}`;
+    }
+
+    return `${basename} (1).${extname}`;
+  }
+
+  public static triggerSingleFileDownload(fileBlob: Blob, filename: string): void {
+    const blobUrl = window.URL.createObjectURL(fileBlob);
+    const link = this.createHiddenDownloadLink(blobUrl, filename);
+
+    // Append the link to the body and click to trigger download
+    document.body.appendChild(link);
+    link.click();
+
+    // Remove the link
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(blobUrl);
+  }
+
+  private static createHiddenDownloadLink(blobUrl: string, filename: string): HTMLAnchorElement {
+    const link = document.createElement('a');
+
+    link.href = blobUrl;
+    link.download = filename;
+    link.style.display = 'none';
+    return link;
   }
 }

--- a/frontend/src/app/core/utils/file-util.ts
+++ b/frontend/src/app/core/utils/file-util.ts
@@ -12,7 +12,7 @@ export class FileUtil {
     return filenameMatches && filenameMatches.length > 1 ? filenameMatches[1] : null;
   }
 
-  public static async triggerDownloadFilesAsZip(files: NamedFileBlob[], nameOfZippedFile: string) {
+  public static async downloadFilesAsZip(files: NamedFileBlob[], nameOfZippedFile: string) {
     const zippedFileAsBlob = await this.zipFilesAsBlob(files);
     this.triggerSingleFileDownload(zippedFileAsBlob, nameOfZippedFile);
   }
@@ -32,6 +32,7 @@ export class FileUtil {
       filenameUsed.add(filename);
     }
     const zippedFileBlob = await zipWriter.close();
+
     return zippedFileBlob;
   }
 

--- a/frontend/src/app/features/training-and-qualifications/add-edit-qualification/add-edit-qualification.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-qualification/add-edit-qualification.component.spec.ts
@@ -18,7 +18,7 @@ import { of, throwError } from 'rxjs';
 
 import { AddEditQualificationComponent } from './add-edit-qualification.component';
 import { QualificationCertificateService } from '@core/services/certificate.service';
-import { MockQualificationCertificateService } from '@core/test-utils/MockCertificationService';
+import { MockQualificationCertificateService } from '@core/test-utils/MockCertificateService';
 
 describe('AddEditQualificationComponent', () => {
   async function setup(qualificationId = '1', qualificationInService = null, override: any = {}) {

--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
@@ -23,7 +23,7 @@ import sinon from 'sinon';
 import { SelectUploadFileComponent } from '../../../shared/components/select-upload-file/select-upload-file.component';
 import { AddEditTrainingComponent } from './add-edit-training.component';
 import { TrainingCertificateService } from '@core/services/certificate.service';
-import { MockTrainingCertificateService } from '@core/test-utils/MockCertificationService';
+import { MockTrainingCertificateService } from '@core/test-utils/MockCertificateService';
 
 describe('AddEditTrainingComponent', () => {
   async function setup(trainingRecordId = '1', qsParamGetMock = sinon.fake()) {

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/download-pdf/download-pdf-training-and-qualification.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/download-pdf/download-pdf-training-and-qualification.component.html
@@ -1,5 +1,5 @@
 <a
-  class="govuk-list govuk-list--inline govuk-list govuk__flex govuk__align-items-flex-start"
+  class="govuk-list govuk-list--inline govuk__flex govuk__width-fit-content govuk__align-items-flex-start"
   role="button"
   draggable="false"
   href="{{ linkUrl }}"

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/download-pdf/download-pdf-training-and-qualification.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/download-pdf/download-pdf-training-and-qualification.component.html
@@ -9,6 +9,6 @@
 >
   <img alt="" src="/assets/images/icon-download.svg" />
   <span class="govuk-!-margin-left-1" data-testid="DownloadLink">
-    Download training and qualifications (PDF, 430KB, {{ pdfCount }} pages)
+    Download this training and qualifications summary
   </span>
 </a>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/download-pdf/download-pdf-training-and-qualification.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/download-pdf/download-pdf-training-and-qualification.component.ts
@@ -1,12 +1,11 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
-  selector: 'app-download-pdf-traininf-and-qualification',
+  selector: 'app-download-pdf-training-and-qualification',
   templateUrl: './download-pdf-training-and-qualification.component.html',
 })
 export class DownloadPdfTrainingAndQualificationComponent {
   @Input() linkUrl: string;
-  @Input() pdfCount: number;
   @Output() downloadPDF = new EventEmitter();
 
   public downloadAsPDF(event: Event): void {

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -94,7 +94,8 @@
     role="button"
     draggable="false"
     (click)="downloadAllCertificates($event)"
-    href="#"
+    href="./all-certificates.zip"
+    *ngIf="workerHasCertificate"
   >
     <img alt="" src="/assets/images/icon-download.svg" />
     <span class="govuk-!-margin-left-1"> Download all their training and qualifications certificates </span>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -85,11 +85,10 @@
   *ngIf="mandatoryTraining.length + nonMandatoryTraining.length + qualificationsByGroup.count"
   class="govuk-!-margin-bottom-8"
 >
-  <app-download-pdf-traininf-and-qualification
+  <app-download-pdf-training-and-qualification
     [linkUrl]="'/trainingAndQualification.pdf'"
     (downloadPDF)="downloadAsPDF()"
-    [pdfCount]="pdfCount"
-  ></app-download-pdf-traininf-and-qualification>
+  ></app-download-pdf-training-and-qualification>
 </div>
 <div *ngIf="actionsListData.length > 0" class="govuk-grid-row govuk-!-margin-top-6">
   <div class="govuk-grid-column-full">

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -98,7 +98,7 @@
     *ngIf="workerHasCertificate"
   >
     <img alt="" src="/assets/images/icon-download.svg" />
-    <span class="govuk-!-margin-left-1"> Download all their training and qualifications certificates </span>
+    <span class="govuk-!-margin-left-1"> Download all their training and qualification certificates </span>
   </a>
 </div>
 

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -89,7 +89,18 @@
     [linkUrl]="'/trainingAndQualification.pdf'"
     (downloadPDF)="downloadAsPDF()"
   ></app-download-pdf-training-and-qualification>
+  <a
+    class="govuk-list govuk-list--inline govuk__flex govuk__width-fit-content govuk__align-items-flex-start govuk-!-margin-bottom-0"
+    role="button"
+    draggable="false"
+    (click)="downloadAllCertificates($event)"
+    href="#"
+  >
+    <img alt="" src="/assets/images/icon-download.svg" />
+    <span class="govuk-!-margin-left-1"> Download all their training and qualifications certificates </span>
+  </a>
 </div>
+
 <div *ngIf="actionsListData.length > 0" class="govuk-grid-row govuk-!-margin-top-6">
   <div class="govuk-grid-column-full">
     <table class="govuk-table">

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -1212,7 +1212,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
     });
   });
 
-  fdescribe('download all certificates', () => {
+  describe('download all certificates', () => {
     it('should display a link for downloading all certificates', async () => {
       const { getByText } = await setup();
 
@@ -1238,10 +1238,10 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
       );
     });
 
-    it('should call downloadFilesAsZip with all the certificates', async () => {
+    it('should call saveFilesAsZip with all the certificates', async () => {
       const { component, getByText } = await setup();
 
-      const fileUtilSpy = spyOn(FileUtil, 'downloadFilesAsZip').and.callThrough();
+      const fileUtilSpy = spyOn(FileUtil, 'saveFilesAsZip').and.callThrough();
 
       const downloadAllButton = getByText('Download all their training and qualifications certificates');
       userEvent.click(downloadAllButton);

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -32,6 +32,7 @@ import { QualificationCertificateService, TrainingCertificateService } from '@co
 import {
   MockQualificationCertificateService,
   MockTrainingCertificateService,
+  mockCertificateFileBlob,
   mockTrainingCertificates,
 } from '@core/test-utils/MockCertificateService';
 import { QualificationsByGroup } from '@core/model/qualification.model';
@@ -1257,7 +1258,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
 
     it('should call saveFilesAsZip with all the downloaded certificates', async () => {
       const { component, getByText } = await setup();
-      const expectedZipFileName = `all certificates - ${component.worker.nameOrId}.zip`;
+      const expectedZipFileName = `All certificates - ${component.worker.nameOrId}.zip`;
 
       const fileUtilSpy = spyOn(FileUtil, 'saveFilesAsZip').and.callThrough();
 
@@ -1274,16 +1275,16 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
       mockTrainingCertificates.forEach((certificate) => {
         expect(contentsOfZipFile).toContain(
           jasmine.objectContaining({
-            filename: 'training certificates/' + certificate.filename,
-            fileBlob: jasmine.anything(),
+            filename: 'Training certificates/' + certificate.filename,
+            fileBlob: mockCertificateFileBlob,
           }),
         );
       });
       mockQualificationCertificates.forEach((certificate) => {
         expect(contentsOfZipFile).toContain(
           jasmine.objectContaining({
-            filename: 'qualification certificates/' + certificate.filename,
-            fileBlob: jasmine.anything(),
+            filename: 'Qualification certificates/' + certificate.filename,
+            fileBlob: mockCertificateFileBlob,
           }),
         );
       });

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -1205,4 +1205,12 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
       });
     });
   });
+
+  describe('download all certificates', () => {
+    it('should display a link for downloading all certificates', async () => {
+      const { getByText } = await setup();
+
+      expect(getByText('Download all their training and qualifications certificates')).toBeTruthy();
+    });
+  });
 });

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -1240,13 +1240,13 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
 
     it('should call saveFilesAsZip with all the certificates', async () => {
       const { component, getByText } = await setup();
+      const expectedZipFileName = `all certificates - ${component.worker.nameOrId}.zip`;
 
       const fileUtilSpy = spyOn(FileUtil, 'saveFilesAsZip').and.callThrough();
 
       const downloadAllButton = getByText('Download all their training and qualifications certificates');
       userEvent.click(downloadAllButton);
 
-      const expectedZipFileName = `all certificates - ${component.worker.nameOrId}.zip`;
       expect(fileUtilSpy).toHaveBeenCalled();
 
       const contentsOfZipFile = fileUtilSpy.calls.mostRecent().args[0];
@@ -1270,6 +1270,20 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
           }),
         );
       });
+    });
+
+    it('should not start a new download if already downloading all certificates in background', async () => {
+      const { getByText, trainingCertificateService, qualificationCertificateService } = await setup();
+
+      const downloadAllButton = getByText('Download all their training and qualifications certificates');
+      spyOn(trainingCertificateService, 'downloadAllCertificatesAsBlobs').and.callThrough();
+      spyOn(qualificationCertificateService, 'downloadAllCertificatesAsBlobs').and.callThrough();
+
+      userEvent.click(downloadAllButton);
+      userEvent.click(downloadAllButton);
+
+      expect(trainingCertificateService.downloadAllCertificatesAsBlobs).toHaveBeenCalledTimes(1);
+      expect(qualificationCertificateService.downloadAllCertificatesAsBlobs).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -792,7 +792,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
 
       fixture.detectChanges();
 
-      fireEvent.click(getByText('Download training and qualifications', { exact: false }));
+      fireEvent.click(getByText('Download this training and qualifications summary'));
 
       expect(downloadFunctionSpy).toHaveBeenCalled();
       expect(pdfTrainingAndQualsServiceSpy).toHaveBeenCalled();

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -1220,7 +1220,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
     it('should display a link for downloading all certificates', async () => {
       const { getByText } = await setup();
 
-      expect(getByText('Download all their training and qualifications certificates')).toBeTruthy();
+      expect(getByText('Download all their training and qualification certificates')).toBeTruthy();
     });
 
     it('should not display the download all link if worker has got no certificates', async () => {
@@ -1233,7 +1233,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
         nonMandatoryTraining: nonMandatorytrainingWithNoCerts,
       });
 
-      expect(queryByText('Download all their training and qualifications certificates')).toBeFalsy();
+      expect(queryByText('Download all their training and qualification certificates')).toBeFalsy();
     });
 
     it('should download all training and qualification certificates for the worker when clicked', async () => {
@@ -1242,7 +1242,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
       spyOn(trainingCertificateService, 'downloadAllCertificatesAsBlobs').and.callThrough();
       spyOn(qualificationCertificateService, 'downloadAllCertificatesAsBlobs').and.callThrough();
 
-      const downloadAllButton = getByText('Download all their training and qualifications certificates');
+      const downloadAllButton = getByText('Download all their training and qualification certificates');
       userEvent.click(downloadAllButton);
 
       expect(trainingCertificateService.downloadAllCertificatesAsBlobs).toHaveBeenCalledWith(
@@ -1261,7 +1261,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
 
       const fileUtilSpy = spyOn(FileUtil, 'saveFilesAsZip').and.callThrough();
 
-      const downloadAllButton = getByText('Download all their training and qualifications certificates');
+      const downloadAllButton = getByText('Download all their training and qualification certificates');
       userEvent.click(downloadAllButton);
 
       expect(fileUtilSpy).toHaveBeenCalled();
@@ -1292,7 +1292,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
     it('should not start a new download on click if still downloading certificates in the background', async () => {
       const { getByText, trainingCertificateService, qualificationCertificateService } = await setup();
 
-      const downloadAllButton = getByText('Download all their training and qualifications certificates');
+      const downloadAllButton = getByText('Download all their training and qualification certificates');
       spyOn(trainingCertificateService, 'downloadAllCertificatesAsBlobs').and.callThrough();
       spyOn(qualificationCertificateService, 'downloadAllCertificatesAsBlobs').and.callThrough();
 

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -420,8 +420,8 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     );
 
     const zipFileName = this.worker.nameOrId
-      ? `all certificates - ${this.worker.nameOrId}.zip`
-      : 'all certificates.zip';
+      ? `All certificates - ${this.worker.nameOrId}.zip`
+      : 'All certificates.zip';
 
     const downloadAllCertificatesAsZip$ = merge(allTrainingCerts$, allQualificationCerts$).pipe(
       toArray(),

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -425,14 +425,16 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
 
     const downloadAllCertificatesAsZip = merge(allTrainingCerts, allQualificationCerts).pipe(
       toArray(),
-      mergeMap((allFileBlobs) => from(FileUtil.downloadFilesAsZip(allFileBlobs, zipFileName))),
+      mergeMap((allFileBlobs) => from(FileUtil.saveFilesAsZip(allFileBlobs, zipFileName))),
     );
 
-    downloadAllCertificatesAsZip.subscribe(
-      () => {
-        console.log('finished download at: ', new Date());
-      },
-      (err) => console.error('error handled at component:', err),
+    this.subscriptions.add(
+      downloadAllCertificatesAsZip.subscribe(
+        () => {
+          console.log('finished download at: ', new Date());
+        },
+        (err) => console.error('error handled at component:', err),
+      ),
     );
   }
 

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -54,10 +54,10 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     nonMandatoryTraining: 'non-mandatory-training',
     qualifications: 'qualifications',
   };
-  public pdfCount: number;
   public certificateErrors: Record<string, string> = {}; // {categoryName: errorMessage}
   private trainingRecords: TrainingRecords;
   private downloadingAllCertsInBackground = false;
+  public workerHasCertificate = false;
 
   constructor(
     private breadcrumbService: BreadcrumbService,
@@ -84,9 +84,9 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.setUpTabSubscription();
     this.updateTrainingExpiresSoonDate();
     this.setTraining();
+    this.checkWorkerHasCertificateOrNot();
     this.setUpAlertSubscription();
     this.setReturnRoute();
-    this.getPdfCount();
   }
 
   public async downloadAsPDF(save: boolean = true) {
@@ -107,13 +107,6 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     } catch (error) {
       console.error(error);
     }
-  }
-
-  private async getPdfCount() {
-    const pdf = await this.downloadAsPDF(false);
-    const numberOfPages = pdf?.getNumberOfPages();
-
-    return (this.pdfCount = numberOfPages);
   }
 
   private setPageData(): void {
@@ -456,5 +449,18 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.trainingRecords = updatedData.training;
     this.qualificationsByGroup = updatedData.qualifications;
     this.setTraining();
+    this.checkWorkerHasCertificateOrNot();
+  }
+
+  private checkWorkerHasCertificateOrNot() {
+    const allTrainingRecords = [...this.trainingRecords.mandatory, ...this.trainingRecords.nonMandatory];
+    const hasTrainingCertificate = allTrainingRecords.some((record) =>
+      record?.trainingRecords?.some((record) => record?.trainingCertificates?.length > 0),
+    );
+    const hasQualificationCertificate = this.qualificationsByGroup.groups.some((group) =>
+      group?.records?.some((record) => record?.qualificationCertificates?.length > 0),
+    );
+
+    this.workerHasCertificate = hasTrainingCertificate || hasQualificationCertificate;
   }
 }

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -404,6 +404,10 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.subscriptions.add(subscription);
   }
 
+  public downloadAllCertificates(event: Event) {
+    event.preventDefault();
+  }
+
   private async refreshTrainingAndQualificationRecords() {
     const updatedData: TrainingAndQualificationRecords = await this.workerService
       .getAllTrainingAndQualificationRecords(this.workplace.uid, this.worker.uid)

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -1,5 +1,5 @@
 import { from, merge, Subscription } from 'rxjs';
-import { mergeMap, toArray } from 'rxjs/operators';
+import { mergeMap, tap, toArray } from 'rxjs/operators';
 
 import { Component, OnDestroy, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -419,14 +419,18 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
       this.worker.uid,
     );
 
+    const zipFileName = this.worker.nameOrId
+      ? `all certificates - ${this.worker.nameOrId}.zip`
+      : 'all certificates.zip';
+
     const downloadAllCertificatesAsZip = merge(allTrainingCerts, allQualificationCerts).pipe(
       toArray(),
-      mergeMap((allFileBlobs) => from(FileUtil.triggerDownloadFilesAsZip(allFileBlobs, 'all certificates.zip'))),
+      mergeMap((allFileBlobs) => from(FileUtil.downloadFilesAsZip(allFileBlobs, zipFileName))),
     );
 
     downloadAllCertificatesAsZip.subscribe(
       () => {
-        console.log('finished download');
+        console.log('finished download at: ', new Date());
       },
       (err) => console.error('error handled at component:', err),
     );

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -431,11 +431,10 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.subscriptions.add(
       downloadAllCertificatesAsZip$.subscribe(
         () => {
-          console.log('Finished download at: ', new Date());
           this.downloadingAllCertsInBackground = false;
         },
         (err) => {
-          console.error('Error handled at component: ', err);
+          console.error('Error occurred when downloading all certificates: ', err);
           this.downloadingAllCertsInBackground = false;
         },
       ),

--- a/frontend/src/assets/scss/modules/_utils.scss
+++ b/frontend/src/assets/scss/modules/_utils.scss
@@ -122,6 +122,10 @@
 .govuk-max-width {
   max-width: calc(100vh - 274px);
 }
+.govuk__width-fit-content {
+  width: fit-content;
+}
+
 .asc-font-19 {
   @include govuk-font($size: 19);
 }


### PR DESCRIPTION
#### Work done
- Added a link to download all certificates for a worker 
- Added a package for zipping files, add method to convert a list of downloaded file blobs to one zipped file blob
- Amend link text `Download training and qualifications (PDF, 430KB, 2 pages)` --> `Download this training and qualifications summary`
- Fixed a bug at saveHtmlToPdf, which caused the pdf not rendered correctly


#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
