### PR TITLE
Update Continue button on thank you page to go to dashboard

### DIFF
--- a/frontend/src/app/core/breadcrumb/journey.public.ts
+++ b/frontend/src/app/core/breadcrumb/journey.public.ts
@@ -10,7 +10,6 @@ enum Path {
   CONTACT_US_OR_LEAVE_FEEDBACK = '/contact-us-or-leave-feedback',
   THANK_YOU = '/thank-you',
   CERTIFICATES = '/asc-wds-certificate',
-  FIRST_LOGIN_WIZARD = '/first-login-wizard'
 }
 
 export const publicJourney: JourneyRoute = {

--- a/frontend/src/app/features/registration-survey/thank-you/thank-you.component.spec.ts
+++ b/frontend/src/app/features/registration-survey/thank-you/thank-you.component.spec.ts
@@ -37,6 +37,6 @@ describe('ThankYouComponent', () => {
     const component = await setup();
 
     const nextPage = component.fixture.componentInstance.nextPage;
-    expect(nextPage.url).toEqual(['/first-login-wizard']);
+    expect(nextPage.url).toEqual(['/dashboard']);
   });
 });

--- a/frontend/src/app/features/registration-survey/thank-you/thank-you.component.ts
+++ b/frontend/src/app/features/registration-survey/thank-you/thank-you.component.ts
@@ -12,6 +12,6 @@ export class ThankYouComponent implements OnInit {
   constructor(protected registrationSurveyService: RegistrationSurveyService) {}
 
   ngOnInit(): void {
-    this.nextPage = { url: ['/first-login-wizard'] };
+    this.nextPage = { url: ['/dashboard'] };
   }
 }


### PR DESCRIPTION
#### Work done
- Updated Continue button on thank you page after registration survey to go to dashboard
- Button was taking user to `first-login-wizard`, a page which no longer exists after the introduction of the help section

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
