### PR TITLE
Fix: Stop showing add workplace details after bulk upload

### DIFF
--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -847,7 +847,7 @@ class Establishment extends EntityValidator {
             this._doNewStartersRepeatMandatoryTrainingFromPreviousEmployment,
           wouldYouAcceptCareCertificatesFromPreviousEmployment:
             this._wouldYouAcceptCareCertificatesFromPreviousEmployment,
-          showAddWorkplaceDetailsBanner: this._showAddWorkplaceDetailsBanner,
+          showAddWorkplaceDetailsBanner: bulkUploaded ? false : this._showAddWorkplaceDetailsBanner,
           careWorkersCashLoyaltyForFirstTwoYears: this._careWorkersCashLoyaltyForFirstTwoYears,
           sickPay: this._sickPay,
           pensionContribution: this._pensionContribution,


### PR DESCRIPTION
#### Work done
- Added check for bulk upload in establishment creation to set showAddWorkplaceDetailsBanner to false to stop add more details being displayed for new workplaces created in bulk upload instead of whole workplace page

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [X] No, I found it difficult to test
- [ ] No, they are not required for this change
