### PR TITLE
Reset actions list when training is refreshed to prevent duplication after upload of training certificate

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -91,7 +91,7 @@
     [pdfCount]="pdfCount"
   ></app-download-pdf-traininf-and-qualification>
 </div>
-<div *ngIf="actionsListData.length > 0" class="govuk-grid-row govuk-!-margin-top-6">
+<div data-testid="actions-list-table" *ngIf="actionsListData.length > 0" class="govuk-grid-row govuk-!-margin-top-6">
   <div class="govuk-grid-column-full">
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m">

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -153,6 +153,7 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     this.setMissingMandatoryTraining(this.mandatoryTraining);
     this.setNonMandatoryTraining();
 
+    this.clearActionsList();
     this.populateActionsList(this.mandatoryTraining, 'Mandatory');
     this.populateActionsList(this.missingMandatoryTraining, 'Mandatory');
     this.populateActionsList(this.nonMandatoryTraining, 'Non-mandatory');
@@ -251,6 +252,10 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
         );
       });
     });
+  }
+
+  private clearActionsList(): void {
+    this.actionsListData = [];
   }
 
   private populateActionsList(trainingCategories: any, typeOfTraining: string): void {


### PR DESCRIPTION
#### Issue
In testing of the training certificates feature, an issue was spotted where after you have uploaded a certificate on the training and qualifications summary page, everything in the actions list was duplicated. This was due to the actions list not being cleared and training data being pushed to it again when the data is refreshed after an upload.

#### Work done
- Clear the actions list before populating it when setting training, to ensure that there is no unintended duplication.

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
