### PR TITLE
Fix/1633 unable to access workplaces

### DIFF
--- a/backend/server/routes/v2/establishments/benchmarks/benchmarksService.js
+++ b/backend/server/routes/v2/establishments/benchmarks/benchmarksService.js
@@ -184,7 +184,7 @@ const getComparisonGroupRankings = async function ({
   mainJob,
   cssr,
 }) {
-  if (!cssr) return {};
+  if (!cssr) return [];
 
   const where = mainJob ? { MainJobRole: mainJob } : {};
   return await benchmarksModel.findAll({

--- a/backend/server/routes/v2/establishments/benchmarks/index.js
+++ b/backend/server/routes/v2/establishments/benchmarks/index.js
@@ -212,7 +212,6 @@ const getBenchmarksData = async (establishmentId, mainService) => {
 
   const cssr = await models.cssr.getCSSRFromEstablishmentId(establishmentId);
 
-  if (cssr) {
     data.careWorkerPay = await payBenchmarks(establishmentId, mainService, CARE_WORKER_ID, cssr);
     data.seniorCareWorkerPay = await payBenchmarks(establishmentId, mainService, SENIOR_CARE_WORKER_ID, cssr);
     data.registeredNursePay = await payBenchmarks(establishmentId, mainService, REGISTERED_NURSE_ID, cssr);
@@ -224,7 +223,6 @@ const getBenchmarksData = async (establishmentId, mainService) => {
     data.timeInRole = await timeInRoleBenchmarks(establishmentId, mainService, cssr);
 
     data.meta = await getMetaData(mainService, cssr);
-  }
   return data;
 };
 

--- a/backend/server/test/unit/routes/v2/establishments/benchmarks/benchmarksService.spec.js
+++ b/backend/server/test/unit/routes/v2/establishments/benchmarks/benchmarksService.spec.js
@@ -1,0 +1,37 @@
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const models = require('../../../../../../models');
+const { getComparisonGroupRankings } = require('../../../../../../routes/v2/establishments/benchmarks/benchmarksService');
+
+describe.only('getComparisonGroupRankings', async () => {
+  it('returns empty array when cssr not provided', async () => {
+    testData = {};
+
+    const result = await getComparisonGroupRankings(testData);
+
+    expect(result).to.be.an('array');
+    expect(result.length).to.equal(0);
+  });
+
+  it('returns benchmarks from provided benchmarks model', async () => {
+    const mockResponse = [{ LocalAuthorityArea: 'test', MainServiceFK: 1, CssrID: 2 }];
+
+    const stubBenchmarksModel = sinon.stub(models.benchmarksPay, 'findAll').callsFake(() => {
+      return mockResponse;
+    });
+
+    testData = {
+      benchmarksModel: models.benchmarksPay,
+      establishmentId: 1,
+      mainService: 1,
+      attributes: ['Attribute 1', 'Attribute 2'],
+      cssr: {id: 1}
+    };
+
+    const result = await getComparisonGroupRankings(testData);
+
+    expect(stubBenchmarksModel).to.be.calledOnce;
+    expect(result).to.equal(mockResponse);
+  })
+})

--- a/backend/server/test/unit/routes/v2/establishments/benchmarks/benchmarksService.spec.js
+++ b/backend/server/test/unit/routes/v2/establishments/benchmarks/benchmarksService.spec.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const models = require('../../../../../../models');
 const { getComparisonGroupRankings } = require('../../../../../../routes/v2/establishments/benchmarks/benchmarksService');
 
-describe.only('getComparisonGroupRankings', async () => {
+describe('getComparisonGroupRankings', async () => {
   it('returns empty array when cssr not provided', async () => {
     testData = {};
 

--- a/frontend/src/app/core/services/benchmarks-v2.service.ts
+++ b/frontend/src/app/core/services/benchmarks-v2.service.ts
@@ -41,12 +41,12 @@ export class BenchmarksV2Service implements BenchmarksServiceBase {
     }
 
     return {
-      workplaceValue: initialiseOldBenchmarkValue(tileData.workplaceValue),
-      comparisonGroup: initialiseOldBenchmarkValue(tileData.comparisonGroup),
-      goodCqc: initialiseOldBenchmarkValue(tileData.goodCqc),
-      lowTurnover: initialiseOldBenchmarkValue(tileData.lowTurnover),
-      workplaces: tileData.workplaces ? tileData.workplaces : 0,
-      staff: tileData.staff ? tileData.staff : 0,
+      workplaceValue: initialiseOldBenchmarkValue(tileData?.workplaceValue),
+      comparisonGroup: initialiseOldBenchmarkValue(tileData?.comparisonGroup),
+      goodCqc: initialiseOldBenchmarkValue(tileData?.goodCqc),
+      lowTurnover: initialiseOldBenchmarkValue(tileData?.lowTurnover),
+      workplaces: tileData?.workplaces ? tileData?.workplaces : 0,
+      staff: tileData?.staff ? tileData?.staff : 0,
     };
   }
 


### PR DESCRIPTION
#### Work done
- getComparisonGroupRankings ow returns an empty array instead of an empty object when no Cssr is provided
- benchmarks service now handles null tile data

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
