### PR TITLE
Fix/update funding warning messaging for capacities

### DIFF
--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-workplaces-summary/wdf-workplaces-summary.component.html
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-workplaces-summary/wdf-workplaces-summary.component.html
@@ -48,7 +48,7 @@
         <app-funding-requirements-state
           [overallWdfEligibility]="workplace.wdf.overall"
           [currentWdfEligibility]="workplace.wdf.workplace"
-          orangeFlagMessage="Number of staff mismatch"
+          orangeFlagMessage="Check your workplace data"
         ></app-funding-requirements-state>
       </td>
       <td class="govuk-table__cell">

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
@@ -181,7 +181,7 @@ describe('WdfWorkplacesSummaryComponent', () => {
         expect(getByText(meetingMessage, { exact: true })).toBeTruthy();
       });
 
-      it("should display orange flag and 'Number of staff mismatch' message when the workplace has qualified for funding but workplace is ineligible", async () => {
+      it("should display orange flag and 'Check your workplace data' message when the workplace has qualified for funding but workplace is ineligible", async () => {
         const workplaces = [
           {
             name: 'Workplace name',
@@ -196,7 +196,7 @@ describe('WdfWorkplacesSummaryComponent', () => {
         const { getByText } = await setup({ workplaces });
 
         expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-        expect(getByText('Number of staff mismatch', { exact: true })).toBeTruthy();
+        expect(getByText('Check your workplace data', { exact: true })).toBeTruthy();
       });
 
       it("should display orange flag and 'New staff records' message when the workplace has qualified for funding but staff records are ineligible", async () => {

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
@@ -256,6 +256,7 @@
     <app-wdf-warning-message
       *ngIf="workplace.wdf?.capacities?.isEligible === Eligibility.NO"
       [overallWdfEligibility]="overallWdfEligibility"
+      warningMessage="Add the capacity of your main service"
       data-testid="capacitiesWdfWarning"
     ></app-wdf-warning-message>
 

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
@@ -1215,6 +1215,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
       {
         name: 'capacities',
         validResponse: [{ message: '10 beds used (care home)' }],
+        specificMessage: 'Add the capacity of your main service',
       },
       {
         name: 'serviceUsers',
@@ -1247,7 +1248,9 @@ describe('WDFWorkplaceSummaryComponent', () => {
         validResponse: { name: 'Care Giving' },
       },
     ].forEach((field) => {
-      it(`should show 'Add this information' message and red flag when workplace is not eligible and needs to add ${field.name}`, async () => {
+      const expectedWarningMessage = field.specificMessage ?? 'Add this information';
+
+      it(`should show '${expectedWarningMessage}' message and red flag when workplace is not eligible and needs to add ${field.name}`, async () => {
         const workplace = establishmentWithWdfBuilder() as Establishment;
         workplace[field.name] = null;
         workplace.wdf[field.name].isEligible = Eligibility.NO;
@@ -1256,11 +1259,11 @@ describe('WDFWorkplaceSummaryComponent', () => {
 
         const wdfWarningSection = getByTestId(field.name + 'WdfWarning');
 
-        expect(within(wdfWarningSection).getByText('Add this information')).toBeTruthy();
+        expect(within(wdfWarningSection).getByText(expectedWarningMessage)).toBeTruthy();
         expect(within(wdfWarningSection).getByAltText('Red flag icon')).toBeTruthy();
       });
 
-      it(`should not show 'Add this information' message when workplace is not eligible but has added ${field.name}`, async () => {
+      it(`should not show '${expectedWarningMessage}' message when workplace is not eligible but has added ${field.name}`, async () => {
         const workplace = establishmentWithWdfBuilder() as Establishment;
         workplace[field.name] = field.validResponse;
         workplace.wdf[field.name].isEligible = Eligibility.YES;
@@ -1272,7 +1275,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         expect(wdfWarningSection).toBeFalsy();
       });
 
-      it(`should show 'Add this information' and orange flag when workplace does not have ${field.name} added but workplace has met WDF eligibility`, async () => {
+      it(`should show '${expectedWarningMessage}' and orange flag when workplace does not have ${field.name} added but workplace has met WDF eligibility`, async () => {
         const workplace = establishmentWithWdfBuilder() as Establishment;
         workplace[field.name] = null;
         workplace.wdf[field.name].isEligible = Eligibility.NO;
@@ -1281,7 +1284,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
 
         const wdfWarningSection = getByTestId(field.name + 'WdfWarning');
 
-        expect(within(wdfWarningSection).queryByText('Add this information')).toBeTruthy();
+        expect(within(wdfWarningSection).queryByText(expectedWarningMessage)).toBeTruthy();
         expect(within(wdfWarningSection).getByAltText('Orange flag icon')).toBeTruthy();
       });
     });

--- a/frontend/src/app/shared/components/staff-record-summary/wdf-warning-message/wdf-warning-message.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/wdf-warning-message/wdf-warning-message.component.html
@@ -16,7 +16,7 @@
           class="govuk-!-margin-right-1 govuk-util__vertical-align-top"
         />
       </ng-template>
-      Add this information
+      {{ warningMessage ?? 'Add this information' }}
     </div>
   </dd>
   <dd class="govuk-summary-list__value govuk-summary-list__message"></dd>

--- a/frontend/src/app/shared/components/staff-record-summary/wdf-warning-message/wdf-warning-message.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/wdf-warning-message/wdf-warning-message.component.spec.ts
@@ -12,7 +12,9 @@ describe('WdfWarningMessageComponent', () => {
     const { fixture, getByText, queryByAltText, queryByText } = await render(WdfWarningMessageComponent, {
       imports: [SharedModule, RouterTestingModule, HttpClientTestingModule, BrowserModule, WdfModule],
       componentProperties: {
-        overallWdfEligibility: overrides.overallWdfEligibility,
+        overallWdfEligibility: false,
+        warningMessage: null,
+        ...overrides,
       },
     });
 
@@ -42,6 +44,34 @@ describe('WdfWarningMessageComponent', () => {
     expect(queryByAltText('Red flag icon')).toBeFalsy();
 
     expect(getByText('Add this information')).toBeTruthy();
+    expect(queryByAltText('Orange flag icon')).toBeTruthy();
+  });
+
+  it('should display message passed in and red flag when not eligible overall  and specific warning message provided', async () => {
+    const specificMessage = 'Add the capacity of your main service';
+
+    const { getByText, queryByAltText } = await setup({
+      overallWdfEligibility: false,
+      warningMessage: specificMessage,
+    });
+
+    expect(getByText(specificMessage)).toBeTruthy();
+    expect(queryByAltText('Red flag icon')).toBeTruthy();
+
+    expect(queryByAltText('Orange flag icon')).toBeFalsy();
+  });
+
+  it('should display message passed in and orange flag when eligible overall and specific warning message provided', async () => {
+    const specificMessage = 'Add the capacity of your main service';
+
+    const { getByText, queryByAltText } = await setup({
+      overallWdfEligibility: true,
+      warningMessage: specificMessage,
+    });
+
+    expect(queryByAltText('Red flag icon')).toBeFalsy();
+
+    expect(getByText(specificMessage)).toBeTruthy();
     expect(queryByAltText('Orange flag icon')).toBeTruthy();
   });
 });

--- a/frontend/src/app/shared/components/staff-record-summary/wdf-warning-message/wdf-warning-message.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/wdf-warning-message/wdf-warning-message.component.ts
@@ -7,4 +7,5 @@ import { Component, Input } from '@angular/core';
 })
 export class WdfWarningMessageComponent {
   @Input() overallWdfEligibility: boolean;
+  @Input() warningMessage: string;
 }


### PR DESCRIPTION
#### Work done
- Updated staff mismatch warning message on funding workplaces summary to be generic as other cases found for workplace becoming ineligible
- Set specific warning message for Capacities to make clear they must add capacity for main service for funding eligibility

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
