### PR TITLE
Fix: Maintain/Create qualification records when doing CHGSUB in Bulk Upload 

### DIFF
--- a/backend/server/models/classes/worker.js
+++ b/backend/server/models/classes/worker.js
@@ -553,7 +553,7 @@ class Worker extends EntityValidator {
         });
       }
 
-      if (bulkUploaded && ['NEW', 'UPDATE'].includes(this.status)) {
+      if (bulkUploaded && ['NEW', 'UPDATE', 'CHGSUB'].includes(this.status)) {
         const qualificationHelper = new BulkUploadQualificationHelper({
           workerId: this._id,
           workerUid: this._uid,


### PR DESCRIPTION
#### Issue
Qualifications were not being created/copied across when doing CHGSUB in Bulk Upload. This was due to the qualification logic only running when the status was NEW or UPDATE. There is still an issue with qualification certificates being copied across but a fix for this will go through after the quals certificates feature.

#### Work done
- Added CHGSUB to the if branch condition to call BulkUploadQualificationHelper

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
