### PR TITLE
Feat/1654 remove reference to wdf cqc message

### DIFF
--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
@@ -42,7 +42,7 @@
         >
         and then add any you want to include in ASC-WDS.
       </p>
-      <p>You may be able to claim from the Workforce Development Fund for each workplace that you add into ASC-WDS.</p>
+      <p>You may be able to claim funding for each workplace that you add into ASC-WDS.</p>
     </div>
   </app-inset-text>
 </div>

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { GetChildWorkplacesResponse } from '@core/model/my-workplaces.model';
 import { AlertService } from '@core/services/alert.service';
 import { AuthService } from '@core/services/auth.service';
@@ -31,7 +30,7 @@ describe('ViewMyWorkplacesComponent', () => {
   async function setup(hasChildWorkplaces = true, qsParamGetMock = sinon.fake()) {
     const { fixture, getByText, getByTestId, queryByText, getByLabelText, queryByLabelText, queryByTestId } =
       await render(ViewMyWorkplacesComponent, {
-        imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+        imports: [SharedModule, RouterModule, HttpClientTestingModule],
         declarations: [WorkplaceInfoPanelComponent],
         providers: [
           AlertService,


### PR DESCRIPTION
#### Work done
- Remove wdf reference in CQC message for view-my-workplaces
- Remove RouterTestingModule from test as now deprecated 

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
