### PR TITLE
Fix: Hide qualification certificate links for read only users

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.component.html
@@ -41,29 +41,31 @@
               </td>
               <td class="govuk-table__cell">{{ qualificationRecord?.year ? qualificationRecord.year : '-' }}</td>
               <td class="govuk-table__cell">
-                <span *ngIf="qualificationRecord.qualificationCertificates?.length == 1">
-                  <a
-                    href="#"
-                    class="govuk-link govuk-link--no-visited-state"
-                    (click)="handleDownloadCertificate($event, qualificationGroup, qualificationRecord)"
-                  >
-                    <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
-                      class="govuk-!-margin-left-1"
-                      >Download</span
+                <ng-container *ngIf="canEditWorker">
+                  <span *ngIf="qualificationRecord.qualificationCertificates?.length == 1">
+                    <a
+                      href="#"
+                      class="govuk-link govuk-link--no-visited-state"
+                      (click)="handleDownloadCertificate($event, qualificationGroup, qualificationRecord)"
                     >
-                    <span class="govuk-visually-hidden"
-                      >the certificate {{ qualificationRecord.qualificationCertificates[0].filename }}</span
-                    >
-                  </a>
-                </span>
-                <span *ngIf="qualificationRecord.qualificationCertificates?.length > 1">
-                  <a [routerLink]="['../qualification', qualificationRecord.uid]" class="govuk-link govuk-link--no-visited-state">
-                    Select a download
-                  </a>
-                </span>
-                <span *ngIf="qualificationRecord.qualificationCertificates?.length === 0">
-                  <app-select-upload-file accept=".pdf" buttonText="Upload file" buttonClasses="govuk-!-margin-bottom-0 govuk-!-padding-top-1 govuk-!-padding-bottom-1" (selectFiles)="handleUploadCertificate($event, qualificationGroup, qualificationRecord)" />
-                </span>
+                      <img alt="" src="/assets/images/icon-download.svg" class="govuk-util__vertical-align-bottom" /><span
+                        class="govuk-!-margin-left-1"
+                        >Download</span
+                      >
+                      <span class="govuk-visually-hidden"
+                        >the certificate {{ qualificationRecord.qualificationCertificates[0].filename }}</span
+                      >
+                    </a>
+                  </span>
+                  <span *ngIf="qualificationRecord.qualificationCertificates?.length > 1">
+                    <a [routerLink]="['../qualification', qualificationRecord.uid]" class="govuk-link govuk-link--no-visited-state">
+                      Select a download
+                    </a>
+                  </span>
+                  <span *ngIf="qualificationRecord.qualificationCertificates?.length === 0">
+                    <app-select-upload-file accept=".pdf" buttonText="Upload file" buttonClasses="govuk-!-margin-bottom-0 govuk-!-padding-top-1 govuk-!-padding-bottom-1" (selectFiles)="handleUploadCertificate($event, qualificationGroup, qualificationRecord)" />
+                  </span>
+                </ng-container>
               </td>
             </tr>
           </tbody>

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-qualifications/new-qualifications.spec.ts
@@ -156,7 +156,7 @@ describe('NewQualificationsComponent', () => {
     });
   });
 
-  describe('no training', () => {
+  describe('no qualification', () => {
     it('should render an add a qualification link if canEditWorker is true', async () => {
       const { fixture, component, getByText } = await setup();
       component.qualificationsByGroup.count = 0;
@@ -193,14 +193,14 @@ describe('NewQualificationsComponent', () => {
       { uid: 'certificate2uid', filename: 'First aid award 2024.pdf', uploadDate: '20240101T234516Z' },
     ];
 
-    it('should display Download link when training record has one certificate associated with it', async () => {
+    it('should display Download link when qualification record has one certificate associated with it', async () => {
       const { getByTestId } = await setupWithCertificates(singleQualificationCertificate());
 
       const recordRow = getByTestId(qualificationUid);
       expect(within(recordRow).getByText('Download')).toBeTruthy();
     });
 
-    it('should not display Download link when training record has one certificate associated with it but user does not have edit permissions', async () => {
+    it('should not display Download link when qualification record has one certificate associated with it but user does not have edit permissions', async () => {
       const { getByTestId } = await setupWithCertificates(singleQualificationCertificate(), false);
 
       const recordRow = getByTestId(qualificationUid);
@@ -224,21 +224,21 @@ describe('NewQualificationsComponent', () => {
       expect(downloadFileSpy).toHaveBeenCalledWith(expectedDownloadEvent);
     });
 
-    it('should display Select a download link when training record has more than one certificate associated with it', async () => {
+    it('should display Select a download link when qualification record has more than one certificate associated with it', async () => {
       const { getByTestId } = await setupWithCertificates(multipleQualificationCertificates());
 
       const recordRow = getByTestId('firstAwardQualUid');
       expect(within(recordRow).getByText('Select a download')).toBeTruthy();
     });
 
-    it('should not display Select a download link when training record has more than one certificate associated with it but user does not have edit permissions', async () => {
+    it('should not display Select a download link when qualification record has more than one certificate associated with it but user does not have edit permissions', async () => {
       const { getByTestId } = await setupWithCertificates(multipleQualificationCertificates(), false);
 
       const recordRow = getByTestId('firstAwardQualUid');
       expect(within(recordRow).queryByText('Select a download')).toBeFalsy();
     });
 
-    it('should have href of training record on Select a download link', async () => {
+    it('should have href of qualification record on Select a download link', async () => {
       const { getByTestId } = await setupWithCertificates(multipleQualificationCertificates());
 
       const recordRow = getByTestId('firstAwardQualUid');
@@ -246,14 +246,14 @@ describe('NewQualificationsComponent', () => {
       expect(selectADownloadLink.getAttribute('href')).toEqual(`/qualification/firstAwardQualUid`);
     });
 
-    it('should display Upload file button when training record has no certificates associated with it', async () => {
+    it('should display Upload file button when qualification record has no certificates associated with it', async () => {
       const { getByTestId } = await setupWithCertificates([]);
 
       const recordRow = getByTestId(qualificationUid);
       expect(within(recordRow).getByRole('button', { name: 'Upload file' })).toBeTruthy();
     });
 
-    it('should not display Upload file button when training record has no certificates associated with it but user does not have edit permissions', async () => {
+    it('should not display Upload file button when qualification record has no certificates associated with it but user does not have edit permissions', async () => {
       const { getByTestId } = await setupWithCertificates([], false);
 
       const recordRow = getByTestId(qualificationUid);


### PR DESCRIPTION
#### Work done
- Added canEditWorker check for displaying qualification certificate links on training and quals summary page to ensure that parents viewing subs who own their data or subs viewing data owned by the parent cannot see these actions they don't have permission for 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
