### PR TITLE
Feat/1577 mandatory training select job roles

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -4,9 +4,7 @@ import { ErrorHandler, NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import {
-  ProblemWithTheServiceComponent,
-} from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
+import { ProblemWithTheServiceComponent } from '@core/components/error/problem-with-the-service/problem-with-the-service.component';
 import { ServiceUnavailableComponent } from '@core/components/error/service-unavailable/service-unavailable.component';
 import { FooterComponent } from '@core/components/footer/footer.component';
 import { HeaderComponent } from '@core/components/header/header.component';
@@ -20,9 +18,7 @@ import { AllUsersForEstablishmentResolver } from '@core/resolvers/dashboard/all-
 import { TotalStaffRecordsResolver } from '@core/resolvers/dashboard/total-staff-records.resolver';
 import { FundingReportResolver } from '@core/resolvers/funding-report.resolver';
 import { GetMissingCqcLocationsResolver } from '@core/resolvers/getMissingCqcLocations/getMissingCqcLocations.resolver';
-import {
-  GetNoOfWorkersWhoRequireInternationalRecruitmentAnswersResolver,
-} from '@core/resolvers/international-recruitment/no-of-workers-who-require-international-recruitment-answers.resolver';
+import { GetNoOfWorkersWhoRequireInternationalRecruitmentAnswersResolver } from '@core/resolvers/international-recruitment/no-of-workers-who-require-international-recruitment-answers.resolver';
 import { LoggedInUserResolver } from '@core/resolvers/logged-in-user.resolver';
 import { NotificationsListResolver } from '@core/resolvers/notifications-list.resolver';
 import { PageResolver } from '@core/resolvers/page.resolver';
@@ -51,17 +47,13 @@ import { PreviousRouteService } from '@core/services/previous-route.service';
 import { QualificationService } from '@core/services/qualification.service';
 import { RecruitmentService } from '@core/services/recruitment.service';
 import { RegistrationService } from '@core/services/registration.service';
-import { TrainingService } from '@core/services/training.service';
+import { MandatoryTrainingService, TrainingService } from '@core/services/training.service';
 import { windowProvider, WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
 import { AdminSkipService } from '@features/bulk-upload/admin-skip.service';
-import {
-  ParentWorkplaceAccounts,
-} from '@features/create-account/workplace/parent-workplace-accounts/parent-workplace-accounts.component';
-import {
-  SelectMainServiceComponent,
-} from '@features/create-account/workplace/select-main-service/select-main-service.component';
+import { ParentWorkplaceAccounts } from '@features/create-account/workplace/parent-workplace-accounts/parent-workplace-accounts.component';
+import { SelectMainServiceComponent } from '@features/create-account/workplace/select-main-service/select-main-service.component';
 import { AscWdsCertificateComponent } from '@features/dashboard/asc-wds-certificate/asc-wds-certificate.component';
 import { DashboardHeaderComponent } from '@features/dashboard/dashboard-header/dashboard-header.component';
 import { DashboardComponent } from '@features/dashboard/dashboard.component';
@@ -88,9 +80,7 @@ import { NewWorkplaceTabComponent } from '@features/new-dashboard/workplace-tab/
 import { ResetPasswordConfirmationComponent } from '@features/reset-password/confirmation/confirmation.component';
 import { ResetPasswordEditComponent } from '@features/reset-password/edit/edit.component';
 import { ResetPasswordComponent } from '@features/reset-password/reset-password.component';
-import {
-  SelectStarterJobRolesComponent,
-} from '@features/workplace/select-starter-job-roles/select-starter-job-roles.component';
+import { SelectStarterJobRolesComponent } from '@features/workplace/select-starter-job-roles/select-starter-job-roles.component';
 import { BenchmarksModule } from '@shared/components/benchmarks-tab/benchmarks.module';
 import { DataAreaTabModule } from '@shared/components/data-area-tab/data-area-tab.module';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
@@ -100,12 +90,8 @@ import { HighchartsChartModule } from 'highcharts-angular';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import {
-  StaffMismatchBannerComponent,
-} from './features/dashboard/home-tab/staff-mismatch-banner/staff-mismatch-banner.component';
-import {
-  MigratedUserTermsConditionsComponent,
-} from './features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
+import { StaffMismatchBannerComponent } from './features/dashboard/home-tab/staff-mismatch-banner/staff-mismatch-banner.component';
+import { MigratedUserTermsConditionsComponent } from './features/migrated-user-terms-conditions/migrated-user-terms-conditions.component';
 import { SatisfactionSurveyComponent } from './features/satisfaction-survey/satisfaction-survey.component';
 import { SentryErrorHandler } from './SentryErrorHandler.component';
 
@@ -191,6 +177,7 @@ import { SentryErrorHandler } from './SentryErrorHandler.component';
     RegistrationService,
     { provide: ErrorHandler, useClass: SentryErrorHandler },
     TrainingService,
+    MandatoryTrainingService,
     WindowRef,
     WorkerService,
     InternationalRecruitmentService,

--- a/frontend/src/app/core/services/training.service.ts
+++ b/frontend/src/app/core/services/training.service.ts
@@ -125,3 +125,20 @@ export class TrainingService {
     this.updatingSelectedStaffForMultipleTraining = null;
   }
 }
+
+export class MandatoryTrainingService extends TrainingService {
+  _onlySelectedJobRoles: boolean = null;
+
+  public get onlySelectedJobRoles(): boolean {
+    return this._onlySelectedJobRoles;
+  }
+
+  public set onlySelectedJobRoles(onlySelected: boolean) {
+    this._onlySelectedJobRoles = onlySelected;
+  }
+
+  public resetState(): void {
+    this.onlySelectedJobRoles = null;
+    super.resetState();
+  }
+}

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-routing.module.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { JobsResolver } from '@core/resolvers/jobs.resolver';
 import { MandatoryTrainingCategoriesResolver } from '@core/resolvers/mandatory-training-categories.resolver';
 import { TrainingCategoriesResolver } from '@core/resolvers/training-categories.resolver';
 import { DeleteMandatoryTrainingCategoryComponent } from '@features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component';
@@ -8,6 +9,7 @@ import { AddAndManageMandatoryTrainingComponent } from './add-and-manage-mandato
 import { AddMandatoryTrainingComponent } from './add-mandatory-training.component';
 import { AllOrSelectedJobRolesComponent } from './all-or-selected-job-roles/all-or-selected-job-roles.component';
 import { RemoveAllMandatoryTrainingComponent } from './delete-mandatory-training/delete-all-mandatory-training.component';
+import { SelectJobRolesMandatoryComponent } from './select-job-roles-mandatory/select-job-roles-mandatory.component';
 import { SelectTrainingCategoryMandatoryComponent } from './select-training-category-mandatory/select-training-category-mandatory.component';
 
 const routes: Routes = [
@@ -32,6 +34,12 @@ const routes: Routes = [
         path: 'all-or-selected-job-roles',
         component: AllOrSelectedJobRolesComponent,
         data: { title: 'All or Selected Job Roles?' },
+      },
+      {
+        path: 'select-job-roles',
+        component: SelectJobRolesMandatoryComponent,
+        data: { title: 'Select Job Roles' },
+        resolve: { jobs: JobsResolver },
       },
       {
         path: 'remove-all-mandatory-training',

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-training.module.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-training.module.ts
@@ -11,6 +11,7 @@ import { AddAndManageMandatoryTrainingComponent } from './add-and-manage-mandato
 import { AddMandatoryTrainingComponent } from './add-mandatory-training.component';
 import { AllOrSelectedJobRolesComponent } from './all-or-selected-job-roles/all-or-selected-job-roles.component';
 import { RemoveAllMandatoryTrainingComponent } from './delete-mandatory-training/delete-all-mandatory-training.component';
+import { SelectJobRolesMandatoryComponent } from './select-job-roles-mandatory/select-job-roles-mandatory.component';
 import { SelectTrainingCategoryMandatoryComponent } from './select-training-category-mandatory/select-training-category-mandatory.component';
 
 @NgModule({
@@ -22,6 +23,7 @@ import { SelectTrainingCategoryMandatoryComponent } from './select-training-cate
     AddAndManageMandatoryTrainingComponent,
     DeleteMandatoryTrainingCategoryComponent,
     AllOrSelectedJobRolesComponent,
+    SelectJobRolesMandatoryComponent,
   ],
   providers: [TrainingCategoriesResolver, MandatoryTrainingCategoriesResolver],
 })

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/all-or-selected-job-roles/all-or-selected-job-roles.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/all-or-selected-job-roles/all-or-selected-job-roles.component.ts
@@ -9,7 +9,7 @@ import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { TrainingService } from '@core/services/training.service';
+import { MandatoryTrainingService } from '@core/services/training.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -36,7 +36,7 @@ export class AllOrSelectedJobRolesComponent {
     private errorSummaryService: ErrorSummaryService,
     private backLinkService: BackLinkService,
     public route: ActivatedRoute,
-    private trainingService: TrainingService,
+    private trainingService: MandatoryTrainingService,
     private alertService: AlertService,
     private establishmentService: EstablishmentService,
   ) {
@@ -46,6 +46,10 @@ export class AllOrSelectedJobRolesComponent {
   ngOnInit(): void {
     this.establishment = this.route.snapshot.parent?.data?.establishment;
     this.selectedTrainingCategory = this.trainingService.selectedTraining;
+
+    if (this.trainingService.onlySelectedJobRoles) {
+      this.form.setValue({ allOrSelectedJobRoles: 'selectJobRoles' });
+    }
 
     if (!this.selectedTrainingCategory) {
       this.router.navigate(['../select-training-category'], { relativeTo: this.route });
@@ -79,6 +83,7 @@ export class AllOrSelectedJobRolesComponent {
       if (this.selectedRadio == 'allJobRoles') {
         this.createMandatoryTraining();
       } else {
+        this.trainingService.onlySelectedJobRoles = true;
         this.navigateToSelectJobRolesPage();
       }
     } else {

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.html
@@ -1,6 +1,8 @@
+<app-error-summary *ngIf="submitted && form.invalid" [formErrorsMap]="formErrorsMap" [form]="form"> </app-error-summary>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <form #formEl [formGroup]="form">
+    <form #formEl (ngSubmit)="onSubmit()" [formGroup]="form">
       <fieldset class="govuk-fieldset">
         <div class="govuk-form-group govuk-!-margin-bottom-2">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -38,18 +40,18 @@
           </app-accordion-group>
         </div>
       </fieldset>
-    </form>
 
-    <div class="govuk-button-group govuk-!-margin-top-4">
-      <button type="submit" class="govuk-button govuk-!-margin-right-9">Save mandatory training</button>
-      <a
-        role="button"
-        href="#"
-        class="govuk-button govuk-button--link govuk-!-margin-left-9"
-        draggable="false"
-        (click)="onCancel($event)"
-        >Cancel</a
-      >
-    </div>
+      <div class="govuk-button-group govuk-!-margin-top-4">
+        <button type="submit" class="govuk-button govuk-!-margin-right-9">Save mandatory training</button>
+        <a
+          role="button"
+          href="#"
+          class="govuk-button govuk-button--link govuk-!-margin-left-9"
+          draggable="false"
+          (click)="onCancel($event)"
+          >Cancel</a
+        >
+      </div>
+    </form>
   </div>
 </div>

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.html
@@ -1,8 +1,14 @@
-<app-error-summary *ngIf="submitted && form.invalid" [formErrorsMap]="formErrorsMap" [form]="form"> </app-error-summary>
+<app-error-summary
+  *ngIf="submitted && (form.invalid || serverError)"
+  [formErrorsMap]="formErrorsMap"
+  [form]="form"
+  [serverError]="serverError"
+>
+</app-error-summary>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <form #formEl (ngSubmit)="onSubmit()" [formGroup]="form">
+    <form #formEl (ngSubmit)="onSubmit()" [formGroup]="form" id="server-error">
       <fieldset class="govuk-fieldset">
         <div class="govuk-form-group govuk-!-margin-bottom-2">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.html
@@ -13,7 +13,7 @@
         <div class="govuk-form-group govuk-!-margin-bottom-2">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <span class="govuk-caption-l" data-testid="section-heading">Add a mandatory training category</span>
-            <h1 class="govuk-fieldset__heading">Select the job roles which need this training</h1>
+            <h1 class="govuk-fieldset__heading">Select the job roles that need this training</h1>
           </legend>
         </div>
 

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.html
@@ -1,0 +1,55 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form #formEl [formGroup]="form">
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group govuk-!-margin-bottom-2">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <span class="govuk-caption-l" data-testid="section-heading">Add a mandatory training category</span>
+            <h1 class="govuk-fieldset__heading">Select the job roles which need this training</h1>
+          </legend>
+        </div>
+
+        <div [class.govuk-form-group--error]="submitted && form.invalid">
+          <app-accordion-group #accordion data-testid="selectJobRolesAccordion" contentName="job roles">
+            <p *ngIf="submitted && form.invalid" id="selectedJobRoles-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ errorMessageOnEmptyInput }}
+            </p>
+            <app-accordion-section
+              *ngFor="let group of jobGroups"
+              [title]="group.title"
+              [description]="group.descriptionText"
+              [expandedAtStart]="false"
+            >
+              <ng-container *ngFor="let job of group.items">
+                <div class="govuk-checkboxes__item">
+                  <input
+                    type="checkbox"
+                    class="govuk-checkboxes__input"
+                    [id]="'job-' + job.id"
+                    [name]="job.label"
+                    [value]="job.id"
+                    [checked]="form.get('selectedJobRoles').value.includes(job.id)"
+                    (change)="onCheckboxClick($event.target)"
+                  />
+                  <label class="govuk-label govuk-checkboxes__label" [for]="'job-' + job.id"> {{ job.label }} </label>
+                </div>
+              </ng-container>
+            </app-accordion-section>
+          </app-accordion-group>
+        </div>
+      </fieldset>
+    </form>
+
+    <div class="govuk-button-group govuk-!-margin-top-4">
+      <button type="submit" class="govuk-button govuk-!-margin-right-9">Save mandatory training</button>
+      <a
+        role="button"
+        href="#"
+        class="govuk-button govuk-button--link govuk-!-margin-left-9"
+        draggable="false"
+        (click)="onCancel($event)"
+        >Cancel</a
+      >
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.spec.ts
@@ -13,7 +13,7 @@ import { MockTrainingService } from '@core/test-utils/MockTrainingService';
 import { GroupedRadioButtonAccordionComponent } from '@shared/components/accordions/radio-button-accordion/grouped-radio-button-accordion/grouped-radio-button-accordion.component';
 import { RadioButtonAccordionComponent } from '@shared/components/accordions/radio-button-accordion/radio-button-accordion.component';
 import { SharedModule } from '@shared/shared.module';
-import { render } from '@testing-library/angular';
+import { render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
 import { AddMandatoryTrainingModule } from '../add-mandatory-training.module';
@@ -138,6 +138,57 @@ describe('SelectJobRolesMandatoryComponent', () => {
         const checkbox = getByRole('checkbox', { name: job.title });
         expect(checkbox).toBeTruthy();
       });
+    });
+  });
+
+  describe('Errors', () => {
+    const expectedErrorMessage = 'Select the job roles that need this training';
+    const errorSummaryBoxHeading = 'There is a problem';
+
+    it('should display an error message on submit if no job roles are selected', async () => {
+      const { fixture, getByRole, getByText, getByTestId } = await setup();
+
+      userEvent.click(getByRole('button', { name: 'Save mandatory training' }));
+      fixture.detectChanges();
+
+      const accordion = getByTestId('selectJobRolesAccordion');
+      expect(within(accordion).getByText(expectedErrorMessage)).toBeTruthy();
+
+      const thereIsAProblemMessage = getByText(errorSummaryBoxHeading);
+
+      const errorSummaryBox = thereIsAProblemMessage.parentElement;
+      expect(within(errorSummaryBox).getByText(expectedErrorMessage)).toBeTruthy();
+    });
+
+    it('should expand the whole accordion on error', async () => {
+      const { fixture, getByRole, getByText } = await setup();
+
+      userEvent.click(getByRole('button', { name: 'Save mandatory training' }));
+      fixture.detectChanges();
+
+      expect(getByText('Hide all job roles')).toBeTruthy();
+    });
+
+    it('should continue to display error messages after empty submit and then user selects job roles', async () => {
+      const { fixture, getByRole, getByText } = await setup();
+
+      userEvent.click(getByRole('button', { name: 'Save mandatory training' }));
+      fixture.detectChanges();
+
+      const errorSummaryBox = getByText(errorSummaryBoxHeading).parentElement;
+
+      expect(errorSummaryBox).toBeTruthy();
+      expect(within(errorSummaryBox).getByText(expectedErrorMessage)).toBeTruthy();
+
+      userEvent.click(getByText('Care worker'));
+      userEvent.click(getByText('Registered nurse'));
+
+      fixture.detectChanges();
+
+      const errorSummaryBoxStillThere = getByText(errorSummaryBoxHeading).parentElement;
+
+      expect(errorSummaryBoxStillThere).toBeTruthy();
+      expect(within(errorSummaryBoxStillThere).getByText(expectedErrorMessage)).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.spec.ts
@@ -12,8 +12,12 @@ import { MandatoryTrainingService } from '@core/services/training.service';
 import { WindowRef } from '@core/services/window.ref';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockRouter } from '@core/test-utils/MockRouter';
-import { GroupedRadioButtonAccordionComponent } from '@shared/components/accordions/radio-button-accordion/grouped-radio-button-accordion/grouped-radio-button-accordion.component';
-import { RadioButtonAccordionComponent } from '@shared/components/accordions/radio-button-accordion/radio-button-accordion.component';
+import {
+  GroupedRadioButtonAccordionComponent,
+} from '@shared/components/accordions/radio-button-accordion/grouped-radio-button-accordion/grouped-radio-button-accordion.component';
+import {
+  RadioButtonAccordionComponent,
+} from '@shared/components/accordions/radio-button-accordion/radio-button-accordion.component';
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
@@ -139,7 +143,7 @@ describe('SelectJobRolesMandatoryComponent', () => {
   it('should show the page heading', async () => {
     const { getByText } = await setup();
 
-    const heading = getByText('Select the job roles which need this training');
+    const heading = getByText('Select the job roles that need this training');
 
     expect(heading).toBeTruthy();
   });

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.spec.ts
@@ -1,0 +1,163 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Establishment } from '@core/model/establishment.model';
+import { BackLinkService } from '@core/services/backLink.service';
+import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { TrainingService } from '@core/services/training.service';
+import { WindowRef } from '@core/services/window.ref';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
+import { MockTrainingService } from '@core/test-utils/MockTrainingService';
+import { GroupedRadioButtonAccordionComponent } from '@shared/components/accordions/radio-button-accordion/grouped-radio-button-accordion/grouped-radio-button-accordion.component';
+import { RadioButtonAccordionComponent } from '@shared/components/accordions/radio-button-accordion/radio-button-accordion.component';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+import { AddMandatoryTrainingModule } from '../add-mandatory-training.module';
+import { SelectJobRolesMandatoryComponent } from './select-job-roles-mandatory.component';
+
+describe('SelectJobRolesMandatoryComponent', () => {
+  const mockAvailableJobs = [
+    {
+      id: 4,
+      title: 'Allied health professional (not occupational therapist)',
+      jobRoleGroup: 'Professional and related roles',
+    },
+    {
+      id: 10,
+      title: 'Care worker',
+      jobRoleGroup: 'Care providing roles',
+    },
+    {
+      id: 23,
+      title: 'Registered nurse',
+      jobRoleGroup: 'Professional and related roles',
+    },
+    {
+      id: 27,
+      title: 'Social worker',
+      jobRoleGroup: 'Professional and related roles',
+    },
+    {
+      id: 20,
+      title: 'Other (directly involved in providing care)',
+      jobRoleGroup: 'Care providing roles',
+    },
+  ];
+
+  async function setup() {
+    const establishment = establishmentBuilder() as Establishment;
+
+    const setupTools = await render(SelectJobRolesMandatoryComponent, {
+      imports: [HttpClientTestingModule, SharedModule, RouterModule, RouterTestingModule, AddMandatoryTrainingModule],
+      declarations: [GroupedRadioButtonAccordionComponent, RadioButtonAccordionComponent],
+      providers: [
+        BackLinkService,
+        ErrorSummaryService,
+        WindowRef,
+        FormBuilder,
+        {
+          provide: TrainingService,
+          useClass: MockTrainingService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                establishment,
+                jobs: mockAvailableJobs,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const component = setupTools.fixture.componentInstance;
+
+    const injector = getTestBed();
+
+    const router = injector.inject(Router) as Router;
+    const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+
+    const trainingService = injector.inject(TrainingService) as TrainingService;
+    const resetStateInTrainingServiceSpy = spyOn(trainingService, 'resetState').and.callThrough();
+
+    return {
+      ...setupTools,
+      component,
+      routerSpy,
+      resetStateInTrainingServiceSpy,
+    };
+  }
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should show the page caption', async () => {
+    const { getByText } = await setup();
+
+    const caption = getByText('Add a mandatory training category');
+
+    expect(caption).toBeTruthy();
+  });
+
+  it('should show the page heading', async () => {
+    const { getByText } = await setup();
+
+    const heading = getByText('Select the job roles which need this training');
+
+    expect(heading).toBeTruthy();
+  });
+
+  describe('Accordion', () => {
+    it('should render an accordion for job role selection', async () => {
+      const { getByTestId, getByText } = await setup();
+
+      expect(getByTestId('selectJobRolesAccordion')).toBeTruthy();
+      expect(getByText('Show all job roles')).toBeTruthy();
+    });
+
+    it('should render an accordion section for each job role group', async () => {
+      const { getByText } = await setup();
+
+      expect(getByText('Care providing roles')).toBeTruthy();
+      expect(getByText('Professional and related roles')).toBeTruthy();
+    });
+
+    it('should render a checkbox for each job role', async () => {
+      const { getByRole } = await setup();
+
+      mockAvailableJobs.forEach((job) => {
+        const checkbox = getByRole('checkbox', { name: job.title });
+        expect(checkbox).toBeTruthy();
+      });
+    });
+  });
+
+  describe('On click of Cancel button', () => {
+    it('should return to the add-and-manage-mandatory-training page', async () => {
+      const { component, getByText, routerSpy } = await setup();
+
+      const cancelButton = getByText('Cancel');
+      userEvent.click(cancelButton);
+
+      expect(routerSpy).toHaveBeenCalledWith(['../'], { relativeTo: component.route });
+    });
+
+    it('should clear state in training service', async () => {
+      const { getByText, resetStateInTrainingServiceSpy } = await setup();
+
+      const cancelButton = getByText('Cancel');
+      userEvent.click(cancelButton);
+
+      expect(resetStateInTrainingServiceSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.spec.ts
@@ -8,7 +8,7 @@ import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { TrainingService } from '@core/services/training.service';
+import { MandatoryTrainingService } from '@core/services/training.service';
 import { WindowRef } from '@core/services/window.ref';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockRouter } from '@core/test-utils/MockRouter';
@@ -75,7 +75,7 @@ describe('SelectJobRolesMandatoryComponent', () => {
         { provide: Router, useFactory: MockRouter.factory({ navigate: routerSpy }) },
         { provide: EstablishmentService, useClass: MockEstablishmentService },
         {
-          provide: TrainingService,
+          provide: MandatoryTrainingService,
           useValue: {
             selectedTraining: overrides.selectedTraining !== undefined ? overrides.selectedTraining : selectedTraining,
             resetState: () => {},
@@ -102,7 +102,7 @@ describe('SelectJobRolesMandatoryComponent', () => {
     const alertService = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alertService, 'addAlert').and.callThrough();
 
-    const trainingService = injector.inject(TrainingService) as TrainingService;
+    const trainingService = injector.inject(MandatoryTrainingService) as MandatoryTrainingService;
     const resetStateInTrainingServiceSpy = spyOn(trainingService, 'resetState').and.callThrough();
 
     const establishmentService = injector.inject(EstablishmentService) as EstablishmentService;

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
@@ -41,6 +41,7 @@ export class SelectJobRolesMandatoryComponent {
   public selectedJobIds: number[] = [];
   public errorMessageOnEmptyInput: string = 'Select the job roles that need this training';
   public formErrorsMap: Array<ErrorDetails> = [];
+  public serverError: string;
   public subscriptions: Subscription = new Subscription();
   private establishment: Establishment;
   private selectedTrainingCategory: SelectedTraining;
@@ -125,7 +126,9 @@ export class SelectJobRolesMandatoryComponent {
             message: 'Mandatory training category added',
           });
         },
-        () => {},
+        () => {
+          this.serverError = 'There has been a problem saving your mandatory training. Please try again.';
+        },
       ),
     );
   }

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
@@ -1,9 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ErrorDetails } from '@core/model/errorSummary.model';
 import { Job, JobGroup } from '@core/model/job.model';
+import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { JobService } from '@core/services/job.service';
 import { TrainingService } from '@core/services/training.service';
+import { AccordionGroupComponent } from '@shared/components/accordions/generic-accordion/accordion-group/accordion-group.component';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
 
 @Component({
@@ -15,14 +18,20 @@ export class SelectJobRolesMandatoryComponent {
     private formBuilder: UntypedFormBuilder,
     private trainingService: TrainingService,
     private router: Router,
+    private errorSummaryService: ErrorSummaryService,
     public route: ActivatedRoute,
   ) {}
+
+  @ViewChild('accordion') accordion: AccordionGroupComponent;
+  @ViewChild('formEl') formEl: ElementRef;
 
   public form: UntypedFormGroup;
   public jobGroups: JobGroup[] = [];
   public jobsAvailable: Job[] = [];
   public submitted: boolean;
   public selectedJobIds: number[] = [];
+  public errorMessageOnEmptyInput: string = 'Select the job roles that need this training';
+  public formErrorsMap: Array<ErrorDetails> = [];
 
   ngOnInit(): void {
     this.getJobs();
@@ -38,6 +47,18 @@ export class SelectJobRolesMandatoryComponent {
     this.form = this.formBuilder.group({
       selectedJobRoles: [[], { validators: CustomValidators.validateArrayNotEmpty(), updateOn: 'submit' }],
     });
+
+    this.formErrorsMap = [
+      {
+        item: 'selectedJobRoles',
+        type: [
+          {
+            name: 'selectedNone',
+            message: this.errorMessageOnEmptyInput,
+          },
+        ],
+      },
+    ];
   }
 
   public onCheckboxClick(target: HTMLInputElement) {
@@ -50,10 +71,24 @@ export class SelectJobRolesMandatoryComponent {
     }
   }
 
+  public onSubmit(): void {
+    this.submitted = true;
+
+    this.form.get('selectedJobRoles').setValue(this.selectedJobIds);
+
+    if (this.form.invalid) {
+      this.accordion.showAll();
+    }
+  }
+
   public onCancel(event: Event): void {
     event.preventDefault();
 
     this.trainingService.resetState();
     this.router.navigate(['../'], { relativeTo: this.route });
+  }
+
+  ngAfterViewInit() {
+    this.errorSummaryService.formEl$.next(this.formEl);
   }
 }

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
@@ -3,6 +3,8 @@ import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ErrorDetails } from '@core/model/errorSummary.model';
 import { Job, JobGroup } from '@core/model/job.model';
+import { AlertService } from '@core/services/alert.service';
+import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { JobService } from '@core/services/job.service';
 import { TrainingService } from '@core/services/training.service';
@@ -19,6 +21,8 @@ export class SelectJobRolesMandatoryComponent {
     private trainingService: TrainingService,
     private router: Router,
     private errorSummaryService: ErrorSummaryService,
+    private backLinkService: BackLinkService,
+    private alertService: AlertService,
     public route: ActivatedRoute,
   ) {}
 
@@ -36,6 +40,7 @@ export class SelectJobRolesMandatoryComponent {
   ngOnInit(): void {
     this.getJobs();
     this.setupForm();
+    this.backLinkService.showBackLink();
   }
 
   private getJobs(): void {
@@ -78,13 +83,26 @@ export class SelectJobRolesMandatoryComponent {
 
     if (this.form.invalid) {
       this.accordion.showAll();
+      this.errorSummaryService.scrollToErrorSummary();
+      return;
     }
+
+    this.navigateBackToAddMandatoryTrainingPage();
+    this.alertService.addAlert({
+      type: 'success',
+      message: 'Mandatory training category added',
+    });
+    this.trainingService.resetState();
   }
 
   public onCancel(event: Event): void {
     event.preventDefault();
 
     this.trainingService.resetState();
+    this.navigateBackToAddMandatoryTrainingPage();
+  }
+
+  private navigateBackToAddMandatoryTrainingPage(): void {
     this.router.navigate(['../'], { relativeTo: this.route });
   }
 

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
@@ -10,7 +10,7 @@ import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { JobService } from '@core/services/job.service';
-import { TrainingService } from '@core/services/training.service';
+import { MandatoryTrainingService } from '@core/services/training.service';
 import { AccordionGroupComponent } from '@shared/components/accordions/generic-accordion/accordion-group/accordion-group.component';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
 import { Subscription } from 'rxjs';
@@ -22,7 +22,7 @@ import { Subscription } from 'rxjs';
 export class SelectJobRolesMandatoryComponent {
   constructor(
     private formBuilder: UntypedFormBuilder,
-    private trainingService: TrainingService,
+    private trainingService: MandatoryTrainingService,
     private router: Router,
     private errorSummaryService: ErrorSummaryService,
     private backLinkService: BackLinkService,

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
@@ -1,0 +1,59 @@
+import { Component } from '@angular/core';
+import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Job, JobGroup } from '@core/model/job.model';
+import { JobService } from '@core/services/job.service';
+import { TrainingService } from '@core/services/training.service';
+import { CustomValidators } from '@shared/validators/custom-form-validators';
+
+@Component({
+  selector: 'app-select-job-roles-mandatory',
+  templateUrl: './select-job-roles-mandatory.component.html',
+})
+export class SelectJobRolesMandatoryComponent {
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private trainingService: TrainingService,
+    private router: Router,
+    public route: ActivatedRoute,
+  ) {}
+
+  public form: UntypedFormGroup;
+  public jobGroups: JobGroup[] = [];
+  public jobsAvailable: Job[] = [];
+  public submitted: boolean;
+  public selectedJobIds: number[] = [];
+
+  ngOnInit(): void {
+    this.getJobs();
+    this.setupForm();
+  }
+
+  private getJobs(): void {
+    this.jobsAvailable = this.route.snapshot.data.jobs;
+    this.jobGroups = JobService.sortJobsByJobGroup(this.jobsAvailable);
+  }
+
+  private setupForm(): void {
+    this.form = this.formBuilder.group({
+      selectedJobRoles: [[], { validators: CustomValidators.validateArrayNotEmpty(), updateOn: 'submit' }],
+    });
+  }
+
+  public onCheckboxClick(target: HTMLInputElement) {
+    const jobId = Number(target.value);
+
+    if (this.selectedJobIds.includes(jobId)) {
+      this.selectedJobIds = this.selectedJobIds.filter((id) => id !== jobId);
+    } else {
+      this.selectedJobIds = [...this.selectedJobIds, jobId];
+    }
+  }
+
+  public onCancel(event: Event): void {
+    event.preventDefault();
+
+    this.trainingService.resetState();
+    this.router.navigate(['../'], { relativeTo: this.route });
+  }
+}

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-job-roles-mandatory/select-job-roles-mandatory.component.ts
@@ -3,6 +3,7 @@ import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ErrorDetails } from '@core/model/errorSummary.model';
 import { Job, JobGroup } from '@core/model/job.model';
+import { SelectedTraining } from '@core/model/training.model';
 import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
@@ -36,11 +37,18 @@ export class SelectJobRolesMandatoryComponent {
   public selectedJobIds: number[] = [];
   public errorMessageOnEmptyInput: string = 'Select the job roles that need this training';
   public formErrorsMap: Array<ErrorDetails> = [];
+  private selectedTrainingCategory: SelectedTraining;
 
   ngOnInit(): void {
+    this.selectedTrainingCategory = this.trainingService.selectedTraining;
+
+    if (!this.selectedTrainingCategory) {
+      this.router.navigate(['../select-training-category'], { relativeTo: this.route });
+    }
+
+    this.backLinkService.showBackLink();
     this.getJobs();
     this.setupForm();
-    this.backLinkService.showBackLink();
   }
 
   private getJobs(): void {

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-training-category-mandatory/select-training-category-mandatory.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-training-category-mandatory/select-training-category-mandatory.component.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { TrainingService } from '@core/services/training.service';
+import { MandatoryTrainingService } from '@core/services/training.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
 import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
@@ -39,7 +39,7 @@ describe('SelectTrainingCategoryMandatoryComponent', () => {
           useClass: MockWorkerService,
         },
         {
-          provide: TrainingService,
+          provide: MandatoryTrainingService,
           useClass: overrides.prefill ? MockTrainingServiceWithPreselectedStaff : MockTrainingService,
         },
         {
@@ -64,7 +64,7 @@ describe('SelectTrainingCategoryMandatoryComponent', () => {
     const injector = getTestBed();
 
     const router = injector.inject(Router) as Router;
-    const trainingService = injector.inject(TrainingService) as TrainingService;
+    const trainingService = injector.inject(MandatoryTrainingService) as MandatoryTrainingService;
 
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
 

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-training-category-mandatory/select-training-category-mandatory.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/select-training-category-mandatory/select-training-category-mandatory.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
-import { TrainingService } from '@core/services/training.service';
+import { MandatoryTrainingService } from '@core/services/training.service';
 import { WorkerService } from '@core/services/worker.service';
 
 import { SelectTrainingCategoryDirective } from '../../../../shared/directives/select-training-category/select-training-category.directive';
@@ -15,7 +15,7 @@ import { SelectTrainingCategoryDirective } from '../../../../shared/directives/s
 export class SelectTrainingCategoryMandatoryComponent extends SelectTrainingCategoryDirective {
   constructor(
     protected formBuilder: FormBuilder,
-    protected trainingService: TrainingService,
+    protected trainingService: MandatoryTrainingService,
     protected router: Router,
     protected backLinkService: BackLinkService,
     protected workerService: WorkerService,


### PR DESCRIPTION
#### Work done
- Created new '_Select job roles_' page for new add mandatory training flow
- Created MandatoryTrainingService which extends the functionality of the training service and stores when user has chosen only selected job roles which allows pre-selecting radio on return to page. 

#### Note
My thinking with creating an extending service for mandatory training is that it removes the risk of side effects in other training flows which I had spotted. If you began selecting mandatory training and then navigated to a different area without clicking Cancel, pages could be pre-populated as they were using the same data fields stored in the service. A class which extends has its own instantiation of its parent class which should prevent this issue.

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
