### PR TITLE
Fix/navigation after deletion of training or qual record

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -155,8 +155,31 @@ describe('DeleteRecordComponent', () => {
         );
       });
 
-      it('should navigate to the worker training and qualifications summary page and set a training deleted alert after user clicks delete button', async () => {
+      it("should navigate to previousUrl and set training deleted alert after clicking 'Delete record' when previousUrl exists", async () => {
         const { component, fixture, getByText, routerSpy, alertServiceSpy } = await setup();
+
+        const previousUrl = '/goToPreviousUrl';
+        spyOn(localStorage, 'getItem').and.returnValue(previousUrl);
+        component.ngOnInit();
+
+        const deleteButton = getByText('Delete record');
+        fireEvent.click(deleteButton);
+
+        expect(routerSpy).toHaveBeenCalledWith([previousUrl]);
+
+        fixture.whenStable().then(() => {
+          expect(alertServiceSpy).toHaveBeenCalledWith({
+            type: 'success',
+            message: 'Training record deleted',
+          });
+        });
+      });
+
+      it("should navigate to worker training and quals summary page and set training deleted alert after clicking 'Delete record' when previousUrl doesn't exist", async () => {
+        const { component, fixture, getByText, routerSpy, alertServiceSpy } = await setup();
+
+        spyOn(localStorage, 'getItem').and.returnValue(null);
+        component.ngOnInit();
 
         const deleteButton = getByText('Delete record');
         fireEvent.click(deleteButton);
@@ -240,8 +263,31 @@ describe('DeleteRecordComponent', () => {
         );
       });
 
-      it('should navigate to the worker training and qualifications summary page and set a qualification deleted alert after user clicks delete button', async () => {
+      it("should navigate to previousUrl and set qualification deleted alert after clicking 'Delete record' when previousUrl exists", async () => {
         const { component, fixture, getByText, routerSpy, alertServiceSpy } = await setup(false);
+
+        const previousUrl = '/goToPreviousUrl';
+        spyOn(localStorage, 'getItem').and.returnValue(previousUrl);
+        component.ngOnInit();
+
+        const deleteButton = getByText('Delete record');
+        fireEvent.click(deleteButton);
+
+        expect(routerSpy).toHaveBeenCalledWith([previousUrl]);
+
+        fixture.whenStable().then(() => {
+          expect(alertServiceSpy).toHaveBeenCalledWith({
+            type: 'success',
+            message: 'Qualification record deleted',
+          });
+        });
+      });
+
+      it("should navigate to worker training and quals summary page and set qualification deleted alert after clicking 'Delete record' when previousUrl doesn't exist", async () => {
+        const { component, fixture, getByText, routerSpy, alertServiceSpy } = await setup(false);
+
+        spyOn(localStorage, 'getItem').and.returnValue(null);
+        component.ngOnInit();
 
         const deleteButton = getByText('Delete record');
         fireEvent.click(deleteButton);

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.spec.ts
@@ -155,15 +155,16 @@ describe('DeleteRecordComponent', () => {
         );
       });
 
-      it('should navigate to the view training page when pressing the delete button and set an alert message in thw history state', async () => {
+      it('should navigate to the worker training and qualifications summary page and set a training deleted alert after user clicks delete button', async () => {
         const { component, fixture, getByText, routerSpy, alertServiceSpy } = await setup();
-        component.previousUrl = ['/goToPreviousUrl'];
-        fixture.detectChanges();
 
         const deleteButton = getByText('Delete record');
         fireEvent.click(deleteButton);
 
-        expect(routerSpy).toHaveBeenCalledWith(['/goToPreviousUrl']);
+        expect(routerSpy).toHaveBeenCalledWith([
+          `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
+          'training',
+        ]);
 
         fixture.whenStable().then(() => {
           expect(alertServiceSpy).toHaveBeenCalledWith({
@@ -239,25 +240,24 @@ describe('DeleteRecordComponent', () => {
         );
       });
 
-      it('should navigate to the qualification page when pressing the delete button and set a alert message in the history state', async () => {
+      it('should navigate to the worker training and qualifications summary page and set a qualification deleted alert after user clicks delete button', async () => {
         const { component, fixture, getByText, routerSpy, alertServiceSpy } = await setup(false);
-        component.previousUrl = ['/goToPreviousUrl'];
-        fixture.detectChanges();
 
         const deleteButton = getByText('Delete record');
         fireEvent.click(deleteButton);
 
-        expect(routerSpy).toHaveBeenCalledWith(['/goToPreviousUrl']);
+        expect(routerSpy).toHaveBeenCalledWith([
+          `workplace/${component.workplace.uid}/training-and-qualifications-record/${component.worker.uid}`,
+          'training',
+        ]);
 
         fixture.whenStable().then(() => {
           expect(alertServiceSpy).toHaveBeenCalledWith({
             type: 'success',
-            message:  'Qualification record deleted',
+            message: 'Qualification record deleted',
           });
         });
       });
     });
   });
 });
-
-

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -45,6 +45,7 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   private setTrainingView(): void {
     this.trainingView = this.route.snapshot.data.trainingRecord ? true : false;
     this.trainingOrQualification = this.trainingView ? 'training' : 'qualification';
+
     if (this.trainingView) {
       this.trainingRecord = this.route.snapshot.data.trainingRecord;
       this.recordUid = this.trainingRecord.uid;
@@ -72,7 +73,7 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
     const message = `${this.capitalizeFirstLetter(this.trainingOrQualification)} record deleted`;
     this.subscriptions.add(
       this.deleteTrainingOrQualificationRecord().subscribe(() => {
-        this.router.navigate(this.previousUrl).then(()=>{
+        this.router.navigate([this.trainingPageUrl, 'training']).then(() => {
           this.alertService.addAlert({
             type: 'success',
             message: message,

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -23,7 +23,6 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   private trainingPageUrl: string;
   private recordUid: string;
   private subscriptions: Subscription = new Subscription();
-  public previousUrl: string[];
 
   constructor(
     private route: ActivatedRoute,
@@ -36,7 +35,6 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.setTrainingView();
     this.setVariables();
-    this.previousUrl = [localStorage.getItem('previousUrl')];
 
     this.trainingPageUrl = `workplace/${this.workplace.uid}/training-and-qualifications-record/${this.worker.uid}`;
     this.setBackLink();
@@ -96,6 +94,5 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
-    localStorage.removeItem('previousUrl');
   }
 }

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -21,6 +21,7 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   public trainingOrQualification: string;
   public trainingView: boolean;
   private workerTrainingAndQualsSummaryUrl: string;
+  public previousUrl: string;
   private recordUid: string;
   private subscriptions: Subscription = new Subscription();
 
@@ -37,6 +38,7 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
     this.setVariables();
 
     this.workerTrainingAndQualsSummaryUrl = `workplace/${this.workplace.uid}/training-and-qualifications-record/${this.worker.uid}`;
+    this.previousUrl = localStorage.getItem('previousUrl');
     this.setBackLink();
   }
 
@@ -71,12 +73,14 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
     const message = `${this.capitalizeFirstLetter(this.trainingOrQualification)} record deleted`;
     this.subscriptions.add(
       this.deleteTrainingOrQualificationRecord().subscribe(() => {
-        this.router.navigate([this.workerTrainingAndQualsSummaryUrl, 'training']).then(() => {
-          this.alertService.addAlert({
-            type: 'success',
-            message: message,
+        this.router
+          .navigate(this.previousUrl ? [this.previousUrl] : [this.workerTrainingAndQualsSummaryUrl, 'training'])
+          .then(() => {
+            this.alertService.addAlert({
+              type: 'success',
+              message: message,
+            });
           });
-        });
       }),
     );
   }
@@ -94,5 +98,6 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
+    localStorage.removeItem('previousUrl');
   }
 }

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component.ts
@@ -20,7 +20,7 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
   public qualificationRecord: QualificationResponse;
   public trainingOrQualification: string;
   public trainingView: boolean;
-  private trainingPageUrl: string;
+  private workerTrainingAndQualsSummaryUrl: string;
   private recordUid: string;
   private subscriptions: Subscription = new Subscription();
 
@@ -36,7 +36,7 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
     this.setTrainingView();
     this.setVariables();
 
-    this.trainingPageUrl = `workplace/${this.workplace.uid}/training-and-qualifications-record/${this.worker.uid}`;
+    this.workerTrainingAndQualsSummaryUrl = `workplace/${this.workplace.uid}/training-and-qualifications-record/${this.worker.uid}`;
     this.setBackLink();
   }
 
@@ -64,14 +64,14 @@ export class DeleteRecordComponent implements OnInit, OnDestroy {
 
   public returnToEditPage(event: Event): void {
     event.preventDefault();
-    this.router.navigate([this.trainingPageUrl, this.trainingOrQualification, this.recordUid]);
+    this.router.navigate([this.workerTrainingAndQualsSummaryUrl, this.trainingOrQualification, this.recordUid]);
   }
 
   public deleteRecord(): void {
     const message = `${this.capitalizeFirstLetter(this.trainingOrQualification)} record deleted`;
     this.subscriptions.add(
       this.deleteTrainingOrQualificationRecord().subscribe(() => {
-        this.router.navigate([this.trainingPageUrl, 'training']).then(() => {
+        this.router.navigate([this.workerTrainingAndQualsSummaryUrl, 'training']).then(() => {
           this.alertService.addAlert({
             type: 'success',
             message: message,


### PR DESCRIPTION
#### Issue
A small bug was found where if you click on ‘Delete this training/qualification record’ and then click back or cancel, then go back to the delete page and confirm deletion, the page freezes but if you then go back to the worker’s training and quals summary, the record has been deleted.

This was due to previousUrl in localStorage (used to allow navigation to either the worker training and quals summary or the expired/expiring training pages) getting cleared on destroy of the Delete record component. As this was considered a minor issue, this fix just sets the worker training and quals summary as a default to navigate to for the case where there is no previousUrl set.

#### Work done
- Set the worker training and quals summary as a default for navigation after qualification/training record deletion to prevent the page freezing and confusion of record still being deleted when user has navigated back and forth from Delete record page

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
