### PR TITLE
Feat/1564 - add other job role column

### DIFF
--- a/backend/migrations/20241128152100-other-job-role-name-column.js
+++ b/backend/migrations/20241128152100-other-job-role-name-column.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const mainTable = { tableName: 'EstablishmentJobs', schema: 'cqc' };
+const viewTables = [
+  { tableName: 'StartersVW', jobType: 'Starters' },
+  { tableName: 'LeaversVW', jobType: 'Leavers' },
+  { tableName: 'VacanciesVW', jobType: 'Vacancies' },
+];
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((transaction) => {
+      const promises = [];
+
+      promises.push(
+        queryInterface.addColumn(
+          mainTable,
+          'OtherJobRoleName',
+          {
+            type: Sequelize.DataTypes.TEXT,
+            allowNull: true,
+          },
+          { transaction },
+        ),
+      );
+
+      viewTables.forEach(({ tableName, jobType }) => {
+        const sqlString = `
+          CREATE OR REPLACE VIEW cqc."${tableName}" AS
+            SELECT "EstablishmentJobs"."EstablishmentJobID",
+            "EstablishmentJobs"."EstablishmentID",
+            "EstablishmentJobs"."JobID",
+            "EstablishmentJobs"."JobType",
+            "EstablishmentJobs"."Total",
+            "EstablishmentJobs"."OtherJobRoleName"
+          FROM cqc."EstablishmentJobs"
+          WHERE ("EstablishmentJobs"."JobType" = '${jobType}'::cqc.job_type);
+        `;
+
+        promises.push(queryInterface.sequelize.query(sqlString, { transaction }));
+      });
+
+      return Promise.all(promises);
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((transaction) => {
+      const promises = [];
+
+      viewTables.forEach(({ tableName, jobType }) => {
+        const sqlString = `
+          DROP VIEW IF EXISTS cqc."${tableName}";
+          CREATE OR REPLACE VIEW cqc."${tableName}" AS
+            SELECT "EstablishmentJobs"."EstablishmentJobID",
+            "EstablishmentJobs"."EstablishmentID",
+            "EstablishmentJobs"."JobID",
+            "EstablishmentJobs"."JobType",
+            "EstablishmentJobs"."Total"
+          FROM cqc."EstablishmentJobs"
+          WHERE ("EstablishmentJobs"."JobType" = '${jobType}'::cqc.job_type);
+        `;
+
+        promises.push(queryInterface.sequelize.query(sqlString, { transaction }));
+      });
+
+      promises.push(queryInterface.removeColumn(mainTable, 'OtherJobRoleName', { transaction }));
+
+      return Promise.all(promises);
+    });
+  },
+};

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -1450,7 +1450,7 @@ class Establishment extends EntityValidator {
                 order: [['title', 'ASC']],
               },
             ],
-            attributes: ['id', 'type', 'total'],
+            attributes: ['id', 'type', 'total', 'other'],
             order: [['type', 'ASC']],
           }),
         ]);

--- a/backend/server/models/classes/establishment/properties/jobHelper.js
+++ b/backend/server/models/classes/establishment/properties/jobHelper.js
@@ -8,19 +8,19 @@ const _valid = (thisJob) => {
   if (!(thisJob.jobId || thisJob.title)) return false;
 
   // if job idis given, it must be an integer
-  if (thisJob.jobId && !(Number.isInteger(thisJob.jobId))) return false;
+  if (thisJob.jobId && !Number.isInteger(thisJob.jobId)) return false;
 
   // must also exist a total and it must be an integer
-  if (!(Number.isInteger(thisJob.total))) return false;
+  if (!Number.isInteger(thisJob.total)) return false;
 
   // total must be between 0 and 999
-  const MIN_JOB_TOTAL=0; const MAX_JOB_TOTAL=999;
-  if (thisJob.total < MIN_JOB_TOTAL ||
-      thisJob.total > MAX_JOB_TOTAL) return false;
+  const MIN_JOB_TOTAL = 0;
+  const MAX_JOB_TOTAL = 999;
+  if (thisJob.total < MIN_JOB_TOTAL || thisJob.total > MAX_JOB_TOTAL) return false;
 
   // gets here, and it's valid
   return true;
-}
+};
 
 // returns false if job definitions are not valid, otherwise returns
 //  a well formed set of job definitions using data as given in jobs reference lookup
@@ -29,75 +29,75 @@ exports.validateJobs = async (jobDefs) => {
   let setOfValidatedJobsInvalid = false;
 
   // need a set of LAs (CSSRs) to validate against
-  const allJobs =  await models.job.findAll({
-      attributes: ['id', 'title']
+  const allJobs = await models.job.findAll({
+    attributes: ['id', 'title'],
   });
   if (!allJobs) {
-      console.error('validateJobs - unable to retrieve all known jobs');
-      return false;
+    console.error('validateJobs - unable to retrieve all known jobs');
+    return false;
   }
 
   for (let thisJob of jobDefs) {
-      if (!_valid(thisJob)) {
-          // first check the given data structure
-          setOfValidatedJobsInvalid = true;
-          break;
-      }
+    if (!_valid(thisJob)) {
+      // first check the given data structure
+      setOfValidatedJobsInvalid = true;
+      break;
+    }
 
-      // jobId overrides title, because jobId is indexed whereas title is not!
-      let referenceJob = null;
-      if (thisJob.jobId) {
-          referenceJob = allJobs.find(thisKnownjob => {
-              return thisKnownjob.id === thisJob.jobId;
-          });
-      } else {
-          referenceJob = allJobs.find(thisKnownjob => {
-              return thisKnownjob.title === thisJob.title;
-          });
-      }
+    // jobId overrides title, because jobId is indexed whereas title is not!
+    let referenceJob = null;
+    if (thisJob.jobId) {
+      referenceJob = allJobs.find((thisKnownjob) => {
+        return thisKnownjob.id === thisJob.jobId;
+      });
+    } else {
+      referenceJob = allJobs.find((thisKnownjob) => {
+        return thisKnownjob.title === thisJob.title;
+      });
+    }
 
-      if (referenceJob && referenceJob.id) {
-          // found a job  match - prevent duplicates by checking if the reference job already exists
-          if (!setOfValidatedJobs.find(thisExistingJob => thisExistingJob.jobId === referenceJob.id)) {
-              setOfValidatedJobs.push({
-                  jobId: referenceJob.id,
-                  title: referenceJob.title,
-                  total: thisJob.total
-              });
-          }
-      } else {
-          setOfValidatedJobsInvalid = true;
-          break;
+    if (referenceJob && referenceJob.id) {
+      // found a job  match - prevent duplicates by checking if the reference job already exists
+      if (!setOfValidatedJobs.find((thisExistingJob) => thisExistingJob.jobId === referenceJob.id)) {
+        setOfValidatedJobs.push({
+          jobId: referenceJob.id,
+          title: referenceJob.title,
+          total: thisJob.total,
+          other: thisJob.other ? thisJob.other : null,
+        });
       }
-
+    } else {
+      setOfValidatedJobsInvalid = true;
+      break;
+    }
   }
 
   // if having processed each service correctly, return the set of now validated services
   if (!setOfValidatedJobsInvalid) return setOfValidatedJobs;
 
   return false;
-}
+};
 
 exports.formatJSON = (jobs, propName, propTotalName) => {
-    let jobTotal=0;
-    const jsonResponse = {
-    };
+  let jobTotal = 0;
+  const jsonResponse = {};
 
-    if (Array.isArray(jobs)) {
-            jsonResponse[propName] = jobs.map(thisJob => {
-                jobTotal += thisJob.total;
-                return {
-                    // id: thisJob.id,      // the primary key of the job record does not need to be exposed
-                    jobId: thisJob.jobId,
-                    title: thisJob.title,
-                    total: thisJob.total
-                };
-            });
-            jsonResponse[propTotalName] = jobTotal;
-    } else {
-            jsonResponse[propName] = jobs;
-            jsonResponse[propTotalName] = 0;
-    }
-    
-    return jsonResponse;
-}
+  if (Array.isArray(jobs)) {
+    jsonResponse[propName] = jobs.map((thisJob) => {
+      jobTotal += thisJob.total;
+      return {
+        // id: thisJob.id,      // the primary key of the job record does not need to be exposed
+        jobId: thisJob.jobId,
+        title: thisJob.title,
+        total: thisJob.total,
+        ...(thisJob.other ? { other: thisJob.other } : {}),
+      };
+    });
+    jsonResponse[propTotalName] = jobTotal;
+  } else {
+    jsonResponse[propName] = jobs;
+    jsonResponse[propTotalName] = 0;
+  }
+
+  return jsonResponse;
+};

--- a/backend/server/models/classes/establishment/properties/leaversProperty.js
+++ b/backend/server/models/classes/establishment/properties/leaversProperty.js
@@ -46,7 +46,7 @@ exports.LeaversProperty = class LeaversProperty extends ChangePropertyPrototype 
             jobId: thisJob.reference.id,
             title: thisJob.reference.title,
             total: thisJob.total,
-            ...(thisJob.other ? { other: thisJob.other } : {}),
+            other: thisJob.other ? thisJob.other : null,
           };
         });
       return restoredProperty;

--- a/backend/server/models/classes/establishment/properties/leaversProperty.js
+++ b/backend/server/models/classes/establishment/properties/leaversProperty.js
@@ -46,6 +46,7 @@ exports.LeaversProperty = class LeaversProperty extends ChangePropertyPrototype 
             jobId: thisJob.reference.id,
             title: thisJob.reference.title,
             total: thisJob.total,
+            ...(thisJob.other ? { other: thisJob.other } : {}),
           };
         });
       return restoredProperty;
@@ -68,6 +69,7 @@ exports.LeaversProperty = class LeaversProperty extends ChangePropertyPrototype 
             jobId: thisJob.jobId,
             type: 'Leavers',
             total: thisJob.total,
+            other: thisJob.other ? thisJob.other : null,
           };
         }),
       };
@@ -94,7 +96,9 @@ exports.LeaversProperty = class LeaversProperty extends ChangePropertyPrototype 
         //  Array.every will drop out on the first iteration to return false
         arraysEqual = currentValue.every((thisJob) => {
           return newValue.find((thatJob) => {
-            return thatJob.jobId === thisJob.jobId && thatJob.total === thisJob.total;
+            return (
+              thatJob.jobId === thisJob.jobId && thatJob.total === thisJob.total && thatJob.other === thisJob.other
+            );
           });
         });
       } else {

--- a/backend/server/models/classes/establishment/properties/startersProperty.js
+++ b/backend/server/models/classes/establishment/properties/startersProperty.js
@@ -46,7 +46,7 @@ exports.StartersProperty = class StartersProperty extends ChangePropertyPrototyp
             jobId: thisJob.reference.id,
             title: thisJob.reference.title,
             total: thisJob.total,
-            ...(thisJob.other ? { other: thisJob.other } : {}),
+            other: thisJob.other ? thisJob.other : null,
           };
         });
       return restoredProperty;

--- a/backend/server/models/classes/establishment/properties/startersProperty.js
+++ b/backend/server/models/classes/establishment/properties/startersProperty.js
@@ -46,6 +46,7 @@ exports.StartersProperty = class StartersProperty extends ChangePropertyPrototyp
             jobId: thisJob.reference.id,
             title: thisJob.reference.title,
             total: thisJob.total,
+            ...(thisJob.other ? { other: thisJob.other } : {}),
           };
         });
       return restoredProperty;
@@ -68,6 +69,7 @@ exports.StartersProperty = class StartersProperty extends ChangePropertyPrototyp
             jobId: thisJob.jobId,
             type: 'Starters',
             total: thisJob.total,
+            other: thisJob.other ? thisJob.other : null,
           };
         }),
       };
@@ -94,7 +96,9 @@ exports.StartersProperty = class StartersProperty extends ChangePropertyPrototyp
         //  Array.every will drop out on the first iteration to return false
         arraysEqual = currentValue.every((thisJob) => {
           return newValue.find((thatJob) => {
-            return thatJob.jobId === thisJob.jobId && thatJob.total === thisJob.total;
+            return (
+              thatJob.jobId === thisJob.jobId && thatJob.total === thisJob.total && thatJob.other === thisJob.other
+            );
           });
         });
       } else {

--- a/backend/server/models/classes/establishment/properties/vacanciesProperty.js
+++ b/backend/server/models/classes/establishment/properties/vacanciesProperty.js
@@ -37,7 +37,6 @@ exports.VacanciesProperty = class VacanciesProperty extends ChangePropertyProtot
 
   restorePropertyFromSequelize(document) {
     if (document.VacanciesValue && document.VacanciesValue === 'With Jobs' && document.jobs) {
-      //console.log("WA DEBUG - all establishment jobs: ", document.jobs)
       // we're only interested in Vacancy jobs
       const restoredProperty = document.jobs
         .filter((thisJob) => thisJob.type === 'Vacancies')
@@ -47,6 +46,7 @@ exports.VacanciesProperty = class VacanciesProperty extends ChangePropertyProtot
             jobId: thisJob.reference.id,
             title: thisJob.reference.title,
             total: thisJob.total,
+            ...(thisJob.other ? { other: thisJob.other } : {}),
           };
         });
       return restoredProperty;
@@ -69,6 +69,7 @@ exports.VacanciesProperty = class VacanciesProperty extends ChangePropertyProtot
             jobId: thisJob.jobId,
             type: 'Vacancies',
             total: thisJob.total,
+            other: thisJob.other ? thisJob.other : null,
           };
         }),
       };
@@ -78,7 +79,6 @@ exports.VacanciesProperty = class VacanciesProperty extends ChangePropertyProtot
         establishmentVacancies: [],
       };
     }
-
     return vacanciesDocument;
   }
 
@@ -95,7 +95,9 @@ exports.VacanciesProperty = class VacanciesProperty extends ChangePropertyProtot
         //  Array.every will drop out on the first iteration to return false
         arraysEqual = currentValue.every((thisJob) => {
           return newValue.find((thatJob) => {
-            return thatJob.jobId === thisJob.jobId && thatJob.total === thisJob.total;
+            return (
+              thatJob.jobId === thisJob.jobId && thatJob.total === thisJob.total && thatJob.other === thisJob.other
+            );
           });
         });
       } else {

--- a/backend/server/models/classes/establishment/properties/vacanciesProperty.js
+++ b/backend/server/models/classes/establishment/properties/vacanciesProperty.js
@@ -46,7 +46,7 @@ exports.VacanciesProperty = class VacanciesProperty extends ChangePropertyProtot
             jobId: thisJob.reference.id,
             title: thisJob.reference.title,
             total: thisJob.total,
-            ...(thisJob.other ? { other: thisJob.other } : {}),
+            other: thisJob.other ? thisJob.other : null,
           };
         });
       return restoredProperty;

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -1435,7 +1435,7 @@ module.exports = function (sequelize, DataTypes) {
         },
         {
           model: sequelize.models.establishmentJobs,
-          attributes: ['jobId', 'type', 'total'],
+          attributes: ['jobId', 'type', 'total', 'other'],
           as: 'jobs',
         },
       ],

--- a/backend/server/models/establishmentJobs.js
+++ b/backend/server/models/establishmentJobs.js
@@ -32,6 +32,11 @@ module.exports = function (sequelize, DataTypes) {
         allowNull: false,
         field: '"Total"',
       },
+      other: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+        field: '"OtherJobRoleName"',
+      },
     },
     {
       tableName: '"EstablishmentJobs"',

--- a/backend/server/models/establishmentLeavers.js
+++ b/backend/server/models/establishmentLeavers.js
@@ -1,41 +1,50 @@
 /* jshint indent: 2 */
 
-module.exports = function(sequelize, DataTypes) {
-  const EstablishmentLeavers = sequelize.define('establishmentLeavers', {
-    jobId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: '"JobID"'
+module.exports = function (sequelize, DataTypes) {
+  const EstablishmentLeavers = sequelize.define(
+    'establishmentLeavers',
+    {
+      jobId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"JobID"',
+      },
+      establishmentId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"EstablishmentID"',
+      },
+      type: {
+        type: DataTypes.ENUM,
+        allowNull: false,
+        values: ['Leavers'],
+        default: 'Leavers',
+        field: '"JobType"',
+      },
+      total: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"Total"',
+      },
+      other: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"OtherJobRoleName"',
+      },
     },
-    establishmentId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: '"EstablishmentID"'
+    {
+      tableName: '"LeaversVW"',
+      schema: 'cqc',
+      createdAt: false,
+      updatedAt: false,
     },
-    type: {
-      type: DataTypes.ENUM,
-      allowNull: false,
-      values: ['Leavers'],
-      default: 'Leavers',
-      field: '"JobType"'
-    },
-    total: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: '"Total"'
-    }
-  }, {
-    tableName: '"LeaversVW"',
-    schema: 'cqc',
-    createdAt: false,
-    updatedAt: false
-  });
+  );
 
   EstablishmentLeavers.associate = (models) => {
     EstablishmentLeavers.belongsTo(models.job, {
       foreignKey: 'jobId',
       targetKey: 'id',
-      as: 'reference'
+      as: 'reference',
     });
   };
 

--- a/backend/server/models/establishmentStarters.js
+++ b/backend/server/models/establishmentStarters.js
@@ -1,42 +1,50 @@
 /* jshint indent: 2 */
 
-module.exports = function(sequelize, DataTypes) {
-  const EstablishmentStarters = sequelize.define('establishmentStarters', {
-
-    jobId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: '"JobID"'
+module.exports = function (sequelize, DataTypes) {
+  const EstablishmentStarters = sequelize.define(
+    'establishmentStarters',
+    {
+      jobId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"JobID"',
+      },
+      establishmentId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"EstablishmentID"',
+      },
+      type: {
+        type: DataTypes.ENUM,
+        allowNull: false,
+        values: ['Starters'],
+        default: 'Starters',
+        field: '"JobType"',
+      },
+      total: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"Total"',
+      },
+      other: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"OtherJobRoleName"',
+      },
     },
-    establishmentId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: '"EstablishmentID"'
+    {
+      tableName: '"StartersVW"',
+      schema: 'cqc',
+      createdAt: false,
+      updatedAt: false,
     },
-    type: {
-      type: DataTypes.ENUM,
-      allowNull: false,
-      values: ['Starters'],
-      default: 'Starters',
-      field: '"JobType"'
-    },
-    total: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: '"Total"'
-    }
-  }, {
-    tableName: '"StartersVW"',
-    schema: 'cqc',
-    createdAt: false,
-    updatedAt: false
-  });
+  );
 
   EstablishmentStarters.associate = (models) => {
     EstablishmentStarters.belongsTo(models.job, {
       foreignKey: 'jobId',
       targetKey: 'id',
-      as: 'reference'
+      as: 'reference',
     });
   };
 

--- a/backend/server/models/establishmentVacancies.js
+++ b/backend/server/models/establishmentVacancies.js
@@ -1,41 +1,50 @@
 /* jshint indent: 2 */
 
-module.exports = function(sequelize, DataTypes) {
-  const EstablishmentVacancies = sequelize.define('establishmentVacancies', {
-    jobId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: '"JobID"'
+module.exports = function (sequelize, DataTypes) {
+  const EstablishmentVacancies = sequelize.define(
+    'establishmentVacancies',
+    {
+      jobId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"JobID"',
+      },
+      establishmentId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"EstablishmentID"',
+      },
+      type: {
+        type: DataTypes.ENUM,
+        allowNull: false,
+        values: ['Vacancies'],
+        default: 'Vacancies',
+        field: '"JobType"',
+      },
+      total: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"Total"',
+      },
+      other: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: '"OtherJobRoleName"',
+      },
     },
-    establishmentId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: '"EstablishmentID"'
+    {
+      tableName: '"VacanciesVW"',
+      schema: 'cqc',
+      createdAt: false,
+      updatedAt: false,
     },
-    type: {
-      type: DataTypes.ENUM,
-      allowNull: false,
-      values: ['Vacancies'],
-      default: 'Vacancies',
-      field: '"JobType"'
-    },
-    total: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: '"Total"'
-    }
-  }, {
-    tableName: '"VacanciesVW"',
-    schema: 'cqc',
-    createdAt: false,
-    updatedAt: false
-  });
+  );
 
   EstablishmentVacancies.associate = (models) => {
     EstablishmentVacancies.belongsTo(models.job, {
       foreignKey: 'jobId',
       targetKey: 'id',
-      as: 'reference'
+      as: 'reference',
     });
   };
 

--- a/backend/server/routes/establishments/jobs.js
+++ b/backend/server/routes/establishments/jobs.js
@@ -132,3 +132,5 @@ router.route('/').get(hasPermission('canViewEstablishment'), getJobs);
 router.route('/').post(hasPermission('canEditEstablishment'), updateJobs);
 
 module.exports = router;
+module.exports.getJobs = getJobs;
+module.exports.updateJobs = updateJobs;

--- a/backend/server/test/unit/routes/establishments/jobs.spec.js
+++ b/backend/server/test/unit/routes/establishments/jobs.spec.js
@@ -1,8 +1,6 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const { build, fake, sequence, oneOf } = require('@jackfranklin/test-data-bot');
 const httpMocks = require('node-mocks-http');
-const moment = require('moment');
 const lodash = require('lodash');
 
 const models = require('../../../../models/index');
@@ -10,7 +8,7 @@ const { Establishment } = require('../../../../models/classes/establishment');
 const { establishmentBuilder } = require('../../../factories/models');
 const { getJobs, updateJobs } = require('../../../../routes/establishments/jobs');
 
-describe.only('backend/server/routes/establishments/jobs.js', () => {
+describe('backend/server/routes/establishments/jobs.js', () => {
   const mockEstablishment = establishmentBuilder();
   mockEstablishment.VacanciesValue = 'With Jobs';
   mockEstablishment.StartersValue = 'With Jobs';
@@ -51,13 +49,23 @@ describe.only('backend/server/routes/establishments/jobs.js', () => {
   ];
 
   beforeEach(() => {
-    sinon.stub(console, 'log'); // suppress irrelevant console.log calls
     sinon.stub(models.establishment, 'findOne').resolves(mockEstablishment);
+    sinon.stub(models.job, 'findAll').resolves([
+      { id: 10, title: 'Care worker' },
+      { id: 17, title: 'Nursing associate' },
+      { id: 15, title: 'Senior care worker' },
+      { id: 20, title: 'Other (directly involved in providing care)' },
+    ]);
+
     sinon.stub(models.services, 'findOne').resolves(null);
     sinon.stub(models.serviceUsers, 'findAll').resolves([]);
+    sinon.stub(models.establishmentServiceUsers, 'findAll').resolves([]);
+    sinon.stub(models.establishmentServices, 'findAll').resolves([]);
+    sinon.stub(models.establishmentAudit, 'findAll').resolves([]);
     sinon.stub(models.establishmentCapacity, 'findAll').resolves([]);
     sinon.stub(models.pcodedata, 'getLinkedCssrRecordsFromPostcode').resolves(null);
     sinon.stub(Establishment.prototype, 'isWdfEligible').resolves({ currentEligibility: false });
+    sinon.stub(models.sequelize, 'transaction').callsFake((func) => func('fake-transaction'));
 
     sinon
       .stub(models.establishmentJobs, 'findAll')

--- a/backend/server/test/unit/routes/establishments/jobs.spec.js
+++ b/backend/server/test/unit/routes/establishments/jobs.spec.js
@@ -1,0 +1,209 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const { build, fake, sequence, oneOf } = require('@jackfranklin/test-data-bot');
+const httpMocks = require('node-mocks-http');
+const moment = require('moment');
+const lodash = require('lodash');
+
+const models = require('../../../../models/index');
+const { Establishment } = require('../../../../models/classes/establishment');
+const { establishmentBuilder } = require('../../../factories/models');
+const { getJobs, updateJobs } = require('../../../../routes/establishments/jobs');
+
+describe.only('backend/server/routes/establishments/jobs.js', () => {
+  const mockEstablishment = establishmentBuilder();
+  mockEstablishment.VacanciesValue = 'With Jobs';
+  mockEstablishment.StartersValue = 'With Jobs';
+  mockEstablishment.LeaversValue = 'With Jobs';
+
+  let req;
+  let res;
+
+  const mockVacanciesDatabaseRecord = [
+    { id: 1, total: 2, type: 'Vacancies', reference: { id: 10, title: 'Care worker' } },
+    {
+      id: 2,
+      total: 3,
+      type: 'Vacancies',
+      other: 'Other job name 1',
+      reference: { id: 20, title: 'Other (directly involved in providing care)' },
+    },
+  ];
+  const mockStartersDatabaseRecord = [
+    { id: 3, total: 5, type: 'Starters', reference: { id: 17, title: 'Nursing associate' } },
+    {
+      id: 4,
+      total: 7,
+      type: 'Starters',
+      other: 'Other job name 2',
+      reference: { id: 20, title: 'Other (directly involved in providing care)' },
+    },
+  ];
+  const mockLeaversDatabaseRecord = [
+    { id: 5, total: 11, type: 'Leavers', reference: { id: 15, title: 'Senior care worker' } },
+    {
+      id: 6,
+      total: 13,
+      type: 'Leavers',
+      other: 'Other job name 3',
+      reference: { id: 20, title: 'Other (directly involved in providing care)' },
+    },
+  ];
+
+  beforeEach(() => {
+    sinon.stub(console, 'log'); // suppress irrelevant console.log calls
+    sinon.stub(models.establishment, 'findOne').resolves(mockEstablishment);
+    sinon.stub(models.services, 'findOne').resolves(null);
+    sinon.stub(models.serviceUsers, 'findAll').resolves([]);
+    sinon.stub(models.establishmentCapacity, 'findAll').resolves([]);
+    sinon.stub(models.pcodedata, 'getLinkedCssrRecordsFromPostcode').resolves(null);
+    sinon.stub(Establishment.prototype, 'isWdfEligible').resolves({ currentEligibility: false });
+
+    sinon
+      .stub(models.establishmentJobs, 'findAll')
+      .resolves([...mockVacanciesDatabaseRecord, ...mockStartersDatabaseRecord, ...mockLeaversDatabaseRecord]);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getJobs', () => {
+    beforeEach(() => {
+      req = httpMocks.createRequest({
+        method: 'GET',
+        url: '/api/establishment/123/jobs',
+        establishmentId: 123,
+      });
+      res = httpMocks.createResponse();
+    });
+
+    it('should include an `other` field in starters/leavers/vacancies if applicable', async () => {
+      await getJobs(req, res);
+
+      expect(res.statusCode).to.equal(200);
+
+      const responseData = res._getJSONData();
+
+      expect(responseData.vacancies).to.deep.equal([
+        { jobId: 10, title: 'Care worker', total: 2 },
+        { jobId: 20, title: 'Other (directly involved in providing care)', total: 3, other: 'Other job name 1' },
+      ]);
+      expect(responseData.starters).to.deep.equal([
+        { jobId: 17, title: 'Nursing associate', total: 5 },
+        { jobId: 20, title: 'Other (directly involved in providing care)', total: 7, other: 'Other job name 2' },
+      ]);
+      expect(responseData.leavers).to.deep.equal([
+        { jobId: 15, title: 'Senior care worker', total: 11 },
+        { jobId: 20, title: 'Other (directly involved in providing care)', total: 13, other: 'Other job name 3' },
+      ]);
+    });
+  });
+
+  describe('updateJobs', () => {
+    beforeEach(() => {
+      sinon
+        .stub(models.establishment, 'update')
+        .callsFake((input) => [1, [{ get: () => ({ ...input, EstablishmentID: 123 }) }]]);
+      sinon.stub(models.establishmentAudit, 'bulkCreate').resolves(null);
+    });
+
+    const testCases = [
+      { jobType: 'vacancies', jobTypeModel: models.establishmentVacancies },
+      { jobType: 'starters', jobTypeModel: models.establishmentStarters },
+      { jobType: 'leavers', jobTypeModel: models.establishmentLeavers },
+    ];
+
+    testCases.forEach(({ jobType, jobTypeModel }) => {
+      describe(`for job type: ${jobType}`, () => {
+        const jobTypeInCapital = lodash.capitalize(jobType);
+
+        it('should update establishment jobs record when `other` field is changed', async () => {
+          const destroySpy = sinon.stub(jobTypeModel, 'destroy').resolves(null);
+          const bulkCreateSpy = sinon.stub(jobTypeModel, 'bulkCreate').resolves(null);
+
+          req = httpMocks.createRequest({
+            method: 'POST',
+            url: '/api/establishment/123/jobs',
+            establishmentId: 123,
+            username: 'adminUser',
+            body: {
+              [jobType]: [
+                { jobId: 10, total: 2 },
+                { jobId: 20, total: 3, other: 'Changed job role name' },
+              ],
+            },
+          });
+          res = httpMocks.createResponse();
+
+          await updateJobs(req, res);
+
+          expect(res.statusCode).to.equal(200);
+
+          expect(destroySpy).to.have.been.calledOnce;
+
+          expect(bulkCreateSpy).to.have.been.calledOnce;
+          expect(bulkCreateSpy.getCall(0).args[0]).to.deep.equal([
+            {
+              establishmentId: 123,
+              jobId: 10,
+              other: null,
+              total: 2,
+              type: jobTypeInCapital,
+            },
+            {
+              establishmentId: 123,
+              jobId: 20,
+              other: 'Changed job role name',
+              total: 3,
+              type: jobTypeInCapital,
+            },
+          ]);
+        });
+
+        it('should clear the text in `other` field if not found in request body', async () => {
+          const destroySpy = sinon.stub(jobTypeModel, 'destroy').resolves(null);
+          const bulkCreateSpy = sinon.stub(jobTypeModel, 'bulkCreate').resolves(null);
+
+          req = httpMocks.createRequest({
+            method: 'POST',
+            url: '/api/establishment/123/jobs',
+            establishmentId: 123,
+            username: 'adminUser',
+            body: {
+              [jobType]: [
+                { jobId: 10, total: 2 },
+                { jobId: 20, total: 3 },
+              ],
+            },
+          });
+          res = httpMocks.createResponse();
+
+          await updateJobs(req, res);
+
+          expect(res.statusCode).to.equal(200);
+
+          expect(destroySpy).to.have.been.calledOnce;
+
+          expect(bulkCreateSpy).to.have.been.calledOnce;
+          expect(bulkCreateSpy.getCall(0).args[0]).to.deep.equal([
+            {
+              establishmentId: 123,
+              jobId: 10,
+              other: null,
+              total: 2,
+              type: jobTypeInCapital,
+            },
+            {
+              establishmentId: 123,
+              jobId: 20,
+              other: null,
+              total: 3,
+              type: jobTypeInCapital,
+            },
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
@@ -389,7 +389,7 @@
           <ng-template #vacancies>
             <ng-container *ngIf="isArray(workplace.vacancies)">
               <ul class="govuk-list govuk-!-margin-bottom-0">
-                <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy.total }} {{ vacancy.title }}</li>
+                <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy | formatSLV }}</li>
               </ul>
             </ng-container>
             <ng-container *ngIf="!isArray(workplace.vacancies)">{{ workplace.vacancies }} </ng-container>
@@ -437,7 +437,7 @@
           <ng-template #starters>
             <ng-container *ngIf="isArray(workplace.starters)">
               <ul class="govuk-list govuk-!-margin-bottom-0">
-                <li *ngFor="let starter of workplace.starters">{{ starter.total }} {{ starter.title }}</li>
+                <li *ngFor="let starter of workplace.starters">{{ starter | formatSLV }}</li>
               </ul>
             </ng-container>
             <ng-container *ngIf="!isArray(workplace.starters)">
@@ -487,7 +487,7 @@
           <ng-template #leavers>
             <ng-container *ngIf="isArray(workplace.leavers)">
               <ul class="govuk-list govuk-!-margin-bottom-0">
-                <li *ngFor="let leaver of workplace.leavers">{{ leaver.total }} {{ leaver.title }}</li>
+                <li *ngFor="let leaver of workplace.leavers">{{ leaver | formatSLV }}</li>
               </ul>
             </ng-container>
             <ng-container *ngIf="!isArray(workplace.leavers)">

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
@@ -715,6 +715,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         component.workplace.vacancies = [
           { jobId: 1, title: 'Administrative', total: 3 },
           { jobId: 2, title: 'Nursing', total: 2 },
+          { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
         ];
         component.canEditEstablishment = true;
         fixture.detectChanges();
@@ -724,6 +725,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         expect(within(vacanciesRow).queryByText('Change')).toBeTruthy();
         expect(within(vacanciesRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(vacanciesRow).queryByText('2 Nursing')).toBeTruthy();
+        expect(within(vacanciesRow).queryByText('4 Other care providing role: Special care worker')).toBeTruthy();
       });
 
       it('should show WdfFieldConfirmation component when is eligible but needs to be confirmed for Current Staff Vacancies', async () => {
@@ -845,6 +847,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         component.workplace.starters = [
           { jobId: 1, title: 'Administrative', total: 3 },
           { jobId: 2, title: 'Nursing', total: 2 },
+          { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
         ];
         component.canEditEstablishment = true;
         fixture.detectChanges();
@@ -854,6 +857,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         expect(within(startersRow).queryByText('Change')).toBeTruthy();
         expect(within(startersRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(startersRow).queryByText('2 Nursing')).toBeTruthy();
+        expect(within(startersRow).queryByText('4 Other care providing role: Special care worker')).toBeTruthy();
       });
 
       it('should show WdfFieldConfirmation component when is eligible but needs to be confirmed for New Starters', async () => {
@@ -975,6 +979,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         component.workplace.leavers = [
           { jobId: 1, title: 'Administrative', total: 3 },
           { jobId: 2, title: 'Nursing', total: 2 },
+          { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
         ];
         component.canEditEstablishment = true;
         fixture.detectChanges();
@@ -984,6 +989,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         expect(within(leaversRow).queryByText('Change')).toBeTruthy();
         expect(within(leaversRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(leaversRow).queryByText('2 Nursing')).toBeTruthy();
+        expect(within(leaversRow).queryByText('4 Other care providing role: Special care worker')).toBeTruthy();
       });
 
       it('should show WdfFieldConfirmation component when is eligible but needs to be confirmed for Staff Leavers', async () => {

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -300,7 +300,7 @@
                 <ng-template #vacancies>
                   <ng-container *ngIf="isArray(workplace.vacancies)">
                     <ul class="govuk-list govuk-!-margin-bottom-0">
-                      <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy.total }} {{ vacancy.title }}</li>
+                      <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy | formatSLV }}</li>
                     </ul>
                   </ng-container>
                   <ng-container *ngIf="!isArray(workplace.vacancies)">{{ workplace.vacancies }} </ng-container>
@@ -334,7 +334,7 @@
               <ng-template #starters>
                 <ng-container *ngIf="isArray(workplace.starters)">
                   <ul class="govuk-list govuk-!-margin-bottom-0">
-                    <li *ngFor="let starter of workplace.starters">{{ starter.total }} {{ starter.title }}</li>
+                    <li *ngFor="let starter of workplace.starters">{{ starter | formatSLV }}</li>
                   </ul>
                 </ng-container>
                 <ng-container *ngIf="!isArray(workplace.starters)">
@@ -361,7 +361,7 @@
               <ng-template #leavers>
                 <ng-container *ngIf="isArray(workplace.leavers)">
                   <ul class="govuk-list govuk-!-margin-bottom-0">
-                    <li *ngFor="let leaver of workplace.leavers">{{ leaver.total }} {{ leaver.title }}</li>
+                    <li *ngFor="let leaver of workplace.leavers">{{ leaver | formatSLV }}</li>
                   </ul>
                 </ng-container>
                 <ng-container *ngIf="!isArray(workplace.leavers)">

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -945,6 +945,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         component.workplace.vacancies = [
           { jobId: 1, title: 'Administrative', total: 3 },
           { jobId: 2, title: 'Nursing', total: 2 },
+          { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
         ];
         component.canEditEstablishment = true;
         fixture.detectChanges();
@@ -954,6 +955,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(within(vacanciesRow).queryByText('Change')).toBeTruthy();
         expect(within(vacanciesRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(vacanciesRow).queryByText('2 Nursing')).toBeTruthy();
+        expect(within(vacanciesRow).queryByText('4 Other care providing role: Special care worker')).toBeTruthy();
       });
 
       it('should show warning message if there is no vacancy value but there is a starters value', async () => {
@@ -1070,6 +1072,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         component.workplace.starters = [
           { jobId: 1, title: 'Administrative', total: 3 },
           { jobId: 2, title: 'Nursing', total: 2 },
+          { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
         ];
         component.canEditEstablishment = true;
         fixture.detectChanges();
@@ -1079,6 +1082,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(within(startersRow).queryByText('Change')).toBeTruthy();
         expect(within(startersRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(startersRow).queryByText('2 Nursing')).toBeTruthy();
+        expect(within(startersRow).queryByText('4 Other care providing role: Special care worker')).toBeTruthy();
       });
     });
 
@@ -1157,6 +1161,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         component.workplace.leavers = [
           { jobId: 1, title: 'Administrative', total: 3 },
           { jobId: 2, title: 'Nursing', total: 2 },
+          { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
         ];
         component.canEditEstablishment = true;
         fixture.detectChanges();
@@ -1166,6 +1171,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(within(leaversRow).queryByText('Change')).toBeTruthy();
         expect(within(leaversRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(leaversRow).queryByText('2 Nursing')).toBeTruthy();
+        expect(within(leaversRow).queryByText('4 Other care providing role: Special care worker')).toBeTruthy();
       });
     });
   });

--- a/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -387,7 +387,7 @@
           <ng-template #vacancies>
             <ng-container *ngIf="isArray(workplace.vacancies)">
               <ul class="govuk-list govuk-!-margin-bottom-0">
-                <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy.total }} {{ vacancy.title }}</li>
+                <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy | formatSLV }}</li>
               </ul>
             </ng-container>
             <ng-container *ngIf="!isArray(workplace.vacancies)">{{ workplace.vacancies }} </ng-container>
@@ -435,7 +435,7 @@
           <ng-template #starters>
             <ng-container *ngIf="isArray(workplace.starters)">
               <ul class="govuk-list govuk-!-margin-bottom-0">
-                <li *ngFor="let starter of workplace.starters">{{ starter.total }} {{ starter.title }}</li>
+                <li *ngFor="let starter of workplace.starters">{{ starter | formatSLV }}</li>
               </ul>
             </ng-container>
             <ng-container *ngIf="!isArray(workplace.starters)">
@@ -485,7 +485,7 @@
           <ng-template #leavers>
             <ng-container *ngIf="isArray(workplace.leavers)">
               <ul class="govuk-list govuk-!-margin-bottom-0">
-                <li *ngFor="let leaver of workplace.leavers">{{ leaver.total }} {{ leaver.title }}</li>
+                <li *ngFor="let leaver of workplace.leavers">{{ leaver | formatSLV }}</li>
               </ul>
             </ng-container>
             <ng-container *ngIf="!isArray(workplace.leavers)">

--- a/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -773,6 +773,7 @@ describe('WorkplaceSummaryComponent', () => {
         component.workplace.vacancies = [
           { jobId: 1, title: 'Administrative', total: 3 },
           { jobId: 2, title: 'Nursing', total: 2 },
+          { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
         ];
         component.canEditEstablishment = true;
         fixture.detectChanges();
@@ -782,6 +783,7 @@ describe('WorkplaceSummaryComponent', () => {
         expect(within(vacanciesRow).queryByText('Change')).toBeTruthy();
         expect(within(vacanciesRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(vacanciesRow).queryByText('2 Nursing')).toBeTruthy();
+        expect(within(vacanciesRow).queryByText('4 Other care providing role: Special care worker')).toBeTruthy();
       });
 
       it('should show WdfFieldConfirmation component when is eligible but needs to be confirmed for Current Staff Vacancies', async () => {
@@ -903,6 +905,7 @@ describe('WorkplaceSummaryComponent', () => {
         component.workplace.starters = [
           { jobId: 1, title: 'Administrative', total: 3 },
           { jobId: 2, title: 'Nursing', total: 2 },
+          { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
         ];
         component.canEditEstablishment = true;
         fixture.detectChanges();
@@ -912,6 +915,7 @@ describe('WorkplaceSummaryComponent', () => {
         expect(within(startersRow).queryByText('Change')).toBeTruthy();
         expect(within(startersRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(startersRow).queryByText('2 Nursing')).toBeTruthy();
+        expect(within(startersRow).queryByText('4 Other care providing role: Special care worker')).toBeTruthy();
       });
 
       it('should show WdfFieldConfirmation component when is eligible but needs to be confirmed for New Starters', async () => {
@@ -1033,6 +1037,7 @@ describe('WorkplaceSummaryComponent', () => {
         component.workplace.leavers = [
           { jobId: 1, title: 'Administrative', total: 3 },
           { jobId: 2, title: 'Nursing', total: 2 },
+          { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
         ];
         component.canEditEstablishment = true;
         fixture.detectChanges();
@@ -1042,6 +1047,7 @@ describe('WorkplaceSummaryComponent', () => {
         expect(within(leaversRow).queryByText('Change')).toBeTruthy();
         expect(within(leaversRow).queryByText(`3 Administrative`)).toBeTruthy();
         expect(within(leaversRow).queryByText('2 Nursing')).toBeTruthy();
+        expect(within(leaversRow).queryByText('4 Other care providing role: Special care worker')).toBeTruthy();
       });
 
       it('should show WdfFieldConfirmation component when is eligible but needs to be confirmed for Staff Leavers', async () => {

--- a/frontend/src/app/shared/pipes/format-starters-leavers-vacancies.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/format-starters-leavers-vacancies.pipe.spec.ts
@@ -1,0 +1,39 @@
+import { Vacancy } from '@core/model/establishment.model';
+import { FormatStartersLeaversVacanciesPipe } from './format-starters-leavers-vacancies.pipe';
+
+describe('FormatStartersLeaversVacanciesPipe', () => {
+  it('should create an instance', () => {
+    const pipe = new FormatStartersLeaversVacanciesPipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should format a starter / leaver / vacancy with total number and job role title', () => {
+    const jobRole: Vacancy = { jobId: 10, title: 'Care worker', total: 2 };
+    const pipe = new FormatStartersLeaversVacanciesPipe();
+
+    const expected = '2 Care worker';
+    expect(pipe.transform(jobRole)).toEqual(expected);
+  });
+
+  it('should show the optional text after a colon if exist', () => {
+    const jobRole: Vacancy = {
+      jobId: 20,
+      title: 'Other (directly involved in providing care)',
+      total: 3,
+      other: 'Special care worker',
+    };
+    const pipe = new FormatStartersLeaversVacanciesPipe();
+
+    const expected = '3 Other (directly involved in providing care): Special care worker';
+    expect(pipe.transform(jobRole)).toEqual(expected);
+  });
+
+  it('should not show the optional text if the field is undefined or null', () => {
+    const jobRole: Vacancy = { jobId: 10, title: 'Care worker', total: 2 };
+    const pipe = new FormatStartersLeaversVacanciesPipe();
+
+    const expected = '2 Care worker';
+    expect(pipe.transform({ ...jobRole, other: null })).toEqual(expected);
+    expect(pipe.transform({ ...jobRole, other: undefined })).toEqual(expected);
+  });
+});

--- a/frontend/src/app/shared/pipes/format-starters-leavers-vacancies.pipe.ts
+++ b/frontend/src/app/shared/pipes/format-starters-leavers-vacancies.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Leaver, Starter, Vacancy } from '@core/model/establishment.model';
+
+@Pipe({
+  name: 'formatSLV',
+})
+export class FormatStartersLeaversVacanciesPipe implements PipeTransform {
+  transform(jobRole: Starter | Leaver | Vacancy): string {
+    if (jobRole.other?.length > 0) {
+      return `${jobRole.total} ${jobRole.title}: ${jobRole.other}`;
+    }
+    return `${jobRole.total} ${jobRole.title}`;
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -125,6 +125,7 @@ import { CertificationsTableComponent } from './components/certifications-table/
 import { SelectUploadFileComponent } from './components/select-upload-file/select-upload-file.component';
 import { AccordionGroupComponent } from './components/accordions/generic-accordion/accordion-group/accordion-group.component';
 import { AccordionSectionComponent } from './components/accordions/generic-accordion/accordion-section/accordion-section.component';
+import { FormatStartersLeaversVacanciesPipe } from './pipes/format-starters-leavers-vacancies.pipe';
 
 @NgModule({
   imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, OverlayModule],
@@ -251,6 +252,7 @@ import { AccordionSectionComponent } from './components/accordions/generic-accor
     SelectUploadFileComponent,
     AccordionGroupComponent,
     AccordionSectionComponent,
+    FormatStartersLeaversVacanciesPipe,
   ],
   exports: [
     AbsoluteNumberPipe,


### PR DESCRIPTION
#### Work done
- Add an "OtherJobRoleName" column to EstablishmentJobs table, update related view tables to include the new column
- Update `/establishment/:establishmentUid/jobs` endpoint to handle an optional "other" field for vacancies/starters/leavers
- Update establishment property and jobs endpoint to return vacancies/starters/leavers with "other" field if exist in database
- Update frontend workplace summary pages to show the optional job role name with a colon
![Screenshot 2024-12-03 at 10 00 58](https://github.com/user-attachments/assets/4aa12879-498b-485b-8035-0c0254b9896a)



#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
