### PR TITLE
Fix/1632 new user validation email

### DIFF
--- a/backend/server/routes/accounts/user.js
+++ b/backend/server/routes/accounts/user.js
@@ -691,7 +691,7 @@ const addUser = async (req, res) => {
     });
 
     if (trackingResponse?.completed) {
-      console.error('POST /api/user/add error - add user tracking record is already completed');
+      console.error('POST /api/user/add error - user with the given uuid token has already completed registration');
       return res.status(400).send();
     }
 

--- a/backend/server/routes/accounts/user.js
+++ b/backend/server/routes/accounts/user.js
@@ -691,7 +691,7 @@ const addUser = async (req, res) => {
     });
 
     if (trackingResponse?.completed) {
-      console.error('api/user/add error - add user tracking record is already completed');
+      console.error('POST /api/user/add error - add user tracking record is already completed');
       return res.status(400).send();
     }
 

--- a/backend/server/routes/accounts/user.js
+++ b/backend/server/routes/accounts/user.js
@@ -690,6 +690,11 @@ const addUser = async (req, res) => {
       ],
     });
 
+    if (trackingResponse?.completed) {
+      console.error('api/user/add error - add user tracking record is already completed');
+      return res.status(400).send();
+    }
+
     if (trackingResponse && trackingResponse.uuid && trackingResponse.user.uid) {
       // use the User properties to load (includes validation)
       const thisUser = new User.User(trackingResponse.user.establishmentId, addUserUUID);
@@ -706,12 +711,8 @@ const addUser = async (req, res) => {
         };
 
         // force the username and email to be lowercase
-        newUserProperties.username = newUserProperties.username
-          ? newUserProperties.username.toLowerCase()
-          : newUserProperties.username;
-        newUserProperties.email = newUserProperties.email
-          ? newUserProperties.email.toLowerCase()
-          : newUserProperties.email;
+        newUserProperties.username = newUserProperties.username?.toLowerCase();
+        newUserProperties.email = newUserProperties.email?.toLowerCase();
 
         const isValidUser = await thisUser.load(newUserProperties);
         // this is a new User, so check mandatory properties and additional the additional default properties required to add a user!
@@ -730,18 +731,18 @@ const addUser = async (req, res) => {
       }
     } else {
       // not found the given add user tracking reference
-      console.error('api/user/add error - failed to match add user tracking and user record');
+      console.error('POST /api/user/add error - failed to match add user tracking and user record');
       return res.status(404).send();
     }
   } catch (err) {
     if (err instanceof User.UserExceptions.UserJsonException) {
-      console.error('/add/establishment/:id POST: ', err.message);
+      console.error('POST /api/user/add error: ', err.message);
       return res.status(400).send(err.safe);
     } else if (err instanceof User.UserExceptions.UserSaveException && err.message === 'Duplicate Username') {
-      console.error('/add/establishment/:id POST: ', err.message);
+      console.error('POST /api/user/add error: ', err.message);
       return res.status(400).send(err.message);
     } else if (err instanceof User.UserExceptions.UserSaveException) {
-      console.error('/add/establishment/:id POST: ', err.message);
+      console.error('POST /api/user/add error: ', err.message);
       return res.status(500).send(err.safe);
     }
 
@@ -970,9 +971,10 @@ router.use('/swap/establishment/:id', authLimiter);
 router.route('/swap/establishment/:id').post(Authorization.isAdmin, swapEstablishment);
 
 module.exports = router;
+
 module.exports.meetsMaxUserLimit = meetsMaxUserLimit;
 module.exports.partAddUser = partAddUser;
-
 module.exports.listAdminUsers = listAdminUsers;
 module.exports.updateUser = updateUser;
 module.exports.updateLastViewedVacanciesAndTurnoverMessage = updateLastViewedVacanciesAndTurnoverMessage;
+module.exports.addUser = addUser;

--- a/backend/server/routes/accounts/user.js
+++ b/backend/server/routes/accounts/user.js
@@ -692,7 +692,7 @@ const addUser = async (req, res) => {
 
     if (trackingResponse?.completed) {
       console.error('POST /api/user/add error - user with the given uuid token has already completed registration');
-      return res.status(400).send();
+      return res.status(401).send({ message: 'Activation link expired' });
     }
 
     if (trackingResponse && trackingResponse.uuid && trackingResponse.user.uid) {

--- a/backend/server/test/unit/routes/accounts/user.spec.js
+++ b/backend/server/test/unit/routes/accounts/user.spec.js
@@ -441,11 +441,12 @@ describe('user.js', () => {
       expect(stubUserSave).to.have.been.calledOnce;
     });
 
-    it('should respond with 400 error and not save the user if the addUserTracking uuid token is already used', async () => {
+    it('should respond with 401 error and not save the user if the addUserTracking uuid token is already used', async () => {
       stubAddUserTrackingFindOne.resolves({ ...addUserTrackingRecord, completed: '2025-01-01 12:00:00:000' });
 
       await addUser(req, res);
-      expect(res.statusCode).to.equal(400);
+      expect(res.statusCode).to.equal(401);
+      expect(res._getData()).to.deep.equal({ message: 'Activation link expired' });
       expect(stubUserSave).not.to.be.called;
     });
   });

--- a/backend/server/test/unit/routes/accounts/user.spec.js
+++ b/backend/server/test/unit/routes/accounts/user.spec.js
@@ -394,7 +394,7 @@ describe('user.js', () => {
     });
   });
 
-  describe('addUser, POST /api/user', () => {
+  describe('POST /api/user/add', () => {
     let stubUserSave;
     let stubAddUserTrackingFindOne;
     const requestBody = {

--- a/backend/server/test/unit/routes/accounts/user.spec.js
+++ b/backend/server/test/unit/routes/accounts/user.spec.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const httpMocks = require('node-mocks-http');
 
 const {
+  addUser,
   meetsMaxUserLimit,
   partAddUser,
   listAdminUsers,
@@ -390,6 +391,62 @@ describe('user.js', () => {
 
       expect(res.statusCode).to.equal(500);
       expect(res._getData()).to.deep.equal('Failed to update last viewed date');
+    });
+  });
+
+  describe('addUser, POST /api/user', () => {
+    let stubUserSave;
+    let stubAddUserTrackingFindOne;
+    const requestBody = {
+      email: 'test@example.com',
+      fullname: 'new user',
+      jobTitle: 'test user',
+      password: 'Some very secure password e.g. Password!1',
+      phone: '0123456789',
+      securityQuestion: 'what is the colour of a blue orange?',
+      securityQuestionAnswer: 'blue',
+      username: 'test-user',
+      addUserUUID: '09009bc3-409b-49ff-aa67-9c9c64339cbf',
+    };
+    const addUserTrackingRecord = {
+      uuid: '09009bc3-409b-49ff-aa67-9c9c64339cbf',
+      user: {
+        id: 'userId',
+        uid: 'some-uuid',
+        UserRoleValue: 'Read',
+        establishmentId: 'mock-establishment-id',
+      },
+      completed: null,
+    };
+
+    beforeEach(() => {
+      req = httpMocks.createRequest({
+        method: 'POST',
+        url: '/api/users/add',
+        body: requestBody,
+      });
+      res = httpMocks.createResponse();
+
+      stubAddUserTrackingFindOne = sinon.stub(models.addUserTracking, 'findOne').resolves(addUserTrackingRecord);
+      sinon.stub(User.prototype, 'restore').resolves(true);
+      sinon.stub(User.prototype, 'load').resolves(true);
+      sinon.stub(User.prototype, 'hasDefaultNewUserProperties').value(true);
+      stubUserSave = sinon.stub(User.prototype, 'save');
+      sinon.stub(User.prototype, 'toJSON');
+    });
+
+    it('should respond with 200 and save a new user to database', async () => {
+      await addUser(req, res);
+      expect(res.statusCode).to.equal(200);
+      expect(stubUserSave).to.have.been.calledOnce;
+    });
+
+    it('should respond with 400 error and not save the user if the addUserTracking uuid token is already used', async () => {
+      stubAddUserTrackingFindOne.resolves({ ...addUserTrackingRecord, completed: '2025-01-01 12:00:00:000' });
+
+      await addUser(req, res);
+      expect(res.statusCode).to.equal(400);
+      expect(stubUserSave).not.to.be.called;
     });
   });
 });

--- a/frontend/src/app/features/activate-user-account/activate-user-account-routing.module.ts
+++ b/frontend/src/app/features/activate-user-account/activate-user-account-routing.module.ts
@@ -26,21 +26,24 @@ const routes: Routes = [
         path: 'change-your-details',
         component: ChangeYourDetailsComponent,
         data: { title: 'Change Your Details' },
+        canActivate: [CreateUserGuard],
       },
       {
         path: 'create-username',
         component: CreateUsernameComponent,
         data: { title: 'Create Username' },
+        canActivate: [CreateUserGuard],
       },
       {
         path: 'security-question',
         component: SecurityQuestionComponent,
-        canActivate: [ActivationCompleteWithOutChildGuard],
+        canActivate: [CreateUserGuard, ActivationCompleteWithOutChildGuard],
         data: { title: 'Security Question' },
       },
 
       {
         path: 'confirm-account-details',
+        canActivate: [CreateUserGuard],
         canActivateChild: [ActivationCompleteGuard],
         children: [
           {

--- a/frontend/src/app/features/activate-user-account/confirm-account-details/confirm-account-details.component.ts
+++ b/frontend/src/app/features/activate-user-account/confirm-account-details/confirm-account-details.component.ts
@@ -130,6 +130,8 @@ export class ConfirmAccountDetailsComponent extends ConfirmAccountDetailsDirecti
   private _onError(error) {
     if (error.status === 403 || error.status === 404) {
       this.router.navigate(['/problem-with-the-service']);
+    } else if (error.status === 401 && error?.error?.message === 'Activation link expired') {
+      this.router.navigate(['/activate-account', '/expired-activation-link']);
     } else {
       this.onError(error);
     }


### PR DESCRIPTION
#### Work done
- Add `CreateUserGuard` to sub pages under `/activate-account/{uid}/` , ensuring every sub page in the register new user journey to check that the uuid token is still valid
- Amend POST `/api/user/add` endpoint to validate that the uuid token was't used before. Respond with an error if already used

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
