### PR TITLE
Feat/1549 bulk upload retain existing qualifications

### DIFF
--- a/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
+++ b/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
@@ -4,12 +4,12 @@ const models = require('../../index');
 const WorkerCertificateService = require('../../../routes/establishments/workerCertificate/workerCertificateService');
 
 class BulkUploadQualificationHelper {
-  constructor({ workerId, workerUid, establishmentId, savedBy, bulkUploaded = true, externalTransaction }) {
+  constructor({ workerId, workerUid, establishmentId, savedBy, externalTransaction }) {
     this.workerId = workerId;
     this.workerUid = workerUid;
     this.establishmentId = establishmentId;
     this.savedBy = savedBy;
-    this.bulkUploaded = bulkUploaded;
+    this.bulkUploaded = true;
     this.externalTransaction = externalTransaction;
     this.qualificationCertificateService = WorkerCertificateService.initialiseQualifications();
   }
@@ -59,7 +59,7 @@ class BulkUploadQualificationHelper {
 
   updateQualification(existingRecord, entityFromBulkUpload) {
     const fieldsToUpdate = {
-      source: this.bulkUploaded ? 'Bulk' : 'Online',
+      source: 'Bulk',
       updatedBy: this.savedBy.toLowerCase(),
       notes: entityFromBulkUpload.notes ?? existingRecord.notes,
       year: entityFromBulkUpload.year ?? existingRecord.year,

--- a/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
+++ b/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
@@ -55,7 +55,6 @@ class BulkUploadQualificationHelper {
   createNewQualification(entityFromBulkUpload) {
     entityFromBulkUpload.workerId = this.workerId;
     entityFromBulkUpload.workerUid = this.workerUid;
-    entityFromBulkUpload._workerUid = this.workerUid;
     entityFromBulkUpload.establishmentId = this.establishmentId;
 
     return entityFromBulkUpload.save(this.savedBy, this.bulkUploaded, 0, this.externalTransaction);

--- a/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
+++ b/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
@@ -73,7 +73,7 @@ class BulkUploadQualificationHelper {
   async deleteQualification(existingRecord) {
     const certificatesFound = await existingRecord.getQualificationCertificates();
     if (certificatesFound?.length) {
-      this.qualificationCertificateService.deleteCertificatesWithTransaction(
+      await this.qualificationCertificateService.deleteCertificatesWithTransaction(
         certificatesFound,
         this.externalTransaction,
       );

--- a/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
+++ b/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
@@ -31,20 +31,17 @@ class BulkUploadQualificationHelper {
       const qualificationExists = existingQualificationFks.includes(currentQualificationId);
 
       if (qualificationExists) {
-        console.log('modify current qualification: ', bulkUploadEntity._qualification.title);
         const recordToUpdate = allQualificationRecords.find(
           (record) => record.qualificationFk === currentQualificationId,
         );
         promisesToReturn.push(this.updateQualification(recordToUpdate, bulkUploadEntity));
       } else {
-        console.log('create new qualification: ', bulkUploadEntity._qualification.title);
         promisesToReturn.push(this.createNewQualification(bulkUploadEntity));
       }
     }
 
     for (const qualification of allQualificationRecords) {
       if (!bulkUploadQualificationFks.includes(qualification.qualificationFk)) {
-        console.log('delete current qualification: ', qualification.id);
         promisesToReturn.push(this.deleteQualification(qualification));
       }
     }

--- a/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
+++ b/backend/server/models/classes/helpers/bulkUploadQualificationHelper.js
@@ -1,0 +1,80 @@
+const { compact } = require('lodash');
+
+const models = require('../../index');
+
+class BulkUploadQualificationHelper {
+  constructor({ workerId, workerUid, establishmentId, savedBy, bulkUploaded = true, externalTransaction }) {
+    this.workerId = workerId;
+    this.workerUid = workerUid;
+    this.establishmentId = establishmentId;
+    this.savedBy = savedBy;
+    this.bulkUploaded = bulkUploaded;
+    this.externalTransaction = externalTransaction;
+  }
+
+  async processQualificationsEntities(qualificationsEntities) {
+    const promisesToReturn = [];
+
+    const allExistingQualifications = await models.workerQualifications.findAll({
+      where: {
+        workerFk: this.workerId,
+      },
+    });
+
+    const existingQualificationFks = allExistingQualifications.map((record) => record.qualificationFk);
+    const bulkUploadQualificationFks = compact(qualificationsEntities.map((entity) => entity?._qualification?.id));
+
+    for (const bulkUploadEntity of qualificationsEntities) {
+      const currentQualificationId = bulkUploadEntity?._qualification?.id;
+      const qualificationExists = existingQualificationFks.includes(currentQualificationId);
+
+      if (qualificationExists) {
+        console.log('modify current qualification: ', bulkUploadEntity._qualification.title);
+        const recordToUpdate = allExistingQualifications.find(
+          (record) => record.qualificationFk === currentQualificationId,
+        );
+        promisesToReturn.push(this.updateQualification(recordToUpdate, bulkUploadEntity));
+      } else {
+        console.log('create new qualification: ', bulkUploadEntity._qualification.title);
+        promisesToReturn.push(this.createNewQualification(bulkUploadEntity));
+      }
+    }
+
+    for (const qualification of allExistingQualifications) {
+      if (!bulkUploadQualificationFks.includes(qualification.qualificationFk)) {
+        console.log('delete current qualification: ', qualification._id);
+        promisesToReturn.push(this.deleteQualification(qualification));
+      }
+    }
+
+    return promisesToReturn;
+  }
+
+  createNewQualification(entityFromBulkUpload) {
+    entityFromBulkUpload.workerId = this.workerId;
+    entityFromBulkUpload.workerUid = this.workerUid;
+    entityFromBulkUpload._workerUid = this.workerUid;
+    entityFromBulkUpload.establishmentId = this.establishmentId;
+
+    return entityFromBulkUpload.save(this.savedBy, this.bulkUploaded, 0, this.externalTransaction);
+  }
+
+  updateQualification(existingRecord, entityFromBulkUpload) {
+    const fieldsToUpdate = {
+      source: this.bulkUploaded ? 'Bulk' : 'Online',
+      updatedBy: this.savedBy.toLowerCase(),
+      notes: entityFromBulkUpload.notes ?? existingRecord.notes,
+      year: entityFromBulkUpload.year ?? existingRecord.year,
+    };
+
+    existingRecord.set(fieldsToUpdate);
+
+    return existingRecord.save({ transaction: this.externalTransaction });
+  }
+
+  deleteQualification(existingRecord) {
+    throw new Error('to be implemented when feat/1544 is in place');
+  }
+}
+
+module.exports = BulkUploadQualificationHelper;

--- a/backend/server/models/classes/qualification.js
+++ b/backend/server/models/classes/qualification.js
@@ -106,7 +106,7 @@ class Qualification extends EntityValidator {
   }
 
   get workerId() {
-    return this._workerUid;
+    return this._workerId;
   }
   get workerUid() {
     return this._workerUid;

--- a/backend/server/models/classes/worker.js
+++ b/backend/server/models/classes/worker.js
@@ -475,7 +475,6 @@ class Worker extends EntityValidator {
           // and qualifications records
           this._qualificationsEntities = [];
           if (document.qualifications && Array.isArray(document.qualifications)) {
-            console.log('WA DEBUG - document.qualifications: ', document.qualifications);
             document.qualifications.forEach((thisQualificationRecord) => {
               const newQualificationRecord = new Qualification(null, null);
 
@@ -553,17 +552,19 @@ class Worker extends EntityValidator {
         });
       }
 
-      const qualificationHelper = new BulkUploadQualificationHelper({
-        workerId: this._id,
-        workerUid: this._uid,
-        establishmentId: this._establishmentId,
-        savedBy,
-        bulkUploaded,
-        externalTransaction,
-      });
-      const qualificationEntities = this._qualificationsEntities ? this._qualificationsEntities : [];
-      const promisesToPush = await qualificationHelper.processQualificationsEntities(qualificationEntities);
-      qualificationChangePromises.push(...promisesToPush);
+      if (bulkUploaded && ['NEW', 'UPDATE'].includes(this.status)) {
+        const qualificationHelper = new BulkUploadQualificationHelper({
+          workerId: this._id,
+          workerUid: this._uid,
+          establishmentId: this._establishmentId,
+          savedBy,
+          bulkUploaded,
+          externalTransaction,
+        });
+        const qualificationEntities = this._qualificationsEntities ? this._qualificationsEntities : [];
+        const promisesToPush = await qualificationHelper.processQualificationsEntities(qualificationEntities);
+        qualificationChangePromises.push(...promisesToPush);
+      }
 
       await Promise.all(newTrainingPromises);
       await Promise.all(qualificationChangePromises);

--- a/backend/server/models/classes/worker.js
+++ b/backend/server/models/classes/worker.js
@@ -32,6 +32,8 @@ const TrainingCertificateRoute = require('../../routes/establishments/workerCert
 // WDF Calculator
 const WdfCalculator = require('./wdfCalculator').WdfCalculator;
 
+const BulkUploadQualificationHelper = require('./helpers/bulkUploadQualificationHelper');
+
 const STOP_VALIDATING_ON = ['UNCHECKED', 'DELETE', 'DELETED', 'NOCHANGE'];
 
 class Worker extends EntityValidator {
@@ -473,7 +475,7 @@ class Worker extends EntityValidator {
           // and qualifications records
           this._qualificationsEntities = [];
           if (document.qualifications && Array.isArray(document.qualifications)) {
-            // console.log("WA DEBUG - document.qualifications: ", document.qualifications)
+            console.log('WA DEBUG - document.qualifications: ', document.qualifications);
             document.qualifications.forEach((thisQualificationRecord) => {
               const newQualificationRecord = new Qualification(null, null);
 
@@ -528,7 +530,7 @@ class Worker extends EntityValidator {
   }
 
   async saveAssociatedEntities(savedBy, bulkUploaded = false, externalTransaction) {
-    const newQualificationsPromises = [];
+    const qualificationChangePromises = [];
     const newTrainingPromises = [];
 
     try {
@@ -551,29 +553,21 @@ class Worker extends EntityValidator {
         });
       }
 
-      // there is no change audit on qualifications; simply delete all that is there and recreate
       if (this._qualificationsEntities && this._qualificationsEntities.length > 0) {
-        // delete all existing training records for this worker
-        await models.workerQualifications.destroy({
-          where: {
-            workerFk: this._id,
-          },
-          transaction: externalTransaction,
+        const helper = new BulkUploadQualificationHelper({
+          workerId: this._id,
+          workerUid: this._uid,
+          establishmentId: this._establishmentId,
+          savedBy,
+          bulkUploaded,
+          externalTransaction,
         });
-
-        // now create new training records
-        this._qualificationsEntities.forEach((currentQualificationRecord) => {
-          currentQualificationRecord.workerId = this._id;
-          currentQualificationRecord.workerUid = this._uid;
-          currentQualificationRecord.establishmentId = this._establishmentId;
-          newQualificationsPromises.push(
-            currentQualificationRecord.save(savedBy, bulkUploaded, 0, externalTransaction),
-          );
-        });
+        const promisesToPush = await helper.processQualificationsEntities(this._qualificationsEntities);
+        qualificationChangePromises.push(...promisesToPush);
       }
 
       await Promise.all(newTrainingPromises);
-      await Promise.all(newQualificationsPromises);
+      await Promise.all(qualificationChangePromises);
     } catch (err) {
       console.error('Worker::saveAssociatedEntities error: ', err);
       // rethrow error to ensure the transaction is rolled back

--- a/backend/server/models/classes/worker.js
+++ b/backend/server/models/classes/worker.js
@@ -553,18 +553,17 @@ class Worker extends EntityValidator {
         });
       }
 
-      if (this._qualificationsEntities && this._qualificationsEntities.length > 0) {
-        const helper = new BulkUploadQualificationHelper({
-          workerId: this._id,
-          workerUid: this._uid,
-          establishmentId: this._establishmentId,
-          savedBy,
-          bulkUploaded,
-          externalTransaction,
-        });
-        const promisesToPush = await helper.processQualificationsEntities(this._qualificationsEntities);
-        qualificationChangePromises.push(...promisesToPush);
-      }
+      const qualificationHelper = new BulkUploadQualificationHelper({
+        workerId: this._id,
+        workerUid: this._uid,
+        establishmentId: this._establishmentId,
+        savedBy,
+        bulkUploaded,
+        externalTransaction,
+      });
+      const qualificationEntities = this._qualificationsEntities ? this._qualificationsEntities : [];
+      const promisesToPush = await qualificationHelper.processQualificationsEntities(qualificationEntities);
+      qualificationChangePromises.push(...promisesToPush);
 
       await Promise.all(newTrainingPromises);
       await Promise.all(qualificationChangePromises);

--- a/backend/server/routes/establishments/qualification/index.js
+++ b/backend/server/routes/establishments/qualification/index.js
@@ -5,8 +5,8 @@ const QualificationCertificateRoute = require('../workerCertificate/qualificatio
 
 // all user functionality is encapsulated
 const Qualification = require('../../../models/classes/qualification').Qualification;
-const QualificationDuplicateException = require('../../../models/classes/qualification')
-  .QualificationDuplicateException;
+const QualificationDuplicateException =
+  require('../../../models/classes/qualification').QualificationDuplicateException;
 
 const { hasPermission } = require('../../../utils/security/hasPermission');
 const WorkerCertificateService = require('../workerCertificate/workerCertificateService');
@@ -180,7 +180,14 @@ const deleteQualificationRecord = async (req, res) => {
 
       const qualificationCertificateService = WorkerCertificateService.initialiseQualifications();
 
-      await qualificationCertificateService.deleteCertificates(qualificationCertificates, establishmentUid, workerUid, qualificationUid);
+      if (qualificationCertificates?.length) {
+        await qualificationCertificateService.deleteCertificates(
+          qualificationCertificates,
+          establishmentUid,
+          workerUid,
+          qualificationUid,
+        );
+      }
 
       // by deleting after the restore we can be sure this qualification record belongs to the given worker
       const deleteSuccess = await thisQualificationRecord.delete();

--- a/backend/server/routes/establishments/training/index.js
+++ b/backend/server/routes/establishments/training/index.js
@@ -174,7 +174,14 @@ const deleteTrainingRecord = async (req, res) => {
 
       const trainingCertificateService = WorkerCertificateService.initialiseTraining();
 
-      await trainingCertificateService.deleteCertificates(trainingCertificates, establishmentUid, workerUid, trainingUid);
+      if (this.trainingCertificates?.length) {
+        await trainingCertificateService.deleteCertificates(
+          trainingCertificates,
+          establishmentUid,
+          workerUid,
+          trainingUid,
+        );
+      }
 
       // by deleting after the restore we can be sure this training record belongs to the given worker
       const deleteSuccess = await thisTrainingRecord.delete();

--- a/backend/server/routes/establishments/workerCertificate/qualificationCertificate.js
+++ b/backend/server/routes/establishments/workerCertificate/qualificationCertificate.js
@@ -8,13 +8,18 @@ const router = express.Router({ mergeParams: true });
 
 const initialiseCertificateService = () => {
   return WorkerCertificateService.initialiseQualifications();
-}
+};
 
 const requestUploadUrlEndpoint = async (req, res) => {
   const certificateService = initialiseCertificateService();
 
   try {
-    const responsePayload = await certificateService.requestUploadUrl(req.body.files, req.params.id, req.params.workerId, req.params.qualificationUid);
+    const responsePayload = await certificateService.requestUploadUrl(
+      req.body.files,
+      req.params.id,
+      req.params.workerId,
+      req.params.qualificationUid,
+    );
     return res.status(200).json({ files: responsePayload });
   } catch (err) {
     return res.status(err.statusCode).send(err.message);
@@ -36,7 +41,12 @@ const getPresignedUrlForCertificateDownloadEndpoint = async (req, res) => {
   const certificateService = initialiseCertificateService();
 
   try {
-    const responsePayload = await certificateService.getPresignedUrlForCertificateDownload(req.body.files, req.params.id, req.params.workerId, req.params.qualificationUid);
+    const responsePayload = await certificateService.getPresignedUrlForCertificateDownload(
+      req.body.files,
+      req.params.id,
+      req.params.workerId,
+      req.params.qualificationUid,
+    );
     return res.status(200).json({ files: responsePayload });
   } catch (err) {
     return res.status(err.statusCode).send(err.message);
@@ -47,7 +57,12 @@ const deleteCertificatesEndpoint = async (req, res) => {
   const certificateService = initialiseCertificateService();
 
   try {
-    await certificateService.deleteCertificates(req.body.files, req.params.id, req.params.workerId, req.params.qualificationUid);
+    await certificateService.deleteCertificates(
+      req.body.files,
+      req.params.id,
+      req.params.workerId,
+      req.params.qualificationUid,
+    );
     return res.status(200).send();
   } catch (err) {
     return res.status(err.statusCode).send(err.message);

--- a/backend/server/routes/establishments/workerCertificate/workerCertificateService.js
+++ b/backend/server/routes/establishments/workerCertificate/workerCertificateService.js
@@ -14,7 +14,6 @@ class WorkerCertificateService {
   certificatesModel;
   certificateTypeModel;
   recordType;
-  recordTypeAlias;
 
   static initialiseQualifications = () => {
     const service = new WorkerCertificateService();

--- a/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
+++ b/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
@@ -42,7 +42,7 @@ const buildMockWorkerQualification = (override = {}) => {
   });
 };
 
-describe.only('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () => {
+describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () => {
   const mockWorkerId = '100';
   const mockWorkerUid = uuidv4();
   const mockEstablishmentId = '210';

--- a/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
+++ b/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
@@ -45,7 +45,7 @@ const buildMockWorkerQualification = (override = {}) => {
   });
 };
 
-describe.only('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () => {
+describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () => {
   const mockWorkerId = '100';
   const mockWorkerUid = uuidv4();
   const mockEstablishmentId = '1234';

--- a/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
+++ b/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
@@ -76,10 +76,10 @@ describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () =
 
     beforeEach(async () => {
       mockExistingQualifications = [
-        buildMockWorkerQualification({ qualificationFk: 31 }), // to modify
-        buildMockWorkerQualification({ qualificationFk: 1 }), // to delete
-        buildMockWorkerQualification({ qualificationFk: 2 }), // to delete
-        buildMockWorkerQualification({ qualificationFk: 152 }), // to modify
+        buildMockWorkerQualification({ qualificationFk: 31 }), // should be modified
+        buildMockWorkerQualification({ qualificationFk: 1 }), // should be deleted
+        buildMockWorkerQualification({ qualificationFk: 2 }), // should be deleted
+        buildMockWorkerQualification({ qualificationFk: 152 }), // should be modified
       ];
       mockQualificationsEntities = await Promise.all(
         [
@@ -107,7 +107,7 @@ describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () =
       sinon.restore();
     });
 
-    it('should call createNewQualification for each new qualification added', async () => {
+    it('should call createNewQualification for each qualification that is not in database but appear in bulk upload entities', async () => {
       const returnedPromises = await helper.processQualificationsEntities(mockQualificationsEntities);
 
       expect(helper.createNewQualification).to.have.been.calledTwice;
@@ -119,7 +119,7 @@ describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () =
         .that.includes(helper.createNewQualification.returnValues[0], helper.createNewQualification.returnValues[1]);
     });
 
-    it('should call updateQualification for each qualification that is modified', async () => {
+    it('should call updateQualification for each existing qualification that also appear in bulk upload entities', async () => {
       const returnedPromises = await helper.processQualificationsEntities(mockQualificationsEntities);
 
       expect(helper.updateQualification).to.have.been.calledTwice;

--- a/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
+++ b/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
@@ -206,4 +206,12 @@ describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () =
       expect(returnedPromise).to.equal(mockExistingRecord.save.returnValues[0]);
     });
   });
+
+  describe('deleteQualification', () => {
+    // TODO: implement tests for deleting qualification
+
+    it('should delete the qualification record from database');
+
+    it('should call deleteCertificatesWithTransaction if there are any certificates attached to this qualification');
+  });
 });

--- a/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
+++ b/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
@@ -1,0 +1,209 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const { v4: uuidv4 } = require('uuid');
+
+const models = require('../../../../../models');
+const Qualification = require('../../../../../models/classes/qualification').Qualification;
+const BulkUploadQualificationHelper = require('../../../../../models/classes/helpers/bulkUploadQualificationHelper');
+
+const buildMockQualificationEntity = async (override = {}) => {
+  const mockQualificationEntity = new Qualification(null, null);
+
+  await mockQualificationEntity.load({
+    uid: null,
+    created: null,
+    updated: null,
+    updatedBy: null,
+    qualification: {
+      id: 152,
+      title: 'Level 2 Adult Social Care Certificate',
+      level: null,
+      group: 'Certificate',
+    },
+    year: 2023,
+    notes: 'test notes',
+    qualificationCertificates: [],
+    ...override,
+  });
+
+  return mockQualificationEntity;
+};
+
+const buildMockWorkerQualification = (override = {}) => {
+  return new models.workerQualifications({
+    uid: uuidv4(),
+    workerFk: '100',
+    qualificationFk: 152,
+    created: new Date(),
+    updated: new Date(),
+    source: 'Online',
+    updatedBy: 'test',
+    ...override,
+  });
+};
+
+describe.only('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () => {
+  const mockWorkerId = '100';
+  const mockWorkerUid = uuidv4();
+  const mockEstablishmentId = '210';
+  const mockSavedBy = 'admin3';
+  const mockBulkUploaded = true;
+  const mockExternalTransaction = { sequelize: 'mockSequelizeTransactionObject' };
+
+  const setupHelper = () => {
+    return new BulkUploadQualificationHelper({
+      workerId: mockWorkerId,
+      workerUid: mockWorkerUid,
+      establishmentId: mockEstablishmentId,
+      savedBy: mockSavedBy,
+      bulkUploaded: mockBulkUploaded,
+      externalTransaction: mockExternalTransaction,
+    });
+  };
+
+  it('should instantiates', () => {
+    const helper = setupHelper();
+    expect(helper instanceof BulkUploadQualificationHelper).to.be.true;
+  });
+
+  describe('makePromisesForQualificationsEntities', () => {
+    let mockExistingQualifications = [];
+    let mockQualificationsEntities = [];
+    const helper = setupHelper();
+
+    beforeEach(async () => {
+      mockExistingQualifications = [
+        buildMockWorkerQualification({ qualificationFk: 31 }), // to modify
+        buildMockWorkerQualification({ qualificationFk: 1 }), // to delete
+        buildMockWorkerQualification({ qualificationFk: 2 }), // to delete
+        buildMockWorkerQualification({ qualificationFk: 152 }), // to modify
+      ];
+      mockQualificationsEntities = await Promise.all(
+        [
+          { qualification: { id: 3 } }, // new
+          { qualification: { id: 4 } }, // new
+          { qualification: { id: 152 } }, // existing
+          { qualification: { id: 31 } }, // existing
+        ].map(buildMockQualificationEntity),
+      );
+
+      sinon.stub(helper, 'createNewQualification').callsFake(() => {
+        return Promise.resolve();
+      });
+      sinon.stub(helper, 'updateQualification').callsFake(() => {
+        return Promise.resolve();
+      });
+      sinon.stub(helper, 'deleteQualification').callsFake(() => {
+        return Promise.resolve();
+      });
+
+      sinon.stub(models.workerQualifications, 'findAll').resolves(mockExistingQualifications);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should call createNewQualification for each new qualification added', async () => {
+      const returnedPromises = await helper.processQualificationsEntities(mockQualificationsEntities);
+
+      expect(helper.createNewQualification).to.have.been.calledTwice;
+      expect(helper.createNewQualification).to.have.been.calledWith(mockQualificationsEntities[0]);
+      expect(helper.createNewQualification).to.have.been.calledWith(mockQualificationsEntities[1]);
+
+      expect(returnedPromises)
+        .to.be.an('array')
+        .that.includes(helper.createNewQualification.returnValues[0], helper.createNewQualification.returnValues[1]);
+    });
+
+    it('should call updateQualification for each qualification that is modified', async () => {
+      const returnedPromises = await helper.processQualificationsEntities(mockQualificationsEntities);
+
+      expect(helper.updateQualification).to.have.been.calledTwice;
+      expect(helper.updateQualification).to.have.been.calledWith(
+        mockExistingQualifications[0],
+        mockQualificationsEntities[3],
+      );
+      expect(helper.updateQualification).to.have.been.calledWith(
+        mockExistingQualifications[3],
+        mockQualificationsEntities[2],
+      );
+
+      expect(returnedPromises)
+        .to.be.an('array')
+        .that.includes(helper.updateQualification.returnValues[0], helper.updateQualification.returnValues[1]);
+    });
+
+    it('should call deleteQualification for each existing qualification that is not in the bulk upload entities', async () => {
+      const returnedPromises = await helper.processQualificationsEntities(mockQualificationsEntities);
+
+      expect(helper.deleteQualification).to.have.been.calledTwice;
+      expect(helper.deleteQualification).to.have.been.calledWith(mockExistingQualifications[1]);
+      expect(helper.deleteQualification).to.have.been.calledWith(mockExistingQualifications[2]);
+
+      expect(returnedPromises)
+        .to.be.an('array')
+        .that.includes(helper.deleteQualification.returnValues[0], helper.deleteQualification.returnValues[1]);
+    });
+  });
+
+  describe('createNewQualification', () => {
+    beforeEach(() => {
+      sinon.stub(Qualification.prototype, 'save').callsFake(() => {
+        return Promise.resolve();
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    const helper = setupHelper();
+
+    it('should return a promise that saves the new qualification to database', async () => {
+      const entityFromBulkUpload = await buildMockQualificationEntity();
+      const returnedPromise = helper.createNewQualification(entityFromBulkUpload);
+
+      expect(entityFromBulkUpload.workerId).to.equal(mockWorkerId);
+      expect(entityFromBulkUpload.workerUid).to.equal(mockWorkerUid);
+      expect(entityFromBulkUpload.establishmentId).to.equal(mockEstablishmentId);
+
+      expect(entityFromBulkUpload.save).to.have.been.calledWith(
+        mockSavedBy,
+        mockBulkUploaded,
+        0,
+        mockExternalTransaction,
+      );
+
+      expect(returnedPromise).to.be.a('promise');
+      expect(returnedPromise).to.equal(entityFromBulkUpload.save.returnValues[0]);
+    });
+  });
+
+  describe('updateQualification', () => {
+    beforeEach(() => {
+      sinon.stub(models.workerQualifications.prototype, 'save').callsFake(() => {
+        return Promise.resolve();
+      });
+    });
+
+    const helper = setupHelper();
+
+    it('should return a promise that updates the existing record according to incoming bulk upload entity', async () => {
+      const mockExistingRecord = buildMockWorkerQualification();
+      const mockEntityFromBulkUpload = await buildMockQualificationEntity();
+
+      const returnedPromise = helper.updateQualification(mockExistingRecord, mockEntityFromBulkUpload);
+
+      expect(mockExistingRecord.updatedBy).to.equal(mockSavedBy.toLowerCase());
+      expect(mockExistingRecord.source).to.equal('Bulk');
+      expect(mockExistingRecord.notes).to.equal(mockEntityFromBulkUpload.notes);
+      expect(mockExistingRecord.year).to.equal(mockEntityFromBulkUpload.year);
+
+      expect(mockExistingRecord.save).to.have.been.calledWith({ transaction: mockExternalTransaction });
+
+      expect(returnedPromise).to.be.a('promise');
+      expect(returnedPromise).to.equal(mockExistingRecord.save.returnValues[0]);
+    });
+  });
+});

--- a/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
+++ b/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
@@ -69,7 +69,7 @@ describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () =
     expect(helper instanceof BulkUploadQualificationHelper).to.be.true;
   });
 
-  describe('makePromisesForQualificationsEntities', () => {
+  describe('processQualificationsEntities', () => {
     let mockExistingQualifications = [];
     let mockQualificationsEntities = [];
     const helper = setupHelper();
@@ -171,15 +171,15 @@ describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () =
       expect(entityFromBulkUpload.workerUid).to.equal(mockWorkerUid);
       expect(entityFromBulkUpload.establishmentId).to.equal(mockEstablishmentId);
 
+      expect(returnedPromise).to.be.a('promise');
+
+      await returnedPromise;
       expect(entityFromBulkUpload.save).to.have.been.calledWith(
         mockSavedBy,
         mockBulkUploaded,
         0,
         mockExternalTransaction,
       );
-
-      expect(returnedPromise).to.be.a('promise');
-      expect(returnedPromise).to.equal(entityFromBulkUpload.save.returnValues[0]);
     });
   });
 
@@ -232,8 +232,10 @@ describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () =
       const mockExistingRecord = buildMockWorkerQualification();
       sinon.stub(mockExistingRecord, 'getQualificationCertificates').returns([]);
 
-      await helper.deleteQualification(mockExistingRecord);
+      const returnedPromise = helper.deleteQualification(mockExistingRecord);
+      expect(returnedPromise).to.be.a('promise');
 
+      await returnedPromise;
       expect(mockExistingRecord.destroy).to.have.been.calledWith({ transaction: mockExternalTransaction });
       expect(qualificationCertificateServiceSpy).not.to.have.been.called;
     });
@@ -246,8 +248,10 @@ describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () =
       ];
       sinon.stub(mockExistingRecord, 'getQualificationCertificates').returns(mockCertificateRecords);
 
-      await helper.deleteQualification(mockExistingRecord);
+      const returnedPromise = helper.deleteQualification(mockExistingRecord);
+      expect(returnedPromise).to.be.a('promise');
 
+      await returnedPromise;
       expect(qualificationCertificateServiceSpy).to.have.been.calledWith(
         mockCertificateRecords,
         mockExternalTransaction,

--- a/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
+++ b/backend/server/test/unit/models/classes/helpers/bulkUploadQualificationHelper.spec.js
@@ -59,7 +59,6 @@ describe('/server/models/classes/helpers/bulkUploadQualificationHelper.js', () =
       workerUid: mockWorkerUid,
       establishmentId: mockEstablishmentId,
       savedBy: mockSavedBy,
-      bulkUploaded: mockBulkUploaded,
       externalTransaction: mockExternalTransaction,
     });
   };


### PR DESCRIPTION
#### Work done
- Add a helper class to manage qualification changes in bulk upload
- On UPDATE, modify existing qualification records instead of always deleting and creating again
- On DELETE, delete any certificates record first before deleting the qualification record, so that we don't trigger fk violation errors.
- When downloading or deleting certificates, use the key from database instead of calling `makeFileKey` all the time

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
