### PR TITLE
Fix: Breadcrumbs on individual Q&A pages

### DIFF
--- a/frontend/src/app/core/breadcrumb/journey.help.ts
+++ b/frontend/src/app/core/breadcrumb/journey.help.ts
@@ -5,6 +5,7 @@ enum Path {
   WHATS_NEW = '/help/whats-new',
   HELPFUL_DOWNLOADS = '/help/helpful-downloads',
   QUESTIONS_AND_ANSWERS = '/help/questions-and-answers',
+  Q_AND_A_PAGE = '/help/questions-and-answers/:slug',
   CONTACT_US = '/help/contact-us',
 }
 
@@ -23,12 +24,16 @@ export const helpJourney: JourneyRoute = {
       path: Path.HELPFUL_DOWNLOADS,
     },
     {
+      title: 'Get help and tips: contact us',
+      path: Path.CONTACT_US,
+    },
+    {
       title: 'Get help and tips: questions and answers',
       path: Path.QUESTIONS_AND_ANSWERS,
     },
     {
-      title: 'Get help and tips: contact us',
-      path: Path.CONTACT_US,
+      title: 'Get help and tips: questions and answers',
+      path: Path.Q_AND_A_PAGE,
     },
   ],
 };


### PR DESCRIPTION
#### Work done
- Added breadcrumb journey for individual Q&A page which matches main Questions and answers page

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
