### PR TITLE
Add check for canEditWorker on rendering of certificate buttons on tr…

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -314,7 +314,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
           },
           { provide: EstablishmentService, useClass: MockEstablishmentService },
           { provide: BreadcrumbService, useClass: MockBreadcrumbService },
-          { provide: PermissionsService, useClass: MockPermissionsService },
+          { provide: PermissionsService, useFactory: MockPermissionsService.factory(['canEditWorker']) },
         ],
       },
     );
@@ -387,21 +387,13 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
     });
 
     it('should display the View staff record button', async () => {
-      const { component, getByText, fixture } = await setup();
-
-      component.canEditWorker = true;
-
-      fixture.detectChanges();
+      const { getByText } = await setup();
 
       expect(getByText('View staff record', { exact: false })).toBeTruthy();
     });
 
     it('should have correct href on the View staff record button', async () => {
-      const { component, getByText, fixture } = await setup();
-
-      component.canEditWorker = true;
-
-      fixture.detectChanges();
+      const { component, getByText } = await setup();
 
       const viewStaffRecordButton = getByText('View staff record', { exact: false });
 
@@ -462,7 +454,6 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
       const { component, fixture, getByText } = await setup();
 
       component.worker.longTermAbsence = null;
-      component.canEditWorker = true;
       fixture.detectChanges();
 
       expect(getByText('Flag long-term absence')).toBeTruthy();
@@ -472,7 +463,6 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
       const { component, fixture, getByTestId, routerSpy } = await setup();
 
       component.worker.longTermAbsence = null;
-      component.canEditWorker = true;
       fixture.detectChanges();
 
       const flagLongTermAbsenceLink = getByTestId('flagLongTermAbsence');
@@ -550,7 +540,11 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
     });
 
     it('should render Autism as an expired training without an update link if canEditWorker is false', async () => {
-      const { fixture } = await setup();
+      const { component, fixture } = await setup();
+
+      component.canEditWorker = false;
+      fixture.detectChanges();
+
       const actionListTableRows = fixture.nativeElement.querySelectorAll('tr');
       const rowOne = actionListTableRows[1];
       expect(rowOne.cells['0'].innerHTML).toBe('Autism');
@@ -573,7 +567,11 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
     });
 
     it('should render Coshh as an expiring soon training without an update link if canEditWorker is false', async () => {
-      const { fixture } = await setup();
+      const { component, fixture } = await setup();
+
+      component.canEditWorker = false;
+      fixture.detectChanges();
+
       const actionListTableRows = fixture.nativeElement.querySelectorAll('tr');
       const rowTwo = actionListTableRows[2];
       expect(rowTwo.cells['0'].innerHTML).toBe('Coshh');

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.html
@@ -92,29 +92,31 @@
                 </div>
               </td>
               <td class="govuk-table__cell">
-                <span *ngIf="trainingRecord.trainingCertificates?.length == 1">
-                  <a
-                    href="#"
-                    class="govuk-link govuk-link--no-visited-state"
-                    (click)="handleDownloadCertificate($event, trainingRecord)"
-                  >
-                    <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
-                      class="govuk-!-margin-left-1"
-                      >Download</span
+                <ng-container *ngIf="canEditWorker">
+                  <span *ngIf="trainingRecord.trainingCertificates?.length == 1">
+                    <a
+                      href="#"
+                      class="govuk-link govuk-link--no-visited-state"
+                      (click)="handleDownloadCertificate($event, trainingRecord)"
                     >
-                    <span class="govuk-visually-hidden"
-                      >the certificate {{ trainingRecord.trainingCertificates[0].filename }}</span
-                    >
-                  </a>
-                </span>
-                <span *ngIf="trainingRecord.trainingCertificates?.length > 1">
-                  <a [routerLink]="['../training', trainingRecord.uid]" class="govuk-link govuk-link--no-visited-state">
-                    Select a download
-                  </a>
-                </span>
-                <span *ngIf="trainingRecord.trainingCertificates?.length === 0">
-                  <app-select-upload-file accept=".pdf" buttonText="Upload file" buttonClasses="govuk-!-margin-bottom-0 govuk-!-padding-top-1 govuk-!-padding-bottom-1" (selectFiles)="handleUploadCertificate($event, trainingRecord)" />
-                </span>
+                      <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
+                        class="govuk-!-margin-left-1"
+                        >Download</span
+                      >
+                      <span class="govuk-visually-hidden"
+                        >the certificate {{ trainingRecord.trainingCertificates[0].filename }}</span
+                      >
+                    </a>
+                  </span>
+                  <span *ngIf="trainingRecord.trainingCertificates?.length > 1">
+                    <a [routerLink]="['../training', trainingRecord.uid]" class="govuk-link govuk-link--no-visited-state">
+                      Select a download
+                    </a>
+                  </span>
+                  <span *ngIf="trainingRecord.trainingCertificates?.length === 0">
+                    <app-select-upload-file accept=".pdf" buttonText="Upload file" buttonClasses="govuk-!-margin-bottom-0 govuk-!-padding-top-1 govuk-!-padding-bottom-1" (selectFiles)="handleUploadCertificate($event, trainingRecord)" />
+                  </span>
+                </ng-container>
               </td>
             </tr>
           </tbody>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training/new-training.component.spec.ts
@@ -270,9 +270,13 @@ describe('NewTrainingComponent', async () => {
       component.missingMandatoryTraining = false;
       component.ngOnChanges();
       fixture.detectChanges();
-      const mandatoryTrainingMissingLink = fixture.debugElement.query(By.css('[data-testid="no-mandatory-training-link"]'));
+      const mandatoryTrainingMissingLink = fixture.debugElement.query(
+        By.css('[data-testid="no-mandatory-training-link"]'),
+      );
       const messageText = 'No mandatory training has been added for this job role yet.';
-      const mandatoryTrainingMessage = fixture.debugElement.query(debugElement => debugElement.nativeElement.textContent === messageText);
+      const mandatoryTrainingMessage = fixture.debugElement.query(
+        (debugElement) => debugElement.nativeElement.textContent === messageText,
+      );
 
       expect(mandatoryTrainingMessage).toBeTruthy();
       expect(mandatoryTrainingMissingLink).toBeTruthy();
@@ -286,9 +290,13 @@ describe('NewTrainingComponent', async () => {
       component.missingMandatoryTraining = true;
       component.ngOnChanges();
       fixture.detectChanges();
-      const mandatoryTrainingMissingLink = fixture.debugElement.query(By.css('[data-testid="mandatory-training-missing-link"]'));
+      const mandatoryTrainingMissingLink = fixture.debugElement.query(
+        By.css('[data-testid="mandatory-training-missing-link"]'),
+      );
       const messageText = 'No mandatory training records have been added for this person yet.';
-      const mandatoryTrainingMessage = fixture.debugElement.query(debugElement => debugElement.nativeElement.textContent === messageText);
+      const mandatoryTrainingMessage = fixture.debugElement.query(
+        (debugElement) => debugElement.nativeElement.textContent === messageText,
+      );
 
       expect(mandatoryTrainingMessage).toBeTruthy();
       expect(mandatoryTrainingMissingLink).toBeTruthy();
@@ -378,32 +386,51 @@ describe('NewTrainingComponent', async () => {
   });
 
   describe('Training certificates', () => {
+    const singleTrainingCertificate = () => [
+      {
+        filename: 'test.pdf',
+        uid: '1872ec19-510d-41de-995d-6abfd3ae888a',
+        uploadDate: '2024-09-20T08:57:45.000Z',
+      },
+    ];
+
+    const multipleTrainingCertificates = () => [
+      {
+        filename: 'test.pdf',
+        uid: '1872ec19-510d-41de-995d-6abfd3ae888a',
+        uploadDate: '2024-09-20T08:57:45.000Z',
+      },
+      {
+        filename: 'test2.pdf',
+        uid: '1872ec19-510d-41de-995d-6abfd3ae888b',
+        uploadDate: '2024-09-19T08:57:45.000Z',
+      },
+    ];
+
     it('should display Download link when training record has one certificate associated with it', async () => {
       const { component, fixture, getByTestId } = await setup();
 
-      component.trainingCategories[0].trainingRecords[0].trainingCertificates = [
-        {
-          filename: 'test.pdf',
-          uid: '1872ec19-510d-41de-995d-6abfd3ae888a',
-          uploadDate: '2024-09-20T08:57:45.000Z',
-        },
-      ];
+      component.trainingCategories[0].trainingRecords[0].trainingCertificates = singleTrainingCertificate();
       fixture.detectChanges();
 
       const trainingRecordWithCertificateRow = getByTestId('someAutismUid');
       expect(within(trainingRecordWithCertificateRow).getByText('Download')).toBeTruthy();
     });
 
+    it('should not display Download link when training record has one certificate associated with it but user does not have edit permissions', async () => {
+      const { component, fixture, getByTestId } = await setup(false);
+
+      component.trainingCategories[0].trainingRecords[0].trainingCertificates = singleTrainingCertificate();
+      fixture.detectChanges();
+
+      const trainingRecordWithCertificateRow = getByTestId('someAutismUid');
+      expect(within(trainingRecordWithCertificateRow).queryByText('Download')).toBeFalsy();
+    });
+
     it('should trigger download file emitter when Download link is clicked', async () => {
       const { component, fixture, getByTestId } = await setup();
 
-      component.trainingCategories[0].trainingRecords[0].trainingCertificates = [
-        {
-          filename: 'test.pdf',
-          uid: '1872ec19-510d-41de-995d-6abfd3ae888a',
-          uploadDate: '2024-09-20T08:57:45.000Z',
-        },
-      ];
+      component.trainingCategories[0].trainingRecords[0].trainingCertificates = singleTrainingCertificate();
       fixture.detectChanges();
 
       const downloadFileSpy = spyOn(component.downloadFile, 'emit');
@@ -419,39 +446,27 @@ describe('NewTrainingComponent', async () => {
     it('should display Select a download link when training record has more than one certificate associated with it', async () => {
       const { component, fixture, getByTestId } = await setup();
 
-      component.trainingCategories[0].trainingRecords[0].trainingCertificates = [
-        {
-          filename: 'test.pdf',
-          uid: '1872ec19-510d-41de-995d-6abfd3ae888a',
-          uploadDate: '2024-09-20T08:57:45.000Z',
-        },
-        {
-          filename: 'test2.pdf',
-          uid: '1872ec19-510d-41de-995d-6abfd3ae888b',
-          uploadDate: '2024-09-19T08:57:45.000Z',
-        },
-      ];
+      component.trainingCategories[0].trainingRecords[0].trainingCertificates = multipleTrainingCertificates();
       fixture.detectChanges();
 
       const trainingRecordWithCertificateRow = getByTestId('someAutismUid');
       expect(within(trainingRecordWithCertificateRow).getByText('Select a download')).toBeTruthy();
     });
 
+    it('should not display Select a download link when training record has more than one certificate associated with it but user does not have edit permissions', async () => {
+      const { component, fixture, getByTestId } = await setup(false);
+
+      component.trainingCategories[0].trainingRecords[0].trainingCertificates = multipleTrainingCertificates();
+      fixture.detectChanges();
+
+      const trainingRecordWithCertificateRow = getByTestId('someAutismUid');
+      expect(within(trainingRecordWithCertificateRow).queryByText('Select a download')).toBeFalsy();
+    });
+
     it('should have href of training record on Select a download link', async () => {
       const { component, fixture, getByTestId } = await setup();
 
-      component.trainingCategories[0].trainingRecords[0].trainingCertificates = [
-        {
-          filename: 'test.pdf',
-          uid: '1872ec19-510d-41de-995d-6abfd3ae888a',
-          uploadDate: '2024-09-20T08:57:45.000Z',
-        },
-        {
-          filename: 'test2.pdf',
-          uid: '1872ec19-510d-41de-995d-6abfd3ae888b',
-          uploadDate: '2024-09-19T08:57:45.000Z',
-        },
-      ];
+      component.trainingCategories[0].trainingRecords[0].trainingCertificates = multipleTrainingCertificates();
       fixture.detectChanges();
 
       const trainingRecordUid = component.trainingCategories[0].trainingRecords[0].uid;
@@ -462,7 +477,7 @@ describe('NewTrainingComponent', async () => {
       expect(selectADownloadLink.getAttribute('href')).toEqual(`/training/${trainingRecordUid}`);
     });
 
-    it('should display Upload file button when training record has no certificates associated with it', async () => {
+    it('should display Upload file button when training record has no certificates associated with it but user does not have edit permissions', async () => {
       const { component, fixture, getByTestId } = await setup();
 
       component.trainingCategories[0].trainingRecords[0].trainingCertificates = [];
@@ -470,6 +485,16 @@ describe('NewTrainingComponent', async () => {
 
       const trainingRecordWithCertificateRow = getByTestId('someAutismUid');
       expect(within(trainingRecordWithCertificateRow).getByText('Upload file')).toBeTruthy();
+    });
+
+    it('should not display Upload file button when training record has no certificates associated with it', async () => {
+      const { component, fixture, getByTestId } = await setup(false);
+
+      component.trainingCategories[0].trainingRecords[0].trainingCertificates = [];
+      fixture.detectChanges();
+
+      const trainingRecordWithCertificateRow = getByTestId('someAutismUid');
+      expect(within(trainingRecordWithCertificateRow).queryByText('Upload file')).toBeFalsy();
     });
 
     it('should trigger the upload file emitter when a file is selected by the Upload file button', async () => {


### PR DESCRIPTION
#### Issue
Parents viewing subs who own their own data or subs viewing their data owned by parents could see the certificate upload/download buttons on the training and qualifications summary. Users would be logged out on click of these buttons as they require edit permissions.

#### Work done
- Added check for edit permissions to display the certificate buttons
- Updated `new-training-and-qualifications-record` tests to default to having edit permissions, due to certificate related tests in this spec file failing on introduction of permission check and more tests being reliant on having edit permissions

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
