### PR TITLE
fix/routing-on-vacancy-first-page

### DIFF
--- a/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.spec.ts
@@ -310,87 +310,97 @@ describe('DoYouHaveVacanciesComponent', () => {
 
         expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'starters']);
       });
+
+      it('should navigate to the starters page when clicking Skip this question link', async () => {
+        const overrides = { returnUrl: false };
+        const { fixture, getByText, routerSpy } = await setup(overrides);
+
+        const link = getByText('Skip this question');
+        fireEvent.click(link);
+        fixture.detectChanges();
+
+        expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'starters']);
+      });
+
+      it(`should call the setSubmitAction function with an action of skip and save as false when clicking 'Skip this question' link`, async () => {
+        const overrides = { returnUrl: false };
+
+        const { component, getByText } = await setup(overrides);
+
+        const setSubmitActionSpy = spyOn(component, 'setSubmitAction').and.callThrough();
+
+        const link = getByText('Skip this question');
+        fireEvent.click(link);
+
+        expect(setSubmitActionSpy).toHaveBeenCalledWith({ action: 'skip', save: false });
+      });
     });
 
-    it('should navigate to the starters page when clicking Skip this question link', async () => {
-      const overrides = { returnUrl: false };
-      const { fixture, getByText, routerSpy } = await setup(overrides);
+    describe('workplace summary page', () => {
+      it(`should show 'Continue' cta button and 'Cancel' link if a return url is provided`, async () => {
+        const overrides = { returnUrl: true };
 
-      const link = getByText('Skip this question');
-      fireEvent.click(link);
-      fixture.detectChanges();
+        const { getByText } = await setup(overrides);
 
-      expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'starters']);
-    });
+        expect(getByText('Continue')).toBeTruthy();
+        expect(getByText('Cancel')).toBeTruthy();
+      });
 
-    it(`should call the setSubmitAction function with an action of skip and save as false when clicking 'Skip this question' link`, async () => {
-      const overrides = { returnUrl: false };
+      it("should navigate to the select vacancy job roles page when submitting 'Yes'", async () => {
+        const overrides = { returnUrl: true };
 
-      const { component, getByText } = await setup(overrides);
+        const { component, fixture, getByText, routerSpy } = await setup(overrides);
 
-      const setSubmitActionSpy = spyOn(component, 'setSubmitAction').and.callThrough();
+        component.form.get('vacanciesKnown').setValue('With Jobs');
 
-      const link = getByText('Skip this question');
-      fireEvent.click(link);
+        const button = getByText('Continue');
+        fireEvent.click(button);
+        fixture.detectChanges();
 
-      expect(setSubmitActionSpy).toHaveBeenCalledWith({ action: 'skip', save: false });
-    });
+        expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'select-vacancy-job-roles']);
+      });
 
-    it(`should show 'Continue' cta button and 'Cancel' link if a return url is provided`, async () => {
-      const overrides = { returnUrl: true };
+      it("should navigate to the workplace summary page when submitting 'None'", async () => {
+        const overrides = { returnUrl: true };
 
-      const { getByText } = await setup(overrides);
+        const { component, fixture, getByText, routerSpy } = await setup(overrides);
 
-      expect(getByText('Continue')).toBeTruthy();
-      expect(getByText('Cancel')).toBeTruthy();
-    });
+        component.form.get('vacanciesKnown').setValue('None');
 
-    it("should navigate to the select vacancy job roles page when submitting 'Yes'", async () => {
-      const { component, fixture, getByText, routerSpy } = await setup();
+        const button = getByText('Continue');
+        fireEvent.click(button);
+        fixture.detectChanges();
 
-      component.form.get('vacanciesKnown').setValue('With Jobs');
+        expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
+      });
 
-      const button = getByText('Continue');
-      fireEvent.click(button);
-      fixture.detectChanges();
+      it("should navigate to the workplace summary page when submitting 'I do not know'", async () => {
+        const overrides = { returnUrl: true };
 
-      expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'select-vacancy-job-roles']);
-    });
+        const { component, fixture, getByText, routerSpy } = await setup(overrides);
 
-    it("should navigate to the workplace summary page when submitting 'None'", async () => {
-      const { component, fixture, getByText, routerSpy } = await setup();
+        component.form.get('vacanciesKnown').setValue('I do not know');
 
-      component.form.get('vacanciesKnown').setValue('None');
+        const button = getByText('Continue');
+        fireEvent.click(button);
+        fixture.detectChanges();
 
-      const button = getByText('Continue');
-      fireEvent.click(button);
-      fixture.detectChanges();
+        expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
+      });
 
-      expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
-    });
+      it('should navigte to the correct page when clicking the cancel link', async () => {
+        const overrides = { returnUrl: true };
 
-    it("should navigate to the workplace summary page when submitting 'I do not know'", async () => {
-      const { component, fixture, getByText, routerSpy } = await setup();
+        const { component, fixture, getByText, routerSpy } = await setup(overrides);
 
-      component.form.get('vacanciesKnown').setValue('I do not know');
+        component.form.get('vacanciesKnown').setValue('None');
 
-      const button = getByText('Continue');
-      fireEvent.click(button);
-      fixture.detectChanges();
+        const link = getByText('Cancel');
+        fireEvent.click(link);
+        fixture.detectChanges();
 
-      expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
-    });
-
-    it('should navigte to the correct page when clicking the cancel link', async () => {
-      const { component, fixture, getByText, routerSpy } = await setup();
-
-      component.form.get('vacanciesKnown').setValue('None');
-
-      const link = getByText('Cancel');
-      fireEvent.click(link);
-      fixture.detectChanges();
-
-      expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
+        expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
+      });
     });
   });
 

--- a/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.spec.ts
@@ -268,7 +268,7 @@ describe('DoYouHaveVacanciesComponent', () => {
     });
 
     describe('workplace flow', () => {
-      it("should navigate to the starters page when submitting 'Yes'", async () => {
+      it("should navigate to the select vacancy job roles page when submitting 'Yes'", async () => {
         const overrides = { returnUrl: false };
 
         const { component, fixture, getByText, routerSpy } = await setup(overrides);
@@ -345,10 +345,34 @@ describe('DoYouHaveVacanciesComponent', () => {
       expect(getByText('Cancel')).toBeTruthy();
     });
 
-    it('should navigate to the summary page when submitting', async () => {
+    it("should navigate to the select vacancy job roles page when submitting 'Yes'", async () => {
+      const { component, fixture, getByText, routerSpy } = await setup();
+
+      component.form.get('vacanciesKnown').setValue('With Jobs');
+
+      const button = getByText('Continue');
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'select-vacancy-job-roles']);
+    });
+
+    it("should navigate to the workplace summary page when submitting 'None'", async () => {
       const { component, fixture, getByText, routerSpy } = await setup();
 
       component.form.get('vacanciesKnown').setValue('None');
+
+      const button = getByText('Continue');
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
+    });
+
+    it("should navigate to the workplace summary page when submitting 'I do not know'", async () => {
+      const { component, fixture, getByText, routerSpy } = await setup();
+
+      component.form.get('vacanciesKnown').setValue('I do not know');
 
       const button = getByText('Continue');
       fireEvent.click(button);

--- a/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.ts
@@ -100,6 +100,8 @@ export class DoYouHaveVacanciesComponent extends Question implements OnInit {
   protected onSuccess(): void {
     if (this.hasVacancies) {
       this.nextRoute = ['/workplace', `${this.establishment.uid}`, 'select-vacancy-job-roles'];
+    } else if (!this.hasVacancies && this.return) {
+      this.submitAction = { action: 'return', save: true };
     } else {
       this.nextRoute = ['/workplace', `${this.establishment.uid}`, 'starters'];
     }

--- a/frontend/src/app/shared/components/workplace-submit-button/workplace-submit-button.component.html
+++ b/frontend/src/app/shared/components/workplace-submit-button/workplace-submit-button.component.html
@@ -22,7 +22,7 @@
   </ng-container>
   <ng-template #summary>
     <ng-container *ngIf="continue; else saveAndContinue">
-      <button type="submit" class="govuk-button govuk-!-margin-right-9" (click)="onButtonClick('return', true)">
+      <button type="submit" class="govuk-button govuk-!-margin-right-9" (click)="onButtonClick('continue', true)">
         Continue
       </button>
     </ng-container>


### PR DESCRIPTION
#### Work done
- Fix routing issue when selecting yes for vacancies outside flow so it goes to the second page

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
