### PR TITLE
Fix/add some subs meeting message to summary panel

### DIFF
--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.html
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.html
@@ -21,7 +21,7 @@
       [wdfEndDate]="wdfEndDate"
       [workplaceWdfEligibilityStatus]="wdfEligibilityStatus.currentWorkplace"
       [staffWdfEligibilityStatus]="wdfEligibilityStatus.currentStaff"
-      [parentOverallWdfEligibility]="parentOverallWdfEligibility"
+      [subsidiariesOverallWdfEligibility]="parentOverallWdfEligibility"
       [overallWdfEligibility]="wdfEligibilityStatus.overall"
       [isParent]="isParent"
       [activatedFragment]="activeTab.fragment"

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.html
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.html
@@ -21,9 +21,10 @@
       [wdfEndDate]="wdfEndDate"
       [workplaceWdfEligibilityStatus]="wdfEligibilityStatus.currentWorkplace"
       [staffWdfEligibilityStatus]="wdfEligibilityStatus.currentStaff"
-      [subsidiariesOverallWdfEligibility]="parentOverallWdfEligibility"
       [overallWdfEligibility]="wdfEligibilityStatus.overall"
       [isParent]="isParent"
+      [subsidiariesOverallWdfEligibility]="subsidiariesOverallWdfEligibility"
+      [someSubsidiariesMeetingRequirements]="someSubsidiariesMeetingRequirements"
       [activatedFragment]="activeTab.fragment"
     ></app-wdf-summary-panel>
   </div>

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-data/wdf-data.component.ts
@@ -38,8 +38,10 @@ export class WdfDataComponent implements OnInit {
   public returnUrl: URLStructure;
   private subscriptions: Subscription = new Subscription();
   private activeTabIndex: number;
-  public parentOverallWdfEligibility: boolean;
   public overallWdfEligibility: boolean;
+  public subsidiariesOverallWdfEligibility: boolean;
+  public someSubsidiariesMeetingRequirements: boolean;
+
   public isParent: boolean;
   public subsidiaryWorkplaces = [];
   public viewingSub: boolean;
@@ -176,15 +178,19 @@ export class WdfDataComponent implements OnInit {
           );
           this.subsidiaryWorkplaces = orderBy(activeSubsidiaryWorkplaces, ['wdf.overall', 'updated'], ['asc', 'desc']);
         }
-        this.getParentOverallWdfEligibility();
+
+        this.setSubsidiariesEligibility();
       }),
     );
   }
 
-  public getParentOverallWdfEligibility(): void {
-    this.parentOverallWdfEligibility = ![this.workplace, ...this.subsidiaryWorkplaces].some((workplace) => {
-      return workplace.wdf.overall === false;
-    });
+  public setSubsidiariesEligibility(): void {
+    this.subsidiariesOverallWdfEligibility = this.subsidiaryWorkplaces.every(
+      (workplace) => workplace.wdf.overall === true,
+    );
+    this.someSubsidiariesMeetingRequirements = this.subsidiaryWorkplaces.some(
+      (workplace) => workplace.wdf.overall === true,
+    );
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.html
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.html
@@ -24,6 +24,7 @@
       [parentOverallWdfEligibility]="parentOverallWdfEligibility"
       [overallWdfEligibility]="overallWdfEligibility"
       [isParent]="isParent"
+      [someSubsidiariesMeetingRequirements]="someSubsidiariesMeetingRequirements"
       [onDataPage]="false"
     ></app-wdf-summary-panel>
   </div>

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.html
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.html
@@ -21,9 +21,9 @@
       [wdfEndDate]="wdfEndDate"
       [workplaceWdfEligibilityStatus]="wdfEligibilityStatus.currentWorkplace"
       [staffWdfEligibilityStatus]="wdfEligibilityStatus.currentStaff"
-      [subsidiariesOverallWdfEligibility]="subsidiariesOverallWdfEligibility"
       [overallWdfEligibility]="overallWdfEligibility"
       [isParent]="isParent"
+      [subsidiariesOverallWdfEligibility]="subsidiariesOverallWdfEligibility"
       [someSubsidiariesMeetingRequirements]="someSubsidiariesMeetingRequirements"
       [onDataPage]="false"
     ></app-wdf-summary-panel>

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.html
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.html
@@ -21,7 +21,7 @@
       [wdfEndDate]="wdfEndDate"
       [workplaceWdfEligibilityStatus]="wdfEligibilityStatus.currentWorkplace"
       [staffWdfEligibilityStatus]="wdfEligibilityStatus.currentStaff"
-      [parentOverallWdfEligibility]="parentOverallWdfEligibility"
+      [subsidiariesOverallWdfEligibility]="subsidiariesOverallWdfEligibility"
       [overallWdfEligibility]="overallWdfEligibility"
       [isParent]="isParent"
       [someSubsidiariesMeetingRequirements]="someSubsidiariesMeetingRequirements"

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.html
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.html
@@ -36,8 +36,8 @@
     >
       <div data-testid="dataMetFunding">
         <p>
-          Your data met the funding requirements on {{ overallEligibilityDate }} and will continue to meet them until 31
-          March {{ wdfEndDate | date: 'yyyy' }}.
+          Your data met the funding requirements on {{ parentOverallEligibilityDate ?? overallEligibilityDate }} and
+          will continue to meet them until 31 March {{ wdfEndDate | date: 'yyyy' }}.
           <a [routerLink]="['data']" [relativeTo]="route">Keep your data current</a>, it might save you time next year.
         </p>
         <p class="govuk-!-margin-bottom-6">

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
@@ -278,22 +278,6 @@ describe('WdfOverviewComponent', () => {
       expect(workplacesRow).toBeTruthy();
     });
 
-    it('should display data has met paragraph', async () => {
-      const overrides = {
-        wdf: { overall: true, workplace: true, staff: true },
-        isParent: true,
-        parentOverallWdfEligibility: true,
-      };
-
-      const { getByText, getByTestId } = await setup(overrides);
-
-      const dataMetFundingParagraph = getByTestId('dataMetFunding');
-      const keepYourDataCurrentLink = getByText('Keep your data current');
-
-      expect(dataMetFundingParagraph).toBeTruthy();
-      expect(keepYourDataCurrentLink.getAttribute('ng-reflect-router-link')).toEqual('data');
-    });
-
     it('should not display the funding requirements inset text when requirements are met', async () => {
       const overrides = {
         wdf: { overall: true, workplace: true, staff: true },
@@ -306,6 +290,64 @@ describe('WdfOverviewComponent', () => {
       const fundingInsetText = queryByTestId('fundingInsetText');
 
       expect(fundingInsetText).toBeFalsy();
+    });
+
+    describe('Data has met paragraph', () => {
+      it('should display data has met paragraph', async () => {
+        const overrides = {
+          wdf: { overall: true, workplace: true, staff: true },
+          isParent: true,
+          parentOverallWdfEligibility: true,
+        };
+
+        const { getByText, getByTestId } = await setup(overrides);
+
+        const dataMetFundingParagraph = getByTestId('dataMetFunding');
+        const keepYourDataCurrentLink = getByText('Keep your data current');
+
+        expect(dataMetFundingParagraph).toBeTruthy();
+        expect(keepYourDataCurrentLink.getAttribute('ng-reflect-router-link')).toEqual('data');
+      });
+
+      it('should display overall eligibility date from parent when parent has latest eligibility date', async () => {
+        const overrides = {
+          wdf: { overall: true, workplace: true, staff: true, overallWdfEligibility: '2024-07-31' },
+          isParent: true,
+          getParentAndSubs: {
+            primary: { wdf: { overall: true, overallWdfEligibility: '2024-07-31' } },
+            subsidaries: {
+              establishments: [
+                { wdf: { overall: true, overallWdfEligibility: '2024-06-11' } },
+                { wdf: { overall: true, overallWdfEligibility: '2024-05-13' } },
+              ],
+            },
+          },
+        };
+
+        const { getByText } = await setup(overrides);
+
+        expect(getByText('Your data met the funding requirements on 31 July', { exact: false })).toBeTruthy();
+      });
+
+      it('should display overall eligibility date from latest sub when a sub has latest eligibility date', async () => {
+        const overrides = {
+          wdf: { overall: true, workplace: true, staff: true, overallWdfEligibility: '2024-07-31' },
+          isParent: true,
+          getParentAndSubs: {
+            primary: { wdf: { overall: true, overallWdfEligibility: '2024-07-31' } },
+            subsidaries: {
+              establishments: [
+                { wdf: { overall: true, overallWdfEligibility: '2024-06-11' } },
+                { wdf: { overall: true, overallWdfEligibility: '2024-10-13' } },
+              ],
+            },
+          },
+        };
+
+        const { getByText } = await setup(overrides);
+
+        expect(getByText('Your data met the funding requirements on 13 October', { exact: false })).toBeTruthy();
+      });
     });
   });
 
@@ -440,28 +482,6 @@ describe('WdfOverviewComponent', () => {
       fixture.detectChanges();
 
       expect(component.parentOverallWdfEligibility).toBeFalse();
-    });
-
-    it('should correctly calculate parentOverallEligibilityDate if all workplaces are eligible', async () => {
-      const overrides = {
-        isParent: true,
-        getParentAndSubs: {
-          primary: { wdf: { overall: true, overallWdfEligibility: '2021-08-31' } },
-          subsidaries: {
-            establishments: [
-              { wdf: { overall: true, overallWdfEligibility: '2021-07-31' } },
-              { wdf: { overall: true, overallWdfEligibility: '2021-05-01' } },
-            ],
-          },
-        },
-      };
-
-      const { component, fixture } = await setup(overrides);
-
-      component.getLastOverallEligibilityDate();
-      fixture.detectChanges();
-
-      expect(component.parentOverallEligibilityDate).toEqual('31 July 2021');
     });
   });
 });

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.spec.ts
@@ -314,7 +314,15 @@ describe('WdfOverviewComponent', () => {
       const overrides = {
         wdf: { overall: false, workplace: false, staff: false },
         isParent: true,
-        parentOverallWdfEligibility: false,
+        getParentAndSubs: {
+          primary: { wdf: { overall: false, overallWdfEligibility: null } },
+          subsidaries: {
+            establishments: [
+              { wdf: { overall: true, overallWdfEligibility: '2021-07-31' } },
+              { wdf: { overall: false, overallWdfEligibility: null } },
+            ],
+          },
+        },
       };
 
       const { queryByText, queryByTestId } = await setup(overrides);
@@ -328,9 +336,17 @@ describe('WdfOverviewComponent', () => {
 
     it('should display the funding requirements inset text when requirements are not met', async () => {
       const overrides = {
-        wdf: { overall: false, workplace: true, staff: true },
+        wdf: { overall: false, workplace: false, staff: true },
         isParent: true,
-        parentOverallWdfEligibility: false,
+        getParentAndSubs: {
+          primary: { wdf: { overall: false, overallWdfEligibility: null } },
+          subsidaries: {
+            establishments: [
+              { wdf: { overall: false, overallWdfEligibility: null } },
+              { wdf: { overall: false, overallWdfEligibility: null } },
+            ],
+          },
+        },
       };
 
       const { queryByTestId } = await setup(overrides);
@@ -338,6 +354,49 @@ describe('WdfOverviewComponent', () => {
       const fundingInsetText = queryByTestId('fundingInsetText');
 
       expect(fundingInsetText).toBeTruthy();
+    });
+
+    it('should display some data not meeting message when not eligible overall but some sub workplaces are eligible', async () => {
+      const overrides = {
+        isParent: true,
+        getParentAndSubs: {
+          primary: { wdf: { overall: true, overallWdfEligibility: '2021-08-31' } },
+          subsidaries: {
+            establishments: [
+              { wdf: { overall: true, overallWdfEligibility: '2021-07-31' } },
+              { wdf: { overall: false, overallWdfEligibility: null } },
+            ],
+          },
+        },
+      };
+
+      const { getByText } = await setup(overrides);
+
+      expect(
+        getByText(`Some data does not meet the funding requirements for ${currentYear} to ${currentYear + 1}`),
+      ).toBeTruthy();
+    });
+
+    it('should display meeting message for Your other workplaces when parent not eligible but all sub workplaces are eligible', async () => {
+      const overrides = {
+        isParent: true,
+        wdf: { overall: false, workplace: false, staff: false },
+        getParentAndSubs: {
+          primary: { wdf: { overall: false, overallWdfEligibility: null } },
+          subsidaries: {
+            establishments: [
+              { wdf: { overall: true, overallWdfEligibility: '2021-07-31' } },
+              { wdf: { overall: true, overallWdfEligibility: '2021-09-31' } },
+            ],
+          },
+        },
+      };
+
+      const { getByText } = await setup(overrides);
+
+      expect(
+        getByText(`Your data has met the funding requirements for ${currentYear} to ${currentYear + 1}`),
+      ).toBeTruthy();
     });
   });
 
@@ -403,25 +462,6 @@ describe('WdfOverviewComponent', () => {
       fixture.detectChanges();
 
       expect(component.parentOverallEligibilityDate).toEqual('31 July 2021');
-    });
-
-    it('should display some data not meeting message when not eligible overall but some sub workplaces are eligible', async () => {
-      const overrides = {
-        isParent: true,
-        getParentAndSubs: {
-          primary: { wdf: { overall: true, overallWdfEligibility: '2021-08-31' } },
-          subsidaries: {
-            establishments: [
-              { wdf: { overall: true, overallWdfEligibility: '2021-07-31' } },
-              { wdf: { overall: false, overallWdfEligibility: null } },
-            ],
-          },
-        },
-      };
-
-      const { getByText } = await setup(overrides);
-
-      expect(getByText('Some data does not meet the funding requirements for 2024 to 2025')).toBeTruthy();
     });
   });
 });

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.ts
@@ -24,6 +24,7 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
   public wdfEndDate: string;
   public overallWdfEligibility: boolean;
   public parentOverallWdfEligibility: boolean;
+  public subsidiariesOverallWdfEligibility: boolean;
   public someSubsidiariesMeetingRequirements: boolean;
   public overallEligibilityDate: string;
   public parentOverallEligibilityDate: string;
@@ -73,7 +74,8 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
           this.workplaces = orderBy(this.workplaces, ['wdf.overall', 'updated'], ['asc', 'desc']);
 
           this.getParentOverallWdfEligibility();
-          this.setSomeSubsidiariesMeetingRequirements(activeSubsidiaryWorkplaces);
+          this.getLastOverallEligibilityDate();
+          this.setSubsidiariesEligibility(activeSubsidiaryWorkplaces);
         }
       }),
     );
@@ -91,7 +93,8 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
     }
   }
 
-  public setSomeSubsidiariesMeetingRequirements(subsidiaryWorkplaces): void {
+  public setSubsidiariesEligibility(subsidiaryWorkplaces): void {
+    this.subsidiariesOverallWdfEligibility = subsidiaryWorkplaces.every((workplace) => workplace.wdf.overall === true);
     this.someSubsidiariesMeetingRequirements = subsidiaryWorkplaces.some((workplace) => workplace.wdf.overall === true);
   }
 

--- a/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.ts
+++ b/frontend/src/app/features/wdf/wdf-data-change/wdf-overview/wdf-overview.component.ts
@@ -71,7 +71,7 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
           );
 
           this.workplaces = [...activeSubsidiaryWorkplaces, workplaces.primary];
-          this.workplaces = orderBy(this.workplaces, ['wdf.overall', 'updated'], ['asc', 'desc']);
+          this.workplaces = orderBy(this.workplaces, ['wdf.overall', 'wdf.overallWdfEligibility'], ['desc', 'desc']);
 
           this.getParentOverallWdfEligibility();
           this.getLastOverallEligibilityDate();

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.html
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.html
@@ -19,13 +19,11 @@
               class="govuk-link--no-visited-state"
               data-testid="met-funding-message"
             >
-              Your data has met the funding requirements for {{ wdfStartDate | date: 'yyyy' }} to
-              {{ wdfEndDate | date: 'yyyy' }}
+              {{ section.meetingMessage }}
             </a>
           </ng-container>
           <ng-template #noLink>
-            Your data has met the funding requirements for {{ wdfStartDate | date: 'yyyy' }} to
-            {{ wdfEndDate | date: 'yyyy' }}
+            {{ section.meetingMessage }}
           </ng-template>
         </ng-container>
         <ng-template #redFlag>
@@ -42,13 +40,11 @@
               class="govuk-link--no-visited-state"
               data-testid="not-met-funding-message"
             >
-              Your data does not meet the funding requirements for {{ wdfStartDate | date: 'yyyy' }} to
-              {{ wdfEndDate | date: 'yyyy' }}
+              {{ section.notMeetingMessage }}
             </a>
           </ng-container>
           <ng-template #noLink>
-            Your data does not meet the funding requirements for {{ wdfStartDate | date: 'yyyy' }} to
-            {{ wdfEndDate | date: 'yyyy' }}
+            {{ section.notMeetingMessage }}
           </ng-template>
         </ng-template>
       </div>

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.scss
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.scss
@@ -1,10 +1,10 @@
 .summary-section {
   &__title {
-    width: 31%;
+    width: 29%;
     padding: 0 15px;
   }
 
   &__summary-text {
-    width: 69%;
+    width: 71%;
   }
 }

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
@@ -109,7 +109,7 @@ describe('WdfSummaryPanel', () => {
 
     it('should display the correct message with timeframe for meeting WDF requirements for all other workplaces', async () => {
       const overrides = {
-        parentOverallWdfEligibility: true,
+        subsidiariesOverallWdfEligibility: true,
         isParent: true,
       };
 
@@ -186,7 +186,7 @@ describe('WdfSummaryPanel', () => {
         const overrides = {
           workplaceWdfEligibilityStatus: true,
           staffWdfEligibilityStatus: true,
-          parentOverallWdfEligibility: true,
+          subsidiariesOverallWdfEligibility: true,
           isParent: true,
         };
 
@@ -209,7 +209,7 @@ describe('WdfSummaryPanel', () => {
         const overrides = {
           workplaceWdfEligibilityStatus: true,
           staffWdfEligibilityStatus: true,
-          parentOverallWdfEligibility: true,
+          subsidiariesOverallWdfEligibility: true,
           isParent: true,
           activatedFragment: 'workplaces',
         };
@@ -270,7 +270,7 @@ describe('WdfSummaryPanel', () => {
       const overrides = {
         workplaceWdfEligibilityStatus: false,
         staffWdfEligibilityStatus: false,
-        parentOverallWdfEligibility: false,
+        subsidiariesOverallWdfEligibility: false,
         isParent: true,
         overallWdfEligibility: false,
       };
@@ -289,7 +289,7 @@ describe('WdfSummaryPanel', () => {
       const overrides = {
         workplaceWdfEligibilityStatus: false,
         staffWdfEligibilityStatus: false,
-        parentOverallWdfEligibility: false,
+        subsidiariesOverallWdfEligibility: false,
         someSubsidiariesMeetingRequirements: true,
         isParent: true,
         overallWdfEligibility: false,
@@ -366,7 +366,7 @@ describe('WdfSummaryPanel', () => {
 
         it(`should navigate to your other workplaces when clicked ${scenario}`, async () => {
           const overrides = {
-            parentOverallWdfEligibility: isEligible,
+            subsidiariesOverallWdfEligibility: isEligible,
             isParent: true,
             onDataPage,
           };

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
@@ -14,6 +14,7 @@ describe('WdfSummaryPanel', () => {
   const messages = {
     fundingMet: `Your data has met the funding requirements for ${currentYear} to ${currentYear + 1}`,
     fundingNotMet: `Your data does not meet the funding requirements for ${currentYear} to ${currentYear + 1}`,
+    fundingMetBySomeSubs: `Some data does not meet the funding requirements for ${currentYear} to ${currentYear + 1}`,
   };
 
   const setup = async (overrides: any = {}) => {
@@ -282,6 +283,27 @@ describe('WdfSummaryPanel', () => {
       expect(within(workplacesRow).queryByText(messages.fundingMet)).toBeFalsy();
       expect(within(workplacesRow).getByText(messages.fundingNotMet)).toBeTruthy();
       expect(within(workplacesRow).getByTestId('red-flag')).toBeTruthy();
+    });
+
+    it('should display some subs not meeting requirements message when some sub workplaces are meeting', async () => {
+      const overrides = {
+        workplaceWdfEligibilityStatus: false,
+        staffWdfEligibilityStatus: false,
+        parentOverallWdfEligibility: false,
+        someSubsidiariesMeetingRequirements: true,
+        isParent: true,
+        overallWdfEligibility: false,
+      };
+
+      const { getByTestId } = await setup(overrides);
+
+      const workplacesRow = getByTestId('workplaces-row');
+
+      expect(within(workplacesRow).getByText(messages.fundingMetBySomeSubs)).toBeTruthy();
+      expect(within(workplacesRow).getByTestId('red-flag')).toBeTruthy();
+
+      expect(within(workplacesRow).queryByText(messages.fundingMet)).toBeFalsy();
+      expect(within(workplacesRow).queryByText(messages.fundingNotMet)).toBeFalsy();
     });
   });
 

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
@@ -18,7 +18,7 @@ describe('WdfSummaryPanel', () => {
   };
 
   const setup = async (overrides: any = {}) => {
-    const { fixture, getByText, queryByText, getByTestId, queryByTestId } = await render(WdfSummaryPanel, {
+    const setupTools = await render(WdfSummaryPanel, {
       imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule],
       providers: [],
       componentProperties: {
@@ -27,13 +27,13 @@ describe('WdfSummaryPanel', () => {
         ...overrides,
       },
     });
-    const component = fixture.componentInstance;
+    const component = setupTools.fixture.componentInstance;
 
     const injector = getTestBed();
     const router = injector.inject(Router) as Router;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
 
-    return { component, fixture, getByText, queryByText, getByTestId, queryByTestId, routerSpy };
+    return { ...setupTools, component, routerSpy };
   };
 
   it('should create', async () => {
@@ -285,7 +285,7 @@ describe('WdfSummaryPanel', () => {
       expect(within(workplacesRow).getByTestId('red-flag')).toBeTruthy();
     });
 
-    it('should display some subs not meeting requirements message when some sub workplaces are meeting', async () => {
+    it('should display some data not meeting requirements message when ineligible but some sub workplaces are meeting', async () => {
       const overrides = {
         workplaceWdfEligibilityStatus: false,
         staffWdfEligibilityStatus: false,

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
@@ -14,7 +14,7 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   @Input() wdfStartDate: string;
   @Input() wdfEndDate: string;
   @Input() isParent: boolean;
-  @Input() parentOverallWdfEligibility: boolean;
+  @Input() subsidiariesOverallWdfEligibility: boolean;
   @Input() overallWdfEligibility: boolean;
   @Input() activatedFragment: string;
   @Input() onDataPage: boolean = true;
@@ -71,7 +71,7 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
     if (this.isParent) {
       this.sections.push({
         title: 'Your other workplaces',
-        eligibility: this.parentOverallWdfEligibility,
+        eligibility: this.subsidiariesOverallWdfEligibility,
         fragment: 'workplaces',
         showLink: true,
         meetingMessage: this.meetingMessage,
@@ -88,7 +88,7 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   }
 
   private getOtherWorkplacesNotMeetingMessage(): string {
-    if (!this.parentOverallWdfEligibility && this.someSubsidiariesMeetingRequirements) {
+    if (!this.subsidiariesOverallWdfEligibility && this.someSubsidiariesMeetingRequirements) {
       return this.someSubsMeetingMessage;
     }
     return this.notMeetingMessage;

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
@@ -1,3 +1,4 @@
+import { DatePipe } from '@angular/common';
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
@@ -5,6 +6,7 @@ import { Router } from '@angular/router';
   selector: 'app-wdf-summary-panel',
   templateUrl: './wdf-summary-panel.component.html',
   styleUrls: ['../summary-section/summary-section.component.scss', './wdf-summary-panel.component.scss'],
+  providers: [DatePipe],
 })
 export class WdfSummaryPanel implements OnInit, OnChanges {
   @Input() workplaceWdfEligibilityStatus: boolean;
@@ -16,12 +18,17 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   @Input() overallWdfEligibility: boolean;
   @Input() activatedFragment: string;
   @Input() onDataPage: boolean = true;
+  @Input() someSubsidiariesMeetingRequirements: boolean;
 
   public sections: any = [];
+  public meetingMessage: string;
+  public notMeetingMessage: string;
+  public someSubsMeetingMessage: string;
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private datePipe: DatePipe) {}
 
   ngOnInit(): void {
+    this.setMessages();
     this.getSections();
     this.showLink(this.activatedFragment);
   }
@@ -29,6 +36,15 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   ngOnChanges(): void {
     this.getSections();
     this.showLink(this.activatedFragment);
+  }
+
+  private setMessages(): void {
+    const formattedStartDate = this.datePipe.transform(this.wdfStartDate, 'yyyy');
+    const formattedEndDate = this.datePipe.transform(this.wdfEndDate, 'yyyy');
+
+    this.meetingMessage = `Your data has met the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
+    this.notMeetingMessage = `Your data does not meet the funding requirements for  ${formattedStartDate} to ${formattedEndDate}`;
+    this.someSubsMeetingMessage = `Some data does not meet the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
   }
 
   public getSections(): void {
@@ -39,12 +55,16 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
           this.workplaceWdfEligibilityStatus || (!this.workplaceWdfEligibilityStatus && this.overallWdfEligibility),
         fragment: 'workplace',
         showLink: true,
+        meetingMessage: this.meetingMessage,
+        notMeetingMessage: this.notMeetingMessage,
       },
       {
         title: 'Staff records',
         eligibility: this.staffWdfEligibilityStatus || (!this.staffWdfEligibilityStatus && this.overallWdfEligibility),
         fragment: 'staff',
         showLink: true,
+        meetingMessage: this.meetingMessage,
+        notMeetingMessage: this.notMeetingMessage,
       },
     ];
 
@@ -54,6 +74,8 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
         eligibility: this.parentOverallWdfEligibility,
         fragment: 'workplaces',
         showLink: true,
+        meetingMessage: this.meetingMessage,
+        notMeetingMessage: this.getOtherWorkplacesNotMeetingMessage(),
       });
     }
   }
@@ -63,6 +85,13 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
 
     const urlToNavigateTo = this.onDataPage ? [] : ['/wdf/data'];
     this.router.navigate(urlToNavigateTo, { fragment: fragment });
+  }
+
+  private getOtherWorkplacesNotMeetingMessage(): string {
+    if (!this.parentOverallWdfEligibility && this.someSubsidiariesMeetingRequirements) {
+      return this.someSubsMeetingMessage;
+    }
+    return this.notMeetingMessage;
   }
 
   public showLink(fragment: string): void {

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
@@ -43,7 +43,7 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
     const formattedEndDate = this.datePipe.transform(this.wdfEndDate, 'yyyy');
 
     this.meetingMessage = `Your data has met the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
-    this.notMeetingMessage = `Your data does not meet the funding requirements for  ${formattedStartDate} to ${formattedEndDate}`;
+    this.notMeetingMessage = `Your data does not meet the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
     this.someSubsMeetingMessage = `Some data does not meet the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
   }
 


### PR DESCRIPTION
#### Work done
- Changed funding summary panel to display '_Some data does not meet the funding requirements..._' message in Your other workplaces section when some sub workplaces eligible
- Updated funding overview page to display latest eligibility date for parent and sub eligibility instead of the parent's

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
