### PR TITLE
Fix: Only return expected error messages from certificate endpoints

### DIFF
--- a/backend/server/routes/establishments/workerCertificate/qualificationCertificate.js
+++ b/backend/server/routes/establishments/workerCertificate/qualificationCertificate.js
@@ -22,7 +22,7 @@ const requestUploadUrlEndpoint = async (req, res) => {
     );
     return res.status(200).json({ files: responsePayload });
   } catch (err) {
-    return res.status(err.statusCode).send(err.message);
+    return certificateService.sendErrorResponse(res, err);
   }
 };
 
@@ -33,7 +33,7 @@ const confirmUploadEndpoint = async (req, res) => {
     await certificateService.confirmUpload(req.body.files, req.params.qualificationUid);
     return res.status(200).send();
   } catch (err) {
-    return res.status(err.statusCode).send(err.message);
+    return certificateService.sendErrorResponse(res, err);
   }
 };
 
@@ -49,7 +49,7 @@ const getPresignedUrlForCertificateDownloadEndpoint = async (req, res) => {
     );
     return res.status(200).json({ files: responsePayload });
   } catch (err) {
-    return res.status(err.statusCode).send(err.message);
+    return certificateService.sendErrorResponse(res, err);
   }
 };
 
@@ -65,7 +65,7 @@ const deleteCertificatesEndpoint = async (req, res) => {
     );
     return res.status(200).send();
   } catch (err) {
-    return res.status(err.statusCode).send(err.message);
+    return certificateService.sendErrorResponse(res, err);
   }
 };
 

--- a/backend/server/routes/establishments/workerCertificate/trainingCertificate.js
+++ b/backend/server/routes/establishments/workerCertificate/trainingCertificate.js
@@ -8,16 +8,21 @@ const router = express.Router({ mergeParams: true });
 
 const initialiseCertificateService = () => {
   return WorkerCertificateService.initialiseTraining();
-}
+};
 
 const requestUploadUrlEndpoint = async (req, res) => {
   const certificateService = initialiseCertificateService();
 
   try {
-    const responsePayload = await certificateService.requestUploadUrl(req.body.files, req.params.id, req.params.workerId, req.params.trainingUid);
+    const responsePayload = await certificateService.requestUploadUrl(
+      req.body.files,
+      req.params.id,
+      req.params.workerId,
+      req.params.trainingUid,
+    );
     return res.status(200).json({ files: responsePayload });
   } catch (err) {
-    return res.status(err.statusCode).send(err.message);
+    return certificateService.sendErrorResponse(res, err);
   }
 };
 
@@ -28,7 +33,7 @@ const confirmUploadEndpoint = async (req, res) => {
     await certificateService.confirmUpload(req.body.files, req.params.trainingUid);
     return res.status(200).send();
   } catch (err) {
-    return res.status(err.statusCode).send(err.message);
+    return certificateService.sendErrorResponse(res, err);
   }
 };
 
@@ -36,10 +41,15 @@ const getPresignedUrlForCertificateDownloadEndpoint = async (req, res) => {
   const certificateService = initialiseCertificateService();
 
   try {
-    const responsePayload = await certificateService.getPresignedUrlForCertificateDownload(req.body.files, req.params.id, req.params.workerId, req.params.trainingUid);
+    const responsePayload = await certificateService.getPresignedUrlForCertificateDownload(
+      req.body.files,
+      req.params.id,
+      req.params.workerId,
+      req.params.trainingUid,
+    );
     return res.status(200).json({ files: responsePayload });
   } catch (err) {
-    return res.status(err.statusCode).send(err.message);
+    return certificateService.sendErrorResponse(res, err);
   }
 };
 
@@ -47,10 +57,15 @@ const deleteCertificatesEndpoint = async (req, res) => {
   const certificateService = initialiseCertificateService();
 
   try {
-    await certificateService.deleteCertificates(req.body.files, req.params.id, req.params.workerId, req.params.trainingUid);
+    await certificateService.deleteCertificates(
+      req.body.files,
+      req.params.id,
+      req.params.workerId,
+      req.params.trainingUid,
+    );
     return res.status(200).send();
   } catch (err) {
-    return res.status(err.statusCode).send(err.message);
+    return certificateService.sendErrorResponse(res, err);
   }
 };
 

--- a/backend/server/routes/establishments/workerCertificate/workerCertificateService.js
+++ b/backend/server/routes/establishments/workerCertificate/workerCertificateService.js
@@ -251,6 +251,14 @@ class WorkerCertificateService {
     });
     await this.certificatesModel.destroy({ where: { uid: certificateRecordUids }, transaction: externalTransaction });
   }
+
+  sendErrorResponse(res, err) {
+    if (err instanceof HttpError) {
+      return res.status(err.statusCode).send(err.message);
+    }
+    console.error('WorkerCertificateService error: ', err);
+    return res.status(500).send('Internal server error');
+  }
 }
 
 module.exports = WorkerCertificateService;

--- a/backend/server/test/unit/routes/establishments/workerCertificate/workerCertificateService.spec.js
+++ b/backend/server/test/unit/routes/establishments/workerCertificate/workerCertificateService.spec.js
@@ -10,6 +10,7 @@ const s3 = require('../../../../../routes/establishments/workerCertificate/s3');
 const config = require('../../../../../config/config');
 
 const WorkerCertificateService = require('../../../../../routes/establishments/workerCertificate/workerCertificateService');
+const HttpError = require('../../../../../utils/errors/httpError');
 
 describe('backend/server/routes/establishments/workerCertificate/workerCertificateService.js', () => {
   const user = buildUser();
@@ -31,7 +32,6 @@ describe('backend/server/routes/establishments/workerCertificate/workerCertifica
   describe('requestUploadUrl', () => {
     const mockUploadFiles = ['cert1.pdf', 'cert2.pdf'];
     const mockSignedUrl = 'http://localhost/mock-upload-url';
-    let res;
 
     beforeEach(() => {
       mockRequestBody = {
@@ -639,6 +639,30 @@ describe('backend/server/routes/establishments/workerCertificate/workerCertifica
         { Key: 'file-key-2' },
         { Key: 'file-key-3' },
       ]);
+    });
+  });
+
+  describe('sendErrorResponse', () => {
+    let res;
+
+    beforeEach(() => {
+      res = httpMocks.createResponse();
+    });
+
+    it('should send status code and message from error when HttpError thrown', async () => {
+      const errorThrown = new HttpError('Invalid request', 400);
+
+      services.qualifications.sendErrorResponse(res, errorThrown);
+      expect(res.statusCode).to.equal(400);
+      expect(res._getData()).to.equal('Invalid request');
+    });
+
+    it('should send 500 status code and Internal server error message when unexpected error', async () => {
+      const errorThrown = new Error('Unexpected error');
+
+      services.qualifications.sendErrorResponse(res, errorThrown);
+      expect(res.statusCode).to.equal(500);
+      expect(res._getData()).to.equal('Internal server error');
     });
   });
 });


### PR DESCRIPTION
#### Work done
- Updated certificate endpoints to send default Internal server error message when unexpected errors occur in the WorkerCertificate service

#### Reasoning
- We should not send error messages which come directly from unexpected errors being thrown in our codebase, these can confuse the user or give insight into issues with our code. This change means that expected cases where the requests are incorrectly formatted return specific messages, otherwise a generic message is returned. 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
