### PR TITLE
fix/order-of-q-and-a-search-results

### DIFF
--- a/frontend/src/app/features/help/questions-and-answers/questions-and-answers.component.spec.ts
+++ b/frontend/src/app/features/help/questions-and-answers/questions-and-answers.component.spec.ts
@@ -375,4 +375,27 @@ describe('QuestionsAndAnswersComponent', () => {
 
     expect(within(matchingResults).getByText('Why should we share our data?')).toBeTruthy();
   });
+
+  it('should show the matching titles first then content', async () => {
+    const { getByRole, fixture, getByTestId } = await setup();
+
+    const expectedResult = [
+      'What workplace data is needed?',
+      'What can you do as a parent workplace?',
+      'Why should we share our data?',
+    ];
+
+    const button = getByRole('button');
+    userEvent.type(getByRole('textbox'), 'workplace');
+    fixture.detectChanges();
+
+    userEvent.click(button);
+    fixture.detectChanges();
+
+    const matchingResultsList = within(getByTestId('matching-results')).queryAllByRole('listitem');
+
+    expect(matchingResultsList[0].textContent).toEqual(expectedResult[0]);
+    expect(matchingResultsList[1].textContent).toEqual(expectedResult[1]);
+    expect(matchingResultsList[2].textContent).toEqual(expectedResult[2]);
+  });
 });

--- a/frontend/src/app/features/help/questions-and-answers/questions-and-answers.component.ts
+++ b/frontend/src/app/features/help/questions-and-answers/questions-and-answers.component.ts
@@ -91,11 +91,20 @@ export class QuestionsAndAnswersComponent implements OnInit {
   public filterTitleAndContent(searchTerm): any[] {
     const searchTermLowerCase = searchTerm.toLowerCase();
 
-    return this.qAndASlugContentAndTitles.filter(
-      (qAndASlugContentAndTitle) =>
-        qAndASlugContentAndTitle.title.toLowerCase().includes(searchTermLowerCase) ||
-        qAndASlugContentAndTitle.content.toLowerCase().includes(searchTermLowerCase),
+    let filteredTitles = [];
+    let filteredContent = [];
+
+    filteredTitles = this.qAndASlugContentAndTitles.filter((qAndASlugContentAndTitle) =>
+      qAndASlugContentAndTitle.title.toLowerCase().includes(searchTermLowerCase),
     );
+
+    filteredContent = this.qAndASlugContentAndTitles.filter(
+      (qAndASlugContentAndTitle) =>
+        qAndASlugContentAndTitle.content.toLowerCase().includes(searchTermLowerCase) &&
+        !qAndASlugContentAndTitle.title.toLowerCase().includes(searchTermLowerCase),
+    );
+
+    return filteredTitles.concat(filteredContent);
   }
 
   /**

--- a/frontend/src/app/features/help/questions-and-answers/questions-and-answers.component.ts
+++ b/frontend/src/app/features/help/questions-and-answers/questions-and-answers.component.ts
@@ -91,14 +91,11 @@ export class QuestionsAndAnswersComponent implements OnInit {
   public filterTitleAndContent(searchTerm): any[] {
     const searchTermLowerCase = searchTerm.toLowerCase();
 
-    let filteredTitles = [];
-    let filteredContent = [];
-
-    filteredTitles = this.qAndASlugContentAndTitles.filter((qAndASlugContentAndTitle) =>
+    const filteredTitles = this.qAndASlugContentAndTitles.filter((qAndASlugContentAndTitle) =>
       qAndASlugContentAndTitle.title.toLowerCase().includes(searchTermLowerCase),
     );
 
-    filteredContent = this.qAndASlugContentAndTitles.filter(
+    const filteredContent = this.qAndASlugContentAndTitles.filter(
       (qAndASlugContentAndTitle) =>
         qAndASlugContentAndTitle.content.toLowerCase().includes(searchTermLowerCase) &&
         !qAndASlugContentAndTitle.title.toLowerCase().includes(searchTermLowerCase),


### PR DESCRIPTION
#### Work done
- Update Q and A search results to place matching titles above matching content

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
