### PR TITLE
removed get started link and tests from dashboard pages

### DIFF
--- a/frontend/src/app/features/dashboard/home-tab/home-tab.component.html
+++ b/frontend/src/app/features/dashboard/home-tab/home-tab.component.html
@@ -119,9 +119,6 @@
           <a (click)="becomeAParent($event)" href="#">Become a parent organisation</a>
         </ng-template>
       </li>
-      <li class="govuk-!-margin-bottom-3">
-        <a [routerLink]="['/first-login-wizard']">Help to get you started</a>
-      </li>
     </ul>
     <div *ngIf="canRunLocalAuthorityReport && workplace" data-cy="download-report">
       <h3 class="govuk-heading-s govuk-!-margin-top-1">Download reports</h3>

--- a/frontend/src/app/features/dashboard/home-tab/home-tab.component.spec.ts
+++ b/frontend/src/app/features/dashboard/home-tab/home-tab.component.spec.ts
@@ -567,12 +567,5 @@ describe('HomeTabComponent', () => {
       expect(becomeAParentLink).toBeTruthy();
       expect(linkToParentLink).toBeTruthy();
     });
-
-    it('should link to the first login wizard page when clicking "Help to get you started"', async () => {
-      const { component } = await setup();
-
-      const firstLoginWizardLink = component.getByText('Help to get you started');
-      expect(firstLoginWizardLink.getAttribute('href')).toBe('/first-login-wizard');
-    });
   });
 });

--- a/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
@@ -151,10 +151,6 @@
               <a [routerLink]="['/remove-link-to-parent']">Remove the link to your parent workplace</a>
             </ng-template>
           </app-link-with-arrow>
-
-          <app-link-with-arrow>
-            <a class="govuk-link" [routerLink]="['/first-login-wizard']">Help to get you started</a>
-          </app-link-with-arrow>
         </ul>
       </div>
     </div>

--- a/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.spec.ts
@@ -209,15 +209,6 @@ describe('NewHomeTabComponent', () => {
       });
     });
 
-    describe('Help to get you started link', () => {
-      it('should render the link with the correct href', async () => {
-        const { getByText } = await setup();
-        const link = getByText('Help to get you started');
-        expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual('/first-login-wizard');
-      });
-    });
-
     describe('Link to my parent organisation', () => {
       describe('without parent home tab feature flag', () => {
         it('should show Link to my parent organisation pending when trying to link to a parent', async () => {
@@ -763,13 +754,6 @@ describe('NewHomeTabComponent', () => {
           expect(removeLinkToParentlink.getAttribute('href')).toBe('/remove-link-to-parent');
         });
       });
-    });
-
-    it('should link to the first login wizard page when clicking "Help to get you started"', async () => {
-      const { getByText } = await setup();
-
-      const firstLoginWizardLink = getByText('Help to get you started');
-      expect(firstLoginWizardLink.getAttribute('href')).toBe('/first-login-wizard');
     });
   });
 

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.spec.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.spec.ts
@@ -192,22 +192,6 @@ describe('ViewSubsidiaryHomeComponent', () => {
         expect(link.getAttribute('href')).toEqual('/about-ascwds');
       });
     });
-
-    describe('Help to get you started link', () => {
-      it('should render the link with the correct href', async () => {
-        const { getByText } = await setup();
-        const link = getByText('Help to get you started');
-        expect(link).toBeTruthy();
-        expect(link.getAttribute('href')).toEqual('/first-login-wizard');
-      });
-    });
-
-    it('should link to the first login wizard page when clicking "Help to get you started"', async () => {
-      const { getByText } = await setup();
-
-      const firstLoginWizardLink = getByText('Help to get you started');
-      expect(firstLoginWizardLink.getAttribute('href')).toBe('/first-login-wizard');
-    });
   });
 
   describe('cards', () => {

--- a/frontend/src/app/shared/components/other-links/other-links.component.html
+++ b/frontend/src/app/shared/components/other-links/other-links.component.html
@@ -19,9 +19,5 @@
     <app-link-with-arrow>
       <a class="govuk-link" [routerLink]="['/about-ascwds']">About ASC-WDS</a>
     </app-link-with-arrow>
-
-    <app-link-with-arrow>
-      <a class="govuk-link" [routerLink]="['/first-login-wizard']">Help to get you started</a>
-    </app-link-with-arrow>
   </ul>
 </div>

--- a/frontend/src/app/shared/components/other-links/other-links.component.spec.ts
+++ b/frontend/src/app/shared/components/other-links/other-links.component.spec.ts
@@ -151,13 +151,4 @@ describe('OtherLinksComponent', () => {
     expect(otherLinkText).toBeTruthy();
     expect(otherLinkText.getAttribute('href')).toEqual('/about-ascwds');
   });
-
-  it('should show Help to get you started link', async () => {
-    const { getByText } = await setup();
-
-    const otherLinkText = getByText('Help to get you started');
-
-    expect(otherLinkText).toBeTruthy();
-    expect(otherLinkText.getAttribute('href')).toEqual('/first-login-wizard');
-  });
 });


### PR DESCRIPTION
#### Work done
- Removed "Help to get you started" links from the various versions of the dashboard

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
