### PR TITLE
Feat/1644 workplace updates after deleting staff record

### DIFF
--- a/frontend/src/app/core/services/update-workplace-after-staff-changes.service.spec.ts
+++ b/frontend/src/app/core/services/update-workplace-after-staff-changes.service.spec.ts
@@ -3,7 +3,9 @@ import { TestBed } from '@angular/core/testing';
 
 import {
   AddStaffWorkplaceUpdatePage,
+  DeleteStaffWorkplaceUpdatePage,
   UpdateWorkplaceAfterStaffChangesService,
+  WorkplaceUpdateFlowType,
 } from './update-workplace-after-staff-changes.service';
 
 describe('UpdateWorkplaceAfterStaffChangesService', () => {
@@ -21,22 +23,30 @@ describe('UpdateWorkplaceAfterStaffChangesService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('allUpdatePagesVisitedForAdd', () => {
+  describe('allUpdatePagesVisited', () => {
     [
       [],
       [AddStaffWorkplaceUpdatePage.TOTAL_STAFF],
       [AddStaffWorkplaceUpdatePage.TOTAL_STAFF, AddStaffWorkplaceUpdatePage.UPDATE_VACANCIES],
     ].forEach((visitedPages) => {
-      it(`should return false when not all pages in visitedPages (${visitedPages})`, async () => {
+      it(`should return false when not all add pages in visitedPages when ADD passed in (${visitedPages})`, async () => {
         visitedPages.forEach((page) => {
           service.addToVisitedPages(page);
         });
 
-        expect(service.allUpdatePagesVisitedForAdd()).toBeFalse();
+        expect(service.allUpdatePagesVisited(WorkplaceUpdateFlowType.ADD)).toBeFalse();
+      });
+
+      it(`should return false when not all delete pages in visitedPage when DELETE passed in (${visitedPages})`, async () => {
+        visitedPages.forEach((page) => {
+          service.addToVisitedPages(page);
+        });
+
+        expect(service.allUpdatePagesVisited(WorkplaceUpdateFlowType.DELETE)).toBeFalse();
       });
     });
 
-    it('should return true when all pages in visitedPages', async () => {
+    it('should return true when all pages in visitedPages for add flow', async () => {
       [
         AddStaffWorkplaceUpdatePage.TOTAL_STAFF,
         AddStaffWorkplaceUpdatePage.UPDATE_VACANCIES,
@@ -45,7 +55,19 @@ describe('UpdateWorkplaceAfterStaffChangesService', () => {
         service.addToVisitedPages(page);
       });
 
-      expect(service.allUpdatePagesVisitedForAdd()).toBeTrue();
+      expect(service.allUpdatePagesVisited(WorkplaceUpdateFlowType.ADD)).toBeTrue();
+    });
+
+    it('should return true when all pages in visitedPages for delete flow', async () => {
+      [
+        DeleteStaffWorkplaceUpdatePage.TOTAL_STAFF,
+        DeleteStaffWorkplaceUpdatePage.UPDATE_VACANCIES,
+        DeleteStaffWorkplaceUpdatePage.UPDATE_LEAVERS,
+      ].forEach((page) => {
+        service.addToVisitedPages(page);
+      });
+
+      expect(service.allUpdatePagesVisited(WorkplaceUpdateFlowType.DELETE)).toBeTrue();
     });
   });
 });

--- a/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
+++ b/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
@@ -28,3 +28,8 @@ export enum AddStaffWorkplaceUpdatePage {
   UPDATE_VACANCIES = 'update-vacancies',
   UPDATE_STARTERS = 'update-starters',
 }
+
+export enum WorkplaceUpdateFlowType {
+  ADD = 'ADD',
+  DELETE = 'DELETE',
+}

--- a/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
+++ b/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
@@ -6,9 +6,9 @@ import { Injectable } from '@angular/core';
 export class UpdateWorkplaceAfterStaffChangesService {
   constructor() {}
 
-  private visitedPages: Set<AddStaffWorkplaceUpdatePage> = new Set();
+  private visitedPages: Set<WorkplaceUpdatePage> = new Set();
 
-  public addToVisitedPages(page: AddStaffWorkplaceUpdatePage): void {
+  public addToVisitedPages(page: WorkplaceUpdatePage): void {
     this.visitedPages.add(page);
   }
 
@@ -16,8 +16,11 @@ export class UpdateWorkplaceAfterStaffChangesService {
     this.visitedPages.clear();
   }
 
-  public allUpdatePagesVisitedForAdd(): boolean {
-    return Object.values(AddStaffWorkplaceUpdatePage).every((page) => {
+  public allUpdatePagesVisited(flowType: WorkplaceUpdateFlowType): boolean {
+    const pages =
+      flowType === WorkplaceUpdateFlowType.ADD ? AddStaffWorkplaceUpdatePage : DeleteStaffWorkplaceUpdatePage;
+
+    return Object.values(pages).every((page) => {
       return this.visitedPages.has(page);
     });
   }
@@ -28,6 +31,14 @@ export enum AddStaffWorkplaceUpdatePage {
   UPDATE_VACANCIES = 'update-vacancies',
   UPDATE_STARTERS = 'update-starters',
 }
+
+export enum DeleteStaffWorkplaceUpdatePage {
+  TOTAL_STAFF = 'update-total-staff',
+  UPDATE_VACANCIES = 'update-vacancies',
+  UPDATE_LEAVERS = 'update-leavers',
+}
+
+type WorkplaceUpdatePage = AddStaffWorkplaceUpdatePage | DeleteStaffWorkplaceUpdatePage;
 
 export enum WorkplaceUpdateFlowType {
   ADD = 'ADD',

--- a/frontend/src/app/features/workers/add-another-staff-record/add-another-staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/add-another-staff-record/add-another-staff-record.component.spec.ts
@@ -1,30 +1,27 @@
-import { render } from '@testing-library/angular';
-import { AddAnotherStaffRecordComponent } from './add-another-staff-record.component'
-import userEvent from '@testing-library/user-event';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
-import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
+import { render } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 
+import { AddAnotherStaffRecordComponent } from './add-another-staff-record.component';
 
 describe('AddAnotherStaffRecordComponent', () => {
   async function setup() {
-    const setupTools = await render(
-      AddAnotherStaffRecordComponent,
-      {
-        imports: [RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
-        providers: [
-          UntypedFormBuilder,
-          {
-            provide: EstablishmentService,
-            useClass: MockEstablishmentService
-          },
-        ]
-      }
-    );
+    const setupTools = await render(AddAnotherStaffRecordComponent, {
+      imports: [RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+      providers: [
+        UntypedFormBuilder,
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
+        },
+      ],
+    });
 
     const component = setupTools.fixture.componentInstance;
 
@@ -35,10 +32,9 @@ describe('AddAnotherStaffRecordComponent', () => {
     return {
       ...setupTools,
       component,
-      navigateSpy
+      navigateSpy,
     };
   }
-
 
   it('renders a component', async () => {
     const { component } = await setup();
@@ -46,19 +42,19 @@ describe('AddAnotherStaffRecordComponent', () => {
   });
 
   it('displays the header text', async () => {
-    const { component, getByText } = await setup();
+    const { getByText } = await setup();
 
     expect(getByText('Do you want to add another staff record?')).toBeTruthy();
   });
 
   it('displays the section text', async () => {
-    const { component, getByText } = await setup();
+    const { getByText } = await setup();
 
     expect(getByText('Staff records')).toBeTruthy();
   });
 
   it('displays the yes/no radio buttons', async () => {
-    const { component, fixture, getByLabelText } = await setup();
+    const { getByLabelText } = await setup();
 
     const yesRadioButton = getByLabelText('Yes');
     const noRadioButton = getByLabelText('No');
@@ -68,8 +64,6 @@ describe('AddAnotherStaffRecordComponent', () => {
     expect(yesRadioButton).toBeTruthy();
     expect(noRadioButton).toBeTruthy();
   });
-
-
 
   describe('continue button', () => {
     it('is rendered', async () => {
@@ -89,7 +83,7 @@ describe('AddAnotherStaffRecordComponent', () => {
         'mocked-uid',
         'staff-record',
         'create-staff-record',
-        'staff-details'
+        'staff-details',
       ]);
     });
 
@@ -104,7 +98,7 @@ describe('AddAnotherStaffRecordComponent', () => {
         '/workplace',
         'mocked-uid',
         'staff-record',
-        'update-workplace-details-after-staff-changes'
+        'update-workplace-details-after-adding-staff',
       ]);
     });
 
@@ -118,8 +112,8 @@ describe('AddAnotherStaffRecordComponent', () => {
         '/workplace',
         'mocked-uid',
         'staff-record',
-        'update-workplace-details-after-staff-changes'
+        'update-workplace-details-after-adding-staff',
       ]);
     });
   });
-})
+});

--- a/frontend/src/app/features/workers/add-another-staff-record/add-another-staff-record.component.ts
+++ b/frontend/src/app/features/workers/add-another-staff-record/add-another-staff-record.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { UntypedFormArray, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BackLinkService } from '@core/services/backLink.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -8,7 +8,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
   selector: 'app-add-another-staff-record',
   templateUrl: './add-another-staff-record.component.html',
 })
-export class AddAnotherStaffRecordComponent implements OnInit{
+export class AddAnotherStaffRecordComponent implements OnInit {
   public form: UntypedFormGroup;
   private workplaceUid: string;
 
@@ -31,9 +31,12 @@ export class AddAnotherStaffRecordComponent implements OnInit{
     if (this.form.controls['addAnotherStaffRecord'].value === 'YES') {
       this.router.navigate(['/workplace', this.workplaceUid, 'staff-record', 'create-staff-record', 'staff-details']);
     } else {
-      this.router.navigate(['/workplace', this.workplaceUid, 'staff-record', 'update-workplace-details-after-staff-changes']);
+      this.router.navigate([
+        '/workplace',
+        this.workplaceUid,
+        'staff-record',
+        'update-workplace-details-after-adding-staff',
+      ]);
     }
   }
-
-
 }

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
@@ -58,7 +58,7 @@
             </dd>
           </div>
 
-          <div class="govuk-summary-list__row" data-testid="starters">
+          <div *ngIf="flowType === WorkplaceUpdateFlowType.ADD" class="govuk-summary-list__row" data-testid="starters">
             <dt class="govuk-summary-list__key">New starters in the last 12 months</dt>
             <dd class="govuk-summary-list__value">
               <app-summary-record-value>

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
@@ -83,6 +83,36 @@
               ></app-summary-record-change>
             </dd>
           </div>
+
+          <div
+            *ngIf="flowType === WorkplaceUpdateFlowType.DELETE"
+            class="govuk-summary-list__row"
+            data-testid="leavers"
+          >
+            <dt class="govuk-summary-list__key">Leavers in the last 12 months</dt>
+            <dd class="govuk-summary-list__value">
+              <app-summary-record-value>
+                <ng-container *ngIf="!workplace.leavers?.length; else leavers"> - </ng-container>
+                <ng-template #leavers>
+                  <ng-container *ngIf="isArray(workplace.leavers)">
+                    <ul class="govuk-list govuk-!-margin-bottom-0">
+                      <li *ngFor="let leaver of workplace.leavers">{{ leaver | formatSLV }}</li>
+                    </ul>
+                  </ng-container>
+                  <ng-container *ngIf="!isArray(workplace.leavers)">
+                    {{ workplace.leavers }}
+                  </ng-container>
+                </ng-template>
+              </app-summary-record-value>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <app-summary-record-change
+                [explanationText]="' new leavers'"
+                [link]="['/workplace', workplace.uid, 'update-leavers']"
+                [hasData]="workplace.leavers?.length"
+              ></app-summary-record-change>
+            </dd>
+          </div>
         </dl>
       </div>
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
@@ -108,7 +108,7 @@
             <dd class="govuk-summary-list__actions">
               <app-summary-record-change
                 [explanationText]="' new leavers'"
-                [link]="['/workplace', workplace.uid, 'update-leavers']"
+                [link]="['update-leavers']"
                 [hasData]="workplace.leavers?.length"
               ></app-summary-record-change>
             </dd>

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
@@ -12,7 +12,8 @@
           Total number of staff, vacancies and {{ flowType === WorkplaceUpdateFlowType.ADD ? 'starters' : 'leavers' }}
         </h2>
         <span *ngIf="!allPagesVisited" class="govuk-error-message govuk-summary-list__warning-message">
-          This data does not update automatically when you add staff records.
+          This data does not update automatically when you
+          {{ flowType === WorkplaceUpdateFlowType.ADD ? 'add' : 'delete' }} staff records.
           <br />
           You need to check and change these yourself.
         </span>

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
@@ -8,7 +8,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <div [class.govuk-summary-list__warning]="!allPagesVisited">
-        <h2 class="govuk-heading-m">Total number of staff, vacancies and starters</h2>
+        <h2 class="govuk-heading-m">
+          Total number of staff, vacancies and {{ flowType === WorkplaceUpdateFlowType.ADD ? 'starters' : 'leavers' }}
+        </h2>
         <span *ngIf="!allPagesVisited" class="govuk-error-message govuk-summary-list__warning-message">
           This data does not update automatically when you add staff records.
           <br />

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -19,6 +19,7 @@ import userEvent from '@testing-library/user-event';
 import { UpdateWorkplaceDetailsAfterStaffChangesComponent } from './update-workplace-details-after-staff-changes.component';
 
 describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   async function setup(overrides: any = {}) {
     const workplace = { ...establishmentBuilder(), ...overrides.workplace };
     const flowType = overrides?.flowType || WorkplaceUpdateFlowType.ADD;
@@ -311,6 +312,96 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
 
       const startersRow = queryByTestId('starters');
       expect(startersRow).toBeFalsy();
+    });
+  });
+
+  describe('Leavers in the last 12 months', () => {
+    it('should show the correct wording', async () => {
+      const { getByTestId } = await setup({ flowType: WorkplaceUpdateFlowType.DELETE });
+
+      const startersRow = getByTestId('leavers');
+
+      expect(within(startersRow).getByText('Leavers in the last 12 months')).toBeTruthy();
+    });
+
+    it('should show dash and have Add link when leavers is null', async () => {
+      const { workplace, getByTestId } = await setup({
+        flowType: WorkplaceUpdateFlowType.DELETE,
+        workplace: { leavers: null },
+      });
+
+      const leaversRow = getByTestId('leavers');
+      const link = within(leaversRow).queryByText('Add');
+
+      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(within(leaversRow).queryByText('-')).toBeTruthy();
+    });
+
+    it("should show Don't know and a Change link when leavers is set to Don't know", async () => {
+      const { workplace, getByTestId } = await setup({
+        flowType: WorkplaceUpdateFlowType.DELETE,
+        workplace: { leavers: "Don't know" },
+      });
+
+      const leaversRow = getByTestId('leavers');
+      const link = within(leaversRow).queryByText('Change');
+
+      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(within(leaversRow).queryByText("Don't know")).toBeTruthy();
+    });
+
+    it('should show None and a Change link when leavers is set to None', async () => {
+      const { workplace, getByTestId } = await setup({
+        flowType: WorkplaceUpdateFlowType.DELETE,
+        workplace: { leavers: 'None' },
+      });
+
+      const leaversRow = getByTestId('leavers');
+      const link = within(leaversRow).queryByText('Change');
+
+      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(within(leaversRow).queryByText(`None`)).toBeTruthy();
+    });
+
+    it('should show one job with number of leavers and a Change link when there is one job with leavers', async () => {
+      const leavers = [{ jobId: 1, title: 'Administrative', total: 3 }];
+      const { workplace, getByTestId } = await setup({
+        flowType: WorkplaceUpdateFlowType.DELETE,
+        workplace: { leavers },
+      });
+
+      const leaversRow = getByTestId('leavers');
+      const link = within(leaversRow).queryByText('Change');
+
+      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(within(leaversRow).queryByText(`3 x administrative`)).toBeTruthy();
+    });
+
+    it('should show jobs with number of leavers for each job and a Change link when multiple jobs have leavers', async () => {
+      const leavers = [
+        { jobId: 1, title: 'Administrative', total: 3 },
+        { jobId: 2, title: 'Nursing', total: 2 },
+        { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
+      ];
+      const { workplace, getByTestId } = await setup({
+        flowType: WorkplaceUpdateFlowType.DELETE,
+        workplace: { leavers },
+      });
+
+      const leaversRow = getByTestId('leavers');
+      const link = within(leaversRow).queryByText('Change');
+
+      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(within(leaversRow).queryByText(`3 x administrative`)).toBeTruthy();
+      expect(within(leaversRow).queryByText('2 x nursing')).toBeTruthy();
+      expect(within(leaversRow).queryByText('4 x other care providing role: special care worker')).toBeTruthy();
+    });
+
+    it('should not display leavers section if on the staff deleted version of page', async () => {
+      const { queryByTestId } = await setup({ flowType: WorkplaceUpdateFlowType.ADD });
+
+      const leaversRow = queryByTestId('leavers');
+      expect(leaversRow).toBeFalsy();
     });
   });
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -73,21 +73,28 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display the Check information title and sub heading', async () => {
-    const { getByText } = await setup();
-
-    expect(getByText('Check this information and make any changes before you continue')).toBeTruthy();
-    expect(getByText('Total number of staff, vacancies and starters')).toBeTruthy();
-  });
-
   describe('Views when user has visited pages', () => {
-    it('should display warning text when user has not visited all of the update question pages', async () => {
+    it('should display warning text when user has not visited all of the update question pages in add view', async () => {
       const { getByText } = await setup({
-        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisitedForAdd: () => false },
+        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisited: () => false },
       });
 
       expect(
         getByText('This data does not update automatically when you add staff records.', { exact: false }),
+      ).toBeTruthy();
+      expect(getByText('You need to check and change these yourself.', { exact: false })).toBeTruthy();
+    });
+
+    it('should display warning text when user has not visited all of the update question pages in delete view', async () => {
+      const { getByText } = await setup({
+        flowType: WorkplaceUpdateFlowType.DELETE,
+        updateWorkplaceAfterStaffChangesService: {
+          allUpdatePagesVisited: () => false,
+        },
+      });
+
+      expect(
+        getByText('This data does not update automatically when you delete staff records.', { exact: false }),
       ).toBeTruthy();
       expect(getByText('You need to check and change these yourself.', { exact: false })).toBeTruthy();
     });
@@ -127,14 +134,14 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
     });
   });
 
-  describe('Subtitle', () => {
-    it('should include starters in subtitle when on added staff version of page', async () => {
+  describe('Sub heading', () => {
+    it('should include starters in sub heading when on added staff version of page', async () => {
       const { getByText } = await setup();
 
       expect(getByText('Total number of staff, vacancies and starters')).toBeTruthy();
     });
 
-    it('should include leavers in subtitle when on deleted staff version of page', async () => {
+    it('should include leavers in sub heading when on deleted staff version of page', async () => {
       const { getByText } = await setup({ flowType: WorkplaceUpdateFlowType.DELETE });
 
       expect(getByText('Total number of staff, vacancies and leavers')).toBeTruthy();

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -26,7 +25,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
     const alertSpy = jasmine.createSpy('addAlert').and.returnValue(Promise.resolve(true));
 
     const setupTools = await render(UpdateWorkplaceDetailsAfterStaffChangesComponent, {
-      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+      imports: [SharedModule, RouterModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
         {
           provide: EstablishmentService,
@@ -157,7 +156,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const numberOfStaffRow = queryByTestId('numberOfStaff');
       const changeLink = within(numberOfStaffRow).queryByText('Change');
 
-      expect(changeLink.getAttribute('href')).toEqual(`/update-total-staff`);
+      expect(changeLink.getAttribute('ng-reflect-router-link')).toEqual('update-total-staff');
       expect(within(numberOfStaffRow).queryByText('4')).toBeTruthy();
     });
 
@@ -167,7 +166,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const numberOfStaffRow = queryByTestId('numberOfStaff');
       const addLink = within(numberOfStaffRow).queryByText('Add');
 
-      expect(addLink.getAttribute('href')).toEqual(`/update-total-staff`);
+      expect(addLink.getAttribute('ng-reflect-router-link')).toEqual('update-total-staff');
       expect(within(numberOfStaffRow).queryByText('-')).toBeTruthy();
     });
   });
@@ -187,7 +186,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const vacanciesRow = getByTestId('vacancies');
       const link = within(vacanciesRow).queryByText('Add');
 
-      expect(link.getAttribute('href')).toEqual(`/update-vacancies`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-vacancies');
       expect(within(vacanciesRow).queryByText('-')).toBeTruthy();
     });
 
@@ -197,7 +196,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const vacanciesRow = getByTestId('vacancies');
       const link = within(vacanciesRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/update-vacancies`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-vacancies');
       expect(within(vacanciesRow).queryByText("Don't know")).toBeTruthy();
     });
 
@@ -207,7 +206,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const vacanciesRow = getByTestId('vacancies');
       const link = within(vacanciesRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/update-vacancies`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-vacancies');
       expect(within(vacanciesRow).queryByText('None')).toBeTruthy();
     });
 
@@ -218,7 +217,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const vacanciesRow = getByTestId('vacancies');
       const link = within(vacanciesRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/update-vacancies`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-vacancies');
       expect(within(vacanciesRow).queryByText('3 x administrative')).toBeTruthy();
     });
 
@@ -233,7 +232,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const vacanciesRow = getByTestId('vacancies');
       const link = within(vacanciesRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/update-vacancies`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-vacancies');
       expect(within(vacanciesRow).queryByText(`3 x administrative`)).toBeTruthy();
       expect(within(vacanciesRow).queryByText('2 x nursing')).toBeTruthy();
       expect(within(vacanciesRow).queryByText('4 x other care providing role: special care worker')).toBeTruthy();
@@ -255,7 +254,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const startersRow = getByTestId('starters');
       const link = within(startersRow).queryByText('Add');
 
-      expect(link.getAttribute('href')).toEqual(`/update-starters`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-starters');
       expect(within(startersRow).queryByText('-')).toBeTruthy();
     });
 
@@ -265,7 +264,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const startersRow = getByTestId('starters');
       const link = within(startersRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/update-starters`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-starters');
       expect(within(startersRow).queryByText("Don't know")).toBeTruthy();
     });
 
@@ -275,7 +274,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const startersRow = getByTestId('starters');
       const link = within(startersRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/update-starters`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-starters');
       expect(within(startersRow).queryByText(`None`)).toBeTruthy();
     });
 
@@ -286,7 +285,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const startersRow = getByTestId('starters');
       const link = within(startersRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/update-starters`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-starters');
       expect(within(startersRow).queryByText(`3 x administrative`)).toBeTruthy();
     });
 
@@ -301,7 +300,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const startersRow = getByTestId('starters');
       const link = within(startersRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/update-starters`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-starters');
       expect(within(startersRow).queryByText(`3 x administrative`)).toBeTruthy();
       expect(within(startersRow).queryByText('2 x nursing')).toBeTruthy();
       expect(within(startersRow).queryByText('4 x other care providing role: special care worker')).toBeTruthy();
@@ -325,7 +324,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
     });
 
     it('should show dash and have Add link when leavers is null', async () => {
-      const { workplace, getByTestId } = await setup({
+      const { getByTestId } = await setup({
         flowType: WorkplaceUpdateFlowType.DELETE,
         workplace: { leavers: null },
       });
@@ -333,12 +332,12 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const leaversRow = getByTestId('leavers');
       const link = within(leaversRow).queryByText('Add');
 
-      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-leavers');
       expect(within(leaversRow).queryByText('-')).toBeTruthy();
     });
 
     it("should show Don't know and a Change link when leavers is set to Don't know", async () => {
-      const { workplace, getByTestId } = await setup({
+      const { getByTestId } = await setup({
         flowType: WorkplaceUpdateFlowType.DELETE,
         workplace: { leavers: "Don't know" },
       });
@@ -346,12 +345,12 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const leaversRow = getByTestId('leavers');
       const link = within(leaversRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-leavers');
       expect(within(leaversRow).queryByText("Don't know")).toBeTruthy();
     });
 
     it('should show None and a Change link when leavers is set to None', async () => {
-      const { workplace, getByTestId } = await setup({
+      const { getByTestId } = await setup({
         flowType: WorkplaceUpdateFlowType.DELETE,
         workplace: { leavers: 'None' },
       });
@@ -359,13 +358,13 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const leaversRow = getByTestId('leavers');
       const link = within(leaversRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-leavers');
       expect(within(leaversRow).queryByText(`None`)).toBeTruthy();
     });
 
     it('should show one job with number of leavers and a Change link when there is one job with leavers', async () => {
       const leavers = [{ jobId: 1, title: 'Administrative', total: 3 }];
-      const { workplace, getByTestId } = await setup({
+      const { getByTestId } = await setup({
         flowType: WorkplaceUpdateFlowType.DELETE,
         workplace: { leavers },
       });
@@ -373,7 +372,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const leaversRow = getByTestId('leavers');
       const link = within(leaversRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-leavers');
       expect(within(leaversRow).queryByText(`3 x administrative`)).toBeTruthy();
     });
 
@@ -383,7 +382,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
         { jobId: 2, title: 'Nursing', total: 2 },
         { jobId: 3, title: 'Other care providing role', total: 4, other: 'Special care worker' },
       ];
-      const { workplace, getByTestId } = await setup({
+      const { getByTestId } = await setup({
         flowType: WorkplaceUpdateFlowType.DELETE,
         workplace: { leavers },
       });
@@ -391,7 +390,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       const leaversRow = getByTestId('leavers');
       const link = within(leaversRow).queryByText('Change');
 
-      expect(link.getAttribute('href')).toEqual(`/workplace/${workplace.uid}/update-leavers`);
+      expect(link.getAttribute('ng-reflect-router-link')).toEqual('update-leavers');
       expect(within(leaversRow).queryByText(`3 x administrative`)).toBeTruthy();
       expect(within(leaversRow).queryByText('2 x nursing')).toBeTruthy();
       expect(within(leaversRow).queryByText('4 x other care providing role: special care worker')).toBeTruthy();

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -94,7 +94,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
 
     it('should not display warning text when user has visited all of the update question pages', async () => {
       const { queryByText } = await setup({
-        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisitedForAdd: () => true },
+        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisited: () => true },
       });
 
       expect(
@@ -103,14 +103,26 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       expect(queryByText('You need to check and change these yourself.', { exact: false })).toBeFalsy();
     });
 
-    it('should add alert when user has visited all of the update question pages', async () => {
+    it('should add alert with starters in message when user has visited all update question pages from add version', async () => {
       const { alertSpy } = await setup({
-        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisitedForAdd: () => true },
+        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisited: () => true },
       });
 
       expect(alertSpy).toHaveBeenCalledWith({
         type: 'success',
         message: 'Total number of staff, vacancies and starters information saved',
+      });
+    });
+
+    it('should add alert with leavers in message when user has visited all update question pages from delete version', async () => {
+      const { alertSpy } = await setup({
+        flowType: WorkplaceUpdateFlowType.DELETE,
+        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisited: () => true },
+      });
+
+      expect(alertSpy).toHaveBeenCalledWith({
+        type: 'success',
+        message: 'Total number of staff, vacancies and leavers information saved',
       });
     });
   });

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -293,6 +293,13 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       expect(within(startersRow).queryByText('2 x nursing')).toBeTruthy();
       expect(within(startersRow).queryByText('4 x other care providing role: special care worker')).toBeTruthy();
     });
+
+    it('should not display starters section if on the staff deleted version of page', async () => {
+      const { queryByTestId } = await setup({ flowType: WorkplaceUpdateFlowType.DELETE });
+
+      const startersRow = queryByTestId('starters');
+      expect(startersRow).toBeFalsy();
+    });
   });
 
   it('should navigate to the staff records tab on click of Continue', async () => {

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -1,12 +1,15 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
+import {
+  UpdateWorkplaceAfterStaffChangesService,
+  WorkplaceUpdateFlowType,
+} from '@core/services/update-workplace-after-staff-changes.service';
 import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockUpdateWorkplaceAfterStaffChangesService } from '@core/test-utils/MockUpdateWorkplaceAfterStaffChangesService';
 import { SharedModule } from '@shared/shared.module';
@@ -18,6 +21,7 @@ import { UpdateWorkplaceDetailsAfterStaffChangesComponent } from './update-workp
 describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
   async function setup(overrides: any = {}) {
     const workplace = { ...establishmentBuilder(), ...overrides.workplace };
+    const flowType = overrides?.flowType || WorkplaceUpdateFlowType.ADD;
     const alertSpy = jasmine.createSpy('addAlert').and.returnValue(Promise.resolve(true));
 
     const setupTools = await render(UpdateWorkplaceDetailsAfterStaffChangesComponent, {
@@ -36,6 +40,14 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
         {
           provide: AlertService,
           useValue: { addAlert: alertSpy },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: { flowType },
+            },
+          },
         },
         BackLinkService,
       ],
@@ -100,6 +112,20 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
         type: 'success',
         message: 'Total number of staff, vacancies and starters information saved',
       });
+    });
+  });
+
+  describe('Subtitle', () => {
+    it('should include starters in subtitle when on added staff version of page', async () => {
+      const { getByText } = await setup();
+
+      expect(getByText('Total number of staff, vacancies and starters')).toBeTruthy();
+    });
+
+    it('should include leavers in subtitle when on deleted staff version of page', async () => {
+      const { getByText } = await setup({ flowType: WorkplaceUpdateFlowType.DELETE });
+
+      expect(getByText('Total number of staff, vacancies and leavers')).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
@@ -1,10 +1,13 @@
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
+import {
+  UpdateWorkplaceAfterStaffChangesService,
+  WorkplaceUpdateFlowType,
+} from '@core/services/update-workplace-after-staff-changes.service';
 
 @Component({
   selector: 'app-update-workplace-details-after-staff-changes',
@@ -17,12 +20,16 @@ export class UpdateWorkplaceDetailsAfterStaffChangesComponent {
     private backLinkService: BackLinkService,
     private updateWorkplaceAfterStaffChangesService: UpdateWorkplaceAfterStaffChangesService,
     private alertService: AlertService,
+    private route: ActivatedRoute,
   ) {}
 
   public workplace: Establishment;
   public allPagesVisited: boolean;
+  public WorkplaceUpdateFlowType = WorkplaceUpdateFlowType;
+  public flowType: WorkplaceUpdateFlowType;
 
   ngOnInit(): void {
+    this.flowType = this.route.snapshot?.data?.flowType;
     this.workplace = this.establishmentService.establishment;
     this.allPagesVisited = this.updateWorkplaceAfterStaffChangesService.allUpdatePagesVisitedForAdd();
     this.backLinkService.showBackLink();

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
@@ -31,13 +31,15 @@ export class UpdateWorkplaceDetailsAfterStaffChangesComponent {
   ngOnInit(): void {
     this.flowType = this.route.snapshot?.data?.flowType;
     this.workplace = this.establishmentService.establishment;
-    this.allPagesVisited = this.updateWorkplaceAfterStaffChangesService.allUpdatePagesVisitedForAdd();
+    this.allPagesVisited = this.updateWorkplaceAfterStaffChangesService.allUpdatePagesVisited(this.flowType);
     this.backLinkService.showBackLink();
 
     if (this.allPagesVisited) {
       this.alertService.addAlert({
         type: 'success',
-        message: 'Total number of staff, vacancies and starters information saved',
+        message: `Total number of staff, vacancies and ${
+          this.flowType === WorkplaceUpdateFlowType.ADD ? 'starters' : 'leavers'
+        } information saved`,
       });
     }
   }

--- a/frontend/src/app/features/workers/workers-routing.module.ts
+++ b/frontend/src/app/features/workers/workers-routing.module.ts
@@ -13,14 +13,28 @@ import { TrainingRecordResolver } from '@core/resolvers/training-record.resolver
 import { TrainingRecordsForCategoryResolver } from '@core/resolvers/training-records-for-category.resolver';
 import { WorkerReasonsForLeavingResolver } from '@core/resolvers/worker-reasons-for-leaving.resolver';
 import { WorkerResolver } from '@core/resolvers/worker.resolver';
-import { SelectQualificationTypeComponent } from '@features/training-and-qualifications/add-edit-qualification/select-qualification-type/select-qualification-type.component';
-import { SelectTrainingCategoryComponent } from '@features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component';
-import { ViewTrainingComponent } from '@shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component';
+import { WorkplaceUpdateFlowType } from '@core/services/update-workplace-after-staff-changes.service';
+import {
+  SelectQualificationTypeComponent,
+} from '@features/training-and-qualifications/add-edit-qualification/select-qualification-type/select-qualification-type.component';
+import {
+  SelectTrainingCategoryComponent,
+} from '@features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component';
+import {
+  ViewTrainingComponent,
+} from '@shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component';
 
-import { AddEditQualificationComponent } from '../training-and-qualifications/add-edit-qualification/add-edit-qualification.component';
+import {
+  AddEditQualificationComponent,
+} from '../training-and-qualifications/add-edit-qualification/add-edit-qualification.component';
 import { AddEditTrainingComponent } from '../training-and-qualifications/add-edit-training/add-edit-training.component';
-import { DeleteRecordComponent } from '../training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component';
-import { NewTrainingAndQualificationsRecordComponent } from '../training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component';
+import {
+  DeleteRecordComponent,
+} from '../training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component';
+import {
+  NewTrainingAndQualificationsRecordComponent,
+} from '../training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component';
+import { AddAnotherStaffRecordComponent } from './add-another-staff-record/add-another-staff-record.component';
 import { AdultSocialCareStartedComponent } from './adult-social-care-started/adult-social-care-started.component';
 import { ApprenticeshipTrainingComponent } from './apprenticeship-training/apprenticeship-training.component';
 import { AverageWeeklyHoursComponent } from './average-weekly-hours/average-weekly-hours.component';
@@ -39,7 +53,9 @@ import { EthnicityComponent } from './ethnicity/ethnicity.component';
 import { GenderComponent } from './gender/gender.component';
 import { HealthAndCareVisaComponent } from './health-and-care-visa/health-and-care-visa.component';
 import { HomePostcodeComponent } from './home-postcode/home-postcode.component';
-import { Level2AdultSocialCareCertificateComponent } from './level-2-adult-social-care-certificate/level-2-adult-social-care-certificate.component';
+import {
+  Level2AdultSocialCareCertificateComponent,
+} from './level-2-adult-social-care-certificate/level-2-adult-social-care-certificate.component';
 import { LongTermAbsenceComponent } from './long-term-absence/long-term-absence.component';
 import { MainJobRoleComponent } from './main-job-role/main-job-role.component';
 import { MainJobStartDateComponent } from './main-job-start-date/main-job-start-date.component';
@@ -54,16 +70,21 @@ import { OtherQualificationsComponent } from './other-qualifications/other-quali
 import { RecruitedFromComponent } from './recruited-from/recruited-from.component';
 import { SalaryComponent } from './salary/salary.component';
 import { SelectRecordTypeComponent } from './select-record-type/select-record-type.component';
-import { SocialCareQualificationLevelComponent } from './social-care-qualification-level/social-care-qualification-level.component';
+import {
+  SocialCareQualificationLevelComponent,
+} from './social-care-qualification-level/social-care-qualification-level.component';
 import { SocialCareQualificationComponent } from './social-care-qualification/social-care-qualification.component';
 import { StaffDetailsComponent } from './staff-details/staff-details.component';
 import { StaffRecordComponent } from './staff-record/staff-record.component';
 import { TotalStaffChangeComponent } from './total-staff-change/total-staff-change.component';
-import { UpdateWorkplaceDetailsAfterStaffChangesComponent } from './update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component';
+import {
+  UpdateTotalNumberOfStaffComponent,
+} from './update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component';
+import {
+  UpdateWorkplaceDetailsAfterStaffChangesComponent,
+} from './update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component';
 import { WeeklyContractedHoursComponent } from './weekly-contracted-hours/weekly-contracted-hours.component';
 import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.component';
-import { AddAnotherStaffRecordComponent } from './add-another-staff-record/add-another-staff-record.component';
-import { UpdateTotalNumberOfStaffComponent } from './update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component';
 
 const routes: Routes = [
   {
@@ -76,13 +97,33 @@ const routes: Routes = [
     },
   },
   {
-    path: 'update-workplace-details-after-staff-changes',
+    path: 'update-workplace-details-after-adding-staff',
     children: [
       {
         path: '',
         component: UpdateWorkplaceDetailsAfterStaffChangesComponent,
         data: {
           title: 'Update workplace details',
+          flowType: WorkplaceUpdateFlowType.ADD,
+        },
+      },
+      {
+        path: 'update-total-staff',
+        component: UpdateTotalNumberOfStaffComponent,
+        canActivate: [CheckPermissionsGuard],
+        data: { permissions: ['canEditEstablishment'], title: 'Update total number of staff' },
+      },
+    ],
+  },
+  {
+    path: 'update-workplace-details-after-deleting-staff',
+    children: [
+      {
+        path: '',
+        component: UpdateWorkplaceDetailsAfterStaffChangesComponent,
+        data: {
+          title: 'Update workplace details',
+          flowType: WorkplaceUpdateFlowType.DELETE,
         },
       },
       {


### PR DESCRIPTION
#### Work done
- Updated `update-workplace-details-after-staff-changes` component and the service to handle a delete view 
- Added separate url for delete version of page
- Updated url for add version

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
