### PR TITLE
Fix: Update BU flow chart page to use new back link service

### DIFF
--- a/frontend/src/app/features/bulk-upload/help-area/bulk-upload-flowchart/bulk-upload-flowchart.component.spec.ts
+++ b/frontend/src/app/features/bulk-upload/help-area/bulk-upload-flowchart/bulk-upload-flowchart.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BackLinkService } from '@core/services/backLink.service';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 
@@ -8,17 +9,22 @@ import { BulkUploadFlowchartComponent } from './bulk-upload-flowchart.component'
 
 describe('BulkUploadFlowchartComponent', () => {
   async function setup() {
-    const { fixture, getByTestId, getByText } = await render(BulkUploadFlowchartComponent, {
+    const backLinkServiceSpy = jasmine.createSpyObj('BacklinkService', ['showBackLink']);
+
+    const setupTools = await render(BulkUploadFlowchartComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
-      providers: [],
+      providers: [
+        {
+          provide: BackLinkService,
+          useValue: backLinkServiceSpy,
+        },
+      ],
     });
 
-    const component = fixture.componentInstance;
     return {
-      component,
-      getByTestId,
-      getByText,
-      fixture,
+      ...setupTools,
+      component: setupTools.fixture.componentInstance,
+      backLinkServiceSpy,
     };
   }
   it('should render a BulkUploadPageComponent', async () => {
@@ -41,12 +47,8 @@ describe('BulkUploadFlowchartComponent', () => {
   });
 
   it('should set the back link', async () => {
-    const { component, fixture } = await setup();
-    const backLinkSpy = spyOn(component.backService, 'setBackLink');
+    const { backLinkServiceSpy } = await setup();
 
-    component.setBackLink();
-    fixture.detectChanges();
-
-    expect(backLinkSpy).toHaveBeenCalledWith({ url: ['/bulk-upload', 'get-help'] });
+    expect(backLinkServiceSpy.showBackLink).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/features/bulk-upload/help-area/bulk-upload-flowchart/bulk-upload-flowchart.component.ts
+++ b/frontend/src/app/features/bulk-upload/help-area/bulk-upload-flowchart/bulk-upload-flowchart.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { BackService } from '@core/services/back.service';
-import { BulkUploadTopTipsService } from '@core/services/bulk-upload/bulk-upload-top-tips.service';
+import { BackLinkService } from '@core/services/backLink.service';
 
 @Component({
   selector: 'app-bulk-upload-flowchart',
@@ -8,17 +7,9 @@ import { BulkUploadTopTipsService } from '@core/services/bulk-upload/bulk-upload
   styleUrls: ['./bulk-upload-flowchart.component.scss'],
 })
 export class BulkUploadFlowchartComponent implements OnInit {
-  constructor(public backService: BackService, private bulkUploadTopTipsService: BulkUploadTopTipsService) {}
+  constructor(public backLinkService: BackLinkService) {}
 
   ngOnInit(): void {
-    this.setBackLink();
-  }
-
-  public setBackLink(): void {
-    const returnUrl = this.bulkUploadTopTipsService.returnTo
-      ? this.bulkUploadTopTipsService.returnTo
-      : { url: ['/bulk-upload', 'get-help'] };
-
-    this.backService.setBackLink(returnUrl);
+    this.backLinkService.showBackLink();
   }
 }


### PR DESCRIPTION
#### Work done
- Updated bulk upload flow chart page to use new back link service to navigate back to previous page correctly

This resolves issue with navigating to the bulk upload flow chart from new help Q&A page, as it was setting navigation back to bulk upload help and tips page. This is incorrect, but would also log out read only users who don't have permission to view the bulk upload pages. 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
