### PR TITLE
Fix/flickering dates on funding pages

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { BenchmarksResolver } from '@core/resolvers/benchmarks.resolver';
 import { CqcStatusCheckResolver } from '@core/resolvers/cqcStatusCheck/cqcStatusCheck.resolver';
 import { AllUsersForEstablishmentResolver } from '@core/resolvers/dashboard/all-users-for-establishment.resolver';
 import { TotalStaffRecordsResolver } from '@core/resolvers/dashboard/total-staff-records.resolver';
+import { FundingReportResolver } from '@core/resolvers/funding-report.resolver';
 import { GetMissingCqcLocationsResolver } from '@core/resolvers/getMissingCqcLocations/getMissingCqcLocations.resolver';
 import { GetNoOfWorkersWhoRequireInternationalRecruitmentAnswersResolver } from '@core/resolvers/international-recruitment/no-of-workers-who-require-international-recruitment-answers.resolver';
 import { LoggedInUserResolver } from '@core/resolvers/logged-in-user.resolver';
@@ -206,6 +207,7 @@ import { SentryErrorHandler } from './SentryErrorHandler.component';
     GetMissingCqcLocationsResolver,
     WorkplaceResolver,
     GetNoOfWorkersWhoRequireInternationalRecruitmentAnswersResolver,
+    FundingReportResolver,
   ],
   bootstrap: [AppComponent],
 })

--- a/frontend/src/app/core/resolvers/funding-report.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/funding-report.resolver.spec.ts
@@ -1,0 +1,69 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { ReportService } from '@core/services/report.service';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { of } from 'rxjs';
+
+import { FundingReportResolver } from './funding-report.resolver';
+
+describe('FundingReportResolver', () => {
+  function setup(overrides: any = {}) {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [
+        FundingReportResolver,
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
+        },
+        {
+          provide: ActivatedRouteSnapshot,
+          useValue: {
+            paramMap: convertToParamMap({ establishmentuid: overrides.idInParams ?? null }),
+          },
+        },
+      ],
+    });
+
+    const resolver = TestBed.inject(FundingReportResolver);
+    const route = TestBed.inject(ActivatedRouteSnapshot);
+
+    const reportService = TestBed.inject(ReportService);
+    const getWDFReportSpy = spyOn(reportService, 'getWDFReport').and.returnValue(of(null));
+
+    return {
+      resolver,
+      route,
+      getWDFReportSpy,
+    };
+  }
+
+  it('should create', () => {
+    const { resolver } = setup();
+
+    expect(resolver).toBeTruthy();
+  });
+
+  it('should call getWDFReport with id from establishmentService when no uid in params', () => {
+    const { resolver, route, getWDFReportSpy } = setup();
+
+    const idFromEstablishmentService = '98a83eef-e1e1-49f3-89c5-b1287a3cc8dd';
+
+    resolver.resolve(route);
+
+    expect(getWDFReportSpy).toHaveBeenCalledWith(idFromEstablishmentService);
+  });
+
+  it('should call getWDFReport with uid in params when there', () => {
+    const idInParams = '12321nuihniuh4324';
+
+    const { resolver, route, getWDFReportSpy } = setup({ idInParams });
+
+    resolver.resolve(route);
+
+    expect(getWDFReportSpy).toHaveBeenCalledWith(idInParams);
+  });
+});

--- a/frontend/src/app/core/resolvers/funding-report.resolver.ts
+++ b/frontend/src/app/core/resolvers/funding-report.resolver.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, Router } from '@angular/router';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { ReportService } from '@core/services/report.service';
+import { of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable()
+export class FundingReportResolver implements Resolve<any> {
+  constructor(
+    private router: Router,
+    private reportService: ReportService,
+    private establishmentService: EstablishmentService,
+  ) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    const workplaceUid = route.paramMap.get('establishmentuid') ?? this.establishmentService.establishmentId;
+
+    return this.reportService.getWDFReport(workplaceUid).pipe(
+      catchError(() => {
+        this.router.navigate(['/dashboard']);
+        return of(null);
+      }),
+    );
+  }
+}

--- a/frontend/src/app/core/test-utils/MockReportService.ts
+++ b/frontend/src/app/core/test-utils/MockReportService.ts
@@ -18,25 +18,29 @@ export class MockReportService extends ReportService {
   }
 
   public getWDFReport(workplaceUid: string): Observable<WDFReport> {
-    const d = new Date();
-    //21 July YEAR
-    d.setMonth(6);
-    d.setDate(21);
-    d.setHours(0, 0, 0, 0);
-    const dateString = d.toISOString();
-
-    return of({
-      establishmentId: 1,
-      timestamp: dateString,
-      effectiveFrom: dateString,
-      wdf: {
-        overall: true,
-        overallWdfEligibility: dateString,
-        workplace: true,
-        staff: true,
-      },
-      customEffectiveFrom: true,
-      ...this.overrides,
-    });
+    return of(createMockWdfReport(this.overrides));
   }
 }
+
+export const createMockWdfReport = (overrides: any = {}) => {
+  const d = new Date();
+  //21 July YEAR
+  d.setMonth(6);
+  d.setDate(21);
+  d.setHours(0, 0, 0, 0);
+  const dateString = d.toISOString();
+
+  return {
+    establishmentId: 1,
+    timestamp: dateString,
+    effectiveFrom: dateString,
+    wdf: {
+      overall: true,
+      overallWdfEligibility: dateString,
+      workplace: true,
+      staff: true,
+    },
+    customEffectiveFrom: true,
+    ...overrides,
+  };
+};

--- a/frontend/src/app/features/wdf/wdf-data-change/funding-requirements/funding-requirements.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/funding-requirements/funding-requirements.component.spec.ts
@@ -1,19 +1,18 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { MockPagesService } from '@core/test-utils/MockPagesService';
-import { fireEvent, render } from '@testing-library/angular';
 import { RouterTestingModule } from '@angular/router/testing';
-import { EstablishmentService } from '@core/services/establishment.service';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { PagesService } from '@core/services/pages.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
-import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { PagesService } from '@core/services/pages.service';
 import { MockActivatedRoute } from '@core/test-utils/MockActivatedRoute';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockPagesService } from '@core/test-utils/MockPagesService';
+import { createMockWdfReport } from '@core/test-utils/MockReportService';
+import { fireEvent, render } from '@testing-library/angular';
 
 import { FundingRequirementsComponent } from './funding-requirements.component';
-import { ReportService } from '@core/services/report.service';
-import { MockReportService } from '@core/test-utils/MockReportService';
 
 describe('FundingRequirementsComponent', () => {
   const pages = MockPagesService.pagesFactory();
@@ -27,15 +26,12 @@ describe('FundingRequirementsComponent', () => {
         { provide: EstablishmentService, useClass: MockEstablishmentService },
         { provide: BreadcrumbService, useClass: MockBreadcrumbService },
         {
-          provide: ReportService,
-          useClass: MockReportService,
-        },
-        {
           provide: ActivatedRoute,
           useValue: new MockActivatedRoute({
             snapshot: {
               data: {
                 pages,
+                report: createMockWdfReport(),
               },
             },
           }),

--- a/frontend/src/app/features/wdf/wdf-data-change/funding-requirements/funding-requirements.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/funding-requirements/funding-requirements.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { Page } from '@core/model/page.model';
-import { WDFReport } from '@core/model/reports.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { ReportService } from '@core/services/report.service';
@@ -33,16 +32,13 @@ export class FundingRequirementsComponent implements OnInit {
     this.breadcrumbService.show(JourneyType.WDF);
     this.workplace = this.establishmentService.establishment;
     this.pages = this.route.snapshot.data.pages?.data[0];
-    this.getWdfReportForDates();
+    this.setFundingDates();
   }
 
-  private getWdfReportForDates(): void {
-    this.subscriptions.add(
-      this.reportService.getWDFReport(this.workplace.uid).subscribe((report) => {
-        this.wdfStartDate = dayjs(report.effectiveFrom).format('D MMMM YYYY');
-        this.wdfEndDate = dayjs(report.effectiveFrom).add(1, 'years').format('D MMMM YYYY');
-      }),
-    );
+  private setFundingDates(): void {
+    const report = this.route.snapshot.data.report;
+    this.wdfStartDate = dayjs(report.effectiveFrom).format('D MMMM YYYY');
+    this.wdfEndDate = dayjs(report.effectiveFrom).add(1, 'years').format('D MMMM YYYY');
   }
 
   public viewFundingOverviewPage(): void {

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.html
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.html
@@ -49,6 +49,7 @@
     [workers]="workers"
     [standAloneAccount]="standAloneAccount"
     [workerCount]="workerCount"
+    [overallWdfEligibility]="wdfEligibilityStatus.overall"
   ></app-wdf-staff-summary>
 
   <app-wdf-workplaces-summary

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.spec.ts
@@ -8,12 +8,13 @@ import { Worker } from '@core/model/worker.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { ReportService } from '@core/services/report.service';
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { createMockWdfReport } from '@core/test-utils/MockReportService';
+import { createMockWdfReport, MockReportService } from '@core/test-utils/MockReportService';
 import { MockWorkerService, workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
@@ -34,6 +35,7 @@ describe('WdfDataComponent', () => {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
         },
+        { provide: ReportService, useClass: MockReportService },
         { provide: WorkerService, useClass: MockWorkerService },
         {
           provide: PermissionsService,

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.spec.ts
@@ -8,13 +8,12 @@ import { Worker } from '@core/model/worker.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { ReportService } from '@core/services/report.service';
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { MockReportService } from '@core/test-utils/MockReportService';
+import { createMockWdfReport } from '@core/test-utils/MockReportService';
 import { MockWorkerService, workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
@@ -35,7 +34,6 @@ describe('WdfDataComponent', () => {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
         },
-        { provide: ReportService, useClass: MockReportService },
         { provide: WorkerService, useClass: MockWorkerService },
         {
           provide: PermissionsService,
@@ -52,7 +50,7 @@ describe('WdfDataComponent', () => {
           provide: ActivatedRoute,
           useValue: {
             snapshot: {
-              data: { workplace: overrides.workplace ?? establishmentBuilder() },
+              data: { workplace: overrides.workplace ?? establishmentBuilder(), report: createMockWdfReport() },
               params: overrides.viewingSub ? { establishmentuid: '98a83eef-e1e1-49f3-89c5-b1287a3cc8de' } : {},
             },
             fragment: of(overrides.fragment ?? undefined),

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.ts
@@ -8,7 +8,6 @@ import { URLStructure } from '@core/model/url.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { ReportService } from '@core/services/report.service';
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
 import dayjs from 'dayjs';
@@ -53,7 +52,6 @@ export class WdfDataComponent implements OnInit {
 
   constructor(
     private establishmentService: EstablishmentService,
-    private reportService: ReportService,
     private breadcrumbService: BreadcrumbService,
     private workerService: WorkerService,
     private permissionsService: PermissionsService,
@@ -124,14 +122,10 @@ export class WdfDataComponent implements OnInit {
     }
   }
 
-  private getWdfReport() {
-    this.subscriptions.add(
-      this.reportService.getWDFReport(this.workplaceUid).subscribe((report) => {
-        this.report = report;
-        this.setDates(report);
-        this.setWdfEligibility(report);
-      }),
-    );
+  private getWdfReport(): void {
+    this.report = this.route.snapshot.data?.report;
+    this.setDates(this.report);
+    this.setWdfEligibility(this.report);
   }
 
   public handleTabChange(activeTabIndex: number): void {

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.ts
@@ -8,6 +8,7 @@ import { URLStructure } from '@core/model/url.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { ReportService } from '@core/services/report.service';
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
 import dayjs from 'dayjs';
@@ -58,6 +59,7 @@ export class WdfDataComponent implements OnInit {
     private route: ActivatedRoute,
     private userService: UserService,
     private router: Router,
+    private reportService: ReportService,
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -81,7 +83,11 @@ export class WdfDataComponent implements OnInit {
 
     this.getWorkers();
     this.setWorkplace();
-    this.getWdfReport();
+
+    this.report = this.route.snapshot.data?.report;
+    this.setDates(this.report);
+    this.setWdfEligibility(this.report);
+
     this.setWorkerCount();
     this.breadcrumbService.show(JourneyType.WDF);
   }
@@ -123,9 +129,13 @@ export class WdfDataComponent implements OnInit {
   }
 
   private getWdfReport(): void {
-    this.report = this.route.snapshot.data?.report;
-    this.setDates(this.report);
-    this.setWdfEligibility(this.report);
+    this.subscriptions.add(
+      this.reportService.getWDFReport(this.workplaceUid).subscribe((report) => {
+        this.report = report;
+        this.setDates(report);
+        this.setWdfEligibility(report);
+      }),
+    );
   }
 
   public handleTabChange(activeTabIndex: number): void {

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
@@ -1,17 +1,17 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
+import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { ReportService } from '@core/services/report.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
-import { MockReportService } from '@core/test-utils/MockReportService';
+import { createMockWdfReport } from '@core/test-utils/MockReportService';
+import { WdfSummaryPanel } from '@shared/components/wdf-summary-panel/wdf-summary-panel.component';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
+
 import { WdfOverviewComponent } from './wdf-overview.component';
-import { getTestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { WdfSummaryPanel } from '@shared/components/wdf-summary-panel/wdf-summary-panel.component';
 
 describe('WdfOverviewComponent', () => {
   const currentYear = new Date().getFullYear();
@@ -35,8 +35,12 @@ describe('WdfOverviewComponent', () => {
             },
           },
           {
-            provide: ReportService,
-            useFactory: MockReportService.factory(overrides),
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                data: { report: createMockWdfReport(overrides) },
+              },
+            },
           },
         ],
         componentProperties: {
@@ -148,7 +152,7 @@ describe('WdfOverviewComponent', () => {
       const keepYourDataCurrentLink = getByText('Keep your data current');
 
       expect(dataMetFundingParagraph).toBeTruthy();
-      expect(keepYourDataCurrentLink.getAttribute('href')).toEqual('/data');
+      expect(keepYourDataCurrentLink.getAttribute('ng-reflect-router-link')).toEqual('data');
     });
 
     it('should navigate to your data when Check your data is clicked', async () => {
@@ -168,7 +172,7 @@ describe('WdfOverviewComponent', () => {
       const learnMoreLink = getByText('Learn more about the funds that you can claim from');
 
       expect(learnMoreLink).toBeTruthy();
-      expect(learnMoreLink.getAttribute('href')).toEqual('/learn-more');
+      expect(learnMoreLink.getAttribute('ng-reflect-router-link')).toEqual('learn-more');
     });
 
     it('should show the funding requirements link', async () => {
@@ -184,7 +188,7 @@ describe('WdfOverviewComponent', () => {
       );
 
       expect(fundingRequirementsLink).toBeTruthy();
-      expect(fundingRequirementsLink.getAttribute('href')).toEqual('/funding-requirements');
+      expect(fundingRequirementsLink.getAttribute('ng-reflect-router-link')).toEqual('funding-requirements');
     });
   });
 
@@ -229,7 +233,7 @@ describe('WdfOverviewComponent', () => {
       );
 
       expect(fundingRequirementsLink).toBeTruthy();
-      expect(fundingRequirementsLink.getAttribute('href')).toEqual('/funding-requirements');
+      expect(fundingRequirementsLink.getAttribute('ng-reflect-router-link')).toEqual('funding-requirements');
     });
   });
 
@@ -279,7 +283,7 @@ describe('WdfOverviewComponent', () => {
       const keepYourDataCurrentLink = getByText('Keep your data current');
 
       expect(dataMetFundingParagraph).toBeTruthy();
-      expect(keepYourDataCurrentLink.getAttribute('href')).toEqual('/data');
+      expect(keepYourDataCurrentLink.getAttribute('ng-reflect-router-link')).toEqual('data');
     });
 
     it('should not display the funding requirements inset text when requirements are met', async () => {

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
@@ -7,7 +7,6 @@ import { WDFReport } from '@core/model/reports.model';
 import { WdfEligibilityStatus } from '@core/model/wdf.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { ReportService } from '@core/services/report.service';
 import { UserService } from '@core/services/user.service';
 import dayjs from 'dayjs';
 import orderBy from 'lodash/orderBy';
@@ -38,7 +37,6 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
 
   constructor(
     private establishmentService: EstablishmentService,
-    private reportService: ReportService,
     private breadcrumbService: BreadcrumbService,
     private userService: UserService,
     protected router: Router,
@@ -50,8 +48,13 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
     this.workplace = this.establishmentService.primaryWorkplace;
     this.isParent = this.workplace.isParent;
 
-    this.getParentAndSubs();
-    this.getWdfReport();
+    this.report = this.route.snapshot.data?.report;
+    this.setEligibilityStatus();
+    this.setDates();
+
+    if (this.isParent) {
+      this.getParentAndSubs();
+    }
   }
 
   ngOnDestroy(): void {
@@ -84,23 +87,17 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
     }
   }
 
-  private getWdfReport(): void {
-    this.subscriptions.add(
-      this.reportService.getWDFReport(this.workplace.uid).subscribe((report) => {
-        this.report = report;
-        this.overallWdfEligibility = report.wdf.overall;
-        this.wdfEligibilityStatus.overall = report.wdf.overall;
-        this.wdfEligibilityStatus.currentWorkplace = report.wdf.workplace;
-        this.wdfEligibilityStatus.currentStaff = report.wdf.staff;
-        this.setDates(report);
-      }),
-    );
+  private setEligibilityStatus(): void {
+    this.overallWdfEligibility = this.report.wdf.overall;
+    this.wdfEligibilityStatus.overall = this.report.wdf.overall;
+    this.wdfEligibilityStatus.currentWorkplace = this.report.wdf.workplace;
+    this.wdfEligibilityStatus.currentStaff = this.report.wdf.staff;
   }
 
-  private setDates(report: WDFReport): void {
-    this.wdfStartDate = dayjs(report.effectiveFrom).format('D MMMM YYYY');
-    this.wdfEndDate = dayjs(report.effectiveFrom).add(1, 'years').format('D MMMM YYYY');
-    this.overallEligibilityDate = dayjs(report.wdf.overallWdfEligibility).format('D MMMM YYYY');
+  private setDates(): void {
+    this.wdfStartDate = dayjs(this.report.effectiveFrom).format('D MMMM YYYY');
+    this.wdfEndDate = dayjs(this.report.effectiveFrom).add(1, 'years').format('D MMMM YYYY');
+    this.overallEligibilityDate = dayjs(this.report.wdf.overallWdfEligibility).format('D MMMM YYYY');
   }
 
   public viewYourData(): void {

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
@@ -283,6 +283,7 @@ const routes: Routes = [
     data: { title: 'Funding Requirements' },
     resolve: {
       pages: PageResolver,
+      report: FundingReportResolver,
     },
   },
   {

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
@@ -51,12 +51,11 @@ import { WdfStaffRecordComponent } from './wdf-staff-record/wdf-staff-record.com
 const routes: Routes = [
   {
     path: '',
-    // remove following 2 lines when wdf new design feature is live
     component: WdfOverviewComponent,
     data: { title: 'Workforce Development Fund' },
-    // uncomment following 2 lines when wdf new design feature is live
-    // redirectTo: 'data',
-    // pathMatch: 'full',
+    resolve: {
+      report: FundingReportResolver,
+    },
   },
   {
     path: 'data',

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
@@ -91,6 +91,7 @@ const routes: Routes = [
                 path: '',
                 component: WdfStaffRecordComponent,
                 data: { title: 'WDF Staff Record' },
+                resolve: { report: FundingReportResolver },
               },
               {
                 path: 'staff-details',
@@ -293,6 +294,7 @@ const routes: Routes = [
         path: '',
         component: WdfStaffRecordComponent,
         data: { title: 'WDF Staff Record' },
+        resolve: { report: FundingReportResolver },
       },
       {
         path: 'staff-details',

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CheckPermissionsGuard } from '@core/guards/permissions/check-permissions/check-permissions.guard';
 import { HasPermissionsGuard } from '@core/guards/permissions/has-permissions/has-permissions.guard';
+import { FundingReportResolver } from '@core/resolvers/funding-report.resolver';
 import { JobsResolver } from '@core/resolvers/jobs.resolver';
 import { PageResolver } from '@core/resolvers/page.resolver';
 import { WorkerResolver } from '@core/resolvers/worker.resolver';
@@ -65,6 +66,7 @@ const routes: Routes = [
     resolve: {
       workers: WorkersResolver,
       workplace: WorkplaceResolver,
+      report: FundingReportResolver,
     },
   },
   {
@@ -78,7 +80,7 @@ const routes: Routes = [
             component: WdfDataComponent,
             canActivate: [HasPermissionsGuard],
             data: { permissions: ['canViewWdfReport'], title: 'WDF data', withFunding: true },
-            resolve: { workplace: WorkplaceResolver },
+            resolve: { workplace: WorkplaceResolver, report: FundingReportResolver },
           },
           {
             path: 'staff-record/:id',

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.spec.ts
@@ -10,6 +10,7 @@ import { WorkerService } from '@core/services/worker.service';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockInternationalRecruitmentService } from '@core/test-utils/MockInternationalRecruitmentService';
+import { createMockWdfReport } from '@core/test-utils/MockReportService';
 import { MockWorkerService, workerBuilder, workerWithWdf } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
@@ -34,6 +35,7 @@ describe('WdfStaffRecordComponent', () => {
             snapshot: {
               data: {
                 worker: {},
+                report: createMockWdfReport(),
               },
               params: overrides.establishmentuid ? { establishmentuid: overrides.establishmentuid } : {},
               paramMap: {

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-record/wdf-staff-record.component.ts
@@ -86,13 +86,11 @@ export class WdfStaffRecordComponent implements OnInit, OnDestroy {
   }
 
   public getOverallWdfEligibility(): void {
-    this.subscriptions.add(
-      this.reportService.getWDFReport(this.workplaceUid).subscribe((report) => {
-        this.overallWdfEligibility = report.wdf.overall;
-        this.wdfStartDate = dayjs(report.effectiveFrom).format('D MMMM YYYY');
-        this.wdfEndDate = dayjs(report.effectiveFrom).add(1, 'years').format('D MMMM YYYY');
-      }),
-    );
+    const report = this.route.snapshot.data.report;
+
+    this.overallWdfEligibility = report.wdf.overall;
+    this.wdfStartDate = dayjs(report.effectiveFrom).format('D MMMM YYYY');
+    this.wdfEndDate = dayjs(report.effectiveFrom).add(1, 'years').format('D MMMM YYYY');
   }
 
   private setExitUrl(): void {

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.spec.ts
@@ -8,12 +8,10 @@ import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { ReportService } from '@core/services/report.service';
 import { UserService } from '@core/services/user.service';
 import { WorkerService } from '@core/services/worker.service';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { MockReportService } from '@core/test-utils/MockReportService';
 import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { PaginationComponent } from '@shared/components/pagination/pagination.component';
 import { SearchInputComponent } from '@shared/components/search-input/search-input.component';
@@ -36,7 +34,6 @@ describe('WdfStaffSummaryComponent', () => {
       imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, WdfModule, RouterModule],
       declarations: [PaginationComponent, TablePaginationWrapperComponent, SearchInputComponent],
       providers: [
-        { provide: ReportService, useFactory: MockReportService.factory(overrides?.report) },
         {
           provide: PermissionsService,
           useFactory: MockPermissionsService.factory(['canViewWorker']),
@@ -243,8 +240,8 @@ describe('WdfStaffSummaryComponent', () => {
       const overrides = {
         componentProperties: {
           workers,
+          overallWdfEligibility: true,
         },
-        report: { wdf: { overall: true } },
       };
 
       const { getAllByText } = await setup(overrides);
@@ -259,10 +256,7 @@ describe('WdfStaffSummaryComponent', () => {
       workers[1].wdfEligible = true;
       workers[2].wdfEligible = true;
       const overrides = {
-        componentProperties: {
-          workers,
-        },
-        report: { wdf: { overall: true } },
+        componentProperties: { workers, overallWdfEligibility: true },
       };
 
       const { getByText } = await setup(overrides);
@@ -277,10 +271,7 @@ describe('WdfStaffSummaryComponent', () => {
       workers[1].wdfEligible = true;
       workers[2].wdfEligible = true;
       const overrides = {
-        componentProperties: {
-          workers,
-        },
-        report: { wdf: { overall: true } },
+        componentProperties: { workers, overallWdfEligibility: true },
       };
 
       const { getByText, getAllByText } = await setup(overrides);
@@ -297,10 +288,7 @@ describe('WdfStaffSummaryComponent', () => {
       workers[1].wdfEligible = true;
       workers[2].wdfEligible = true;
       const overrides = {
-        componentProperties: {
-          workers,
-        },
-        report: { wdf: { overall: false } },
+        componentProperties: { workers, overallWdfEligibility: false },
       };
 
       const { getByText } = await setup(overrides);
@@ -315,10 +303,7 @@ describe('WdfStaffSummaryComponent', () => {
       workers[1].wdfEligible = true;
       workers[2].wdfEligible = false;
       const overrides = {
-        componentProperties: {
-          workers,
-        },
-        report: { wdf: { overall: false } },
+        componentProperties: { workers, overallWdfEligibility: false },
       };
 
       const { getByText, getAllByText } = await setup(overrides);

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-staff-summary/wdf-staff-summary.component.ts
@@ -1,8 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { ReportService } from '@core/services/report.service';
 import { TabsService } from '@core/services/tabs.service';
 import { WorkerService } from '@core/services/worker.service';
 import { StaffSummaryDirective } from '@shared/directives/staff-summary/staff-summary.directive';
@@ -13,8 +12,10 @@ import { orderBy } from 'lodash';
   templateUrl: './wdf-staff-summary.component.html',
 })
 export class WdfStaffSummaryComponent extends StaffSummaryDirective {
+  @Input() overallWdfEligibility: boolean;
+
+  public wdfView = true;
   public workplaceUid: string;
-  public overallWdfEligibility: boolean;
 
   constructor(
     protected permissionsService: PermissionsService,
@@ -22,10 +23,9 @@ export class WdfStaffSummaryComponent extends StaffSummaryDirective {
     protected router: Router,
     protected route: ActivatedRoute,
     protected establishmentService: EstablishmentService,
-    protected reportService: ReportService,
     protected tabsService: TabsService,
   ) {
-    super(permissionsService, workerService, router, route, establishmentService, reportService, tabsService);
+    super(permissionsService, workerService, router, route, establishmentService, tabsService);
   }
 
   public getWorkerRecordPath(worker) {
@@ -39,7 +39,6 @@ export class WdfStaffSummaryComponent extends StaffSummaryDirective {
   }
 
   protected init() {
-    this.getOverallWdfEligibility();
     this.saveWorkerList();
   }
 
@@ -56,14 +55,6 @@ export class WdfStaffSummaryComponent extends StaffSummaryDirective {
   public saveWorkerList() {
     const listOfWorkerUids = this.workers.map((worker) => worker.uid);
     localStorage.setItem('ListOfWorkers', JSON.stringify(listOfWorkerUids));
-  }
-
-  private getOverallWdfEligibility() {
-    this.subscriptions.add(
-      this.reportService.getWDFReport(this.workplace.uid).subscribe((report) => {
-        this.overallWdfEligibility = report.wdf.overall;
-      }),
-    );
   }
 
   public navigateToStaffRecords(event: Event): void {

--- a/frontend/src/app/shared/components/staff-summary/staff-summary.component.ts
+++ b/frontend/src/app/shared/components/staff-summary/staff-summary.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { ReportService } from '@core/services/report.service';
 import { TabsService } from '@core/services/tabs.service';
 import { WorkerService } from '@core/services/worker.service';
 import { StaffSummaryDirective } from '@shared/directives/staff-summary/staff-summary.directive';
@@ -19,10 +18,9 @@ export class StaffSummaryComponent extends StaffSummaryDirective implements OnIn
     protected router: Router,
     protected route: ActivatedRoute,
     protected establishmentService: EstablishmentService,
-    protected reportService: ReportService,
     protected tabsService: TabsService,
   ) {
-    super(permissionsService, workerService, router, route, establishmentService, reportService, tabsService);
+    super(permissionsService, workerService, router, route, establishmentService, tabsService);
   }
 
   protected init(): void {}

--- a/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
+++ b/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
@@ -4,7 +4,6 @@ import { Establishment, SortStaffOptions, WdfSortStaffOptions } from '@core/mode
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { ReportService } from '@core/services/report.service';
 import { TabsService } from '@core/services/tabs.service';
 import { WorkerService } from '@core/services/worker.service';
 import dayjs from 'dayjs';
@@ -43,7 +42,6 @@ export class StaffSummaryDirective implements OnInit {
     protected router: Router,
     protected route: ActivatedRoute,
     protected establishmentService: EstablishmentService,
-    protected reportService: ReportService,
     protected tabsService: TabsService,
   ) {}
 


### PR DESCRIPTION
#### Work done
- Created FundingReport resolver to use instead of calling `getWDFReport` in funding pages which was causing flickering on page load

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
