### PR TITLE
fix/q-and-a-search-message-showing-incorrectly

### DIFF
--- a/frontend/src/app/features/help/questions-and-answers/questions-and-answers.component.ts
+++ b/frontend/src/app/features/help/questions-and-answers/questions-and-answers.component.ts
@@ -53,8 +53,7 @@ export class QuestionsAndAnswersComponent implements OnInit {
 
   public getPreviousSearchQuery(): void {
     let qAndASearchValue = localStorage.getItem('qAndASearchValue');
-
-    if (this.previousUrl && qAndASearchValue !== 'null' && this.previousUrl.includes('/questions-and-answers/')) {
+    if (qAndASearchValue && qAndASearchValue !== 'null' && this.previousUrl?.includes('/questions-and-answers/')) {
       this.form.patchValue({
         qAndASearch: qAndASearchValue,
       });


### PR DESCRIPTION
#### Work done
- Added extra check on getPreviousSearchQuery for q and a search

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [x] No, I found it difficult to test
- [ ] No, they are not required for this change
