### PR TITLE
on user account not found, give a 200 response with status: AccountNo…

### DIFF
--- a/backend/server/routes/registration/findUserAccount.js
+++ b/backend/server/routes/registration/findUserAccount.js
@@ -66,13 +66,14 @@ const ipAddressReachedMaxAttempt = async (req) => {
 const sendSuccessResponse = (res, userFound) => {
   const { uid, SecurityQuestionValue } = userFound;
   return res.status(200).json({
+    status: 'AccountFound',
     accountUid: uid,
     securityQuestion: SecurityQuestionValue,
   });
 };
 
 const sendNotFoundResponse = (res, remainingAttempts = 0) => {
-  return res.status(404).json({ remainingAttempts });
+  return res.status(200).json({ status: 'AccountNotFound', remainingAttempts });
 };
 
 const sendErrorResponse = (res, err) => {

--- a/backend/server/test/unit/routes/registration/findUserAccount.spec.js
+++ b/backend/server/test/unit/routes/registration/findUserAccount.spec.js
@@ -45,7 +45,7 @@ describe('backend/server/routes/registration/findUserAccount', () => {
     sinon.restore();
   });
 
-  it('should respond with 200 if user account is found', async () => {
+  it('should respond with 200 and status: AccountFound if user account is found', async () => {
     const req = buildRequest(mockRequestBody);
     const res = httpMocks.createResponse();
 
@@ -53,6 +53,7 @@ describe('backend/server/routes/registration/findUserAccount', () => {
 
     expect(res.statusCode).to.equal(200);
     expect(res._getJSONData()).to.deep.equal({
+      status: 'AccountFound',
       accountUid: 'mock-uid',
       securityQuestion: 'What is your favourite colour?',
     });
@@ -73,6 +74,7 @@ describe('backend/server/routes/registration/findUserAccount', () => {
 
     expect(res.statusCode).to.equal(200);
     expect(res._getJSONData()).to.deep.equal({
+      status: 'AccountFound',
       accountUid: 'mock-uid',
       securityQuestion: 'What is your favourite colour?',
     });
@@ -103,28 +105,30 @@ describe('backend/server/routes/registration/findUserAccount', () => {
     });
   });
 
-  it('should respond with 404 and accountFound: false if user account was not found', async () => {
+  it('should respond with 200 and status: AccountNotFound if user account was not found', async () => {
     const req = buildRequest({ ...mockRequestBody, workplaceIdOrPostcode: 'non-exist-workplace-id' });
     const res = httpMocks.createResponse();
 
     await findUserAccount(req, res);
 
-    expect(res.statusCode).to.equal(404);
+    expect(res.statusCode).to.equal(200);
     expect(res._getJSONData()).to.deep.equal({
+      status: 'AccountNotFound',
       remainingAttempts: 4,
     });
     expect(stubRecordFailedAttempt).to.have.been.calledOnce;
   });
 
-  it('should respond with 404 and a reducing number of remainingAttempts on successive failure', async () => {
+  it('should respond with status: AccountNotFound and a reducing number of remainingAttempts on successive failure', async () => {
     for (const expectedRemainingAttempts of [4, 3, 2, 1, 0]) {
       const req = buildRequest({ ...mockRequestBody, workplaceIdOrPostcode: 'non-exist-workplace-id' });
       const res = httpMocks.createResponse();
 
       await findUserAccount(req, res);
 
-      expect(res.statusCode).to.equal(404);
+      expect(res.statusCode).to.equal(200);
       expect(res._getJSONData()).to.deep.equal({
+        status: 'AccountNotFound',
         remainingAttempts: expectedRemainingAttempts,
       });
     }

--- a/frontend/src/app/core/services/find-username.service.spec.ts
+++ b/frontend/src/app/core/services/find-username.service.spec.ts
@@ -37,36 +37,6 @@ describe('FindUsernameService', () => {
       expect(req.request.body).toEqual(mockParams);
     });
 
-    it('should handle a 200 response and convert it to AccountFound', async () => {
-      service.findUserAccount(mockParams).subscribe(mockSubscriber);
-      const req = http.expectOne(`${environment.appRunnerEndpoint}/api/registration/findUserAccount`);
-      req.flush(
-        {
-          accountUid: 'mock-uid',
-          securityQuestion: 'What is your favourite colour?',
-        },
-        { status: 200, statusText: 'Ok' },
-      );
-
-      const expectedResult = {
-        status: 'AccountFound',
-        accountUid: 'mock-uid',
-        securityQuestion: 'What is your favourite colour?',
-      };
-
-      expect(mockSubscriber).toHaveBeenCalledOnceWith(expectedResult);
-    });
-
-    it('should handle a 404 "Not found" response and convert it to AccountNotFound', async () => {
-      service.findUserAccount(mockParams).subscribe(mockSubscriber);
-      const req = http.expectOne(`${environment.appRunnerEndpoint}/api/registration/findUserAccount`);
-      req.flush({ remainingAttempts: 3 }, { status: 404, statusText: 'Not found' });
-
-      const expectedResult = { status: 'AccountNotFound', remainingAttempts: 3 };
-
-      expect(mockSubscriber).toHaveBeenCalledOnceWith(expectedResult);
-    });
-
     it('should handle a 429 "Too many request" response and convert it to AccountNotFound with remainingAttempts: 0', async () => {
       service.findUserAccount(mockParams).subscribe(mockSubscriber);
       const req = http.expectOne(`${environment.appRunnerEndpoint}/api/registration/findUserAccount`);

--- a/frontend/src/app/core/services/find-username.service.ts
+++ b/frontend/src/app/core/services/find-username.service.ts
@@ -54,15 +54,11 @@ export class FindUsernameService {
   findUserAccount(params: FindAccountRequest): Observable<FindUserAccountResponse> {
     return this.http
       .post<FindUserAccountResponse>(`${environment.appRunnerEndpoint}/api/registration/findUserAccount`, params)
-      .pipe(
-        map((res) => ({ ...res, status: 'AccountFound' } as AccountFound)),
-        catchError((res) => this.handleFindUserAccountErrors(res)),
-      );
+      .pipe(catchError((res) => this.handleFindUserAccountErrors(res)));
   }
 
   handleFindUserAccountErrors(err: HttpErrorResponse): Observable<AccountNotFound | AccountLocked> {
     switch (err?.status) {
-      case 404: // Not found
       case 429: // Too many request
         const remainingAttempts = err.error?.remainingAttempts ?? 0;
         return of({


### PR DESCRIPTION
#### Work done
- Change the backend response format of findUserAccount:
  * When an account is found: return a 200 with {status: 'AccountFound'} in body
  * When an account is not found: return a 200 with {status: 'AccountNotFound'} in body (instead of a 404 response)

The reason of this change is that CloudFront settings on staging env seems to intercept any 404 response from backend and replace the response body with a redirection to ./index.html . Therefore, the frontend couldn't get the expected "remainingAttempts" number in response body.
Changing this behaviour of CloudFront might induce other unwanted changes, so here we chan


#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
