### PR TITLE
Add contact us in help section

### DIFF
--- a/frontend/src/app/core/breadcrumb/journey.help.ts
+++ b/frontend/src/app/core/breadcrumb/journey.help.ts
@@ -3,6 +3,7 @@ import { JourneyRoute } from './breadcrumb.model';
 enum Path {
   GET_STARTED = '/help/get-started',
   WHATS_NEW = '/help/whats-new',
+  CONTACT_US = '/help/contact-us',
 }
 
 export const helpJourney: JourneyRoute = {
@@ -14,6 +15,10 @@ export const helpJourney: JourneyRoute = {
     {
       title: "Get help and tips: what's new",
       path: Path.WHATS_NEW,
+    },
+    {
+      title: 'Get help and tips: contact us',
+      path: Path.CONTACT_US,
     },
   ],
 };

--- a/frontend/src/app/features/help/contact-us/contact-us.component.html
+++ b/frontend/src/app/features/help/contact-us/contact-us.component.html
@@ -1,0 +1,5 @@
+<div>
+  <ng-container *ngIf="contactUsPage">
+    <app-help-content data-testid="contact-us-content" [helpPage]="contactUsPage"></app-help-content>
+  </ng-container>
+</div>

--- a/frontend/src/app/features/help/contact-us/contact-us.component.spec.ts
+++ b/frontend/src/app/features/help/contact-us/contact-us.component.spec.ts
@@ -1,0 +1,63 @@
+import { ActivatedRoute } from '@angular/router';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { MockActivatedRoute } from '@core/test-utils/MockActivatedRoute';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { HelpContentComponent } from '@shared/components/help-content/help-content.component';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+import { ContactUsComponent } from './contact-us.component';
+import { MockPagesService } from '@core/test-utils/MockPagesService';
+
+describe('ContactUsComponent', () => {
+  async function setup(overrides: any = {}) {
+    const setupTools = await render(ContactUsComponent, {
+      imports: [SharedModule],
+      providers: [
+        {
+          provide: BreadcrumbService,
+          useClass: MockBreadcrumbService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: new MockActivatedRoute({
+            snapshot: {
+              data: {
+                page: overrides.hasContent ? MockPagesService.pagesFactory() : null,
+              },
+            },
+          }),
+        },
+      ],
+      declarations: [HelpContentComponent],
+    });
+
+    const component = setupTools.fixture.componentInstance;
+    return {
+      ...setupTools,
+      component,
+    };
+  }
+
+  it('should render ContactUsComponent', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should show the content for contact us', async () => {
+    const override = {
+      hasContent: true,
+    };
+
+    const { getByTestId } = await setup(override);
+    expect(getByTestId('contact-us-content')).toBeTruthy();
+  });
+
+  it("should not show if there's no content", async () => {
+    const override = {
+      hasContent: false,
+    };
+
+    const { queryByTestId } = await setup(override);
+    expect(queryByTestId('contact-us-content')).toBeFalsy();
+  });
+});

--- a/frontend/src/app/features/help/contact-us/contact-us.component.ts
+++ b/frontend/src/app/features/help/contact-us/contact-us.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
+import { Page } from '@core/model/page.model';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+
+@Component({
+  selector: 'app-contact-us',
+  templateUrl: './contact-us.component.html',
+})
+export class ContactUsComponent implements OnInit {
+  public contactUsPage: Page;
+
+  constructor(public route: ActivatedRoute, private breadcrumbService: BreadcrumbService) {}
+
+  ngOnInit(): void {
+    this.breadcrumbService.show(JourneyType.HELP);
+    this.contactUsPage = this.route.snapshot.data.page?.data[0];
+  }
+}

--- a/frontend/src/app/features/help/help-routing.module.ts
+++ b/frontend/src/app/features/help/help-routing.module.ts
@@ -6,6 +6,8 @@ import { GetStartedComponent } from './get-started/get-started.component';
 import { HelpAreaComponent } from './help-area/help-area.component';
 import { WhatsNewComponent } from './whats-new/whats-new.component';
 import { HelpPageResolver } from '@core/resolvers/help-pages.resolver';
+import { PageResolver } from '@core/resolvers/page.resolver';
+import { ContactUsComponent } from './contact-us/contact-us.component';
 
 const routes: Routes = [
   {
@@ -27,6 +29,13 @@ const routes: Routes = [
           helpPage: HelpPageResolver,
         },
         data: { title: "What's new" },
+      },
+      {
+        path: 'contact-us',
+        component: ContactUsComponent,
+        resolve: {
+          page: PageResolver,
+        },
       },
     ],
   },

--- a/frontend/src/app/features/help/help.module.ts
+++ b/frontend/src/app/features/help/help.module.ts
@@ -8,10 +8,11 @@ import { GetStartedComponent } from './get-started/get-started.component';
 import { HelpAreaComponent } from './help-area/help-area.component';
 import { HelpRoutingModule } from './help-routing.module';
 import { WhatsNewComponent } from './whats-new/whats-new.component';
+import { ContactUsComponent } from './contact-us/contact-us.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, OverlayModule, HelpRoutingModule],
-  declarations: [HelpAreaComponent, GetStartedComponent, WhatsNewComponent],
+  declarations: [HelpAreaComponent, GetStartedComponent, WhatsNewComponent, ContactUsComponent],
   providers: [],
 })
 export class HelpModule {}


### PR DESCRIPTION
#### Work done
- Created contact us component in help section to use the same CMS content as the contact us in the footer

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
