### PR TITLE
Fix/funding staff summary fixes

### DIFF
--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.html
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.html
@@ -35,6 +35,7 @@
             <app-funding-requirements-state
               [overallWdfEligibility]="overallWdfEligibility"
               [currentWdfEligibility]="worker.wdfEligible"
+              orangeFlagMessage="New staff record"
             ></app-funding-requirements-state>
           </td>
         </tr>

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
@@ -32,42 +32,41 @@ describe('WdfStaffSummaryComponent', () => {
     const establishment = establishmentBuilder() as Establishment;
     const workers = [workerBuilder(), workerBuilder(), workerBuilder()] as Worker[];
 
-    const { fixture, getByText, getAllByText, getByTestId, queryByText, getByLabelText, queryByLabelText } =
-      await render(WdfStaffSummaryComponent, {
-        imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule, RouterModule],
-        declarations: [PaginationComponent, TablePaginationWrapperComponent, SearchInputComponent],
-        providers: [
-          { provide: ReportService, useFactory: MockReportService.factory(overrides?.report) },
-          {
-            provide: PermissionsService,
-            useFactory: MockPermissionsService.factory(['canViewWorker']),
-            deps: [HttpClient, Router, UserService],
-          },
-          WorkerService,
-          {
-            provide: ActivatedRoute,
-            useValue: {
-              snapshot: {
-                queryParamMap: {
-                  get: sinon.fake(),
-                },
-                params: {
-                  establishmentuid: establishment.uid,
-                },
+    const setupTools = await render(WdfStaffSummaryComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule, RouterModule],
+      declarations: [PaginationComponent, TablePaginationWrapperComponent, SearchInputComponent],
+      providers: [
+        { provide: ReportService, useFactory: MockReportService.factory(overrides?.report) },
+        {
+          provide: PermissionsService,
+          useFactory: MockPermissionsService.factory(['canViewWorker']),
+          deps: [HttpClient, Router, UserService],
+        },
+        WorkerService,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: {
+                get: sinon.fake(),
+              },
+              params: {
+                establishmentuid: establishment.uid,
               },
             },
           },
-          { provide: EstablishmentService, useClass: MockEstablishmentService },
-        ],
-        componentProperties: {
-          workplace: establishment,
-          wdfView: true,
-          workers: workers,
-          workerCount: workers.length,
-          ...overrides?.componentProperties,
         },
-      });
-    const component = fixture.componentInstance;
+        { provide: EstablishmentService, useClass: MockEstablishmentService },
+      ],
+      componentProperties: {
+        workplace: establishment,
+        wdfView: true,
+        workers: workers,
+        workerCount: workers.length,
+        ...overrides?.componentProperties,
+      },
+    });
+    const component = setupTools.fixture.componentInstance;
 
     const injector = getTestBed();
     const router = injector.inject(Router) as Router;
@@ -78,14 +77,8 @@ describe('WdfStaffSummaryComponent', () => {
     );
 
     return {
+      ...setupTools,
       component,
-      fixture,
-      getByText,
-      getAllByText,
-      getByTestId,
-      queryByText,
-      getByLabelText,
-      queryByLabelText,
       router,
       getAllWorkersSpy,
     };

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
@@ -189,6 +189,7 @@ describe('WdfStaffSummaryComponent', () => {
     const redFlagVisuallyHiddenMessage = 'Red flag';
     const greenTickVisuallyHiddenMessage = 'Green tick';
     const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
+    const newStaffRecordMessage = 'New staff record';
     const notMeetingMessage = 'Not meeting';
     const meetingMessage = 'Meeting';
 
@@ -210,7 +211,7 @@ describe('WdfStaffSummaryComponent', () => {
       expect(getAllByText(meetingMessage, { exact: true }).length).toBe(3);
     });
 
-    it('should display an orange flag on staff record when the user has qualified for WDF but 1 staff record is no longer eligible', async () => {
+    it("should display an orange flag and 'New staff record' on staff record when the user has qualified for WDF but 1 staff record is not eligible (new)", async () => {
       const workers = [workerBuilder(), workerBuilder(), workerBuilder()] as Worker[];
       workers[0].wdfEligible = false;
       workers[1].wdfEligible = true;
@@ -225,10 +226,10 @@ describe('WdfStaffSummaryComponent', () => {
       const { getByText } = await setup(overrides);
 
       expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-      expect(getByText(notMeetingMessage, { exact: true })).toBeTruthy();
+      expect(getByText(newStaffRecordMessage, { exact: true })).toBeTruthy();
     });
 
-    it('should display one orange flag and two green flags when the user has qualified for WDF but 1 staff record is no longer eligible and two still are', async () => {
+    it('should display one orange flag and two green flags when the user has qualified for WDF but 1 staff record is not eligible and two still are', async () => {
       const workers = [workerBuilder(), workerBuilder(), workerBuilder()] as Worker[];
       workers[0].wdfEligible = false;
       workers[1].wdfEligible = true;
@@ -243,7 +244,7 @@ describe('WdfStaffSummaryComponent', () => {
       const { getByText, getAllByText } = await setup(overrides);
 
       expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-      expect(getByText(notMeetingMessage, { exact: true })).toBeTruthy();
+      expect(getByText(newStaffRecordMessage, { exact: true })).toBeTruthy();
       expect(getAllByText(greenTickVisuallyHiddenMessage, { exact: false }).length).toBe(2);
       expect(getAllByText(meetingMessage, { exact: true }).length).toBe(2);
     });

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
@@ -104,18 +104,20 @@ describe('WdfStaffSummaryComponent', () => {
       ['0_dsc', 'staffNameDesc', 'Staff name (Z to A)'],
       ['1_asc', 'jobRoleAsc', 'Job role (A to Z)'],
       ['1_dsc', 'jobRoleDesc', 'Job role (Z to A)'],
-      ['2_meeting', 'wdfMeeting', 'WDF requirements (meeting)'],
-      ['2_not_meeting', 'wdfNotMeeting', 'WDF requirements (not meeting)'],
+      ['2_meeting', 'wdfMeeting', 'Funding requirements (meeting)'],
+      ['2_not_meeting', 'wdfNotMeeting', 'Funding requirements (not meeting)'],
     ];
 
     for (const option of sortByOptions) {
       it(`should call getAllWorkers with sortBy set to ${option[1]} when sorting by ${option[2]}`, async () => {
-        const { fixture, getAllWorkersSpy, getByLabelText } = await setup();
+        const { component, getAllWorkersSpy, getByLabelText, getByText } = await setup();
 
         const select = getByLabelText('Sort by', { exact: false });
-        fireEvent.change(select, { target: { value: option[0] } });
 
-        const establishmentUid = fixture.componentInstance.workplace.uid;
+        const optionElement = getByText(option[2]) as HTMLOptionElement;
+        fireEvent.change(select, { target: { value: optionElement.value } });
+
+        const establishmentUid = component.workplace.uid;
         const paginationEmission = { pageIndex: 0, itemsPerPage: 15, sortBy: option[1] };
 
         expect(getAllWorkersSpy.calls.mostRecent().args[0]).toEqual(establishmentUid);

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -12,7 +12,7 @@ import { orderBy } from 'lodash';
   selector: 'app-wdf-staff-summary',
   templateUrl: './wdf-staff-summary.component.html',
 })
-export class WdfStaffSummaryComponent extends StaffSummaryDirective implements OnInit {
+export class WdfStaffSummaryComponent extends StaffSummaryDirective {
   public workplaceUid: string;
   public primaryWorkplaceUid: string;
   public overallWdfEligibility: boolean;

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.ts
@@ -16,6 +16,7 @@ export class WdfStaffSummaryComponent extends StaffSummaryDirective {
   public workplaceUid: string;
   public primaryWorkplaceUid: string;
   public overallWdfEligibility: boolean;
+  public wdfView = true;
 
   constructor(
     protected permissionsService: PermissionsService,
@@ -41,9 +42,7 @@ export class WdfStaffSummaryComponent extends StaffSummaryDirective {
 
   protected init() {
     this.getOverallWdfEligibility();
-
     this.saveWorkerList();
-    this.wdfView = true;
   }
 
   ngOnChanges() {

--- a/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
+++ b/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
@@ -54,6 +54,7 @@ export class StaffSummaryDirective implements OnInit {
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
     this.sortStaffOptions = this.wdfView ? WdfSortStaffOptions : SortStaffOptions;
     this.setSearchIfPrevious();
+    this.init();
   }
 
   protected init(): void {}


### PR DESCRIPTION
#### Work done
- Updated funding staff summary to show funding sorting options and correct orange flag and '_New staff record_' message for eligible workplaces

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
