### PR TITLE
Feat/1584 changes to the add and manage mandatory training page

### DIFF
--- a/frontend/src/app/core/model/training.model.ts
+++ b/frontend/src/app/core/model/training.model.ts
@@ -97,8 +97,9 @@ export interface mandatoryJobs {
 
 export interface mandatoryTraining {
   trainingCategoryId: number;
-  allJobRoles: boolean;
+  allJobRoles?: boolean;
   selectedJobRoles?: boolean;
+  category?: string;
   jobs: mandatoryJobs[];
 }
 export interface allMandatoryTrainingCategories {

--- a/frontend/src/app/core/test-utils/MockTrainingService.ts
+++ b/frontend/src/app/core/test-utils/MockTrainingService.ts
@@ -40,32 +40,7 @@ export class MockTrainingService extends TrainingService {
   }
 
   public getAllMandatoryTrainings(): Observable<allMandatoryTrainingCategories> {
-    return of({
-      allJobRolesCount: 37,
-      lastUpdated: new Date(),
-      mandatoryTraining: [
-        {
-          trainingCategoryId: 123,
-          allJobRoles: false,
-          category: 'Autism',
-          selectedJobRoles: true,
-          jobs: [
-            {
-              id: 15,
-              title: 'Activities worker, coordinator',
-            },
-          ],
-        },
-        {
-          trainingCategoryId: 9,
-          allJobRoles: true,
-          category: 'Coshh',
-          selectedJobRoles: true,
-          jobs: this._duplicateJobRoles ? JobsWithDuplicates : AllJobs,
-        },
-      ],
-      mandatoryTrainingCount: 2,
-    });
+    return of(mockMandatoryTraining(this._duplicateJobRoles));
   }
 
   public deleteCategoryById(establishmentId, categoryId) {
@@ -99,3 +74,32 @@ export class MockTrainingServiceWithPreselectedStaff extends MockTrainingService
     };
   }
 }
+
+export const mockMandatoryTraining = (duplicateJobRoles) => {
+  return {
+    allJobRolesCount: 37,
+    lastUpdated: new Date(),
+    mandatoryTraining: [
+      {
+        trainingCategoryId: 123,
+        allJobRoles: false,
+        category: 'Autism',
+        selectedJobRoles: true,
+        jobs: [
+          {
+            id: 15,
+            title: 'Activities worker, coordinator',
+          },
+        ],
+      },
+      {
+        trainingCategoryId: 9,
+        allJobRoles: true,
+        category: 'Coshh',
+        selectedJobRoles: true,
+        jobs: duplicateJobRoles ? JobsWithDuplicates : AllJobs,
+      },
+    ],
+    mandatoryTrainingCount: 2,
+  };
+};

--- a/frontend/src/app/core/test-utils/MockTrainingService.ts
+++ b/frontend/src/app/core/test-utils/MockTrainingService.ts
@@ -75,7 +75,7 @@ export class MockTrainingServiceWithPreselectedStaff extends MockTrainingService
   }
 }
 
-export const mockMandatoryTraining = (duplicateJobRoles) => {
+export const mockMandatoryTraining = (duplicateJobRoles = false) => {
   return {
     allJobRolesCount: 37,
     lastUpdated: new Date(),

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
@@ -6,15 +6,19 @@
     </h1>
   </div>
 </div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half govuk-!-margin-top-2" data-testid="mandatoryTrainingInfo">
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-two-thirds" style="width: 63%" data-testid="mandatoryTrainingInfo">
     <p>
-      Add the training categories you want to make mandatory for your staff. It will help you identify<br />
-      who is missing training and let you know when<br />
-      training expires.
+      Add the training categories you want to make mandatory for your staff. It will help you identify who is missing
+      training and let you know when training expires.
     </p>
   </div>
-  <div class="govuk-grid-column-one-half govuk-util__align-right" data-testid="mandatoryTrainingButton">
+
+  <div
+    class="govuk-grid-column-one-third govuk-util__align-right"
+    style="width: 37%"
+    data-testid="mandatoryTrainingButton"
+  >
     <button (click)="navigateToAddNewMandatoryTraining()" class="govuk-button">
       Add a mandatory training category
     </button>
@@ -29,8 +33,7 @@
       <th class="govuk-table__header" scope="col">
         <a
           *ngIf="existingMandatoryTrainings?.mandatoryTrainingCount > 0"
-          class="govuk-link govuk-link--no-visited-state"
-          style="font-weight: normal"
+          class="govuk-link govuk-link--no-visited-state govuk-util__normal"
           data-testid="removeMandatoryTrainingLink"
           draggable="false"
           role="button"

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
@@ -79,10 +79,11 @@
             <div data-testid="titleJob" *ngFor="let job of records.jobs">{{ job.title }}</div>
           </ng-container>
         </td>
-        <td class="govuk-table__cell">
+        <td class="govuk-table__cell govuk-util__align-right">
           <a
             href="#"
             (click)="navigateToDeletePage($event, records.trainingCategoryId)"
+            class="govuk-link govuk-link--no-visited-state"
             [attr.data-testid]="'remove-link-' + records.category"
           >
             Remove

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
@@ -20,31 +20,29 @@
     </button>
   </div>
 </div>
-<div class="govuk-grid-row">
-  <div
-    class="govuk-grid-column-one-thirds govuk-!-margin-bottom-6 govuk-!-margin-right-4 govuk-util__align-right govuk-list govuk-list--inline"
-    *ngIf="existingMandatoryTrainings?.mandatoryTrainingCount > 0"
-  >
-    <a
-      data-testid="removeMandatoryTrainingLink"
-      draggable="false"
-      role="button"
-      [routerLink]="[
-        '/workplace',
-        establishment.uid,
-        'add-and-manage-mandatory-training',
-        'remove-all-mandatory-training'
-      ]"
-      >Remove all mandatory training categories</a
-    >
-  </div>
-</div>
 
 <table class="govuk-table" data-testid="training-table" *ngIf="existingMandatoryTrainings?.mandatoryTrainingCount > 0">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row" data-testid="training-table-heading">
-      <th class="govuk-table__header" scope="col">Mandatory training categories</th>
-      <th class="govuk-table__header" scope="col">Job roles</th>
+      <th class="govuk-table__header" scope="col">Mandatory training category</th>
+      <th class="govuk-table__header" scope="col">Job role</th>
+      <th class="govuk-table__header" scope="col">
+        <a
+          *ngIf="existingMandatoryTrainings?.mandatoryTrainingCount > 0"
+          class="govuk-link govuk-link--no-visited-state"
+          style="font-weight: normal"
+          data-testid="removeMandatoryTrainingLink"
+          draggable="false"
+          role="button"
+          [routerLink]="[
+            '/workplace',
+            establishment.uid,
+            'add-and-manage-mandatory-training',
+            'remove-all-mandatory-training'
+          ]"
+          >Remove all</a
+        >
+      </th>
     </tr>
   </thead>
   <ng-container>
@@ -78,6 +76,7 @@
             <div data-testid="titleJob" *ngFor="let job of records.jobs">{{ job.title }}</div>
           </ng-container>
         </td>
+        <td class="govuk-table__cell"></td>
       </tr>
     </tbody>
   </ng-container>

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
@@ -79,7 +79,15 @@
             <div data-testid="titleJob" *ngFor="let job of records.jobs">{{ job.title }}</div>
           </ng-container>
         </td>
-        <td class="govuk-table__cell"></td>
+        <td class="govuk-table__cell">
+          <a
+            href="#"
+            (click)="navigateToDeletePage($event, records.trainingCategoryId)"
+            [attr.data-testid]="'remove-link-' + records.category"
+          >
+            Remove
+          </a>
+        </td>
       </tr>
     </tbody>
   </ng-container>

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.spec.ts
@@ -3,12 +3,13 @@ import { getTestBed } from '@angular/core/testing';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { Establishment } from '@core/model/establishment.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { TrainingService } from '@core/services/training.service';
 import { WindowRef } from '@core/services/window.ref';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockTrainingService } from '@core/test-utils/MockTrainingService';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { SharedModule } from '@shared/shared.module';
@@ -18,6 +19,8 @@ import { AddAndManageMandatoryTrainingComponent } from './add-and-manage-mandato
 
 describe('AddAndManageMandatoryTrainingComponent', () => {
   async function setup(isOwnWorkplace = true, duplicateJobRoles = false) {
+    const establishment = establishmentBuilder() as Establishment;
+
     const { getByText, getByLabelText, getByTestId, fixture } = await render(AddAndManageMandatoryTrainingComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [],
@@ -47,9 +50,7 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
             parent: {
               snapshot: {
                 data: {
-                  establishment: {
-                    uid: '123',
-                  },
+                  establishment,
                 },
               },
             },
@@ -73,6 +74,7 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
       component,
       parentSubsidiaryViewService,
       establishmentService,
+      establishment,
     };
   }
 
@@ -96,11 +98,14 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
     expect(addMandatoryTrainingButton.textContent).toContain('Add a mandatory training category');
   });
 
-  it('should show the Remove all mandatory training categories link', async () => {
-    const { getByTestId } = await setup();
+  it('should show the Remove all link with link to the remove all page', async () => {
+    const { getByText, establishment } = await setup();
 
-    const removeMandatoryTrainingLink = getByTestId('removeMandatoryTrainingLink');
-    expect(removeMandatoryTrainingLink).toBeTruthy();
+    const removeMandatoryTrainingLink = getByText('Remove all') as HTMLAnchorElement;
+
+    expect(removeMandatoryTrainingLink.href).toContain(
+      `/workplace/${establishment.uid}/add-and-manage-mandatory-training/remove-all-mandatory-training`,
+    );
   });
 
   it('should show the manage mandatory training table', async () => {
@@ -111,13 +116,13 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
     expect(mandatoryTrainingTable).toBeTruthy();
   });
 
-  it('should show the manage mandatory training table heading', async () => {
+  it('should show the manage mandatory training table headings', async () => {
     const { getByTestId } = await setup();
 
     const mandatoryTrainingTableHeading = getByTestId('training-table-heading');
 
-    expect(mandatoryTrainingTableHeading.textContent).toContain('Mandatory training categories');
-    expect(mandatoryTrainingTableHeading.textContent).toContain('Job roles');
+    expect(mandatoryTrainingTableHeading.textContent).toContain('Mandatory training category');
+    expect(mandatoryTrainingTableHeading.textContent).toContain('Job role');
   });
 
   describe('mandatory training table records', () => {

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -10,7 +9,7 @@ import { TrainingService } from '@core/services/training.service';
 import { WindowRef } from '@core/services/window.ref';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { MockTrainingService } from '@core/test-utils/MockTrainingService';
+import { mockMandatoryTraining, MockTrainingService } from '@core/test-utils/MockTrainingService';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
@@ -46,6 +45,9 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
           useValue: {
             snapshot: {
               url: [{ path: 'add-and-manage-mandatory-training' }],
+              data: {
+                existingMandatoryTraining: mockMandatoryTraining(duplicateJobRoles),
+              },
             },
             parent: {
               snapshot: {
@@ -163,26 +165,6 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
 
       expect(coshCategory.textContent).toContain('All');
       expect(autismCategory.textContent).toContain('Activities worker, coordinator');
-    });
-  });
-
-  describe('getBreadcrumbsJourney', () => {
-    it('should return mandatory training journey when viewing sub as parent', async () => {
-      const { component, parentSubsidiaryViewService } = await setup();
-      spyOn(parentSubsidiaryViewService, 'getViewingSubAsParent').and.returnValue(true);
-      expect(component.getBreadcrumbsJourney()).toBe(JourneyType.MANDATORY_TRAINING);
-    });
-
-    it('should return mandatory training journey when is own workplace', async () => {
-      const { component } = await setup();
-
-      expect(component.getBreadcrumbsJourney()).toBe(JourneyType.MANDATORY_TRAINING);
-    });
-
-    it('should return all workplaces journey when is not own workplace and not in parent sub view', async () => {
-      const { component } = await setup(false);
-
-      expect(component.getBreadcrumbsJourney()).toBe(JourneyType.ALL_WORKPLACES);
     });
   });
 });

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.spec.ts
@@ -46,14 +46,8 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
             snapshot: {
               url: [{ path: 'add-and-manage-mandatory-training' }],
               data: {
+                establishment,
                 existingMandatoryTraining: overrides.mandatoryTraining ?? existingMandatoryTraining,
-              },
-            },
-            parent: {
-              snapshot: {
-                data: {
-                  establishment,
-                },
               },
             },
           },
@@ -84,19 +78,25 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show header, paragraph and links for manage mandatory training', async () => {
+  it('should show header and paragraph', async () => {
     const { getByTestId } = await setup();
 
     const mandatoryTrainingHeader = getByTestId('heading');
-
     const mandatoryTrainingInfo = getByTestId('mandatoryTrainingInfo');
 
-    const addMandatoryTrainingButton = getByTestId('mandatoryTrainingButton');
     expect(mandatoryTrainingHeader.textContent).toContain('Add and manage mandatory training categories');
     expect(mandatoryTrainingInfo.textContent).toContain(
       'Add the training categories you want to make mandatory for your staff. It will help you identify who is missing training and let you know when training expires.',
     );
-    expect(addMandatoryTrainingButton.textContent).toContain('Add a mandatory training category');
+  });
+
+  it("should navigate to the select-training-category page when 'Add a mandatory training category' link is clicked", async () => {
+    const { getByText, routerSpy, currentRoute } = await setup();
+
+    const addMandatoryTrainingButton = getByText('Add a mandatory training category');
+    fireEvent.click(addMandatoryTrainingButton);
+
+    expect(routerSpy).toHaveBeenCalledWith(['select-training-category'], { relativeTo: currentRoute });
   });
 
   describe('Remove all link', () => {

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
@@ -29,8 +29,8 @@ export class AddAndManageMandatoryTrainingComponent implements OnInit {
 
   ngOnInit(): void {
     this.breadcrumbService.show(JourneyType.MANDATORY_TRAINING);
-    this.establishment = this.route.parent.snapshot.data.establishment;
 
+    this.establishment = this.route.snapshot.data?.establishment;
     this.existingMandatoryTrainings = this.route.snapshot.data?.existingMandatoryTraining;
     this.sortTrainingAlphabetically(this.existingMandatoryTrainings.mandatoryTraining);
     this.allJobsLength = this.existingMandatoryTrainings.allJobRolesCount;
@@ -67,12 +67,7 @@ export class AddAndManageMandatoryTrainingComponent implements OnInit {
   }
 
   public navigateToAddNewMandatoryTraining() {
-    this.router.navigate([
-      '/workplace',
-      this.establishmentService.establishment.uid,
-      'add-and-manage-mandatory-training',
-      'select-training-category',
-    ]);
+    this.router.navigate(['select-training-category'], { relativeTo: this.route });
   }
 
   public navigateToDeletePage(event: Event, trainingCategoryId: number): void {

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
@@ -74,4 +74,9 @@ export class AddAndManageMandatoryTrainingComponent implements OnInit {
       'select-training-category',
     ]);
   }
+
+  public navigateToDeletePage(event: Event, trainingCategoryId: number): void {
+    event.preventDefault();
+    this.router.navigate([trainingCategoryId, 'delete-mandatory-training-category'], { relativeTo: this.route });
+  }
 }

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
@@ -6,15 +6,12 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { JobService } from '@core/services/job.service';
 import { TrainingService } from '@core/services/training.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-add-and-manage-mandatory-training',
   templateUrl: './add-and-manage-mandatory-training.component.html',
 })
 export class AddAndManageMandatoryTrainingComponent implements OnInit {
-  private subscriptions: Subscription = new Subscription();
   public establishment: Establishment;
   public existingMandatoryTrainings: any;
   public allJobsLength: Number;
@@ -28,20 +25,16 @@ export class AddAndManageMandatoryTrainingComponent implements OnInit {
     private breadcrumbService: BreadcrumbService,
     private router: Router,
     public establishmentService: EstablishmentService,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
   ) {}
 
   ngOnInit(): void {
-    this.breadcrumbService.show(this.getBreadcrumbsJourney());
+    this.breadcrumbService.show(JourneyType.MANDATORY_TRAINING);
     this.establishment = this.route.parent.snapshot.data.establishment;
-    this.subscriptions.add(
-      this.trainingService.getAllMandatoryTrainings(this.establishment.uid).subscribe((trainings) => {
-        this.existingMandatoryTrainings = trainings;
-        this.sortTrainingAlphabetically(trainings.mandatoryTraining);
-        this.allJobsLength = trainings.allJobRolesCount;
-        this.setMandatoryTrainingHasDuplicateJobRoles();
-      }),
-    );
+
+    this.existingMandatoryTrainings = this.route.snapshot.data?.existingMandatoryTraining;
+    this.sortTrainingAlphabetically(this.existingMandatoryTrainings.mandatoryTraining);
+    this.allJobsLength = this.existingMandatoryTrainings.allJobRolesCount;
+    this.setMandatoryTrainingHasDuplicateJobRoles();
   }
 
   public checkDuplicateJobRoles(jobs): boolean {
@@ -80,11 +73,5 @@ export class AddAndManageMandatoryTrainingComponent implements OnInit {
       'add-and-manage-mandatory-training',
       'select-training-category',
     ]);
-  }
-
-  public getBreadcrumbsJourney(): JourneyType {
-    return this.establishmentService.isOwnWorkplace() || this.parentSubsidiaryViewService.getViewingSubAsParent()
-      ? JourneyType.MANDATORY_TRAINING
-      : JourneyType.ALL_WORKPLACES;
   }
 }

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-routing.module.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-routing.module.ts
@@ -24,6 +24,7 @@ const routes: Routes = [
     resolve: {
       existingMandatoryTraining: MandatoryTrainingCategoriesResolver,
     },
+    runGuardsAndResolvers: 'always',
     children: [
       {
         path: '',

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-routing.module.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-routing.module.ts
@@ -21,14 +21,14 @@ import {
 const routes: Routes = [
   {
     path: '',
+    resolve: {
+      existingMandatoryTraining: MandatoryTrainingCategoriesResolver,
+    },
     children: [
       {
         path: '',
         component: AddAndManageMandatoryTrainingComponent,
         data: { title: 'List Mandatory Training' },
-        resolve: {
-          existingMandatoryTraining: MandatoryTrainingCategoriesResolver,
-        },
       },
       {
         path: 'select-training-category',
@@ -36,7 +36,6 @@ const routes: Routes = [
         data: { title: 'Select Training Category' },
         resolve: {
           trainingCategories: TrainingCategoriesResolver,
-          existingMandatoryTraining: MandatoryTrainingCategoriesResolver,
         },
       },
       {
@@ -60,20 +59,20 @@ const routes: Routes = [
         component: AddMandatoryTrainingComponent,
         data: { title: 'Add New Mandatory Training' },
       },
-    ],
-  },
-  {
-    path: ':trainingCategoryId',
-    children: [
       {
-        path: 'edit-mandatory-training',
-        component: AddMandatoryTrainingComponent,
-        data: { title: 'Edit Mandatory Training' },
-      },
-      {
-        path: 'delete-mandatory-training-category',
-        component: DeleteMandatoryTrainingCategoryComponent,
-        data: { title: 'Delete Mandatory Training Category' },
+        path: ':trainingCategoryId',
+        children: [
+          {
+            path: 'edit-mandatory-training',
+            component: AddMandatoryTrainingComponent,
+            data: { title: 'Edit Mandatory Training' },
+          },
+          {
+            path: 'delete-mandatory-training-category',
+            component: DeleteMandatoryTrainingCategoryComponent,
+            data: { title: 'Delete Mandatory Training Category' },
+          },
+        ],
       },
     ],
   },

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-routing.module.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-mandatory-routing.module.ts
@@ -3,14 +3,20 @@ import { RouterModule, Routes } from '@angular/router';
 import { JobsResolver } from '@core/resolvers/jobs.resolver';
 import { MandatoryTrainingCategoriesResolver } from '@core/resolvers/mandatory-training-categories.resolver';
 import { TrainingCategoriesResolver } from '@core/resolvers/training-categories.resolver';
-import { DeleteMandatoryTrainingCategoryComponent } from '@features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component';
+import {
+  DeleteMandatoryTrainingCategoryComponent,
+} from '@features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component';
 
-import { AddAndManageMandatoryTrainingComponent } from './add-and-manage-mandatory-training/add-and-manage-mandatory-training.component';
+import {
+  AddAndManageMandatoryTrainingComponent,
+} from './add-and-manage-mandatory-training/add-and-manage-mandatory-training.component';
 import { AddMandatoryTrainingComponent } from './add-mandatory-training.component';
 import { AllOrSelectedJobRolesComponent } from './all-or-selected-job-roles/all-or-selected-job-roles.component';
 import { RemoveAllMandatoryTrainingComponent } from './delete-mandatory-training/delete-all-mandatory-training.component';
 import { SelectJobRolesMandatoryComponent } from './select-job-roles-mandatory/select-job-roles-mandatory.component';
-import { SelectTrainingCategoryMandatoryComponent } from './select-training-category-mandatory/select-training-category-mandatory.component';
+import {
+  SelectTrainingCategoryMandatoryComponent,
+} from './select-training-category-mandatory/select-training-category-mandatory.component';
 
 const routes: Routes = [
   {
@@ -20,6 +26,9 @@ const routes: Routes = [
         path: '',
         component: AddAndManageMandatoryTrainingComponent,
         data: { title: 'List Mandatory Training' },
+        resolve: {
+          existingMandatoryTraining: MandatoryTrainingCategoriesResolver,
+        },
       },
       {
         path: 'select-training-category',

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.html
@@ -13,7 +13,7 @@
     <dl class="govuk-summary-list asc-summarylist-border-top">
       <div class="govuk-summary-list__row" scope="row">
         <dt class="govuk-summary-list__key govuk-!-width-one-half">Training category</dt>
-        <dd class="govuk-summary-list__value" data-testid="trainingCategory">{{ selectedCategory?.category }}</dd>
+        <dd class="govuk-summary-list__value">{{ selectedCategory?.category }}</dd>
       </div>
       <div class="govuk-summary-list__row" scope="row">
         <dt class="govuk-summary-list__key">Job roles</dt>

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.html
@@ -31,7 +31,9 @@
       </button>
 
       <span class="govuk-visually-hidden">or</span>
-      <a class="govuk-button govuk-button--link govuk-!-margin-left-9 govuk-!-margin-top-5" (click)="onCancel()"
+      <a
+        class="govuk-button govuk-button--link govuk-!-margin-left-9 govuk-!-margin-top-5"
+        (click)="navigateBackToMandatoryTrainingHomePage()"
         >Cancel</a
       >
     </ng-container>

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.html
@@ -17,7 +17,15 @@
       </div>
       <div class="govuk-summary-list__row" scope="row">
         <dt class="govuk-summary-list__key">Job roles</dt>
-        <dd class="govuk-summary-list__value">All</dd>
+        <dd class="govuk-summary-list__value">
+          <ul
+            *ngIf="selectedCategory?.jobs?.length != allJobRolesCount; else allJobRoles"
+            class="govuk-list govuk-!-margin-bottom-0"
+          >
+            <li *ngFor="let job of selectedCategory?.jobs">{{ job.title }}</li>
+          </ul>
+          <ng-template #allJobRoles> All </ng-template>
+        </dd>
       </div>
     </dl>
 

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.spec.ts
@@ -115,12 +115,35 @@ describe('DeleteMandatoryTrainingCategoryComponent', () => {
     expect(routerSpy).toHaveBeenCalledWith(['/workplace', establishment.uid, 'add-and-manage-mandatory-training']);
   });
 
+  describe('Displaying job roles', () => {
+    it('should display selected job roles for selected mandatory training when it is not for all job roles', async () => {
+      const { getByText, selectedTraining } = await setup();
+
+      selectedTraining.jobs.forEach((job) => {
+        expect(getByText(job.title)).toBeTruthy();
+      });
+    });
+
+    it('should display All when number of job roles for selected training matches allJobRolesCount', async () => {
+      const mandatoryTraining = mockMandatoryTraining();
+      const selectedTraining = mandatoryTraining.mandatoryTraining[1];
+      const trainingIdInParams = selectedTraining.trainingCategoryId;
+
+      const { getByText } = await setup({ mandatoryTraining, trainingCategoryId: trainingIdInParams });
+
+      expect(getByText('All')).toBeTruthy();
+    });
+  });
+
   describe('On submit', () => {
     it('should call deleteCategoryById in the training service', async () => {
-      const { getByText, deleteMandatoryTrainingCategorySpy } = await setup();
+      const { getByText, deleteMandatoryTrainingCategorySpy, establishment, selectedTraining } = await setup();
 
       userEvent.click(getByText('Remove category'));
-      expect(deleteMandatoryTrainingCategorySpy).toHaveBeenCalled();
+      expect(deleteMandatoryTrainingCategorySpy).toHaveBeenCalledWith(
+        establishment.id,
+        selectedTraining.trainingCategoryId,
+      );
     });
 
     it("should display a success banner with 'Mandatory training category removed'", async () => {

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.spec.ts
@@ -4,41 +4,32 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AlertService } from '@core/services/alert.service';
 import { BackService } from '@core/services/back.service';
-import { EstablishmentService } from '@core/services/establishment.service';
+import { TrainingCategoryService } from '@core/services/training-category.service';
 import { TrainingService } from '@core/services/training.service';
 import { WindowRef } from '@core/services/window.ref';
-import { MockArticlesService } from '@core/test-utils/MockArticlesService';
-import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { MockPagesService } from '@core/test-utils/MockPagesService';
+import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
+import { MockTrainingCategoryService } from '@core/test-utils/MockTrainingCategoriesService';
 import { MockTrainingService } from '@core/test-utils/MockTrainingService';
-import { AddMandatoryTrainingModule } from '@features/training-and-qualifications/add-mandatory-training/add-mandatory-training.module';
+import {
+  AddMandatoryTrainingModule,
+} from '@features/training-and-qualifications/add-mandatory-training/add-mandatory-training.module';
 import { SharedModule } from '@shared/shared.module';
-import { fireEvent, getByText, render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
 import { DeleteMandatoryTrainingCategoryComponent } from './delete-mandatory-training-category.component';
-import { TrainingCategoryService } from '@core/services/training-category.service';
-import { MockTrainingCategoryService } from '@core/test-utils/MockTrainingCategoriesService';
 
 describe('DeleteMandatoryTrainingCategoryComponent', () => {
-  const pages = MockPagesService.pagesFactory();
-  const articleList = MockArticlesService.articleListFactory();
-
   async function setup(trainingCategoryId = '1') {
-    const { fixture, getByText, getAllByText } = await render(DeleteMandatoryTrainingCategoryComponent, {
+    const establishment = establishmentBuilder();
+
+    const setupTools = await render(DeleteMandatoryTrainingCategoryComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, AddMandatoryTrainingModule, HttpClientTestingModule],
       declarations: [],
       providers: [
         AlertService,
         BackService,
-        {
-          provide: WindowRef,
-          useClass: WindowRef,
-        },
-        {
-          provide: EstablishmentService,
-          useClass: MockEstablishmentService,
-        },
+        WindowRef,
         {
           provide: TrainingService,
           useClass: MockTrainingService,
@@ -51,13 +42,9 @@ describe('DeleteMandatoryTrainingCategoryComponent', () => {
           provide: ActivatedRoute,
           useValue: {
             snapshot: {
-              parent: {
-                url: [{ path: trainingCategoryId }],
-                data: {
-                  establishment: {
-                    uid: '9',
-                  },
-                },
+              params: { trainingCategoryId },
+              data: {
+                establishment,
               },
               url: [{ path: 'delete-mandatory-training-category' }],
             },
@@ -67,21 +54,25 @@ describe('DeleteMandatoryTrainingCategoryComponent', () => {
     });
 
     const injector = getTestBed();
-    const router = injector.inject(Router) as Router;
+
     const alertService = injector.inject(AlertService) as AlertService;
-    const trainingService = injector.inject(TrainingService) as TrainingService;
-    const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
-    const deleteMandatoryTrainingCategorySpy = spyOn(trainingService, 'deleteCategoryById').and.callThrough();
     const alertSpy = spyOn(alertService, 'addAlert').and.callThrough();
-    const component = fixture.componentInstance;
+
+    const trainingService = injector.inject(TrainingService) as TrainingService;
+    const deleteMandatoryTrainingCategorySpy = spyOn(trainingService, 'deleteCategoryById').and.callThrough();
+
+    const router = injector.inject(Router) as Router;
+    const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+
+    const component = setupTools.fixture.componentInstance;
+
     return {
+      ...setupTools,
       component,
-      fixture,
-      getByText,
-      getAllByText,
       routerSpy,
       deleteMandatoryTrainingCategorySpy,
       alertSpy,
+      establishment,
     };
   }
 
@@ -92,7 +83,7 @@ describe('DeleteMandatoryTrainingCategoryComponent', () => {
 
   it('should display the heading', async () => {
     const { getByText } = await setup();
-    expect(getByText(`You're about to remove this mandatory training category`));
+    expect(getByText("You're about to remove this mandatory training category")).toBeTruthy();
   });
 
   it('should display the correct training name when navigating to the page with a category ID', async () => {
@@ -100,34 +91,21 @@ describe('DeleteMandatoryTrainingCategoryComponent', () => {
     expect(getAllByText('Activity provision/Well-being', { exact: false }).length).toEqual(2);
   });
 
-  it('Should render Remove categories button and cancel link', async () => {
+  it('should render Remove categories button and cancel link', async () => {
     const { getByText } = await setup();
     expect(getByText('Remove category')).toBeTruthy();
     expect(getByText('Cancel')).toBeTruthy();
   });
 
-  describe('Cancel link', () => {
-    it('should navigate back to the mandatory details summary page when clicked', async () => {
-      const { component, getByText, routerSpy } = await setup();
-      userEvent.click(getByText('Cancel'));
-      expect(routerSpy).toHaveBeenCalledWith([
-        '/workplace',
-        component.establishment.uid,
-        'add-and-manage-mandatory-training',
-      ]);
-    });
-  });
-
-  describe('Remove category button', () => {
-    it('should call the deleteCategoryById function in the training service when clicked', async () => {
+  describe('On submit', () => {
+    it('should call deleteCategoryById in the training service', async () => {
       const { getByText, deleteMandatoryTrainingCategorySpy } = await setup();
+
       userEvent.click(getByText('Remove category'));
       expect(deleteMandatoryTrainingCategorySpy).toHaveBeenCalled();
     });
-  });
 
-  describe('success alert', async () => {
-    it('should display a success banner when a category is removed', async () => {
+    it("should display a success banner with 'Mandatory training category removed'", async () => {
       const { alertSpy, getByText } = await setup();
 
       fireEvent.click(getByText('Remove category'));
@@ -135,6 +113,24 @@ describe('DeleteMandatoryTrainingCategoryComponent', () => {
         type: 'success',
         message: 'Mandatory training category removed',
       });
+    });
+
+    it('should navigate back to add-and-manage-mandatory-training page', async () => {
+      const { getByText, routerSpy, establishment } = await setup();
+
+      userEvent.click(getByText('Remove category'));
+
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', establishment.uid, 'add-and-manage-mandatory-training']);
+    });
+  });
+
+  describe('Cancel link', () => {
+    it('should navigate back to the mandatory details summary page when clicked', async () => {
+      const { component, getByText, routerSpy, establishment } = await setup();
+
+      userEvent.click(getByText('Cancel'));
+
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', establishment.uid, 'add-and-manage-mandatory-training']);
     });
   });
 });

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
-import { TrainingCategory } from '@core/model/training.model';
+import { mandatoryTraining } from '@core/model/training.model';
 import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { TrainingCategoryService } from '@core/services/training-category.service';
@@ -13,8 +13,9 @@ import { Subscription } from 'rxjs';
   templateUrl: './delete-mandatory-training-category.component.html',
 })
 export class DeleteMandatoryTrainingCategoryComponent implements OnInit, OnDestroy {
-  public selectedCategory: TrainingCategory;
+  public selectedCategory: mandatoryTraining;
   public establishment: Establishment;
+  public allJobRolesCount: number;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -33,6 +34,8 @@ export class DeleteMandatoryTrainingCategoryComponent implements OnInit, OnDestr
     this.establishment = this.route.snapshot.data.establishment;
     const existingMandatoryTraining = this.route.snapshot.data.existingMandatoryTraining;
 
+    this.allJobRolesCount = existingMandatoryTraining?.allJobRolesCount;
+
     this.selectedCategory = existingMandatoryTraining?.mandatoryTraining.find(
       (category) => category.trainingCategoryId === trainingCategoryIdInParams,
     );
@@ -44,13 +47,15 @@ export class DeleteMandatoryTrainingCategoryComponent implements OnInit, OnDestr
 
   public onDelete(): void {
     this.subscriptions.add(
-      this.trainingService.deleteCategoryById(this.establishment.id, this.selectedCategory.id).subscribe(() => {
-        this.navigateBackToMandatoryTrainingHomePage();
-        this.alertService.addAlert({
-          type: 'success',
-          message: 'Mandatory training category removed',
-        });
-      }),
+      this.trainingService
+        .deleteCategoryById(this.establishment.id, this.selectedCategory.trainingCategoryId)
+        .subscribe(() => {
+          this.navigateBackToMandatoryTrainingHomePage();
+          this.alertService.addAlert({
+            type: 'success',
+            message: 'Mandatory training category removed',
+          });
+        }),
     );
   }
 

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/delete-mandatory-training-category/delete-mandatory-training-category.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { TrainingCategory } from '@core/model/training.model';
@@ -31,10 +31,15 @@ export class DeleteMandatoryTrainingCategoryComponent implements OnInit, OnDestr
 
     const trainingCategoryIdInParams = parseInt(this.route.snapshot.params?.trainingCategoryId);
     this.establishment = this.route.snapshot.data.establishment;
+    const existingMandatoryTraining = this.route.snapshot.data.existingMandatoryTraining;
 
-    this.trainingCategoryService.getCategories().subscribe((x) => {
-      this.selectedCategory = x.find((y) => y.id === trainingCategoryIdInParams);
-    });
+    this.selectedCategory = existingMandatoryTraining?.mandatoryTraining.find(
+      (category) => category.trainingCategoryId === trainingCategoryIdInParams,
+    );
+
+    if (!this.selectedCategory) {
+      this.navigateBackToMandatoryTrainingHomePage();
+    }
   }
 
   public onDelete(): void {
@@ -53,7 +58,7 @@ export class DeleteMandatoryTrainingCategoryComponent implements OnInit, OnDestr
     this.router.navigate(['/workplace', this.establishment.uid, 'add-and-manage-mandatory-training']);
   }
 
-  private ngOnDestroy(): void {
+  ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
   }
 }


### PR DESCRIPTION
#### Work done
- Styling updates and added Remove links for each mandatory training category on the main mandatory training page
- Fixed incorrect display of All for job roles on the _delete-mandatory-training-category_ page, refactored to use resolver  

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
