### PR TITLE
Increase efficiency of check for training certificates on Bulk Upload page

### DIFF
--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2400,8 +2400,7 @@ module.exports = function (sequelize, DataTypes) {
       `
       SELECT 1 FROM cqc."Establishment" establishment
         INNER JOIN cqc."Worker" worker ON establishment."EstablishmentID" = worker."EstablishmentFK"
-        INNER JOIN cqc."WorkerTraining" workerTraining ON worker."ID" = workerTraining."WorkerFK"
-        INNER JOIN cqc."TrainingCertificates" trainingCertificate ON workerTraining."WorkerFK" = trainingCertificate."WorkerFK"
+        INNER JOIN cqc."TrainingCertificates" trainingCertificate ON worker."ID" = trainingCertificate."WorkerFK"
         WHERE establishment."Archived" = false AND worker."Archived" = false
           AND (establishment."EstablishmentID" = :workplaceId OR establishment."ParentID" = :workplaceId)
         LIMIT 1;

--- a/backend/server/routes/establishments/hasTrainingCertificates.js
+++ b/backend/server/routes/establishments/hasTrainingCertificates.js
@@ -3,20 +3,13 @@ const models = require('../../models');
 
 const workplaceOrSubHasTrainingCertificates = async (req, res) => {
   try {
-    const workplacesWithTrainingCertificates = await models.establishment.getTrainingCertificatesForWorkplaceAndAnySubs(
+    const hasTrainingCertificates = await models.establishment.workplaceOrSubHasAtLeastOneTrainingCertificate(
       req.establishmentId,
-    );
-
-    const hasTrainingCertificates = workplacesWithTrainingCertificates.some((workplace) =>
-      workplace.workers.some((worker) =>
-        worker.workerTraining.some(
-          (training) => training.trainingCertificates && training.trainingCertificates.length > 0,
-        ),
-      ),
     );
 
     return res.status(200).json({ hasTrainingCertificates });
   } catch (error) {
+    console.error(error);
     return res.status(500).send('Failed to complete check for training certificates');
   }
 };

--- a/backend/server/test/unit/routes/establishments/hasTrainingCertificates.spec.js
+++ b/backend/server/test/unit/routes/establishments/hasTrainingCertificates.spec.js
@@ -26,21 +26,8 @@ describe('server/routes/establishments/hasTrainingCertificates', () => {
   });
 
   describe('workplaceOrSubHasTrainingCertificates', () => {
-    it('should return 200 status and false when single workplace has no workers with training certificates', async () => {
-      sinon.stub(models.establishment, 'getTrainingCertificatesForWorkplaceAndAnySubs').returns([
-        {
-          id: 123,
-          workers: [
-            {
-              workerTraining: [
-                {
-                  trainingCertificates: [],
-                },
-              ],
-            },
-          ],
-        },
-      ]);
+    it('should return 200 status and hasTrainingCertificates as false when false returned from DB query', async () => {
+      sinon.stub(models.establishment, 'workplaceOrSubHasAtLeastOneTrainingCertificate').returns(false);
 
       await workplaceOrSubHasTrainingCertificates(req, res);
       const response = res._getJSONData();
@@ -49,108 +36,8 @@ describe('server/routes/establishments/hasTrainingCertificates', () => {
       expect(response.hasTrainingCertificates).to.equal(false);
     });
 
-    it('should return 200 status and true when single workplace has workers with training certificates', async () => {
-      sinon.stub(models.establishment, 'getTrainingCertificatesForWorkplaceAndAnySubs').returns([
-        {
-          id: 123,
-          workers: [
-            {
-              workerTraining: [
-                {
-                  trainingCertificates: [],
-                },
-                {
-                  trainingCertificates: [{ id: 123 }],
-                },
-              ],
-            },
-          ],
-        },
-      ]);
-
-      await workplaceOrSubHasTrainingCertificates(req, res);
-      const response = res._getJSONData();
-
-      expect(res.statusCode).to.deep.equal(200);
-      expect(response.hasTrainingCertificates).to.equal(true);
-    });
-
-    it('should return 200 status and false when several workplaces which do not have workers with training certificates', async () => {
-      sinon.stub(models.establishment, 'getTrainingCertificatesForWorkplaceAndAnySubs').returns([
-        {
-          id: 123,
-          workers: [
-            {
-              workerTraining: [
-                {
-                  trainingCertificates: [],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          id: 456,
-          workers: [],
-        },
-        {
-          id: 789,
-          workers: [
-            {
-              workerTraining: [
-                {
-                  trainingCertificates: [],
-                },
-                {
-                  trainingCertificates: [],
-                },
-              ],
-            },
-          ],
-        },
-      ]);
-
-      await workplaceOrSubHasTrainingCertificates(req, res);
-      const response = res._getJSONData();
-
-      expect(res.statusCode).to.deep.equal(200);
-      expect(response.hasTrainingCertificates).to.equal(false);
-    });
-
-    it('should return 200 status and true when several workplaces where one has a worker with a training certificate', async () => {
-      sinon.stub(models.establishment, 'getTrainingCertificatesForWorkplaceAndAnySubs').returns([
-        {
-          id: 123,
-          workers: [
-            {
-              workerTraining: [
-                {
-                  trainingCertificates: [],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          id: 456,
-          workers: [],
-        },
-        {
-          id: 789,
-          workers: [
-            {
-              workerTraining: [
-                {
-                  trainingCertificates: [],
-                },
-                {
-                  trainingCertificates: [{ id: 12 }],
-                },
-              ],
-            },
-          ],
-        },
-      ]);
+    it('should return 200 status and hasTrainingCertificates as true when true returned from DB query', async () => {
+      sinon.stub(models.establishment, 'workplaceOrSubHasAtLeastOneTrainingCertificate').returns(true);
 
       await workplaceOrSubHasTrainingCertificates(req, res);
       const response = res._getJSONData();
@@ -160,7 +47,7 @@ describe('server/routes/establishments/hasTrainingCertificates', () => {
     });
 
     it('should return 500 status and default error message when DB call throws error', async () => {
-      sinon.stub(models.establishment, 'getTrainingCertificatesForWorkplaceAndAnySubs').throws();
+      sinon.stub(models.establishment, 'workplaceOrSubHasAtLeastOneTrainingCertificate').throws();
 
       await workplaceOrSubHasTrainingCertificates(req, res);
 


### PR DESCRIPTION
#### Issue
With the introduction of training certificates, a check was added to the bulk upload page for training certificates for the workplace or any subs, in order to display a warning that the certificates will be deleted if they upload the training file. The functionality worked as expected, but for one particularly large parent workplace, the page was failing to load and the server continually returned a 503 response. This PR attempts to improve the efficiency of the endpoint.  

#### Work done
- Increased efficiency of hasTrainingCertificates endpoint by using raw sql and SELECT 1 instead of returning all data and looping through

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
