### PR TITLE
Fix/1596 linked only subs in workplace dropdown

### DIFF
--- a/frontend/src/app/core/test-utils/MockEstablishmentService.ts
+++ b/frontend/src/app/core/test-utils/MockEstablishmentService.ts
@@ -209,41 +209,47 @@ export class MockEstablishmentService extends EstablishmentService {
     return '98a83eef-e1e1-49f3-89c5-b1287a3cc8dd';
   }
 
+  public _primaryWorkplace: Establishment = {
+    address: '',
+    capacities: [],
+    created: undefined,
+    dataOwner: undefined,
+    dataOwnershipRequested: '',
+    dataPermissions: undefined,
+    employerType: { value: 'Private Sector' },
+    id: 0,
+    isRegulated: false,
+    isParent: false,
+    leavers: undefined,
+    localAuthorities: [],
+    mainService: { name: 'Care', id: 123, isCQC: true },
+    name: 'Test Workplace',
+    nmdsId: 'AB12345',
+    numberOfStaff: 0,
+    otherServices: { value: null, services: [] },
+    postcode: 'AB1 2CD',
+    primaryAuthority: undefined,
+    serviceUsers: [],
+    shareWith: this.shareWith,
+    starters: undefined,
+    totalLeavers: 0,
+    totalStarters: 0,
+    totalVacancies: 0,
+    totalWorkers: 0,
+    uid: '98a83eef-e1e1-49f3-89c5-b1287a3cc8de',
+    updated: undefined,
+    updatedBy: '',
+    vacancies: undefined,
+    locationId: '1-11111111',
+    provId: '1-21232433',
+  };
+
   get primaryWorkplace(): Establishment {
-    return {
-      address: '',
-      capacities: [],
-      created: undefined,
-      dataOwner: undefined,
-      dataOwnershipRequested: '',
-      dataPermissions: undefined,
-      employerType: { value: 'Private Sector' },
-      id: 0,
-      isRegulated: false,
-      isParent: false,
-      leavers: undefined,
-      localAuthorities: [],
-      mainService: { name: 'Care', id: 123, isCQC: true },
-      name: 'Test Workplace',
-      nmdsId: 'AB12345',
-      numberOfStaff: 0,
-      otherServices: { value: null, services: [] },
-      postcode: 'AB1 2CD',
-      primaryAuthority: undefined,
-      serviceUsers: [],
-      shareWith: this.shareWith,
-      starters: undefined,
-      totalLeavers: 0,
-      totalStarters: 0,
-      totalVacancies: 0,
-      totalWorkers: 0,
-      uid: '98a83eef-e1e1-49f3-89c5-b1287a3cc8de',
-      updated: undefined,
-      updatedBy: '',
-      vacancies: undefined,
-      locationId: '1-11111111',
-      provId: '1-21232433',
-    };
+    return this._primaryWorkplace;
+  }
+
+  set primaryWorkplace(value: Establishment) {
+    this._primaryWorkplace = value;
   }
 
   public updateTypeOfEmployer(establishmentId, data: EmployerTypeRequest): Observable<any> {
@@ -432,5 +438,20 @@ export class MockEstablishmentServiceWithNoCapacities extends MockEstablishmentS
     return of({
       allServiceCapacities: [],
     });
+  }
+}
+
+@Injectable()
+export class MockEstablishmentServiceWithOverrides extends MockEstablishmentService {
+  public static factory(overrides: any = {}) {
+    return (httpClient: HttpClient) => {
+      const service = new MockEstablishmentService(httpClient);
+
+      Object.keys(overrides).forEach((overrideName) => {
+        service[overrideName] = overrides[overrideName];
+      });
+
+      return service;
+    };
   }
 }

--- a/frontend/src/app/core/test-utils/MockUserService.ts
+++ b/frontend/src/app/core/test-utils/MockUserService.ts
@@ -40,7 +40,7 @@ nonPrimaryEditUser.isPrimary = false;
 
 export { primaryEditUser, nonPrimaryEditUser, readUser };
 
-const workplaceBuilder = build('Workplace', {
+export const workplaceBuilder = build('Workplace', {
   fields: {
     id: sequence(),
     uid: fake((f) => f.datatype.uuid()),

--- a/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.spec.ts
+++ b/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.spec.ts
@@ -11,8 +11,14 @@ import { fireEvent, render } from '@testing-library/angular';
 import { NavigateToWorkplaceDropdownComponent } from './navigate-to-workplace-dropdown.component';
 
 describe('NavigateToWorkplaceDropdownComponent', () => {
-  const setup = async (maxChildWorkplacesForDropdown = 5, inSubView = true, childWorkplaces = null) => {
-    const { fixture, getByText, getByLabelText } = await render(NavigateToWorkplaceDropdownComponent, {
+  const setup = async (overrides: any = {}) => {
+    const maxChildWorkplacesForDropdown = (
+      'maxChildWorkplacesForDropdown' in overrides ? overrides.maxChildWorkplacesForDropdown : 5
+    ) as number;
+    const inSubView = ('inSubView' in overrides ? overrides.inSubView : true) as boolean;
+    const childWorkplaces = 'childWorkplaces' in overrides ? overrides.childWorkplaces : null;
+
+    const setupTools = await render(NavigateToWorkplaceDropdownComponent, {
       imports: [RouterTestingModule, HttpClientTestingModule],
       providers: [
         {
@@ -25,7 +31,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
       },
     });
 
-    const component = fixture.componentInstance;
+    const component = setupTools.fixture.componentInstance;
     const parentWorkplaceName = component.parentWorkplace.name;
 
     const injector = getTestBed();
@@ -37,11 +43,9 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
     spyOn(parentSubService, 'getViewingSubAsParent').and.returnValue(inSubView);
 
     return {
+      ...setupTools,
       component,
-      fixture,
-      getByText,
       routerSpy,
-      getByLabelText,
       parentWorkplaceName,
       clearViewingSubSpy,
     };
@@ -53,7 +57,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
   });
 
   it('should not display anything when more child workplaces than maxChildWorkplacesForDropdown but not in sub view', async () => {
-    const { fixture } = await setup(3, false);
+    const { fixture } = await setup({ maxChildWorkplacesForDropdown: 3, inSubView: false });
     fixture.detectChanges();
     const navigateToWorkplaceContainer = fixture.nativeElement.querySelector('#navigateToWorkplaceContainer');
 
@@ -61,7 +65,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
   });
 
   it('should not display anything when no child workplaces', async () => {
-    const { fixture } = await setup(31, false, []);
+    const { fixture } = await setup({ maxChildWorkplacesForDropdown: 31, inSubView: false, childWorkplaces: [] });
     fixture.detectChanges();
     const navigateToWorkplaceContainer = fixture.nativeElement.querySelector('#navigateToWorkplaceContainer');
 
@@ -78,7 +82,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
     });
 
     it('should display dropdown when fewer child workplaces than maxChildWorkplacesForDropdown and not in sub view', async () => {
-      const { fixture } = await setup(5, false);
+      const { fixture } = await setup({ inSubView: false });
       fixture.detectChanges();
       const dropdown = fixture.nativeElement.querySelector('.asc-navigate-to-workplace-dropdown');
 
@@ -147,7 +151,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
 
   describe('Back to parent link', () => {
     it('should display when more child workplaces than maxChildWorkplacesForDropdown and in sub view', async () => {
-      const { fixture } = await setup(3);
+      const { fixture } = await setup({ maxChildWorkplacesForDropdown: 3 });
       fixture.detectChanges();
       const backToParentLink = fixture.nativeElement.querySelector('#backToParentLink');
 
@@ -155,7 +159,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
     });
 
     it('should display Return to {parent name passed in}', async () => {
-      const { fixture, getByText, parentWorkplaceName } = await setup(3);
+      const { fixture, getByText, parentWorkplaceName } = await setup({ maxChildWorkplacesForDropdown: 3 });
       fixture.detectChanges();
 
       const expectedMessage = `Back to ${parentWorkplaceName}`;
@@ -163,7 +167,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
     });
 
     it('should display "Return to parent" when cannot retrieve parent workplace', async () => {
-      const { component, fixture, getByText } = await setup(3);
+      const { component, fixture, getByText } = await setup({ maxChildWorkplacesForDropdown: 3 });
       component.parentWorkplace = null;
       fixture.detectChanges();
 
@@ -172,7 +176,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
     });
 
     xit('should navigate to dashboard with home fragment on click of back link', async () => {
-      const { fixture, getByText, parentWorkplaceName, routerSpy } = await setup(3);
+      const { fixture, getByText, parentWorkplaceName, routerSpy } = await setup({ maxChildWorkplacesForDropdown: 3 });
       fixture.detectChanges();
 
       const backToParentLink = getByText(`Back to ${parentWorkplaceName}`);
@@ -184,7 +188,9 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
     });
 
     it('should clear viewing sub view on click of back link', async () => {
-      const { fixture, getByText, parentWorkplaceName, clearViewingSubSpy } = await setup(3);
+      const { fixture, getByText, parentWorkplaceName, clearViewingSubSpy } = await setup({
+        maxChildWorkplacesForDropdown: 3,
+      });
       fixture.detectChanges();
 
       const backToParentLink = getByText(`Back to ${parentWorkplaceName}`);

--- a/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.spec.ts
+++ b/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.spec.ts
@@ -12,7 +12,7 @@ import { fireEvent, render } from '@testing-library/angular';
 
 import { NavigateToWorkplaceDropdownComponent } from './navigate-to-workplace-dropdown.component';
 
-describe('NavigateToWorkplaceDropdownComponent', () => {
+fdescribe('NavigateToWorkplaceDropdownComponent', () => {
   const setup = async (overrides: any = {}) => {
     const maxChildWorkplacesForDropdown = (
       'maxChildWorkplacesForDropdown' in overrides ? overrides.maxChildWorkplacesForDropdown : 5
@@ -96,7 +96,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
       expect(getByText(component.parentWorkplace.name));
     });
 
-    xit('should go to route of main dashboard when selecting primary workplace', async () => {
+    it('should go to route of main dashboard when selecting primary workplace', async () => {
       const { fixture, component, getByText, routerSpy } = await setup();
 
       const selectObject = getByText(component.parentWorkplace.name);
@@ -107,7 +107,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
       });
     });
 
-    xit('should go to route of selected sub (first) when selecting sub workplace', async () => {
+    it('should go to route of selected sub (first) when selecting sub workplace', async () => {
       const { fixture, component, getByText, routerSpy } = await setup();
 
       const selectObject = getByText(component.parentWorkplace.name);
@@ -118,7 +118,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
       });
     });
 
-    xit('should go to route of selected sub (second) when selecting sub workplace', async () => {
+    it('should go to route of selected sub (second) when selecting sub workplace', async () => {
       const { fixture, component, getByText, routerSpy } = await setup();
 
       const selectObject = getByText(component.parentWorkplace.name);
@@ -220,7 +220,7 @@ describe('NavigateToWorkplaceDropdownComponent', () => {
       expect(getByText(expectedMessage)).toBeTruthy();
     });
 
-    xit('should navigate to dashboard with home fragment on click of back link', async () => {
+    it('should navigate to dashboard with home fragment on click of back link', async () => {
       const { fixture, getByText, parentWorkplaceName, routerSpy } = await setup({ maxChildWorkplacesForDropdown: 3 });
       fixture.detectChanges();
 

--- a/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.spec.ts
+++ b/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.spec.ts
@@ -13,7 +13,7 @@ import { fireEvent, render } from '@testing-library/angular';
 
 import { NavigateToWorkplaceDropdownComponent } from './navigate-to-workplace-dropdown.component';
 
-fdescribe('NavigateToWorkplaceDropdownComponent', () => {
+describe('NavigateToWorkplaceDropdownComponent', () => {
   const setup = async (overrides: any = {}) => {
     const establishment = establishmentBuilder();
 

--- a/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.ts
+++ b/frontend/src/app/shared/components/navigate-to-workplace-dropdown/navigate-to-workplace-dropdown.component.ts
@@ -1,7 +1,12 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
-import { GetChildWorkplacesResponse, Workplace } from '@core/model/my-workplaces.model';
+import {
+  DataPermissions,
+  GetChildWorkplacesResponse,
+  Workplace,
+  WorkplaceDataOwner,
+} from '@core/model/my-workplaces.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { TabsService } from '@core/services/tabs.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
@@ -73,7 +78,11 @@ export class NavigateToWorkplaceDropdownComponent implements OnInit {
       this.establishmentService
         .getChildWorkplaces(this.parentWorkplace.uid, { getPendingWorkplaces: false })
         .subscribe((data: GetChildWorkplacesResponse) => {
-          this.childWorkplaces = data.childWorkplaces;
+          this.childWorkplaces = data.childWorkplaces?.filter((workplace) => {
+            return !(
+              workplace.dataOwner === WorkplaceDataOwner.Workplace && workplace.dataPermissions === DataPermissions.None
+            );
+          });
         }),
     );
   }


### PR DESCRIPTION
#### Work done
- Added filtering to the parent navigate-to-workplace dropdown to hide workplaces which parent has no permissions for (clicking on them would break the page for users as parents do not have permission to access these subs' dashboards)
- Added back in skipped tests which were previously failing in pipeline
- Created new MockEstablishmentServiceWithOverrides to allow for mocking any fields in the EstablishmentService more easily

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
