### PR TITLE
Fix: Allow change id and staff transfer

### DIFF
--- a/backend/server/models/BulkImport/csv/crossValidate.js
+++ b/backend/server/models/BulkImport/csv/crossValidate.js
@@ -171,7 +171,9 @@ const _addNewWorkplaceIdToWorkerEntity = (myAPIEstablishments, JSONWorker, newWo
 
   const workerEntity = myAPIEstablishments[oldWorkplaceKey].theWorker(workerEntityKey);
 
-  workerEntity._newWorkplaceId = newWorkplaceId;
+  if (workerEntity) {
+    workerEntity._newWorkplaceId = newWorkplaceId;
+  }
 };
 
 const _crossValidateWorkersWithSameRefMovingToSameWorkplace = (

--- a/backend/server/models/BulkImport/csv/crossValidate.js
+++ b/backend/server/models/BulkImport/csv/crossValidate.js
@@ -65,7 +65,7 @@ const crossValidateTransferStaffRecord = async (
   const allNewWorkers = myJSONWorkers.filter((worker) => worker.status === 'NEW');
   const allOtherWorkers = myJSONWorkers.filter((worker) => !isMovingToNewWorkplace(worker) && worker.status !== 'NEW');
 
-  const newWorkerWithDuplicateIdErrorAdded = _crossValidateWorkersWithSameRefMovingToSameWorkplace(
+  const newWorkerWithDuplicateIdErrorAdded = _crossValidateWorkersWithDuplicateRefsMovingToWorkplace(
     csvWorkerSchemaErrors,
     allMovingWorkers,
     allNewWorkers,
@@ -74,7 +74,7 @@ const crossValidateTransferStaffRecord = async (
 
   if (newWorkerWithDuplicateIdErrorAdded) return;
 
-  const existingWorkerWithDuplicateIdErrorAdded = _crossValidateWorkersWithSameRefMovingToSameWorkplace(
+  const existingWorkerWithDuplicateIdErrorAdded = _crossValidateWorkersWithDuplicateRefsMovingToWorkplace(
     csvWorkerSchemaErrors,
     allMovingWorkers,
     allOtherWorkers,
@@ -88,7 +88,6 @@ const crossValidateTransferStaffRecord = async (
       csvWorkerSchemaErrors,
       relatedEstablishmentIds,
       JSONWorker,
-      allOtherWorkers,
     );
 
     if (newWorkplaceId) {
@@ -101,12 +100,7 @@ const isMovingToNewWorkplace = (JSONWorker) => {
   return JSONWorker.status === 'UPDATE' && JSONWorker.transferStaffRecord;
 };
 
-const _validateTransferIsPossible = async (
-  csvWorkerSchemaErrors,
-  relatedEstablishmentIds,
-  JSONWorker,
-  allOtherWorkers,
-) => {
+const _validateTransferIsPossible = async (csvWorkerSchemaErrors, relatedEstablishmentIds, JSONWorker) => {
   const newWorkplaceLocalRef = JSONWorker.transferStaffRecord;
   const newWorkplaceId = await _getNewWorkplaceId(newWorkplaceLocalRef, relatedEstablishmentIds);
 
@@ -176,13 +170,13 @@ const _addNewWorkplaceIdToWorkerEntity = (myAPIEstablishments, JSONWorker, newWo
   }
 };
 
-const _crossValidateWorkersWithSameRefMovingToSameWorkplace = (
+const _crossValidateWorkersWithDuplicateRefsMovingToWorkplace = (
   csvWorkerSchemaErrors,
   allMovingWorkers,
   otherWorkers,
   errorType,
 ) => {
-  const workplacesDict = _buildWorkplaceDictWithNewWorkers(otherWorkers);
+  const workplacesDict = _buildWorkplaceDictWithOtherWorkers(otherWorkers);
 
   let errorAdded = false;
 
@@ -211,8 +205,8 @@ const _crossValidateWorkersWithSameRefMovingToSameWorkplace = (
   return errorAdded;
 };
 
-const _buildWorkplaceDictWithNewWorkers = (allNewWorkers) => {
-  return chain(allNewWorkers)
+const _buildWorkplaceDictWithOtherWorkers = (otherWorkers) => {
+  return chain(otherWorkers)
     .groupBy('localId') // workplace ref
     .mapValues((JSONWorkers) =>
       JSONWorkers.map((JSONWorker) => {

--- a/backend/server/models/BulkImport/csv/crossValidate.js
+++ b/backend/server/models/BulkImport/csv/crossValidate.js
@@ -211,11 +211,13 @@ const _buildWorkplaceDictWithNewWorkers = (allNewWorkers) => {
     .groupBy('localId') // workplace ref
     .mapValues((JSONWorkers) =>
       JSONWorkers.map((JSONWorker) => {
-        if (JSONWorker.changeUniqueWorker) return JSONWorker.changeUniqueWorker.replace(/\s/g, '');
-        return JSONWorker.uniqueWorkerId.replace(/\s/g, '');
+        if (JSONWorker.changeUniqueWorker) {
+          return [JSONWorker.changeUniqueWorker.replace(/\s/g, ''), JSONWorker.uniqueWorkerId.replace(/\s/g, '')];
+        }
+        return [JSONWorker.uniqueWorkerId.replace(/\s/g, '')];
       }),
     )
-    .mapValues((workerRefs) => new Set(workerRefs))
+    .mapValues((workerRefs) => new Set(workerRefs.flat()))
     .value();
 };
 

--- a/backend/server/models/BulkImport/csv/crossValidateErrors.js
+++ b/backend/server/models/BulkImport/csv/crossValidateErrors.js
@@ -26,7 +26,7 @@ const TRANSFER_STAFF_RECORD_ERRORS = {
     column: 'UNIQUEWORKERID',
     _sourceFieldName: 'uniqueWorkerId',
     error:
-      "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
+      "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID.",
   }),
   SameRefsMovingToWorkplace: Object.freeze({
     errCode: TRANSFER_STAFF_RECORD_BASE_ERROR_CODE + 3,

--- a/backend/server/models/BulkImport/csv/crossValidateErrors.js
+++ b/backend/server/models/BulkImport/csv/crossValidateErrors.js
@@ -25,7 +25,8 @@ const TRANSFER_STAFF_RECORD_ERRORS = {
     errType: 'TRANSFERSTAFFRECORD_ERROR',
     column: 'UNIQUEWORKERID',
     _sourceFieldName: 'uniqueWorkerId',
-    error: 'The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD',
+    error:
+      "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
   }),
   SameRefsMovingToWorkplace: Object.freeze({
     errCode: TRANSFER_STAFF_RECORD_BASE_ERROR_CODE + 3,

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -723,7 +723,9 @@ class Establishment extends EntityValidator {
 
         // new and updated Workers
         const starterSavePromise = Promise.resolve(null);
-        await workersAsArray.reduce(
+        console.log('workersAsArray: ', workersAsArray);
+        const sortedWorkersAsArray = workersAsArray.sort((worker) => worker.changeLocalIdentifier !== null);
+        await sortedWorkersAsArray.reduce(
           (p, thisWorkerToSave) =>
             p.then(() => thisWorkerToSave.save(savedBy, bulkUploaded, 0, externalTransaction, true)).then(log),
           starterSavePromise,

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -724,8 +724,7 @@ class Establishment extends EntityValidator {
         // new and updated Workers
         const starterSavePromise = Promise.resolve(null);
 
-        const sortedWorkersAsArray = workersAsArray.sort((worker) => worker.changeLocalIdentifier !== null);
-        await sortedWorkersAsArray.reduce(
+        await workersAsArray.reduce(
           (p, thisWorkerToSave) =>
             p.then(() => thisWorkerToSave.save(savedBy, bulkUploaded, 0, externalTransaction, true)).then(log),
           starterSavePromise,

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -723,7 +723,6 @@ class Establishment extends EntityValidator {
 
         // new and updated Workers
         const starterSavePromise = Promise.resolve(null);
-
         await workersAsArray.reduce(
           (p, thisWorkerToSave) =>
             p.then(() => thisWorkerToSave.save(savedBy, bulkUploaded, 0, externalTransaction, true)).then(log),

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -723,7 +723,7 @@ class Establishment extends EntityValidator {
 
         // new and updated Workers
         const starterSavePromise = Promise.resolve(null);
-        console.log('workersAsArray: ', workersAsArray);
+
         const sortedWorkersAsArray = workersAsArray.sort((worker) => worker.changeLocalIdentifier !== null);
         await sortedWorkersAsArray.reduce(
           (p, thisWorkerToSave) =>

--- a/backend/server/routes/establishments/bulkUpload/data/workerHeaders.js
+++ b/backend/server/routes/establishments/bulkUpload/data/workerHeaders.js
@@ -56,7 +56,16 @@ const workerHeadersWithTransferStaffRecordAsArray = [
   ...workerHeaders.slice(2),
 ];
 
+const workerHeadersWithChangeUniqueWorkerIdAndTransferStaffRecordAsArray = [
+  ...workerHeaders.slice(0, 2),
+  'CHGUNIQUEWRKID',
+  'TRANSFERSTAFFRECORD',
+  ...workerHeaders.slice(2),
+];
+
 exports.workerHeadersWithCHGUNIQUEWRKID = workerHeadersWithChangeUniqueWorkerIdAsArray.join(',');
 exports.workerHeadersWithTRANSFERSTAFFRECORD = workerHeadersWithTransferStaffRecordAsArray.join(',');
 exports.workerHeadersWithoutCHGUNIQUEWRKID = workerHeaders.join(',');
+exports.workerHeadersWithCHGUNIQUEWRKIDAndTRANSFERSTAFFRECORD =
+  workerHeadersWithChangeUniqueWorkerIdAndTransferStaffRecordAsArray.join(',');
 exports.getWorkerColumnIndex = (columnName) => workerHeaders.findIndex((header) => header === columnName);

--- a/backend/server/routes/establishments/bulkUpload/validate/headers/worker.js
+++ b/backend/server/routes/establishments/bulkUpload/validate/headers/worker.js
@@ -2,6 +2,7 @@ const {
   workerHeadersWithCHGUNIQUEWRKID,
   workerHeadersWithoutCHGUNIQUEWRKID,
   workerHeadersWithTRANSFERSTAFFRECORD,
+  workerHeadersWithCHGUNIQUEWRKIDAndTRANSFERSTAFFRECORD,
 } = require('../../data/workerHeaders');
 
 const validateWorkerHeaders = (headers) => {
@@ -9,6 +10,7 @@ const validateWorkerHeaders = (headers) => {
     workerHeadersWithoutCHGUNIQUEWRKID,
     workerHeadersWithCHGUNIQUEWRKID,
     workerHeadersWithTRANSFERSTAFFRECORD,
+    workerHeadersWithCHGUNIQUEWRKIDAndTRANSFERSTAFFRECORD,
   ];
 
   for (const workerHeadersBeforeExtraQuals of allowedWorkerHeaders) {

--- a/backend/server/routes/establishments/bulkUpload/whichFile.js
+++ b/backend/server/routes/establishments/bulkUpload/whichFile.js
@@ -4,7 +4,15 @@ const isWorkerFile = (fileAsString) => {
   const headersRegexBaseCase = /LOCALESTID,UNIQUEWORKERID,STATUS,DISPLAYID,/;
   const headersRegexChangeUniqueWorkerId = /LOCALESTID,UNIQUEWORKERID,CHGUNIQUEWRKID,STATUS,DISPLAYID,/;
   const headersRegexTransferStaffRecord = /LOCALESTID,UNIQUEWORKERID,TRANSFERSTAFFRECORD,STATUS,DISPLAYID,/;
-  const regexToCheckHeaders = [headersRegexBaseCase, headersRegexChangeUniqueWorkerId, headersRegexTransferStaffRecord];
+  const headersRegexChangeUniqueWorkerIdTransferStaffRecord =
+    /LOCALESTID,UNIQUEWORKERID,CHGUNIQUEWRKID,TRANSFERSTAFFRECORD,STATUS,DISPLAYID,/;
+
+  const regexToCheckHeaders = [
+    headersRegexBaseCase,
+    headersRegexChangeUniqueWorkerId,
+    headersRegexTransferStaffRecord,
+    headersRegexChangeUniqueWorkerIdTransferStaffRecord,
+  ];
 
   const headerRow = fileAsString.split('\n')[0];
 

--- a/backend/server/test/unit/models/Bulkimport/csv/crossValidate.spec.js
+++ b/backend/server/test/unit/models/Bulkimport/csv/crossValidate.spec.js
@@ -303,7 +303,8 @@ describe('crossValidate', () => {
         column: 'UNIQUEWORKERID',
         errCode: 1402,
         errType: 'TRANSFERSTAFFRECORD_ERROR',
-        error: 'The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD',
+        error:
+          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
         worker: movingWorker.uniqueWorkerId,
         name: movingWorker.localId,
         lineNumber: movingWorker.lineNumber,
@@ -335,7 +336,8 @@ describe('crossValidate', () => {
         column: 'UNIQUEWORKERID',
         errCode: 1402,
         errType: 'TRANSFERSTAFFRECORD_ERROR',
-        error: 'The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD',
+        error:
+          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
         worker: movingWorker.uniqueWorkerId,
         name: movingWorker.localId,
         lineNumber: movingWorker.lineNumber,
@@ -400,7 +402,7 @@ describe('crossValidate', () => {
       expect(csvWorkerSchemaErrors).to.deep.equal([expectedError]);
     });
 
-    it("should add an error to csvWorkerSchemaErrors if transferring worker to workplace with worker with same ref but that worker's ID is being changed", async () => {
+    it("should add an error to csvWorkerSchemaErrors if transferring worker to workplace with worker with same ref, even if the worker's ID is being changed", async () => {
       const movingWorker = buildMockJSONWorker({ uniqueWorkerId: 'mock_worker_ref', localId: 'workplace A' });
       const existingWorkerInWorkplace = buildMockJSONWorker({
         uniqueWorkerId: 'mock_worker_ref',
@@ -421,7 +423,8 @@ describe('crossValidate', () => {
         column: 'UNIQUEWORKERID',
         errCode: 1402,
         errType: 'TRANSFERSTAFFRECORD_ERROR',
-        error: 'The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD',
+        error:
+          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
         worker: movingWorker.uniqueWorkerId,
         name: movingWorker.localId,
         lineNumber: movingWorker.lineNumber,
@@ -429,9 +432,6 @@ describe('crossValidate', () => {
       };
 
       expect(csvWorkerSchemaErrors).to.deep.equal([expectedError]);
-
-      // const workerEntity = myAPIEstablishments['workplaceA']._workerEntities['mock_worker_ref'];
-      // expect(workerEntity._newWorkplaceId).to.equal(789);
     });
 
     it("should not add an error to csvWorkerSchemaErrors and add newWorkplaceId to worker entity if transferring worker to workplace with worker with same ref but moving worker's ID is being changed", async () => {
@@ -459,6 +459,7 @@ describe('crossValidate', () => {
 
       const workerEntity = myAPIEstablishments['workplaceA']._workerEntities['mock_worker_ref'];
       expect(workerEntity._newWorkplaceId).to.equal(789);
+      expect(stubWorkerFindOneWithLocalRef).to.have.been.calledWith(789, 'new_unique_worker_ref');
     });
 
     it("should add an error to csvWorkerSchemaErrors if transferring worker to workplace with worker with same ref and moving worker's ID is being changed to existing ref", async () => {
@@ -494,7 +495,8 @@ describe('crossValidate', () => {
         column: 'UNIQUEWORKERID',
         errCode: 1402,
         errType: 'TRANSFERSTAFFRECORD_ERROR',
-        error: 'The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD',
+        error:
+          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
         worker: movingWorker.uniqueWorkerId,
         name: movingWorker.localId,
         lineNumber: movingWorker.lineNumber,

--- a/backend/server/test/unit/models/Bulkimport/csv/crossValidate.spec.js
+++ b/backend/server/test/unit/models/Bulkimport/csv/crossValidate.spec.js
@@ -304,7 +304,7 @@ describe('crossValidate', () => {
         errCode: 1402,
         errType: 'TRANSFERSTAFFRECORD_ERROR',
         error:
-          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
+          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID.",
         worker: movingWorker.uniqueWorkerId,
         name: movingWorker.localId,
         lineNumber: movingWorker.lineNumber,
@@ -337,7 +337,7 @@ describe('crossValidate', () => {
         errCode: 1402,
         errType: 'TRANSFERSTAFFRECORD_ERROR',
         error:
-          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
+          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID.",
         worker: movingWorker.uniqueWorkerId,
         name: movingWorker.localId,
         lineNumber: movingWorker.lineNumber,
@@ -424,7 +424,7 @@ describe('crossValidate', () => {
         errCode: 1402,
         errType: 'TRANSFERSTAFFRECORD_ERROR',
         error:
-          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
+          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID.",
         worker: movingWorker.uniqueWorkerId,
         name: movingWorker.localId,
         lineNumber: movingWorker.lineNumber,
@@ -496,7 +496,7 @@ describe('crossValidate', () => {
         errCode: 1402,
         errType: 'TRANSFERSTAFFRECORD_ERROR',
         error:
-          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID",
+          "The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD. Use CHGUNIQUEWRKID to change this worker's UNIQUEWORKERID.",
         worker: movingWorker.uniqueWorkerId,
         name: movingWorker.localId,
         lineNumber: movingWorker.lineNumber,

--- a/backend/server/test/unit/models/Bulkimport/csv/crossValidate.spec.js
+++ b/backend/server/test/unit/models/Bulkimport/csv/crossValidate.spec.js
@@ -400,7 +400,7 @@ describe('crossValidate', () => {
       expect(csvWorkerSchemaErrors).to.deep.equal([expectedError]);
     });
 
-    it("should not add an error to csvWorkerSchemaErrors and add newWorkplaceId to worker entity if transferring worker to workplace with worker with same ref but that worker's ID is being changed", async () => {
+    it("should add an error to csvWorkerSchemaErrors if transferring worker to workplace with worker with same ref but that worker's ID is being changed", async () => {
       const movingWorker = buildMockJSONWorker({ uniqueWorkerId: 'mock_worker_ref', localId: 'workplace A' });
       const existingWorkerInWorkplace = buildMockJSONWorker({
         uniqueWorkerId: 'mock_worker_ref',
@@ -417,10 +417,21 @@ describe('crossValidate', () => {
         existingWorkerInWorkplace,
       ]);
 
-      expect(csvWorkerSchemaErrors).to.be.empty;
+      const expectedError = {
+        column: 'UNIQUEWORKERID',
+        errCode: 1402,
+        errType: 'TRANSFERSTAFFRECORD_ERROR',
+        error: 'The UNIQUEWORKERID already exists in the LOCALESTID given in TRANSFERSTAFFRECORD',
+        worker: movingWorker.uniqueWorkerId,
+        name: movingWorker.localId,
+        lineNumber: movingWorker.lineNumber,
+        source: movingWorker.uniqueWorkerId,
+      };
 
-      const workerEntity = myAPIEstablishments['workplaceA']._workerEntities['mock_worker_ref'];
-      expect(workerEntity._newWorkplaceId).to.equal(789);
+      expect(csvWorkerSchemaErrors).to.deep.equal([expectedError]);
+
+      // const workerEntity = myAPIEstablishments['workplaceA']._workerEntities['mock_worker_ref'];
+      // expect(workerEntity._newWorkplaceId).to.equal(789);
     });
 
     it("should not add an error to csvWorkerSchemaErrors and add newWorkplaceId to worker entity if transferring worker to workplace with worker with same ref but moving worker's ID is being changed", async () => {

--- a/backend/server/test/unit/routes/establishments/bulkUpload/validate/headers/worker.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/validate/headers/worker.spec.js
@@ -45,7 +45,6 @@ describe('server/routes/establishments/bulkUpload/validate/headers/worker', () =
     });
 
     it('should return true when headings match with CHGUNIQUEWRKID and TRANSFERSTAFFRECORD', async () => {
-      console.log(workerHeadersWithCHGUNIQUEWRKIDAndTRANSFERSTAFFRECORD);
       expect(validateWorkerHeaders(workerHeadersWithCHGUNIQUEWRKIDAndTRANSFERSTAFFRECORD)).to.equal(true);
     });
 

--- a/backend/server/test/unit/routes/establishments/bulkUpload/validate/headers/worker.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/validate/headers/worker.spec.js
@@ -17,6 +17,11 @@ const workerHeadersWithTRANSFERSTAFFRECORD = workerHeadersWithCHGUNIQUEWRKID.rep
   'TRANSFERSTAFFRECORD',
 );
 
+const workerHeadersWithCHGUNIQUEWRKIDAndTRANSFERSTAFFRECORD = workerHeadersWithCHGUNIQUEWRKID.replace(
+  'CHGUNIQUEWRKID',
+  'CHGUNIQUEWRKID,TRANSFERSTAFFRECORD',
+);
+
 const workerHeadersWithoutCHGUNIQUEWRKID =
   'LOCALESTID,UNIQUEWORKERID,STATUS,DISPLAYID,NINUMBER,' +
   'POSTCODE,DOB,GENDER,ETHNICITY,NATIONALITY,BRITISHCITIZENSHIP,COUNTRYOFBIRTH,YEAROFENTRY,' +
@@ -39,6 +44,11 @@ describe('server/routes/establishments/bulkUpload/validate/headers/worker', () =
       expect(validateWorkerHeaders(workerHeadersWithoutCHGUNIQUEWRKID)).to.deep.equal(true);
     });
 
+    it('should return true when headings match with CHGUNIQUEWRKID and TRANSFERSTAFFRECORD', async () => {
+      console.log(workerHeadersWithCHGUNIQUEWRKIDAndTRANSFERSTAFFRECORD);
+      expect(validateWorkerHeaders(workerHeadersWithCHGUNIQUEWRKIDAndTRANSFERSTAFFRECORD)).to.equal(true);
+    });
+
     it('should return false when header (NATIONALITY) missing', async () => {
       const invalidHeaders = workerHeadersWithoutCHGUNIQUEWRKID.replace('NATIONALITY,', '');
 
@@ -50,6 +60,7 @@ describe('server/routes/establishments/bulkUpload/validate/headers/worker', () =
         workerHeadersWithCHGUNIQUEWRKID,
         workerHeadersWithoutCHGUNIQUEWRKID,
         workerHeadersWithTRANSFERSTAFFRECORD,
+        workerHeadersWithCHGUNIQUEWRKIDAndTRANSFERSTAFFRECORD,
       ];
 
       testCases.forEach((workerHeaders) => {

--- a/backend/server/test/unit/routes/establishments/bulkUpload/whichFile.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/whichFile.spec.js
@@ -22,6 +22,11 @@ describe('whichFile', () => {
       expect(isWorkerFile(header)).to.deep.equal(true);
     });
 
+    it('return true when headings match with CHGUNIQUEWRKID and TRANSFERSTAFFRECORD', async () => {
+      const header = 'LOCALESTID,UNIQUEWORKERID,CHGUNIQUEWRKID,TRANSFERSTAFFRECORD,STATUS,DISPLAYID,NINUMBER';
+      expect(isWorkerFile(header)).to.deep.equal(true);
+    });
+
     it("return false when headings don't match", async () => {
       const header = 'NOTATALLWHATWEEXPECT,HOWCOULDYOUUPLOADTHISFILE,';
       expect(isWorkerFile(header)).to.deep.equal(false);


### PR DESCRIPTION
#### Work done
- Updated bulk upload validation to allow both the _CHGUNIQUEWRKID_ and _TRANSFERSTAFFRECORD_ columns in the same file
- This allows users to update the worker reference for a worker they are moving if the reference already exists in the workplace they are being moved to

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
