### PR TITLE
Feat/1556 do you have leavers first page

### DIFF
--- a/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
@@ -379,7 +379,6 @@ const routes: Routes = [
         path: 'do-you-have-vacancies',
         component: DoYouHaveVacanciesComponent,
         canActivate: [CheckPermissionsGuard],
-        resolve: { jobs: JobsResolver },
         data: {
           permissions: ['canEditEstablishment'],
           title: 'Do You Have Vacancies',
@@ -418,7 +417,6 @@ const routes: Routes = [
         path: 'do-you-have-starters',
         component: DoYouHaveStartersComponent,
         canActivate: [CheckPermissionsGuard],
-        resolve: { jobs: JobsResolver },
         data: {
           permissions: ['canEditEstablishment'],
           title: 'Do You Have Starters',
@@ -428,7 +426,6 @@ const routes: Routes = [
         path: 'do-you-have-leavers',
         component: DoYouHaveLeaversComponent,
         canActivate: [CheckPermissionsGuard],
-        resolve: { jobs: JobsResolver },
         data: {
           permissions: ['canEditEstablishment'],
           title: 'Do You Have Leavers',

--- a/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
@@ -32,9 +32,13 @@ import { ConfirmStaffRecruitmentAndBenefitsComponent } from '@features/workplace
 import { CreateUserAccountComponent } from '@features/workplace/create-user-account/create-user-account.component';
 import { DataSharingComponent } from '@features/workplace/data-sharing/data-sharing.component';
 import { DeleteUserAccountComponent } from '@features/workplace/delete-user-account/delete-user-account.component';
+import { DoYouHaveLeaversComponent } from '@features/workplace/do-you-have-leavers/do-you-have-leavers.component';
+import { DoYouHaveStartersComponent } from '@features/workplace/do-you-have-starters/do-you-have-starters.component';
+import { DoYouHaveVacanciesComponent } from '@features/workplace/do-you-have-vacancies/do-you-have-vacancies.component';
 import { EditWorkplaceComponent } from '@features/workplace/edit-workplace/edit-workplace.component';
 import { EmployedFromOutsideUkExistingWorkersComponent } from '@features/workplace/employed-from-outside-uk-existing-workers/employed-from-outside-uk-existing-workers.component';
 import { HealthAndCareVisaExistingWorkers } from '@features/workplace/health-and-care-visa-existing-workers/health-and-care-visa-existing-workers.component';
+import { HowManyVacanciesComponent } from '@features/workplace/how-many-vacancies/how-many-vacancies.component';
 import { LeaversComponent } from '@features/workplace/leavers/leavers.component';
 import { NumberOfInterviewsComponent } from '@features/workplace/number-of-interviews/number-of-interviews.component';
 import { OtherServicesComponent } from '@features/workplace/other-services/other-services.component';
@@ -64,16 +68,13 @@ import { UserAccountViewComponent } from '@features/workplace/user-account-view/
 import { WorkplaceNameAddressComponent } from '@features/workplace/workplace-name-address/workplace-name-address.component';
 import { WorkplaceNotFoundComponent } from '@features/workplace/workplace-not-found/workplace-not-found.component';
 
+import { SelectVacancyJobRolesComponent } from '../workplace/select-vacancy-job-roles/select-vacancy-job-roles.component';
 import { ViewSubsidiaryBenchmarksComponent } from './benchmarks/view-subsidiary-benchmarks.component';
 import { ViewSubsidiaryHomeComponent } from './home/view-subsidiary-home.component';
 import { ViewSubsidiaryStaffRecordsComponent } from './staff-records/view-subsidiary-staff-records.component';
 import { ViewSubsidiaryTrainingAndQualificationsComponent } from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
 import { ViewSubsidiaryWorkplaceUsersComponent } from './workplace-users/view-subsidiary-workplace-users.component';
 import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
-import { DoYouHaveVacanciesComponent } from '@features/workplace/do-you-have-vacancies/do-you-have-vacancies.component';
-import { SelectVacancyJobRolesComponent } from '../workplace/select-vacancy-job-roles/select-vacancy-job-roles.component';
-import { HowManyVacanciesComponent } from '@features/workplace/how-many-vacancies/how-many-vacancies.component';
-import { DoYouHaveStartersComponent } from '@features/workplace/do-you-have-starters/do-you-have-starters.component';
 
 // eslint-disable-next-line max-len
 const routes: Routes = [
@@ -421,6 +422,16 @@ const routes: Routes = [
         data: {
           permissions: ['canEditEstablishment'],
           title: 'Do You Have Starters',
+        },
+      },
+      {
+        path: 'do-you-have-leavers',
+        component: DoYouHaveLeaversComponent,
+        canActivate: [CheckPermissionsGuard],
+        resolve: { jobs: JobsResolver },
+        data: {
+          permissions: ['canEditEstablishment'],
+          title: 'Do You Have Leavers',
         },
       },
       {

--- a/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.spec.ts
@@ -1,0 +1,391 @@
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { jobOptionsEnum } from '@core/model/establishment.model';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { WindowRef } from '@core/services/window.ref';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render, within } from '@testing-library/angular';
+
+import { DoYouHaveLeaversComponent } from './do-you-have-leavers.component';
+
+describe('DoYouHaveLeaversComponent', () => {
+  async function setup(overrides: any = {}) {
+    const setupTools = await render(DoYouHaveLeaversComponent, {
+      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+      providers: [
+        WindowRef,
+        UntypedFormBuilder,
+        {
+          provide: EstablishmentService,
+          useFactory: MockEstablishmentService.factory({ cqc: null, localAuthorities: null }, overrides?.returnUrl, {
+            leavers: overrides?.leavers,
+          }),
+          deps: [HttpClient],
+        },
+      ],
+    });
+    const component = setupTools.fixture.componentInstance;
+
+    const injector = getTestBed();
+    const establishmentService = injector.inject(EstablishmentService) as EstablishmentService;
+    const updateJobsSpy = spyOn(establishmentService, 'updateJobs').and.callThrough();
+    const router = injector.inject(Router) as Router;
+    const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+
+    return {
+      component,
+      ...setupTools,
+      updateJobsSpy,
+      routerSpy,
+    };
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should render a DoYouHaveLeaversComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should show the heading and caption', async () => {
+    const { getByRole, getByTestId } = await setup();
+
+    const heading = getByRole('heading', {
+      name: /Have you had any staff leave in the last 12 months?/i,
+    });
+
+    const sectionHeading = within(getByTestId('section-heading'));
+
+    expect(heading).toBeTruthy();
+    expect(sectionHeading.getByText('Vacancies and turnover')).toBeTruthy();
+  });
+
+  it('should show the hint text', async () => {
+    const { getByTestId } = await setup();
+
+    const hintText = 'We only want to know about leavers who have left permanent and temporary job roles.';
+
+    expect(within(getByTestId('hint-text')).getByText(hintText)).toBeTruthy();
+  });
+
+  it('should show the reveal', async () => {
+    const { getByText } = await setup();
+
+    const reveal = getByText('Why we ask for this information');
+    const revealText = getByText(
+      "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.",
+    );
+
+    expect(reveal).toBeTruthy();
+    expect(revealText).toBeTruthy();
+  });
+
+  it('should show the radio buttons', async () => {
+    const { getByLabelText } = await setup();
+
+    expect(getByLabelText('Yes')).toBeTruthy();
+    expect(getByLabelText('No')).toBeTruthy();
+    expect(getByLabelText('I do not know')).toBeTruthy();
+  });
+
+  describe('Prefilling form', () => {
+    it('should not prefill the form when no leavers in workplace data', async () => {
+      const overrides = {
+        leavers: null,
+      };
+
+      const { component } = await setup(overrides);
+
+      const form = component.form;
+
+      expect(form.value).toEqual({ startersLeaversVacanciesKnown: null });
+    });
+
+    [
+      {
+        leavers: [{ jobRole: 1, total: 1 }],
+        radioOption: jobOptionsEnum.YES,
+      },
+      {
+        leavers: jobOptionsEnum.NONE,
+        radioOption: jobOptionsEnum.NONE,
+      },
+      {
+        leavers: jobOptionsEnum.DONT_KNOW,
+        radioOption: jobOptionsEnum.DONT_KNOW,
+      },
+    ].forEach(({ leavers, radioOption }) => {
+      it(`should preselect ${radioOption} if there was a saved value`, async () => {
+        const overrides = {
+          leavers,
+        };
+        const { component } = await setup(overrides);
+
+        const form = component.form;
+        expect(form.value).toEqual({ startersLeaversVacanciesKnown: radioOption });
+      });
+    });
+
+    it("should preselect 'Yes' if hasLeavers is true in local storage", async () => {
+      localStorage.setItem('hasLeavers', 'true');
+
+      const { component } = await setup();
+
+      const form = component.form;
+
+      expect(form.value).toEqual({ startersLeaversVacanciesKnown: 'With Jobs' });
+    });
+
+    it("should preselect 'Yes' if hasLeavers is true and the database has a different value", async () => {
+      const overrides = { leavers: jobOptionsEnum.NONE };
+      localStorage.setItem('hasLeavers', 'true');
+
+      const { component } = await setup(overrides);
+
+      const form = component.form;
+
+      expect(form.value).toEqual({ startersLeaversVacanciesKnown: 'With Jobs' });
+    });
+  });
+
+  describe('Workplace flow', () => {
+    it(`should show 'Save and continue' cta button and 'Skip this question' link if a return url is not provided`, async () => {
+      const overrides = { returnUrl: false };
+
+      const { getByText } = await setup(overrides);
+
+      expect(getByText('Save and continue')).toBeTruthy();
+      expect(getByText('Skip this question')).toBeTruthy();
+    });
+
+    it("should navigate to the select leaver job roles page when submitting 'Yes'", async () => {
+      const overrides = { returnUrl: false };
+      const { component, fixture, getByText, routerSpy } = await setup(overrides);
+
+      component.form.get('startersLeaversVacanciesKnown').setValue('With Jobs');
+      fixture.detectChanges();
+
+      const button = getByText('Save and continue');
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'select-leaver-job-roles']);
+    });
+
+    it("should navigate to the recruitment-advertising-cost page when submitting 'None'", async () => {
+      const overrides = { returnUrl: false };
+      const { component, fixture, getByText, routerSpy } = await setup(overrides);
+
+      component.form.get('startersLeaversVacanciesKnown').setValue('None');
+
+      const button = getByText('Save and continue');
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'recruitment-advertising-cost']);
+    });
+
+    it("should navigate to the recruitment-advertising-cost page when submitting 'I do not know'", async () => {
+      const overrides = { returnUrl: false };
+      const { component, fixture, getByText, routerSpy } = await setup(overrides);
+
+      component.form.get('startersLeaversVacanciesKnown').setValue('I do not know');
+
+      const button = getByText('Save and continue');
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'recruitment-advertising-cost']);
+    });
+
+    it('should navigate to the recruitment-advertising-cost page when clicking Skip this question link', async () => {
+      const overrides = { returnUrl: false };
+      const { getByText, routerSpy } = await setup(overrides);
+
+      const link = getByText('Skip this question');
+      fireEvent.click(link);
+
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'recruitment-advertising-cost']);
+    });
+
+    it(`should call the setSubmitAction function with an action of skip and save as false when clicking 'Skip this question' link`, async () => {
+      const overrides = { returnUrl: false };
+      const { component, getByText } = await setup(overrides);
+
+      const setSubmitActionSpy = spyOn(component, 'setSubmitAction').and.callThrough();
+      const link = getByText('Skip this question');
+
+      fireEvent.click(link);
+
+      expect(setSubmitActionSpy).toHaveBeenCalledWith({ action: 'skip', save: false });
+    });
+
+    it('should return to how many starters page when you click on the back link', async () => {
+      const overrides = { returnUrl: false };
+
+      const { component } = await setup(overrides);
+
+      expect(component.previousRoute).toEqual(['/workplace', `${component.establishment.uid}`, 'how-many-starters']);
+    });
+  });
+
+  describe('Page accessed from workplace summary page', () => {
+    it(`should show 'Continue' cta button and 'Cancel' link if a return url is provided`, async () => {
+      const overrides = { returnUrl: true };
+
+      const { getByText } = await setup(overrides);
+
+      expect(getByText('Continue')).toBeTruthy();
+      expect(getByText('Cancel')).toBeTruthy();
+    });
+
+    it("should navigate to the select leaver job roles page when submitting 'Yes'", async () => {
+      const overrides = { returnUrl: true };
+
+      const { component, fixture, getByText, routerSpy } = await setup(overrides);
+
+      component.form.get('startersLeaversVacanciesKnown').setValue('With Jobs');
+
+      const button = getByText('Continue');
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'select-leaver-job-roles']);
+    });
+
+    it("should navigate to the workplace summary page when submitting 'None'", async () => {
+      const overrides = { returnUrl: true };
+
+      const { component, fixture, getByText, routerSpy } = await setup(overrides);
+
+      component.form.get('startersLeaversVacanciesKnown').setValue('None');
+
+      const button = getByText('Continue');
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
+    });
+
+    it("should navigate to the workplace tab on the dashboard when submitting 'I do not know'", async () => {
+      const overrides = { returnUrl: true };
+
+      const { component, fixture, getByText, routerSpy } = await setup(overrides);
+
+      component.form.get('startersLeaversVacanciesKnown').setValue('I do not know');
+
+      const button = getByText('Continue');
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
+    });
+
+    it('should navigate to the workplace tab on the dashboard after clicking the cancel link', async () => {
+      const overrides = { returnUrl: true };
+
+      const { component, fixture, getByText, routerSpy } = await setup(overrides);
+
+      component.form.get('startersLeaversVacanciesKnown').setValue('None');
+
+      const link = getByText('Cancel');
+      fireEvent.click(link);
+      fixture.detectChanges();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
+    });
+  });
+
+  describe('local storage', () => {
+    it("should store answer in local storage if 'Yes' is selected and not call updateJobs", async () => {
+      const { component, fixture, getByText, updateJobsSpy } = await setup();
+
+      component.form.get('startersLeaversVacanciesKnown').setValue('With Jobs');
+
+      const button = getByText('Continue');
+      const localStorageSpy = spyOn(localStorage, 'setItem');
+
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(localStorageSpy).toHaveBeenCalledTimes(1);
+      expect(localStorageSpy.calls.all()[0].args).toEqual(['hasLeavers', 'true']);
+      expect(updateJobsSpy).not.toHaveBeenCalled();
+    });
+
+    it("should clear local storage when 'No' is selected and is submitted", async () => {
+      const { component, fixture, getByText } = await setup();
+
+      localStorage.setItem('hasLeavers', 'true');
+
+      component.form.get('startersLeaversVacanciesKnown').setValue(jobOptionsEnum.NONE);
+      const localStorageSpy = spyOn(localStorage, 'setItem');
+
+      const button = getByText('Continue');
+
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(localStorageSpy).toHaveBeenCalledTimes(1);
+      expect(localStorageSpy.calls.all()[0].args).toEqual(['hasLeavers', 'false']);
+    });
+
+    it("should clear local storage when 'I do not know' is selected and is submitted", async () => {
+      const { component, fixture, getByText } = await setup();
+
+      localStorage.setItem('hasLeavers', 'true');
+
+      component.form.get('startersLeaversVacanciesKnown').setValue(jobOptionsEnum.DONT_KNOW);
+      const localStorageSpy = spyOn(localStorage, 'setItem');
+
+      const button = getByText('Continue');
+
+      fireEvent.click(button);
+      fixture.detectChanges();
+
+      expect(localStorageSpy).toHaveBeenCalledTimes(1);
+      expect(localStorageSpy.calls.all()[0].args).toEqual(['hasLeavers', 'false']);
+    });
+  });
+
+  it('should call updateJobs when submitting form with radio button value', async () => {
+    const { component, fixture, getByText, updateJobsSpy } = await setup();
+
+    component.form.get('startersLeaversVacanciesKnown').setValue('None');
+
+    const button = getByText('Continue');
+
+    fireEvent.click(button);
+    fixture.detectChanges();
+
+    expect(updateJobsSpy).toHaveBeenCalledWith('mocked-uid', {
+      leavers: 'None',
+    });
+  });
+
+  describe('progress-bar', () => {
+    it('should render the section, the question but not the progress bar when not in the flow', async () => {
+      const overrides = { returnUrl: true };
+
+      const { getByTestId, queryByTestId } = await setup(overrides);
+
+      expect(getByTestId('section-heading')).toBeTruthy();
+      expect(queryByTestId('progress-bar')).toBeFalsy();
+    });
+
+    it('should render the progress bar when in the flow', async () => {
+      const overrides = { returnUrl: false };
+
+      const { getByTestId } = await setup(overrides);
+
+      expect(getByTestId('progress-bar')).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.spec.ts
@@ -408,6 +408,18 @@ describe('DoYouHaveLeaversComponent', () => {
     });
   });
 
+  describe('Validation', () => {
+    it('should display required warning message when user submits without inputting answer', async () => {
+      const { fixture, getByText, getAllByText } = await setup();
+
+      const continueButton = getByText('Continue');
+      fireEvent.click(continueButton);
+      fixture.detectChanges();
+
+      expect(getAllByText("Select yes if you've had any staff leave in the last 12 months").length).toBe(2);
+    });
+  });
+
   describe('progress-bar', () => {
     it('should render the section, the question but not the progress bar when not in the flow', async () => {
       const overrides = { returnUrl: true };

--- a/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.spec.ts
@@ -98,42 +98,15 @@ describe('DoYouHaveLeaversComponent', () => {
   });
 
   describe('Prefilling form', () => {
-    it('should not prefill the form when no leavers in workplace data', async () => {
-      const overrides = {
-        workplace: {
-          leavers: null,
-        },
-      };
-
-      const { component } = await setup(overrides);
-
-      const form = component.form;
-
-      expect(form.value).toEqual({ startersLeaversVacanciesKnown: null });
-    });
-
-    [
-      {
-        leavers: [{ jobRole: 1, total: 1 }],
-        radioOption: jobOptionsEnum.YES,
-      },
-      {
-        leavers: jobOptionsEnum.NONE,
-        radioOption: jobOptionsEnum.NONE,
-      },
-      {
-        leavers: jobOptionsEnum.DONT_KNOW,
-        radioOption: jobOptionsEnum.DONT_KNOW,
-      },
-    ].forEach(({ leavers, radioOption }) => {
-      it(`should preselect ${radioOption} if there was a saved value`, async () => {
+    [[{ jobRole: 1, total: 1 }], jobOptionsEnum.NONE, jobOptionsEnum.DONT_KNOW, null].forEach((answer) => {
+      it(`should not preselect answer from database (${answer}) even if there is a value saved`, async () => {
         const overrides = {
-          workplace: { leavers },
+          workplace: { leavers: answer },
         };
         const { component } = await setup(overrides);
 
         const form = component.form;
-        expect(form.value).toEqual({ startersLeaversVacanciesKnown: radioOption });
+        expect(form.value).toEqual({ startersLeaversVacanciesKnown: null });
       });
     });
 
@@ -147,7 +120,7 @@ describe('DoYouHaveLeaversComponent', () => {
       expect(form.value).toEqual({ startersLeaversVacanciesKnown: 'With Jobs' });
     });
 
-    it("should preselect 'Yes' if hasLeavers is true and the database has a different value", async () => {
+    it("should preselect 'Yes' if hasLeavers is true even if database has a different value (user has gone back to page)", async () => {
       const overrides = { workplace: { leavers: jobOptionsEnum.NONE } };
       localStorage.setItem('hasLeavers', 'true');
 

--- a/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.spec.ts
@@ -80,7 +80,7 @@ describe('DoYouHaveLeaversComponent', () => {
 
     const reveal = getByText('Why we ask for this information');
     const revealText = getByText(
-      "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.",
+      'To show DHSC and the government the size of staff retention issues and help them make national and local policy and funding decisions.',
     );
 
     expect(reveal).toBeTruthy();

--- a/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
@@ -13,6 +13,7 @@ export class DoYouHaveLeaversComponent extends DoYouHaveStartersLeaversVacancies
     'To show DHSC and the government the size of staff retention issues and help them make national and local policy and funding decisions.';
   public localStorageKey = 'hasLeavers';
   public valueToUpdate = 'leavers';
+  public requiredWarningMessage = "Select yes if you've had any staff leave in the last 12 months";
 
   protected setupRoutes(): void {
     this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'recruitment-advertising-cost'];

--- a/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { DoYouHaveStartersLeaversVacanciesDirective } from '@shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive';
+
+@Component({
+  selector: 'app-do-you-have-leavers',
+  templateUrl:
+    '../../../shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.component.html',
+})
+export class DoYouHaveLeaversComponent extends DoYouHaveStartersLeaversVacanciesDirective {
+  public heading = 'Have you had any staff leave in the last 12 months?';
+  public hintText = 'We only want to know about leavers who have left permanent and temporary job roles.';
+  public revealText =
+    "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.";
+  public localStorageKey = 'hasLeavers';
+  public valueToUpdate = 'leavers';
+
+  protected setupRoutes(): void {
+    this.previousRoute = ['/workplace', this.establishment?.uid, 'how-many-starters'];
+    this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'recruitment-advertising-cost'];
+    this.startersLeaversOrVacanciesPageTwo = 'select-leaver-job-roles';
+  }
+
+  protected getDataFromEstablishment(): any {
+    return this.establishment?.leavers;
+  }
+}

--- a/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
@@ -10,7 +10,7 @@ export class DoYouHaveLeaversComponent extends DoYouHaveStartersLeaversVacancies
   public heading = 'Have you had any staff leave in the last 12 months?';
   public hintText = 'We only want to know about leavers who have left permanent and temporary job roles.';
   public revealText =
-    "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.";
+    'To show DHSC and the government the size of staff retention issues and help them make national and local policy and funding decisions.';
   public localStorageKey = 'hasLeavers';
   public valueToUpdate = 'leavers';
 

--- a/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
@@ -15,9 +15,9 @@ export class DoYouHaveLeaversComponent extends DoYouHaveStartersLeaversVacancies
   public valueToUpdate = 'leavers';
 
   protected setupRoutes(): void {
-    this.previousRoute = ['/workplace', this.establishment?.uid, 'how-many-starters'];
     this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'recruitment-advertising-cost'];
     this.startersLeaversOrVacanciesPageTwo = 'select-leaver-job-roles';
+    this.previousRoute = this.getPreviousRoute('starters');
   }
 
   protected getDataFromEstablishment(): any {

--- a/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-leavers/do-you-have-leavers.component.ts
@@ -20,8 +20,4 @@ export class DoYouHaveLeaversComponent extends DoYouHaveStartersLeaversVacancies
     this.startersLeaversOrVacanciesPageTwo = 'select-leaver-job-roles';
     this.previousRoute = this.getPreviousRoute('starters');
   }
-
-  protected getDataFromEstablishment(): any {
-    return this.establishment?.leavers;
-  }
 }

--- a/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.spec.ts
@@ -267,7 +267,7 @@ describe('DoYouHaveStartersComponent', () => {
         expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'select-starter-job-roles']);
       });
 
-      it("should navigate to the leavers page when submitting 'None'", async () => {
+      it("should navigate to the do-you-have-leavers page when submitting 'None'", async () => {
         const overrides = { returnUrl: false };
         const { component, fixture, getByText, routerSpy } = await setup(overrides);
 
@@ -277,10 +277,10 @@ describe('DoYouHaveStartersComponent', () => {
         fireEvent.click(button);
         fixture.detectChanges();
 
-        expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'leavers']);
+        expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'do-you-have-leavers']);
       });
 
-      it("should navigate to the leavers page when submitting 'I do not know' ", async () => {
+      it("should navigate to the do-you-have-leavers page when submitting 'I do not know' ", async () => {
         const overrides = { returnUrl: false };
         const { component, fixture, getByText, routerSpy } = await setup(overrides);
 
@@ -290,10 +290,10 @@ describe('DoYouHaveStartersComponent', () => {
         fireEvent.click(button);
         fixture.detectChanges();
 
-        expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'leavers']);
+        expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'do-you-have-leavers']);
       });
 
-      it('should navigate to the leavers page when clicking Skip this question link', async () => {
+      it('should navigate to the do-you-have-leavers page when clicking Skip this question link', async () => {
         const overrides = { returnUrl: false };
         const { fixture, getByText, routerSpy } = await setup(overrides);
 
@@ -301,7 +301,7 @@ describe('DoYouHaveStartersComponent', () => {
         fireEvent.click(link);
         fixture.detectChanges();
 
-        expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'leavers']);
+        expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'do-you-have-leavers']);
       });
 
       it(`should call the setSubmitAction function with an action of skip and save as false when clicking 'Skip this question' link`, async () => {

--- a/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.spec.ts
@@ -431,6 +431,18 @@ describe('DoYouHaveStartersComponent', () => {
     });
   });
 
+  describe('Validation', () => {
+    it('should display required warning message when user submits without inputting answer', async () => {
+      const { fixture, getByText, getAllByText } = await setup();
+
+      const continueButton = getByText('Continue');
+      fireEvent.click(continueButton);
+      fixture.detectChanges();
+
+      expect(getAllByText("Select yes if you've had any new starters in the last 12 months").length).toBe(2);
+    });
+  });
+
   describe('progress-bar', () => {
     it('should render the section, the question but not the progress bar when not in the flow', async () => {
       const overrides = { returnUrl: true };

--- a/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.spec.ts
@@ -99,53 +99,25 @@ describe('DoYouHaveStartersComponent', () => {
   });
 
   describe('prefill form', () => {
-    it('should not prefill the form', async () => {
-      const overrides = {
-        workplace: { starters: null },
-      };
+    const starterAnswers: any = [[{ jobRole: 1, total: 1 }], jobOptionsEnum.NONE, jobOptionsEnum.DONT_KNOW, null];
 
-      const { component } = await setup(overrides);
-
-      const form = component.form;
-
-      expect(form.value).toEqual({ startersLeaversVacanciesKnown: null });
-    });
-
-    const starterAnswers: any = [
-      {
-        starterAnswer: [{ jobRole: 1, total: 1 }],
-        value: jobOptionsEnum.YES,
-      },
-      {
-        starterAnswer: jobOptionsEnum.NONE,
-        value: jobOptionsEnum.NONE,
-      },
-      {
-        starterAnswer: jobOptionsEnum.DONT_KNOW,
-        value: jobOptionsEnum.DONT_KNOW,
-      },
-    ];
-
-    starterAnswers.forEach((test: any) => {
-      it(`should preselect ${test.value} if there was a saved value`, async () => {
+    starterAnswers.forEach((answer: any) => {
+      it(`should not preselect answer from database (${answer}) even if there is a value saved`, async () => {
         const overrides = {
-          workplace: { starters: test.starterAnswer },
+          workplace: { starters: answer },
         };
         const { component } = await setup(overrides);
 
         const form = component.form;
-        expect(form.value).toEqual({ startersLeaversVacanciesKnown: test.value });
+        expect(form.value).toEqual({ startersLeaversVacanciesKnown: null });
       });
     });
 
     it("should preselect 'Yes' if hasStarters is true in local storage", async () => {
       const overrides = { returnUrl: false };
-
-      const { component } = await setup(overrides);
-
       localStorage.setItem('hasStarters', 'true');
 
-      component.init();
+      const { component } = await setup(overrides);
 
       const form = component.form;
 
@@ -154,12 +126,9 @@ describe('DoYouHaveStartersComponent', () => {
 
     it("should preselect 'Yes' if hasStarters is true and the database has a different value", async () => {
       const overrides = { returnUrl: false, workplace: { starters: jobOptionsEnum.NONE } };
-
-      const { component } = await setup(overrides);
-
       localStorage.setItem('hasStarters', 'true');
 
-      component.init();
+      const { component } = await setup(overrides);
 
       const form = component.form;
 

--- a/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
@@ -15,7 +15,7 @@ export class DoYouHaveStartersComponent extends DoYouHaveStartersLeaversVacancie
     "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.";
 
   protected setupRoutes(): void {
-    this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'leavers'];
+    this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'do-you-have-leavers'];
     this.startersLeaversOrVacanciesPageTwo = 'select-starter-job-roles';
     this.previousRoute = this.getPreviousRoute('vacancies');
   }

--- a/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
@@ -7,19 +7,17 @@ import { DoYouHaveStartersLeaversVacanciesDirective } from '@shared/directives/d
     '../../../shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.component.html',
 })
 export class DoYouHaveStartersComponent extends DoYouHaveStartersLeaversVacanciesDirective implements OnInit {
+  public heading = 'Have you had any new starters in the last 12 months?';
+  public hintText = 'We only want to know about new starters who are in permanent and temporary job roles.';
+  public localStorageKey = 'hasStarters';
+  public valueToUpdate = 'starters';
+  public revealText =
+    "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.";
+
   protected setupRoutes(): void {
     this.previousRoute = ['/workplace', this.establishment?.uid, 'how-many-vacancies'];
     this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'leavers'];
     this.startersLeaversOrVacanciesPageTwo = 'select-starter-job-roles';
-  }
-
-  protected setPageVariables(): void {
-    this.heading = 'Have you had any new starters in the last 12 months?';
-    this.hintText = 'We only want to know about new starters who are in permanent and temporary job roles.';
-    this.revealText =
-      "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.";
-    this.localStorageKey = 'hasStarters';
-    this.valueToUpdate = 'starters';
   }
 
   protected getDataFromEstablishment(): any {

--- a/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { DoYouHaveStartersLeaversVacanciesDirective } from '@shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive';
 
 @Component({
@@ -6,7 +6,7 @@ import { DoYouHaveStartersLeaversVacanciesDirective } from '@shared/directives/d
   templateUrl:
     '../../../shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.component.html',
 })
-export class DoYouHaveStartersComponent extends DoYouHaveStartersLeaversVacanciesDirective implements OnInit {
+export class DoYouHaveStartersComponent extends DoYouHaveStartersLeaversVacanciesDirective {
   public heading = 'Have you had any new starters in the last 12 months?';
   public hintText = 'We only want to know about new starters who are in permanent and temporary job roles.';
   public localStorageKey = 'hasStarters';
@@ -15,9 +15,9 @@ export class DoYouHaveStartersComponent extends DoYouHaveStartersLeaversVacancie
     "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.";
 
   protected setupRoutes(): void {
-    this.previousRoute = ['/workplace', this.establishment?.uid, 'how-many-vacancies'];
     this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'leavers'];
     this.startersLeaversOrVacanciesPageTwo = 'select-starter-job-roles';
+    this.previousRoute = this.getPreviousRoute('vacancies');
   }
 
   protected getDataFromEstablishment(): any {

--- a/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
@@ -20,8 +20,4 @@ export class DoYouHaveStartersComponent extends DoYouHaveStartersLeaversVacancie
     this.startersLeaversOrVacanciesPageTwo = 'select-starter-job-roles';
     this.previousRoute = this.getPreviousRoute('vacancies');
   }
-
-  protected getDataFromEstablishment(): any {
-    return this.establishment?.starters;
-  }
 }

--- a/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-starters/do-you-have-starters.component.ts
@@ -13,6 +13,7 @@ export class DoYouHaveStartersComponent extends DoYouHaveStartersLeaversVacancie
   public valueToUpdate = 'starters';
   public revealText =
     "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.";
+  public requiredWarningMessage = "Select yes if you've had any new starters in the last 12 months";
 
   protected setupRoutes(): void {
     this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'do-you-have-leavers'];

--- a/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.spec.ts
@@ -105,67 +105,36 @@ describe('DoYouHaveVacanciesComponent', () => {
   });
 
   describe('prefill form', () => {
-    it('should not prefill the form', async () => {
-      const overrides = {
-        vacancies: null,
-      };
+    const vacancyAnswers: any = [[{ jobRole: 1, total: 1 }], jobOptionsEnum.NONE, jobOptionsEnum.DONT_KNOW, null];
 
-      const { component } = await setup(overrides);
-
-      const form = component.form;
-
-      expect(form.value).toEqual({ startersLeaversVacanciesKnown: null });
-    });
-
-    const vacancyAnswers: any = [
-      {
-        vacancyAnswer: [{ jobRole: 1, total: 1 }],
-        value: jobOptionsEnum.YES,
-      },
-      {
-        vacancyAnswer: jobOptionsEnum.NONE,
-        value: jobOptionsEnum.NONE,
-      },
-      {
-        vacancyAnswer: jobOptionsEnum.DONT_KNOW,
-        value: jobOptionsEnum.DONT_KNOW,
-      },
-    ];
-
-    vacancyAnswers.forEach((test: any) => {
-      it(`should preselect ${test.value} if there was a saved value`, async () => {
+    vacancyAnswers.forEach((answer: any) => {
+      it(`should not preselect answer from database (${answer}) even if there is a value saved`, async () => {
         const overrides = {
-          vacancies: test.vacancyAnswer,
+          vacancies: answer,
         };
         const { component } = await setup(overrides);
 
         const form = component.form;
-        expect(form.value).toEqual({ startersLeaversVacanciesKnown: test.value });
+        expect(form.value).toEqual({ startersLeaversVacanciesKnown: null });
       });
     });
 
     it("should preselect 'Yes' if hasVacancies is true in local storage", async () => {
       const overrides = { returnUrl: false };
-
-      const { component } = await setup(overrides);
-
       localStorage.setItem('hasVacancies', 'true');
 
-      component.init();
+      const { component } = await setup(overrides);
 
       const form = component.form;
 
       expect(form.value).toEqual({ startersLeaversVacanciesKnown: 'With Jobs' });
     });
 
-    it("should preselect 'Yes' if hasVacancies is true the database has a different value", async () => {
+    it("should preselect 'Yes' if hasVacancies is true and the database has a different value", async () => {
       const overrides = { returnUrl: false, vacancies: jobOptionsEnum.NONE };
-
-      const { component } = await setup(overrides);
-
       localStorage.setItem('hasVacancies', 'true');
 
-      component.init();
+      const { component } = await setup(overrides);
 
       const form = component.form;
 

--- a/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.spec.ts
+++ b/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.spec.ts
@@ -1,15 +1,16 @@
-import { fireEvent, render, within } from '@testing-library/angular';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { EstablishmentService } from '@core/services/establishment.service';
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
-import { SharedModule } from '@shared/shared.module';
 import { Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { HttpClient } from '@angular/common/http';
 import { jobOptionsEnum } from '@core/model/establishment.model';
-import { getTestBed } from '@angular/core/testing';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { WindowRef } from '@core/services/window.ref';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render, within } from '@testing-library/angular';
+
 import { DoYouHaveVacanciesComponent } from './do-you-have-vacancies.component';
 
 describe('DoYouHaveVacanciesComponent', () => {
@@ -391,6 +392,18 @@ describe('DoYouHaveVacanciesComponent', () => {
 
         expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], { fragment: 'workplace', queryParams: undefined });
       });
+    });
+  });
+
+  describe('Validation', () => {
+    it('should display required warning message when user submits without inputting answer', async () => {
+      const { fixture, getByText, getAllByText } = await setup();
+
+      const continueButton = getByText('Continue');
+      fireEvent.click(continueButton);
+      fixture.detectChanges();
+
+      expect(getAllByText("Select yes if you've any current staff vacancies").length).toBe(2);
     });
   });
 

--- a/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { DoYouHaveStartersLeaversVacanciesDirective } from '@shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive';
 
 @Component({
@@ -6,7 +6,7 @@ import { DoYouHaveStartersLeaversVacanciesDirective } from '@shared/directives/d
   templateUrl:
     '../../../shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.component.html',
 })
-export class DoYouHaveVacanciesComponent extends DoYouHaveStartersLeaversVacanciesDirective implements OnInit {
+export class DoYouHaveVacanciesComponent extends DoYouHaveStartersLeaversVacanciesDirective {
   public heading = 'Do you have any current staff vacancies?';
   public hintText = 'We only want to know about current staff vacancies for permanent and temporary job roles.';
   public localStorageKey = 'hasVacancies';
@@ -19,9 +19,5 @@ export class DoYouHaveVacanciesComponent extends DoYouHaveStartersLeaversVacanci
     this.previousRoute = ['/workplace', this.establishment?.uid, 'service-users'];
     this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'do-you-have-starters'];
     this.startersLeaversOrVacanciesPageTwo = 'select-vacancy-job-roles';
-  }
-
-  protected getDataFromEstablishment(): any {
-    return this.establishment?.vacancies;
   }
 }

--- a/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.ts
@@ -7,19 +7,17 @@ import { DoYouHaveStartersLeaversVacanciesDirective } from '@shared/directives/d
     '../../../shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.component.html',
 })
 export class DoYouHaveVacanciesComponent extends DoYouHaveStartersLeaversVacanciesDirective implements OnInit {
+  public heading = 'Do you have any current staff vacancies?';
+  public hintText = 'We only want to know about current staff vacancies for permanent and temporary job roles.';
+  public localStorageKey = 'hasVacancies';
+  public valueToUpdate = 'vacancies';
+  public revealText =
+    'To show DHSC and others how the level of staff vacancies and the number employed affects the sector over time.';
+
   protected setupRoutes(): void {
     this.previousRoute = ['/workplace', this.establishment?.uid, 'service-users'];
     this.skipRoute = ['/workplace', `${this.establishment?.uid}`, 'do-you-have-starters'];
     this.startersLeaversOrVacanciesPageTwo = 'select-vacancy-job-roles';
-  }
-
-  protected setPageVariables(): void {
-    this.heading = 'Do you have any current staff vacancies?';
-    this.hintText = 'We only want to know about current staff vacancies for permanent and temporary job roles.';
-    this.revealText =
-      'To show DHSC and others how the level of staff vacancies and the number employed affects the sector over time.';
-    this.localStorageKey = 'hasVacancies';
-    this.valueToUpdate = 'vacancies';
   }
 
   protected getDataFromEstablishment(): any {

--- a/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.ts
+++ b/frontend/src/app/features/workplace/do-you-have-vacancies/do-you-have-vacancies.component.ts
@@ -13,6 +13,7 @@ export class DoYouHaveVacanciesComponent extends DoYouHaveStartersLeaversVacanci
   public valueToUpdate = 'vacancies';
   public revealText =
     'To show DHSC and others how the level of staff vacancies and the number employed affects the sector over time.';
+  public requiredWarningMessage = "Select yes if you've any current staff vacancies";
 
   protected setupRoutes(): void {
     this.previousRoute = ['/workplace', this.establishment?.uid, 'service-users'];

--- a/frontend/src/app/features/workplace/workplace-routing.module.ts
+++ b/frontend/src/app/features/workplace/workplace-routing.module.ts
@@ -36,9 +36,13 @@ import { CheckAnswersComponent } from './check-answers/check-answers.component';
 import { ConfirmStaffRecruitmentAndBenefitsComponent } from './confirm-staff-recruitment/confirm-staff-recruitment-and-benefits.component';
 import { DataSharingComponent } from './data-sharing/data-sharing.component';
 import { DeleteUserAccountComponent } from './delete-user-account/delete-user-account.component';
+import { DoYouHaveLeaversComponent } from './do-you-have-leavers/do-you-have-leavers.component';
+import { DoYouHaveStartersComponent } from './do-you-have-starters/do-you-have-starters.component';
+import { DoYouHaveVacanciesComponent } from './do-you-have-vacancies/do-you-have-vacancies.component';
 import { EditWorkplaceComponent } from './edit-workplace/edit-workplace.component';
 import { EmployedFromOutsideUkExistingWorkersComponent } from './employed-from-outside-uk-existing-workers/employed-from-outside-uk-existing-workers.component';
 import { HealthAndCareVisaExistingWorkers } from './health-and-care-visa-existing-workers/health-and-care-visa-existing-workers.component';
+import { HowManyVacanciesComponent } from './how-many-vacancies/how-many-vacancies.component';
 import { LeaversComponent } from './leavers/leavers.component';
 import { NumberOfInterviewsComponent } from './number-of-interviews/number-of-interviews.component';
 import { OtherServicesComponent } from './other-services/other-services.component';
@@ -48,6 +52,7 @@ import { RegulatedByCqcComponent } from './regulated-by-cqc/regulated-by-cqc.com
 import { SelectMainServiceComponent } from './select-main-service/select-main-service.component';
 import { SelectPrimaryUserDeleteComponent } from './select-primary-user-delete/select-primary-user-delete.component';
 import { SelectPrimaryUserComponent } from './select-primary-user/select-primary-user.component';
+import { SelectVacancyJobRolesComponent } from './select-vacancy-job-roles/select-vacancy-job-roles.component';
 import { SelectWorkplaceComponent } from './select-workplace/select-workplace.component';
 import { ServiceUsersComponent } from './service-users/service-users.component';
 import { ServicesCapacityComponent } from './services-capacity/services-capacity.component';
@@ -63,10 +68,6 @@ import { UserAccountEditPermissionsComponent } from './user-account-edit-permiss
 import { UsersComponent } from './users/users.component';
 import { WorkplaceNameAddressComponent } from './workplace-name-address/workplace-name-address.component';
 import { WorkplaceNotFoundComponent } from './workplace-not-found/workplace-not-found.component';
-import { DoYouHaveVacanciesComponent } from './do-you-have-vacancies/do-you-have-vacancies.component';
-import { SelectVacancyJobRolesComponent } from './select-vacancy-job-roles/select-vacancy-job-roles.component';
-import { HowManyVacanciesComponent } from './how-many-vacancies/how-many-vacancies.component';
-import { DoYouHaveStartersComponent } from './do-you-have-starters/do-you-have-starters.component';
 
 // eslint-disable-next-line max-len
 const routes: Routes = [
@@ -310,6 +311,16 @@ const routes: Routes = [
         data: {
           permissions: ['canEditEstablishment'],
           title: 'Do You Have Starters',
+        },
+      },
+      {
+        path: 'do-you-have-leavers',
+        component: DoYouHaveLeaversComponent,
+        canActivate: [CheckPermissionsGuard],
+        resolve: { jobs: JobsResolver },
+        data: {
+          permissions: ['canEditEstablishment'],
+          title: 'Do You Have Leavers',
         },
       },
       {

--- a/frontend/src/app/features/workplace/workplace-routing.module.ts
+++ b/frontend/src/app/features/workplace/workplace-routing.module.ts
@@ -268,7 +268,6 @@ const routes: Routes = [
         path: 'do-you-have-vacancies',
         component: DoYouHaveVacanciesComponent,
         canActivate: [CheckPermissionsGuard],
-        resolve: { jobs: JobsResolver },
         data: {
           permissions: ['canEditEstablishment'],
           title: 'Do You Have Vacancies',
@@ -307,7 +306,6 @@ const routes: Routes = [
         path: 'do-you-have-starters',
         component: DoYouHaveStartersComponent,
         canActivate: [CheckPermissionsGuard],
-        resolve: { jobs: JobsResolver },
         data: {
           permissions: ['canEditEstablishment'],
           title: 'Do You Have Starters',
@@ -317,7 +315,6 @@ const routes: Routes = [
         path: 'do-you-have-leavers',
         component: DoYouHaveLeaversComponent,
         canActivate: [CheckPermissionsGuard],
-        resolve: { jobs: JobsResolver },
         data: {
           permissions: ['canEditEstablishment'],
           title: 'Do You Have Leavers',

--- a/frontend/src/app/features/workplace/workplace.module.ts
+++ b/frontend/src/app/features/workplace/workplace.module.ts
@@ -34,9 +34,13 @@ import { ConfirmStartersComponent } from './confirm-starters/confirm-starters.co
 import { ConfirmVacanciesComponent } from './confirm-vacancies/confirm-vacancies.component';
 import { DataSharingComponent } from './data-sharing/data-sharing.component';
 import { DeleteUserAccountComponent } from './delete-user-account/delete-user-account.component';
+import { DoYouHaveLeaversComponent } from './do-you-have-leavers/do-you-have-leavers.component';
+import { DoYouHaveStartersComponent } from './do-you-have-starters/do-you-have-starters.component';
+import { DoYouHaveVacanciesComponent } from './do-you-have-vacancies/do-you-have-vacancies.component';
 import { EditWorkplaceComponent } from './edit-workplace/edit-workplace.component';
 import { EmployedFromOutsideUkExistingWorkersComponent } from './employed-from-outside-uk-existing-workers/employed-from-outside-uk-existing-workers.component';
 import { HealthAndCareVisaExistingWorkers } from './health-and-care-visa-existing-workers/health-and-care-visa-existing-workers.component';
+import { HowManyVacanciesComponent } from './how-many-vacancies/how-many-vacancies.component';
 import { LeaversComponent } from './leavers/leavers.component';
 import { NumberOfInterviewsComponent } from './number-of-interviews/number-of-interviews.component';
 import { OtherServicesComponent } from './other-services/other-services.component';
@@ -46,6 +50,7 @@ import { RegulatedByCqcComponent } from './regulated-by-cqc/regulated-by-cqc.com
 import { SelectMainServiceComponent } from './select-main-service/select-main-service.component';
 import { SelectPrimaryUserDeleteComponent } from './select-primary-user-delete/select-primary-user-delete.component';
 import { SelectPrimaryUserComponent } from './select-primary-user/select-primary-user.component';
+import { SelectVacancyJobRolesComponent } from './select-vacancy-job-roles/select-vacancy-job-roles.component';
 import { SelectWorkplaceComponent } from './select-workplace/select-workplace.component';
 import { ServiceUsersComponent } from './service-users/service-users.component';
 import { ServicesCapacityComponent } from './services-capacity/services-capacity.component';
@@ -66,10 +71,6 @@ import { WorkplaceInfoPanelComponent } from './workplace-info-panel/workplace-in
 import { WorkplaceNameAddressComponent } from './workplace-name-address/workplace-name-address.component';
 import { WorkplaceNotFoundComponent } from './workplace-not-found/workplace-not-found.component';
 import { WorkplaceRoutingModule } from './workplace-routing.module';
-import { DoYouHaveVacanciesComponent } from './do-you-have-vacancies/do-you-have-vacancies.component';
-import { SelectVacancyJobRolesComponent } from './select-vacancy-job-roles/select-vacancy-job-roles.component';
-import { HowManyVacanciesComponent } from './how-many-vacancies/how-many-vacancies.component';
-import { DoYouHaveStartersComponent } from './do-you-have-starters/do-you-have-starters.component';
 
 @NgModule({
   imports: [
@@ -134,6 +135,7 @@ import { DoYouHaveStartersComponent } from './do-you-have-starters/do-you-have-s
     SelectVacancyJobRolesComponent,
     HowManyVacanciesComponent,
     DoYouHaveStartersComponent,
+    DoYouHaveLeaversComponent,
   ],
   providers: [
     DialogService,

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
@@ -502,7 +502,7 @@
             workplace.wdf?.leavers.isEligible === 'Yes' &&
             !workplace.wdf?.leavers.updatedSinceEffectiveDate
           "
-          [changeLink]="getRoutePath('leavers', wdfView)"
+          [changeLink]="getRoutePath('do-you-have-leavers', wdfView)"
           (fieldConfirmation)="this.confirmField('leavers')"
           (setReturnClicked)="this.setReturn()"
         >
@@ -518,7 +518,7 @@
             )
           "
           [explanationText]="' leavers'"
-          [link]="['/workplace', workplace.uid, 'leavers']"
+          [link]="['/workplace', workplace.uid, 'do-you-have-leavers']"
           [hasData]="workplace.leavers?.length"
           (setReturnClicked)="this.setReturn()"
         ></app-summary-record-change>

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
@@ -904,7 +904,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Add');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText('-')).toBeTruthy();
       });
 
@@ -919,7 +919,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Change');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText(`Don't know`)).toBeTruthy();
       });
 
@@ -934,7 +934,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Change');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText(`None`)).toBeTruthy();
       });
 
@@ -949,7 +949,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Change');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText(`3 Administrative`)).toBeTruthy();
       });
 

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -373,7 +373,7 @@
           <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
             <app-summary-record-change
               [explanationText]="' leavers'"
-              [link]="['/workplace', workplace.uid, 'leavers']"
+              [link]="['/workplace', workplace.uid, 'do-you-have-leavers']"
               [hasData]="workplace.leavers?.length"
               (setReturnClicked)="this.setReturn()"
             ></app-summary-record-change>

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -1086,7 +1086,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Add');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText('-')).toBeTruthy();
       });
 
@@ -1101,7 +1101,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Change');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText(`Don't know`)).toBeTruthy();
       });
 
@@ -1116,7 +1116,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Change');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText(`None`)).toBeTruthy();
       });
 
@@ -1131,7 +1131,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Change');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText(`3 Administrative`)).toBeTruthy();
       });
 

--- a/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -500,7 +500,7 @@
             workplace.wdf?.leavers.isEligible === 'Yes' &&
             !workplace.wdf?.leavers.updatedSinceEffectiveDate
           "
-          [changeLink]="getRoutePath('leavers', wdfView)"
+          [changeLink]="getRoutePath('do-you-have-leavers', wdfView)"
           (fieldConfirmation)="this.confirmField('leavers')"
           (setReturnClicked)="this.setReturn()"
         >
@@ -516,7 +516,7 @@
             )
           "
           [explanationText]="' leavers'"
-          [link]="['/workplace', workplace.uid, 'leavers']"
+          [link]="['/workplace', workplace.uid, 'do-you-have-leavers']"
           [hasData]="workplace.leavers?.length"
           (setReturnClicked)="this.setReturn()"
         ></app-summary-record-change>

--- a/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -962,7 +962,7 @@ describe('WorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Add');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText('-')).toBeTruthy();
       });
 
@@ -977,7 +977,7 @@ describe('WorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Change');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText(`Don't know`)).toBeTruthy();
       });
 
@@ -992,7 +992,7 @@ describe('WorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Change');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText(`None`)).toBeTruthy();
       });
 
@@ -1007,7 +1007,7 @@ describe('WorkplaceSummaryComponent', () => {
         const link = within(leaversRow).queryByText('Change');
 
         expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/leavers`);
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
         expect(within(leaversRow).queryByText(`3 Administrative`)).toBeTruthy();
       });
 

--- a/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.component.html
+++ b/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.component.html
@@ -18,7 +18,10 @@
           </p>
         </app-details>
 
-        <div class="govuk-form-group govuk-!-margin-bottom-3">
+        <div
+          class="govuk-form-group govuk-!-margin-bottom-3"
+          [class.govuk-form-group--error]="submitted && form.invalid"
+        >
           <span id="startersLeaversVacanciesKnown-error" class="govuk-error-message" *ngIf="submitted && form.invalid"
             >{{ requiredWarningMessage }}
           </span>

--- a/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.component.html
+++ b/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.component.html
@@ -1,3 +1,5 @@
+<app-error-summary *ngIf="submitted && form.invalid" [formErrorsMap]="formErrorsMap" [form]="form"> </app-error-summary>
+
 <form #formEl novalidate (ngSubmit)="onSubmit()" [formGroup]="form">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -17,6 +19,9 @@
         </app-details>
 
         <div class="govuk-form-group govuk-!-margin-bottom-3">
+          <span id="startersLeaversVacanciesKnown-error" class="govuk-error-message" *ngIf="submitted && form.invalid"
+            >{{ requiredWarningMessage }}
+          </span>
           <div class="govuk-radios">
             <div class="govuk-radios__item" *ngFor="let option of knownOptions; let i = index">
               <input

--- a/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
@@ -1,5 +1,5 @@
-import { Directive, OnInit } from '@angular/core';
-import { UntypedFormBuilder } from '@angular/forms';
+import { Directive } from '@angular/core';
+import { UntypedFormBuilder, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { jobOptionsEnum, UpdateJobsRequest } from '@core/model/establishment.model';
 import { BackService } from '@core/services/back.service';
@@ -8,7 +8,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { Question } from '@features/workplace/question/question.component';
 
 @Directive({})
-export class DoYouHaveStartersLeaversVacanciesDirective extends Question implements OnInit {
+export class DoYouHaveStartersLeaversVacanciesDirective extends Question {
   public section = 'Vacancies and turnover';
   public heading: string;
   public hintText: string;
@@ -18,6 +18,7 @@ export class DoYouHaveStartersLeaversVacanciesDirective extends Question impleme
   public localStorageKey: string;
   public startersLeaversOrVacanciesPageTwo: string;
   public valueToUpdate: string;
+  public requiredWarningMessage: string;
   public knownOptions = [
     {
       label: 'Yes',
@@ -54,8 +55,22 @@ export class DoYouHaveStartersLeaversVacanciesDirective extends Question impleme
 
   protected setupForm(): void {
     this.form = this.formBuilder.group({
-      startersLeaversVacanciesKnown: null,
+      startersLeaversVacanciesKnown: [null, [Validators.required]],
     });
+  }
+
+  protected setupFormErrorsMap(): void {
+    this.formErrorsMap = [
+      {
+        item: 'startersLeaversVacanciesKnown',
+        type: [
+          {
+            name: 'required',
+            message: this.requiredWarningMessage,
+          },
+        ],
+      },
+    ];
   }
 
   protected getFromLocalStorage(): boolean {

--- a/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
@@ -13,7 +13,6 @@ export class DoYouHaveStartersLeaversVacanciesDirective extends Question {
   public heading: string;
   public hintText: string;
   public revealText: string;
-  public dataFromEstablishment: any;
   public hasSelectedYesWithoutSavingJobRoles: boolean;
   public localStorageKey: string;
   public startersLeaversOrVacanciesPageTwo: string;
@@ -51,7 +50,6 @@ export class DoYouHaveStartersLeaversVacanciesDirective extends Question {
   }
 
   protected setupRoutes(): void {}
-  protected getDataFromEstablishment(): any {}
 
   protected setupForm(): void {
     this.form = this.formBuilder.group({
@@ -78,21 +76,10 @@ export class DoYouHaveStartersLeaversVacanciesDirective extends Question {
   }
 
   protected prefillForm(): void {
-    this.dataFromEstablishment = this.getDataFromEstablishment();
     this.hasSelectedYesWithoutSavingJobRoles = this.getFromLocalStorage();
-    if (
-      (typeof this.dataFromEstablishment === 'object' && this.dataFromEstablishment?.length > 0) ||
-      this.hasSelectedYesWithoutSavingJobRoles
-    ) {
+    if (this.hasSelectedYesWithoutSavingJobRoles) {
       this.form.setValue({
         startersLeaversVacanciesKnown: jobOptionsEnum.YES,
-      });
-    } else if (
-      this.dataFromEstablishment === jobOptionsEnum.NONE ||
-      this.dataFromEstablishment === jobOptionsEnum.DONT_KNOW
-    ) {
-      this.form.setValue({
-        startersLeaversVacanciesKnown: this.dataFromEstablishment,
       });
     }
   }

--- a/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
@@ -110,6 +110,14 @@ export class DoYouHaveStartersLeaversVacanciesDirective extends Question impleme
     );
   }
 
+  protected getPreviousRoute(field: string): Array<string> {
+    if (Array.isArray(this.establishment[field]) && this.establishment[field].length > 0) {
+      return ['/workplace', this.establishment?.uid, `how-many-${field}`];
+    } else {
+      return ['/workplace', this.establishment?.uid, `do-you-have-${field}`];
+    }
+  }
+
   protected onSuccess(): void {
     if (this.hasSelectedYesWithoutSavingJobRoles) {
       this.nextRoute = ['/workplace', `${this.establishment.uid}`, this.startersLeaversOrVacanciesPageTwo];

--- a/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
@@ -45,10 +45,12 @@ export class DoYouHaveStartersLeaversVacanciesDirective extends Question impleme
 
   public init(): void {
     this.setupForm();
-    this.setPageVariables();
     this.prefillForm();
     this.setupRoutes();
   }
+
+  protected setupRoutes(): void {}
+  protected getDataFromEstablishment(): any {}
 
   protected setupForm(): void {
     this.form = this.formBuilder.group({
@@ -56,17 +58,9 @@ export class DoYouHaveStartersLeaversVacanciesDirective extends Question impleme
     });
   }
 
-  protected setupRoutes(): void {}
-
-  protected setPageVariables(): void {}
-
   protected getFromLocalStorage(): boolean {
     return localStorage.getItem(this.localStorageKey) === 'true' ? true : false;
   }
-
-  protected setToLocalStorage(): void {}
-
-  protected getDataFromEstablishment(): any {}
 
   protected prefillForm(): void {
     this.dataFromEstablishment = this.getDataFromEstablishment();


### PR DESCRIPTION
#### Work done
- Created '_Do you have leavers_' first page for accordion changes
- Updated '_Do you have starters_' page to set back link to previous question's (vacancies) first or third page in workplace flow depending on whether the workplace has data for that question
- Updated all three first pages to remove pre-filling from database and only when going back to the page from second question, and added validation to make the question required if user is submitting  

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
