### PR TITLE
Feat/1645 workplace summary restructure after removing questions

### DIFF
--- a/frontend/src/app/core/utils/progress-bar-util.spec.ts
+++ b/frontend/src/app/core/utils/progress-bar-util.spec.ts
@@ -40,7 +40,7 @@ describe('ProgressBarUtil', () => {
     it('should return an array with a length of 5', () => {
       const workplaceFlowProgressBarSections = ProgressBarUtil.workplaceFlowProgressBarSections();
 
-      expect(workplaceFlowProgressBarSections.length).toEqual(5);
+      expect(workplaceFlowProgressBarSections.length).toEqual(4);
     });
 
     it('should return the correct values', () => {
@@ -49,8 +49,7 @@ describe('ProgressBarUtil', () => {
       expect(workplaceFlowProgressBarSections).toEqual([
         'Services',
         'Vacancies and turnover',
-        'Recruitment',
-        'Staff benefits',
+        'Staff recruitment and benefits',
         'Permissions',
       ]);
     });

--- a/frontend/src/app/core/utils/progress-bar-util.ts
+++ b/frontend/src/app/core/utils/progress-bar-util.ts
@@ -8,10 +8,22 @@ export class ProgressBarUtil {
   };
 
   public static workplaceFlowProgressBarSections = (): string[] => {
-    return ['Services', 'Vacancies and turnover', 'Recruitment', 'Staff benefits', 'Permissions'];
+    return [
+      WorkplaceFlowSections.SERVICES,
+      WorkplaceFlowSections.VACANCIES_AND_TURNOVER,
+      WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS,
+      WorkplaceFlowSections.PERMISSIONS,
+    ];
   };
 
   public static staffRecordProgressBarSections = (): string[] => {
     return ['Mandatory information', 'Personal details', 'Employment details', 'Training and qualifications'];
   };
+}
+
+export enum WorkplaceFlowSections {
+  SERVICES = 'Services',
+  VACANCIES_AND_TURNOVER = 'Vacancies and turnover',
+  STAFF_RECRUITMENT_AND_BENEFITS = 'Staff recruitment and benefits',
+  PERMISSIONS = 'Permissions',
 }

--- a/frontend/src/app/features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component.html
+++ b/frontend/src/app/features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component.html
@@ -4,7 +4,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-l" data-testid="section-heading">Recruitment</span>
+            <span class="govuk-caption-l" data-testid="section-heading">{{ section }}</span>
             Would you accept a Care Certificate from a worker's previous employer?
           </h1>
         </legend>

--- a/frontend/src/app/features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component.spec.ts
+++ b/frontend/src/app/features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component.spec.ts
@@ -57,8 +57,10 @@ describe('AcceptPreviousCareCertificateComponent', () => {
   it('should render the heading, input and radio buttons', async () => {
     const { getByText, getByLabelText } = await setup();
     const heading = `Would you accept a Care Certificate from a worker's previous employer?`;
+    const sectionCaption = 'Staff recruitment and benefits';
 
     expect(getByText(heading)).toBeTruthy;
+    expect(getByText(sectionCaption)).toBeTruthy;
     expect(getByLabelText('Yes, always')).toBeTruthy();
     expect(getByLabelText('Yes, very often')).toBeTruthy();
     expect(getByLabelText('Yes, but not very often')).toBeTruthy();

--- a/frontend/src/app/features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component.ts
+++ b/frontend/src/app/features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component.ts
@@ -14,7 +14,7 @@ import { Question } from '../question/question.component';
   templateUrl: './accept-previous-care-certificate.component.html',
 })
 export class AcceptPreviousCareCertificateComponent extends Question implements OnInit, OnDestroy {
-  public section: string;
+  public section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   public previousCareCertificateOptions = [
     {
       label: 'Yes, always',
@@ -49,7 +49,6 @@ export class AcceptPreviousCareCertificateComponent extends Question implements 
     this.setPreviousRoute();
     this.prefill();
     this.skipRoute = ['/workplace', this.establishment.uid, 'cash-loyalty'];
-    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   }
 
   private setPreviousRoute(): void {

--- a/frontend/src/app/features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component.ts
+++ b/frontend/src/app/features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component.ts
@@ -5,6 +5,7 @@ import { staffRecruitmentOptionsEnum } from '@core/model/establishment.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 
 import { Question } from '../question/question.component';
 
@@ -48,7 +49,7 @@ export class AcceptPreviousCareCertificateComponent extends Question implements 
     this.setPreviousRoute();
     this.prefill();
     this.skipRoute = ['/workplace', this.establishment.uid, 'cash-loyalty'];
-    this.section = 'Recruitment';
+    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   }
 
   private setPreviousRoute(): void {

--- a/frontend/src/app/features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component.html
+++ b/frontend/src/app/features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component.html
@@ -4,7 +4,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-l" data-testid="section-heading">Staff benefits</span>
+            <span class="govuk-caption-l" data-testid="section-heading">{{ section }}</span>
             Do you pay your care workers more than Statutory Sick Pay if they cannot work because of illness?
           </h1>
         </legend>

--- a/frontend/src/app/features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component.spec.ts
+++ b/frontend/src/app/features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component.spec.ts
@@ -59,8 +59,10 @@ describe('BenefitsStatutorySickPayComponent', () => {
   it('should render the headings', async () => {
     const { getByText } = await setup();
     const heading = `Do you pay your care workers more than Statutory Sick Pay if they cannot work because of illness?`;
+    const sectionCaption = 'Staff recruitment and benefits';
 
     expect(getByText(heading)).toBeTruthy;
+    expect(getByText(sectionCaption)).toBeTruthy;
   });
 
   it('should render the reveal', async () => {

--- a/frontend/src/app/features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component.ts
+++ b/frontend/src/app/features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component.ts
@@ -5,6 +5,7 @@ import { StaffBenefitEnum } from '@core/model/establishment.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 
 import { Question } from '../question/question.component';
 
@@ -46,7 +47,7 @@ export class BenefitsStatutorySickPayComponent extends Question implements OnIni
     this.setPreviousRoute();
 
     this.skipRoute = ['/workplace', `${this.establishment.uid}`, 'pensions'];
-    this.section = 'Staff benefits';
+    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   }
 
   private setPreviousRoute(): void {

--- a/frontend/src/app/features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component.ts
+++ b/frontend/src/app/features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component.ts
@@ -29,7 +29,7 @@ export class BenefitsStatutorySickPayComponent extends Question implements OnIni
     },
   ];
 
-  public section: string;
+  public section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -47,7 +47,6 @@ export class BenefitsStatutorySickPayComponent extends Question implements OnIni
     this.setPreviousRoute();
 
     this.skipRoute = ['/workplace', `${this.establishment.uid}`, 'pensions'];
-    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   }
 
   private setPreviousRoute(): void {

--- a/frontend/src/app/features/workplace/data-sharing/data-sharing.component.ts
+++ b/frontend/src/app/features/workplace/data-sharing/data-sharing.component.ts
@@ -5,6 +5,7 @@ import { ShareWithRequest } from '@core/model/data-sharing.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 
 import { Question } from '../question/question.component';
 
@@ -13,7 +14,7 @@ import { Question } from '../question/question.component';
   templateUrl: './data-sharing.component.html',
 })
 export class DataSharingComponent extends Question {
-  public section = 'Permissions';
+  public section = WorkplaceFlowSections.PERMISSIONS;
   constructor(
     protected formBuilder: UntypedFormBuilder,
     protected router: Router,

--- a/frontend/src/app/features/workplace/other-services/other-services.component.ts
+++ b/frontend/src/app/features/workplace/other-services/other-services.component.ts
@@ -6,6 +6,7 @@ import { Service, ServiceGroup } from '@core/model/services.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 import filter from 'lodash/filter';
 
 import { Question } from '../question/question.component';
@@ -19,7 +20,7 @@ export class OtherServicesComponent extends Question {
   private allServices: Array<Service> = [];
   private allOtherServices: Array<Service> = [];
   public serviceGroups: Array<ServiceGroup>;
-  public section = 'Services';
+  public section = WorkplaceFlowSections.SERVICES;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,

--- a/frontend/src/app/features/workplace/pensions/pensions.component.html
+++ b/frontend/src/app/features/workplace/pensions/pensions.component.html
@@ -11,7 +11,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-l" data-testid="section-heading">Staff benefits</span>
+            <span class="govuk-caption-l" data-testid="section-heading">{{ section }}</span>
             Do you contribute more than the minimum 3% into workplace pensions for your care workers?
           </h1>
         </legend>

--- a/frontend/src/app/features/workplace/pensions/pensions.component.spec.ts
+++ b/frontend/src/app/features/workplace/pensions/pensions.component.spec.ts
@@ -59,8 +59,10 @@ describe('PensionsComponent', () => {
   it('should render the headings', async () => {
     const { getByText } = await setup();
     const heading = `Do you contribute more than the minimum 3% into workplace pensions for your care workers?`;
+    const sectionCaption = 'Staff recruitment and benefits';
 
     expect(getByText(heading)).toBeTruthy;
+    expect(getByText(sectionCaption)).toBeTruthy;
   });
 
   it('should render the reveal', async () => {

--- a/frontend/src/app/features/workplace/pensions/pensions.component.ts
+++ b/frontend/src/app/features/workplace/pensions/pensions.component.ts
@@ -29,7 +29,7 @@ export class PensionsComponent extends Question implements OnInit, OnDestroy {
     },
   ];
 
-  public section: string;
+  public section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -45,7 +45,6 @@ export class PensionsComponent extends Question implements OnInit, OnDestroy {
     this.setupForm();
     this.setRoutes();
     this.prefill();
-    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   }
 
   private setRoutes(): void {

--- a/frontend/src/app/features/workplace/pensions/pensions.component.ts
+++ b/frontend/src/app/features/workplace/pensions/pensions.component.ts
@@ -5,6 +5,7 @@ import { StaffBenefitEnum } from '@core/model/establishment.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 
 import { Question } from '../question/question.component';
 
@@ -44,7 +45,7 @@ export class PensionsComponent extends Question implements OnInit, OnDestroy {
     this.setupForm();
     this.setRoutes();
     this.prefill();
-    this.section = 'Staff benefits';
+    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   }
 
   private setRoutes(): void {

--- a/frontend/src/app/features/workplace/service-users/service-users.component.ts
+++ b/frontend/src/app/features/workplace/service-users/service-users.component.ts
@@ -7,6 +7,7 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { ServiceUsersService } from '@core/services/service-users.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 import { Question } from '@features/workplace/question/question.component';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
@@ -20,7 +21,7 @@ export class ServiceUsersComponent extends Question {
   public allUserServices: ServiceForUser[] = [];
   public renderForm = false;
   private otherMaxLength = 120;
-  public section = 'Services';
+  public section = WorkplaceFlowSections.SERVICES;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,

--- a/frontend/src/app/features/workplace/services-capacity/services-capacity.component.ts
+++ b/frontend/src/app/features/workplace/services-capacity/services-capacity.component.ts
@@ -6,6 +6,7 @@ import { ErrorDetails } from '@core/model/errorSummary.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 import groupBy from 'lodash/groupBy';
 
 import { Question } from '../question/question.component';
@@ -17,7 +18,7 @@ import { Question } from '../question/question.component';
 export class ServicesCapacityComponent extends Question {
   public capacities = [];
   public intPattern = INT_PATTERN.toString();
-  public section = 'Services';
+  public section = WorkplaceFlowSections.SERVICES;
   public errorsSummaryErrorsMap: ErrorDetails[] = [];
 
   constructor(

--- a/frontend/src/app/features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component.html
+++ b/frontend/src/app/features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component.html
@@ -11,7 +11,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-l" data-testid="section-heading">Staff benefits</span>
+            <span class="govuk-caption-l" data-testid="section-heading">{{ section }}</span>
             Do you pay care workers a cash loyalty bonus within their first 2 years of employment?
           </h1>
         </legend>

--- a/frontend/src/app/features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component.spec.ts
+++ b/frontend/src/app/features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component.spec.ts
@@ -60,8 +60,10 @@ describe('StaffBenefitCashLoyaltyComponent', () => {
     const { getByText } = await setup();
     const heading = 'Do you pay care workers a cash loyalty bonus within their first 2 years of employment?';
     const helpText = 'We only want to know about bonuses given for staying in a role, not for things like performance.';
+    const sectionCaption = 'Staff recruitment and benefits';
 
     expect(getByText(heading)).toBeTruthy;
+    expect(getByText(sectionCaption)).toBeTruthy;
     expect(getByText(helpText)).toBeTruthy;
   });
 

--- a/frontend/src/app/features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component.ts
+++ b/frontend/src/app/features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component.ts
@@ -6,6 +6,7 @@ import { StaffBenefitEnum } from '@core/model/establishment.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 
 import { Question } from '../question/question.component';
 
@@ -50,7 +51,7 @@ export class StaffBenefitCashLoyaltyComponent extends Question implements OnInit
   protected init(): void {
     this.prefill();
     this.setPreviousRoute();
-    this.section = 'Staff benefits';
+    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
     this.skipRoute = ['/workplace', `${this.establishment.uid}`, 'benefits-statutory-sick-pay'];
   }
 

--- a/frontend/src/app/features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component.ts
+++ b/frontend/src/app/features/workplace/staff-benefit-cash-loyalty/staff-benefit-cash-loyalty.component.ts
@@ -31,7 +31,7 @@ export class StaffBenefitCashLoyaltyComponent extends Question implements OnInit
   ];
 
   public showTextBox = false;
-  public section: string;
+  public section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -51,7 +51,6 @@ export class StaffBenefitCashLoyaltyComponent extends Question implements OnInit
   protected init(): void {
     this.prefill();
     this.setPreviousRoute();
-    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
     this.skipRoute = ['/workplace', `${this.establishment.uid}`, 'benefits-statutory-sick-pay'];
   }
 

--- a/frontend/src/app/features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component.html
+++ b/frontend/src/app/features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component.html
@@ -11,7 +11,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-l" data-testid="section-heading">Staff benefits</span>
+            <span class="govuk-caption-l" data-testid="section-heading">{{ section }}</span>
             How many days leave do your full-time care workers get each year?
           </h1>
         </legend>

--- a/frontend/src/app/features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component.spec.ts
+++ b/frontend/src/app/features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component.spec.ts
@@ -61,8 +61,10 @@ describe('StaffBenefitHolidayLeaveComponent', () => {
     const heading = 'How many days leave do your full-time care workers get each year?';
     const helpText =
       'Include bank holidays in the total. For example, 20 days annual leave plus 8 bank holidays would be 28 days in total.';
+    const sectionCaption = 'Staff recruitment and benefits';
 
     expect(getByText(heading)).toBeTruthy;
+    expect(getByText(sectionCaption)).toBeTruthy;
     expect(getByText(helpText)).toBeTruthy;
   });
 

--- a/frontend/src/app/features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component.ts
+++ b/frontend/src/app/features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 
 import { Question } from '../question/question.component';
 
@@ -31,7 +32,7 @@ export class StaffBenefitHolidayLeaveComponent extends Question implements OnIni
     this.prefill();
     this.setPreviousRoute();
 
-    this.section = 'Staff benefits';
+    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
     this.skipRoute = ['/workplace', `${this.establishment.uid}`, 'sharing-data'];
   }
 

--- a/frontend/src/app/features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component.ts
+++ b/frontend/src/app/features/workplace/staff-benefit-holiday-leave/staff-benefit-holiday-leave.component.ts
@@ -13,7 +13,7 @@ import { Question } from '../question/question.component';
   templateUrl: './staff-benefit-holiday-leave.component.html',
 })
 export class StaffBenefitHolidayLeaveComponent extends Question implements OnInit, OnDestroy {
-  public section: string;
+  public section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   private numberCheckRegex = /^-?\d*(\.\d*)?$/;
   private wholeNumberCheckRegex = /^-?[A-Za-z0-9]*$/;
   private positiveNumberCheckRegex = /^[A-Za-z\d*(.\d*)]*$/;
@@ -32,7 +32,6 @@ export class StaffBenefitHolidayLeaveComponent extends Question implements OnIni
     this.prefill();
     this.setPreviousRoute();
 
-    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
     this.skipRoute = ['/workplace', `${this.establishment.uid}`, 'sharing-data'];
   }
 

--- a/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.html
+++ b/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.html
@@ -4,7 +4,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-l" data-testid="section-heading">Recruitment</span>
+            <span class="govuk-caption-l" data-testid="section-heading">{{ section }}</span>
             Do new care workers have to repeat training they've done with previous employers?
           </h1>
         </legend>

--- a/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.spec.ts
+++ b/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.spec.ts
@@ -9,7 +9,9 @@ import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentServ
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
-import { StaffRecruitmentCaptureTrainingRequirementComponent } from './staff-recruitment-capture-training-requirement.component';
+import {
+  StaffRecruitmentCaptureTrainingRequirementComponent,
+} from './staff-recruitment-capture-training-requirement.component';
 
 describe('StaffRecruitmentCaptureTrainingRequirement', () => {
   async function setup(returnUrl = true, repeatTraining = undefined) {
@@ -58,8 +60,10 @@ describe('StaffRecruitmentCaptureTrainingRequirement', () => {
   it('should render the heading, input and radio buttons', async () => {
     const { getByText, getByLabelText } = await setup();
     const heading = `Do new care workers have to repeat training they've done with previous employers?`;
+    const sectionCaption = 'Staff recruitment and benefits';
 
     expect(getByText(heading)).toBeTruthy;
+    expect(getByText(sectionCaption)).toBeTruthy;
     expect(getByLabelText('Yes, always')).toBeTruthy();
     expect(getByLabelText('Yes, very often')).toBeTruthy();
     expect(getByLabelText('Yes, but not very often')).toBeTruthy();

--- a/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.ts
+++ b/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.ts
@@ -33,7 +33,7 @@ export class StaffRecruitmentCaptureTrainingRequirementComponent extends Questio
     },
   ];
 
-  public section: string;
+  public section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -50,7 +50,6 @@ export class StaffRecruitmentCaptureTrainingRequirementComponent extends Questio
     this.setPreviousRoute();
     this.prefill();
     this.skipRoute = ['/workplace', `${this.establishment.uid}`, 'accept-previous-care-certificate'];
-    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   }
 
   private setPreviousRoute(): void {

--- a/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.ts
+++ b/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.ts
@@ -5,6 +5,7 @@ import { staffRecruitmentOptionsEnum } from '@core/model/establishment.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 
 import { Question } from '../question/question.component';
 
@@ -49,7 +50,7 @@ export class StaffRecruitmentCaptureTrainingRequirementComponent extends Questio
     this.setPreviousRoute();
     this.prefill();
     this.skipRoute = ['/workplace', `${this.establishment.uid}`, 'accept-previous-care-certificate'];
-    this.section = 'Recruitment';
+    this.section = WorkplaceFlowSections.STAFF_RECRUITMENT_AND_BENEFITS;
   }
 
   private setPreviousRoute(): void {

--- a/frontend/src/app/features/workplace/vacancies-and-turnover/how-many-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/features/workplace/vacancies-and-turnover/how-many-starters-leavers-vacancies.directive.ts
@@ -1,6 +1,7 @@
 import { Directive, ElementRef, OnDestroy, OnInit, QueryList, ViewChildren } from '@angular/core';
 import { UntypedFormArray, Validators } from '@angular/forms';
 import { Leaver, Starter, UpdateJobsRequest, Vacancy } from '@core/model/establishment.model';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 import { sum } from 'lodash';
 
 import { Question } from '../question/question.component';
@@ -14,7 +15,7 @@ export class HowManyStartersLeaversVacanciesDirective extends Question implement
   public jobRoleType: string;
   public fieldName: string;
   public fieldJobRoles: string;
-  public section: string = 'Vacancies and turnover';
+  public section: string = WorkplaceFlowSections.VACANCIES_AND_TURNOVER;
   public totalNumber = 0;
 
   protected selectedJobRoles: Array<Starter | Leaver | Vacancy> = [];

--- a/frontend/src/app/features/workplace/vacancies-and-turnover/select-job-roles.directive.ts
+++ b/frontend/src/app/features/workplace/vacancies-and-turnover/select-job-roles.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, ViewChild } from '@angular/core';
-import { UntypedFormBuilder, Validators } from '@angular/forms';
+import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Leaver, Starter, Vacancy } from '@core/model/establishment.model';
 import { Job, JobGroup } from '@core/model/job.model';
@@ -7,6 +7,7 @@ import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { JobService } from '@core/services/job.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 import { Question } from '@features/workplace/question/question.component';
 import { AccordionGroupComponent } from '@shared/components/accordions/generic-accordion/accordion-group/accordion-group.component';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
@@ -14,7 +15,7 @@ import { CustomValidators } from '@shared/validators/custom-form-validators';
 @Directive()
 export class SelectJobRolesDirective extends Question {
   @ViewChild('accordion') accordion: AccordionGroupComponent;
-  public section = 'Vacancies and turnover';
+  public section = WorkplaceFlowSections.VACANCIES_AND_TURNOVER;
   public heading: string;
   public errorMessageOnEmptyInput: string;
   public jobGroupsToOpenAtStart: string[] = [];

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
@@ -448,7 +448,9 @@
   <ng-container>
     <div class="govuk-summary-list__row" data-testid="staff-recruitment-and-benefits-section">
       <dt class="govuk-summary-list__key">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5">Staff recruitment and benefits</h2>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5 govuk__nowrap">
+          Staff recruitment and benefits
+        </h2>
       </dt>
       <dd class="govuk-summary-list__value"></dd>
       <dd class="govuk-summary-list__actions"></dd>

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
@@ -446,9 +446,9 @@
   </ng-container>
 
   <ng-container>
-    <div class="govuk-summary-list__row" data-testid="recruitment-section">
+    <div class="govuk-summary-list__row" data-testid="staff-recruitment-and-benefits-section">
       <dt class="govuk-summary-list__key">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5">Recruitment</h2>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5">Staff recruitment and benefits</h2>
       </dt>
       <dd class="govuk-summary-list__value"></dd>
       <dd class="govuk-summary-list__actions"></dd>
@@ -503,16 +503,7 @@
         ></app-summary-record-change>
       </dd>
     </div>
-  </ng-container>
 
-  <ng-container>
-    <div class="govuk-summary-list__row" data-testid="staff-benefits-section">
-      <dt class="govuk-summary-list__key">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5">Staff benefits</h2>
-      </dt>
-      <dd class="govuk-summary-list__value"></dd>
-      <dd class="govuk-summary-list__actions"></dd>
-    </div>
     <div class="govuk-summary-list__row" data-testid="cash-loyalty-bonus-spend">
       <dt class="govuk-summary-list__key">Cash loyalty bonus</dt>
       <dd class="govuk-summary-list__value">

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
@@ -8,7 +8,6 @@ import { CqcStatusChangeService } from '@core/services/cqc-status-change.service
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
-import { WorkerService } from '@core/services/worker.service';
 import { MockCqcStatusChangeService } from '@core/test-utils/MockCqcStatusChangeService';
 import {
   establishmentWithShareWith,
@@ -16,7 +15,6 @@ import {
   MockEstablishmentService,
 } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { MockWorkerService } from '@core/test-utils/MockWorkerService';
 import { WdfModule } from '@features/wdf/wdf-data-change/wdf.module';
 import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
@@ -39,10 +37,6 @@ describe('WDFWorkplaceSummaryComponent', () => {
         {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
-        },
-        {
-          provide: WorkerService,
-          useClass: MockWorkerService,
         },
         {
           provide: CqcStatusChangeService,
@@ -87,9 +81,8 @@ describe('WDFWorkplaceSummaryComponent', () => {
     expect(getByTestId('employerType')).toBeTruthy();
     expect(getByTestId('services-section')).toBeTruthy();
     expect(getByTestId('vacancies-and-turnover-section')).toBeTruthy();
-    expect(getByTestId('recruitment-section')).toBeTruthy();
+    expect(getByTestId('staff-recruitment-and-benefits-section')).toBeTruthy();
     expect(getByTestId('permissions-section')).toBeTruthy();
-    expect(getByTestId('staff-benefits-section')).toBeTruthy();
   });
 
   it('should render the services section with top margin when removeServiceSectionMargin is false, and without margin when true', async () => {
@@ -811,7 +804,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
     });
   });
 
-  describe('Recruitment section', () => {
+  describe('Staff recruitment and benefits section', () => {
     describe('Repeat training', () => {
       it('should show dash and have Add information button on  Repeat Training row when doNewStartersRepeatMandatoryTrainingFromPreviousEmployment is set to null (not answered)', async () => {
         const { component, fixture } = await setup();
@@ -883,9 +876,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
         ).toBeTruthy();
       });
     });
-  });
 
-  describe('Staff benefits section', () => {
     describe('Cash loyalty bonus', () => {
       it('should show dash and have Add information button on Cash loyalty bonus row when careWorkersCashLoyaltyForFirstTwoYears is set to null (not answered)', async () => {
         const { component, fixture } = await setup();

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.ts
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.ts
@@ -6,7 +6,6 @@ import { Eligibility } from '@core/model/wdf.model';
 import { CqcStatusChangeService } from '@core/services/cqc-status-change.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { WorkerService } from '@core/services/worker.service';
 import { WorkplaceUtil } from '@core/utils/workplace-util';
 import { sortBy } from 'lodash';
 import { Subscription } from 'rxjs';
@@ -82,7 +81,6 @@ export class WDFWorkplaceSummaryComponent implements OnInit, OnDestroy, OnChange
     private i18nPluralPipe: I18nPluralPipe,
     private establishmentService: EstablishmentService,
     private permissionsService: PermissionsService,
-    private workerService: WorkerService,
     private cqcStatusChangeService: CqcStatusChangeService,
   ) {
     this.pluralMap['How many beds do you have?'] = {

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -345,10 +345,10 @@
   </dl>
 
   <ng-container *ngIf="!workplace?.showAddWorkplaceDetailsBanner">
-    <h2 class="govuk-heading-m govuk-!-padding-top-1">Recruitment</h2>
+    <h2 class="govuk-heading-m govuk-!-padding-top-1">Staff recruitment and benefits</h2>
     <dl
       class="govuk-summary-list govuk-summary-list--medium govuk-summary-list--top-border"
-      data-testid="recruitment-section"
+      data-testid="staff-recruitment-and-benefits-section"
     >
       <div class="govuk-summary-list__row" data-testid="repeat-training">
         <dt class="govuk-summary-list__key">Repeat training</dt>
@@ -403,13 +403,7 @@
           ></app-summary-record-change>
         </dd>
       </div>
-    </dl>
 
-    <h2 class="govuk-heading-m govuk-!-padding-top-1">Staff benefits</h2>
-    <dl
-      class="govuk-summary-list govuk-summary-list--medium govuk-summary-list--top-border"
-      data-testid="staff-benefits-section"
-    >
       <div class="govuk-summary-list__row" data-testid="cash-loyalty-bonus-spend">
         <dt class="govuk-summary-list__key">Cash loyalty bonus</dt>
         <dd class="govuk-summary-list__value">

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -81,9 +81,8 @@ describe('NewWorkplaceSummaryComponent', () => {
     expect(getByTestId('employerType')).toBeTruthy();
     expect(getByTestId('services-section')).toBeTruthy();
     expect(getByTestId('vacancies-and-turnover-section')).toBeTruthy();
-    expect(getByTestId('recruitment-section')).toBeTruthy();
+    expect(getByTestId('staff-recruitment-and-benefits-section')).toBeTruthy();
     expect(getByTestId('permissions-section')).toBeTruthy();
-    expect(getByTestId('staff-benefits-section')).toBeTruthy();
   });
 
   describe('workplace-section', () => {
@@ -1078,7 +1077,7 @@ describe('NewWorkplaceSummaryComponent', () => {
     });
   });
 
-  describe('Recruitment section', () => {
+  describe('Staff recruitment and benefits section', () => {
     describe('Repeat training', () => {
       it('should show dash and have Add information button on  Repeat Training row when doNewStartersRepeatMandatoryTrainingFromPreviousEmployment is set to null (not answered)', async () => {
         const { component, fixture } = await setup();
@@ -1158,9 +1157,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         ).toBeTruthy();
       });
     });
-  });
 
-  describe('Staff benefits section', () => {
     describe('Cash loyalty bonus', () => {
       it('should show dash and have Add information button on Cash loyalty bonus row when careWorkersCashLoyaltyForFirstTwoYears is set to null (not answered)', async () => {
         const { component, fixture } = await setup();

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
@@ -1,13 +1,11 @@
 import { I18nPluralPipe } from '@angular/common';
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { Service } from '@core/model/services.model';
 import { URLStructure } from '@core/model/url.model';
 import { CqcStatusChangeService } from '@core/services/cqc-status-change.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { TabsService } from '@core/services/tabs.service';
 import { WorkplaceUtil } from '@core/utils/workplace-util';
 import { sortBy } from 'lodash';
 import { Subscription } from 'rxjs';
@@ -45,8 +43,6 @@ export class NewWorkplaceSummaryComponent implements OnInit, OnDestroy {
     private permissionsService: PermissionsService,
     private establishmentService: EstablishmentService,
     private cqcStatusChangeService: CqcStatusChangeService,
-    private router: Router,
-    private tabsService: TabsService,
   ) {
     this.pluralMap['How many beds do you have?'] = {
       '=1': '# bed available',

--- a/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -525,9 +525,11 @@
   </ng-container>
 
   <ng-container *ngIf="!workplace.showAddWorkplaceDetailsBanner">
-    <div class="govuk-summary-list__row" data-testid="recruitment-section">
+    <div class="govuk-summary-list__row" data-testid="staff-recruitment-and-benefits-section">
       <dt class="govuk-summary-list__key">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5">Recruitment</h2>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5 govuk__nowrap">
+          Staff recruitment and benefits
+        </h2>
       </dt>
       <dd class="govuk-summary-list__value"></dd>
       <dd class="govuk-summary-list__actions"></dd>
@@ -594,16 +596,7 @@
         ></app-summary-record-change>
       </dd>
     </div>
-  </ng-container>
 
-  <ng-container *ngIf="!workplace.showAddWorkplaceDetailsBanner">
-    <div class="govuk-summary-list__row" data-testid="staff-benefits-section">
-      <dt class="govuk-summary-list__key">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5">Staff benefits</h2>
-      </dt>
-      <dd class="govuk-summary-list__value"></dd>
-      <dd class="govuk-summary-list__actions"></dd>
-    </div>
     <div class="govuk-summary-list__row" data-testid="cash-loyalty-bonus-spend">
       <dt class="govuk-summary-list__key">Cash loyalty bonus</dt>
       <dd class="govuk-summary-list__value">

--- a/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -77,9 +77,8 @@ describe('WorkplaceSummaryComponent', () => {
     expect(getByTestId('employerType')).toBeTruthy();
     expect(getByTestId('services-section')).toBeTruthy();
     expect(getByTestId('vacancies-and-turnover-section')).toBeTruthy();
-    expect(getByTestId('recruitment-section')).toBeTruthy();
+    expect(getByTestId('staff-recruitment-and-benefits-section')).toBeTruthy();
     expect(getByTestId('permissions-section')).toBeTruthy();
-    expect(getByTestId('staff-benefits-section')).toBeTruthy();
   });
 
   it('should render the certain sections when on the check-answers page', async () => {
@@ -94,9 +93,8 @@ describe('WorkplaceSummaryComponent', () => {
     expect(queryByTestId('employerType')).toBeFalsy();
     expect(getByTestId('services-section')).toBeTruthy();
     expect(getByTestId('vacancies-and-turnover-section')).toBeTruthy();
-    expect(getByTestId('recruitment-section')).toBeTruthy();
+    expect(getByTestId('staff-recruitment-and-benefits-section')).toBeTruthy();
     expect(getByTestId('permissions-section')).toBeTruthy();
-    expect(getByTestId('staff-benefits-section')).toBeTruthy();
   });
 
   it('should render the services section with top margin when removeServiceSectionMargin is false, and without margin when true', async () => {

--- a/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/shared/directives/do-you-have-starters-leavers-vacancies/do-you-have-starters-leavers-vacancies.directive.ts
@@ -5,11 +5,12 @@ import { jobOptionsEnum, UpdateJobsRequest } from '@core/model/establishment.mod
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 import { Question } from '@features/workplace/question/question.component';
 
 @Directive({})
 export class DoYouHaveStartersLeaversVacanciesDirective extends Question implements OnDestroy {
-  public section = 'Vacancies and turnover';
+  public section = WorkplaceFlowSections.VACANCIES_AND_TURNOVER;
   public heading: string;
   public hintText: string;
   public revealText: string;


### PR DESCRIPTION
#### Work done
- Merged together the recruitment and staff benefits sections on the workplace summary
- Updated the progress bar for adding workplace details flow to have new section
- Refactored setting of sections in workplace pages to make relationship between sections and progress bar clearer 

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
