### PR TITLE
Increase size of file limit for uploading training certificates

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-edit-training/add-edit-training.component.spec.ts
@@ -394,7 +394,7 @@ describe('AddEditTrainingComponent', () => {
       const fileInput = getByTestId('fileInput');
 
       let uploadButton = within(uploadSection).getByRole('button', {
-        description: /The certificate must be a PDF file that's no larger than 500KB/,
+        description: /The certificate must be a PDF file that's no larger than 5MB/,
       });
       expect(uploadButton).toBeTruthy();
 
@@ -922,7 +922,7 @@ describe('AddEditTrainingComponent', () => {
     });
 
     describe('uploadCertificate errors', () => {
-      it('should show an error message if the selected file is over 500 KB', async () => {
+      it('should show an error message if the selected file is over 5MB', async () => {
         const { fixture, getByTestId, getByText } = await setup(null);
 
         const mockUploadFile = new File(['some file content'], 'large-file.pdf', { type: 'application/pdf' });
@@ -937,7 +937,7 @@ describe('AddEditTrainingComponent', () => {
 
         fixture.detectChanges();
 
-        expect(getByText('The certificate must be no larger than 500KB')).toBeTruthy();
+        expect(getByText('The certificate must be no larger than 5MB')).toBeTruthy();
       });
 
       it('should show an error message if the selected file is not a pdf file', async () => {

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.spec.ts
@@ -916,10 +916,10 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
         expect(uploadCertificateSpy).not.toHaveBeenCalled();
       });
 
-      it('should show an error message when a file of > 500 KB is selected', async () => {
+      it('should show an error message when a file of > 5MB is selected', async () => {
         const invalidFile = new File(['some file content'], 'certificate.pdf');
         Object.defineProperty(invalidFile, 'size', {
-          value: 600 * 1024, // 600 KB
+          value: 6 * 1024 * 1024, // 6MB
         });
 
         const { fixture, getByTestId, trainingService, getByText } = await setup(false, true, []);
@@ -933,7 +933,7 @@ describe('NewTrainingAndQualificationsRecordComponent', () => {
 
         fixture.detectChanges();
 
-        expect(getByText('The certificate must be no larger than 500KB')).toBeTruthy();
+        expect(getByText('The certificate must be no larger than 5MB')).toBeTruthy();
         expect(uploadCertificateSpy).not.toHaveBeenCalled();
       });
 

--- a/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
+++ b/frontend/src/app/shared/directives/add-edit-training/add-edit-training.component.html
@@ -189,7 +189,7 @@
                   Upload a certificate
                 </label>
                 <div id="uploadCertificate-hint" class="govuk-hint govuk-!-margin-bottom-4">
-                  The certificate must be a PDF file that's no larger than 500KB
+                  The certificate must be a PDF file that's no larger than 5MB
                 </div>
                 <div class="govuk__flex govuk__align-items-center">
                   <app-select-upload-file

--- a/frontend/src/app/shared/validators/custom-form-validators.ts
+++ b/frontend/src/app/shared/validators/custom-form-validators.ts
@@ -132,10 +132,10 @@ export class CustomValidators extends Validators {
 
   static validateUploadCertificates(files: File[]): string[] | null {
     let errors = [];
-    const maxFileSize = 500 * 1024;
+    const maxFileSize = 5 * 1024 * 1024;
 
     if (files.some((file) => file.size > maxFileSize)) {
-      errors.push('The certificate must be no larger than 500KB');
+      errors.push('The certificate must be no larger than 5MB');
     }
 
     if (files.some((file) => !file.name.toLowerCase().endsWith('.pdf'))) {


### PR DESCRIPTION
#### Work done
- Increased the size of file limit for uploading training certificates - agreed that previous limit was too low

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
