### PR TITLE
Feat/1576 keep all job roles bugfix in new mandatory training

### DIFF
--- a/backend/server/routes/establishments/mandatoryTraining/index.js
+++ b/backend/server/routes/establishments/mandatoryTraining/index.js
@@ -93,3 +93,4 @@ router.route('/:categoryId').delete(deleteMandatoryTrainingById);
 module.exports = router;
 module.exports.createAndUpdateMandatoryTraining = createAndUpdateMandatoryTraining;
 module.exports.deleteMandatoryTrainingById = deleteMandatoryTrainingById;
+module.exports.viewMandatoryTraining = viewMandatoryTraining;

--- a/backend/server/routes/establishments/mandatoryTraining/index.js
+++ b/backend/server/routes/establishments/mandatoryTraining/index.js
@@ -14,12 +14,16 @@ const { hasPermission } = require('../../../utils/security/hasPermission');
 
 const viewMandatoryTraining = async (req, res) => {
   const establishmentId = req.establishmentId;
+  const previousAllJobsLengths = [29, 31, 32];
 
   try {
     const allMandatoryTrainingRecords = await MandatoryTraining.fetch(establishmentId);
 
     for (mandatoryTrainingCategory of allMandatoryTrainingRecords.mandatoryTraining) {
-      if (hasDuplicateJobs(mandatoryTrainingCategory.jobs)) {
+      if (
+        hasDuplicateJobs(mandatoryTrainingCategory.jobs) &&
+        previousAllJobsLengths.includes(mandatoryTrainingCategory.jobs.length)
+      ) {
         const thisMandatoryTrainingRecord = new MandatoryTraining(establishmentId);
         await thisMandatoryTrainingRecord.load({
           trainingCategoryId: mandatoryTrainingCategory.trainingCategoryId,
@@ -37,6 +41,19 @@ const viewMandatoryTraining = async (req, res) => {
   }
 };
 
+const hasDuplicateJobs = (jobRoles) => {
+  const seenJobIds = new Set();
+
+  for (const jobRole of jobRoles) {
+    if (seenJobIds.has(jobRole.id)) {
+      return true; // Duplicate found
+    }
+    seenJobIds.add(jobRole.id);
+  }
+
+  return false; // No duplicates found
+};
+
 /**
  * Handle GET request for getting all saved mandatory training for view all mandatory training
  */
@@ -50,19 +67,6 @@ const viewAllMandatoryTraining = async (req, res) => {
     console.error(err);
     return res.status(500).send();
   }
-};
-
-const hasDuplicateJobs = (jobs) => {
-  const seenJobIds = new Set();
-
-  for (const job of jobs) {
-    if (seenJobIds.has(job.id)) {
-      return true; // Duplicate found
-    }
-    seenJobIds.add(job.id);
-  }
-
-  return false; // No duplicates found
 };
 
 /**

--- a/backend/server/routes/establishments/mandatoryTraining/index.js
+++ b/backend/server/routes/establishments/mandatoryTraining/index.js
@@ -17,20 +17,29 @@ const viewMandatoryTraining = async (req, res) => {
   const previousAllJobsLengths = [29, 31, 32];
 
   try {
-    const allMandatoryTrainingRecords = await MandatoryTraining.fetch(establishmentId);
+    let allMandatoryTrainingRecords = await MandatoryTraining.fetch(establishmentId);
+    let duplicateJobRolesUpdated = false;
 
-    for (mandatoryTrainingCategory of allMandatoryTrainingRecords.mandatoryTraining) {
-      if (
-        hasDuplicateJobs(mandatoryTrainingCategory.jobs) &&
-        previousAllJobsLengths.includes(mandatoryTrainingCategory.jobs.length)
-      ) {
-        const thisMandatoryTrainingRecord = new MandatoryTraining(establishmentId);
-        await thisMandatoryTrainingRecord.load({
-          trainingCategoryId: mandatoryTrainingCategory.trainingCategoryId,
-          allJobRoles: true,
-          jobs: [],
-        });
-        await thisMandatoryTrainingRecord.save(req.userUid);
+    if (allMandatoryTrainingRecords?.mandatoryTraining?.length) {
+      for (mandatoryTrainingCategory of allMandatoryTrainingRecords.mandatoryTraining) {
+        if (
+          hasDuplicateJobs(mandatoryTrainingCategory.jobs) &&
+          previousAllJobsLengths.includes(mandatoryTrainingCategory.jobs.length)
+        ) {
+          duplicateJobRolesUpdated = true;
+
+          const thisMandatoryTrainingRecord = new MandatoryTraining(establishmentId);
+          await thisMandatoryTrainingRecord.load({
+            trainingCategoryId: mandatoryTrainingCategory.trainingCategoryId,
+            allJobRoles: true,
+            jobs: [],
+          });
+          await thisMandatoryTrainingRecord.save(req.userUid);
+        }
+      }
+
+      if (duplicateJobRolesUpdated) {
+        allMandatoryTrainingRecords = await MandatoryTraining.fetch(establishmentId);
       }
     }
 

--- a/backend/server/test/unit/routes/establishments/mandatoryTraining/index.spec.js
+++ b/backend/server/test/unit/routes/establishments/mandatoryTraining/index.spec.js
@@ -166,7 +166,7 @@ describe('mandatoryTraining/index.js', () => {
           mockJobRoles.push({ id: 1, title: 'Job role 1' });
           mockFetchData.mandatoryTraining[0].jobs = mockJobRoles;
 
-          sinon.stub(MandatoryTraining, 'fetch').callsFake(() => mockFetchData);
+          const fetchSpy = sinon.stub(MandatoryTraining, 'fetch').callsFake(() => mockFetchData);
 
           await viewMandatoryTraining(req, res);
 
@@ -176,6 +176,7 @@ describe('mandatoryTraining/index.js', () => {
             jobs: [],
           });
           expect(saveSpy).to.have.been.calledWith(req.userUid);
+          expect(fetchSpy).to.have.been.calledTwice;
         });
       });
 

--- a/backend/server/test/unit/routes/establishments/mandatoryTraining/index.spec.js
+++ b/backend/server/test/unit/routes/establishments/mandatoryTraining/index.spec.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 const {
   createAndUpdateMandatoryTraining,
   deleteMandatoryTrainingById,
+  viewMandatoryTraining,
 } = require('../../../../../routes/establishments/mandatoryTraining/index.js');
 
 const MandatoryTraining = require('../../../../../models/classes/mandatoryTraining').MandatoryTraining;
@@ -34,6 +35,7 @@ describe('mandatoryTraining/index.js', () => {
       expect(res.statusCode).to.deep.equal(500);
     });
   });
+
   describe('createAndUpdateMandatoryTraining', () => {
     it('should save the record for mandatory training if isvalid , not exists and all job role is selected', async () => {
       sinon.stub(MandatoryTraining.prototype, 'load').callsFake(() => {
@@ -82,6 +84,47 @@ describe('mandatoryTraining/index.js', () => {
 
       sinon.assert.notCalled(save);
       expect(res.statusCode).to.deep.equal(500);
+    });
+  });
+
+  describe('viewMandatoryTraining', () => {
+    let req;
+    let res;
+
+    beforeEach(() => {
+      req = httpMocks.createRequest();
+      req.establishmentId = 'mockId';
+      res = httpMocks.createResponse();
+    });
+
+    const mockFetchData = {
+      allJobRolesCount: 37,
+      lastUpdated: '2025-01-03T11:55:55.734Z',
+      mandatoryTraining: [{}],
+      mandatoryTrainingCount: 1,
+    };
+
+    it('should fetch all mandatory training for establishment passed in request', async () => {
+      const fetchSpy = sinon.stub(MandatoryTraining, 'fetch').callsFake(() => mockFetchData);
+
+      await viewMandatoryTraining(req, res);
+      expect(res.statusCode).to.deep.equal(200);
+      expect(fetchSpy).to.have.been.calledWith(req.establishmentId);
+    });
+
+    it('should return data from fetch and 200 status if fetch successful', async () => {
+      sinon.stub(MandatoryTraining, 'fetch').callsFake(() => mockFetchData);
+
+      await viewMandatoryTraining(req, res);
+      expect(res.statusCode).to.equal(200);
+      expect(res._getJSONData()).to.deep.equal(mockFetchData);
+    });
+
+    it('should return 500 status if error when fetching data', async () => {
+      sinon.stub(MandatoryTraining, 'fetch').throws('Unexpected error');
+
+      await viewMandatoryTraining(req, res);
+      expect(res.statusCode).to.equal(500);
     });
   });
 });

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.html
@@ -61,21 +61,10 @@
         </td>
 
         <td class="govuk-table__cell">
-          <ng-container
-            *ngIf="
-              records.jobs.length === allJobsLength ||
-              (mandatoryTrainingHasDuplicateJobRoles[i][records.trainingCategoryId].hasPreviousAllJobsLength &&
-                mandatoryTrainingHasDuplicateJobRoles[i][records.trainingCategoryId].hasDuplicates)
-            "
-          >
-            <span data-testid="titleAll">{{ 'All' }}</span>
+          <ng-container *ngIf="records.jobs.length === allJobsLength">
+            <span data-testid="titleAll">All</span>
           </ng-container>
-          <ng-container
-            *ngIf="
-              records.jobs.length < allJobsLength &&
-              !mandatoryTrainingHasDuplicateJobRoles[i][records.trainingCategoryId].hasPreviousAllJobsLength
-            "
-          >
+          <ng-container *ngIf="records.jobs.length < allJobsLength">
             <div data-testid="titleJob" *ngFor="let job of records.jobs">{{ job.title }}</div>
           </ng-container>
         </td>

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.spec.ts
@@ -9,11 +9,7 @@ import { MandatoryTrainingService } from '@core/services/training.service';
 import { WindowRef } from '@core/services/window.ref';
 import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import {
-  mockMandatoryTraining,
-  MockMandatoryTrainingService,
-  MockTrainingService,
-} from '@core/test-utils/MockTrainingService';
+import { mockMandatoryTraining, MockMandatoryTrainingService } from '@core/test-utils/MockTrainingService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
@@ -45,9 +41,7 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
         },
         {
           provide: MandatoryTrainingService,
-          useFactory: overrides.duplicateJobRoles
-            ? MockTrainingService.factory(overrides.duplicateJobRoles)
-            : MockMandatoryTrainingService.factory(),
+          useFactory: MockMandatoryTrainingService.factory(),
         },
         {
           provide: EstablishmentService,
@@ -209,18 +203,6 @@ describe('AddAndManageMandatoryTrainingComponent', () => {
           [trainingCategory.trainingCategoryId, 'delete-mandatory-training-category'],
           { relativeTo: currentRoute },
         );
-      });
-    });
-
-    describe('Handling duplicate job roles', () => {
-      it('should show all if there are any duplicate job roles and the job roles length is the old all job roles length', async () => {
-        const { getByTestId } = await setup({ duplicateJobRoles: true });
-
-        const coshCategory = getByTestId('titleAll');
-        const autismCategory = getByTestId('titleJob');
-
-        expect(coshCategory.textContent).toContain('All');
-        expect(autismCategory.textContent).toContain('Activities worker, coordinator');
       });
     });
   });

--- a/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/add-mandatory-training/add-and-manage-mandatory-training/add-and-manage-mandatory-training.component.ts
@@ -15,8 +15,6 @@ export class AddAndManageMandatoryTrainingComponent implements OnInit {
   public establishment: Establishment;
   public existingMandatoryTrainings: any;
   public allJobsLength: Number;
-  public mandatoryTrainingHasDuplicateJobRoles = [];
-  public previousAllJobsLength = [29, 31, 32];
 
   constructor(
     public trainingService: MandatoryTrainingService,
@@ -34,30 +32,6 @@ export class AddAndManageMandatoryTrainingComponent implements OnInit {
     this.existingMandatoryTrainings = this.route.snapshot.data?.existingMandatoryTraining;
     this.sortTrainingAlphabetically(this.existingMandatoryTrainings.mandatoryTraining);
     this.allJobsLength = this.existingMandatoryTrainings.allJobRolesCount;
-    this.setMandatoryTrainingHasDuplicateJobRoles();
-  }
-
-  public checkDuplicateJobRoles(jobs): boolean {
-    for (let i = 0; i < jobs.length; i++) {
-      for (let j = i + 1; j < jobs.length; j++) {
-        if (jobs[i].id === jobs[j].id) {
-          return true;
-        }
-      }
-    }
-  }
-
-  public setMandatoryTrainingHasDuplicateJobRoles() {
-    let mandatoryTraining = this.existingMandatoryTrainings.mandatoryTraining;
-
-    mandatoryTraining.forEach((trainingCategory, index) => {
-      this.mandatoryTrainingHasDuplicateJobRoles.push({
-        [trainingCategory.trainingCategoryId]: {
-          hasDuplicates: this.checkDuplicateJobRoles(trainingCategory.jobs),
-          hasPreviousAllJobsLength: this.previousAllJobsLength.includes(trainingCategory.jobs.length),
-        },
-      });
-    });
   }
 
   public sortTrainingAlphabetically(training) {


### PR DESCRIPTION
#### Work done
- Added checking of duplicate job roles in backend retrieval of mandatory training
- Removed logic from frontend for handling duplicate job roles

#### Note
This means that all mandatory training with duplicate job roles will be updated for a workplace when they go onto the '_Add and manage mandatory training_' page, rather than the way it worked previously where individual mandatory training records would get updated when the user goes onto the edit page. I've moved it to the backend as changing to multiple edit pages made handling it on the front end more complicated. However, this is still not an ideal setup, as next time job roles are added the same problem could arise. A longer term solution would involve changing the way we store mandatory training with all selected in the database, as currently there is just a row in the MandatoryTraining table for each job role.

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
