### PR TITLE
Feat/1643 confirm staff record

### DIFF
--- a/frontend/src/app/core/services/worker.service.ts
+++ b/frontend/src/app/core/services/worker.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Params } from '@angular/router';
 import { Alert } from '@core/model/alert.model';
+import { Contracts } from '@core/model/contracts.enum';
 import { LocalIdentifiersRequest, LocalIdentifiersResponse } from '@core/model/establishment.model';
 import {
   AvailableQualificationsResponse,
@@ -22,7 +23,6 @@ import { Worker, WorkerEditResponse, WorkersResponse } from '@core/model/worker.
 import { BehaviorSubject, forkJoin, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
-import { Contracts } from '@core/model/contracts.enum';
 
 export interface Reason {
   id: number;
@@ -56,6 +56,7 @@ export class WorkerService {
   public getRoute$: BehaviorSubject<any> = new BehaviorSubject<any>(null);
   public createStaffResponse = null;
   private _newWorkerMandatoryInfo: NewWorkerMandatoryInfo = null;
+  private _hasCompletedStaffRecordFlow: boolean = null;
 
   private _workers$: BehaviorSubject<Worker[]> = new BehaviorSubject<Worker[]>(null);
   public workers$: Observable<Worker[]> = this._workers$.asObservable();
@@ -331,5 +332,17 @@ export class WorkerService {
 
   public clearNewWorkerMandatoryInfo(): void {
     this._newWorkerMandatoryInfo = null;
+  }
+
+  public set hasCompletedStaffRecordFlow(hasCompleted: boolean) {
+    this._hasCompletedStaffRecordFlow = hasCompleted;
+  }
+
+  public get hasCompletedStaffRecordFlow(): boolean {
+    return this._hasCompletedStaffRecordFlow;
+  }
+
+  public clearHasCompletedStaffRecordFlow(): void {
+    this._hasCompletedStaffRecordFlow = null;
   }
 }

--- a/frontend/src/app/core/test-utils/MockWorkerService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkerService.ts
@@ -2,11 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Params } from '@angular/router';
 import { QualificationsByGroup, QualificationType } from '@core/model/qualification.model';
-import {
-  CreateTrainingRecordResponse,
-  MultipleTrainingResponse,
-  TrainingRecordRequest,
-} from '@core/model/training.model';
+import { CreateTrainingRecordResponse, MultipleTrainingResponse, TrainingRecordRequest } from '@core/model/training.model';
 import { URLStructure } from '@core/model/url.model';
 import { Worker, WorkerEditResponse, WorkersResponse } from '@core/model/worker.model';
 import { NewWorkerMandatoryInfo, Reason, WorkerService } from '@core/services/worker.service';
@@ -503,6 +499,10 @@ export class MockWorkerService extends WorkerService {
   getLeaveReasons(): Observable<Reason[]> {
     return of(mockLeaveReasons);
   }
+
+  updateWorker(workplaceUid: string, workerId: string, props): Observable<WorkerEditResponse> {
+    return of({ uid: '1' } as WorkerEditResponse);
+  }
 }
 
 @Injectable()
@@ -560,5 +560,26 @@ export class MockWorkerServiceWithoutReturnUrl extends MockWorkerServiceWithUpda
 
   public get returnTo(): URLStructure {
     return;
+  }
+}
+
+@Injectable()
+export class MockWorkerServiceWithOverrides extends MockWorkerService {
+  public static factory(overrides: any = {}) {
+    return (httpClient: HttpClient) => {
+      const service = new MockWorkerServiceWithOverrides(httpClient);
+
+      Object.keys(overrides).forEach((overrideName) => {
+        if (overrideName == 'worker') {
+          const worker = { ...workerBuilder(), ...overrides[overrideName] };
+          service.worker = worker;
+          service.worker$ = of(worker as Worker);
+        } else {
+          service[overrideName] = overrides[overrideName];
+        }
+      });
+
+      return service;
+    };
   }
 }

--- a/frontend/src/app/features/workers/main-job-role/main-job-role.component.spec.ts
+++ b/frontend/src/app/features/workers/main-job-role/main-job-role.component.spec.ts
@@ -281,7 +281,7 @@ describe('MainJobRoleComponent', () => {
         expect(setAddStaffRecordInProgressSpy).toHaveBeenCalledWith(true);
       });
 
-      it('should call setAddStaffRecordInProgress when clicking save this staff record', async () => {
+      it('should call clearHasCompletedStaffRecordFlow when clicking save this staff record', async () => {
         const { getByText, clearHasCompletedStaffRecordFlowSpy } = await setup(true, false, true);
 
         userEvent.click(getByText('Care providing roles'));

--- a/frontend/src/app/features/workers/main-job-role/main-job-role.component.ts
+++ b/frontend/src/app/features/workers/main-job-role/main-job-role.component.ts
@@ -6,10 +6,10 @@ import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { JobService } from '@core/services/job.service';
 import { NewWorkerMandatoryInfo, WorkerService } from '@core/services/worker.service';
 
 import { QuestionComponent } from '../question/question.component';
-import { JobService } from '@core/services/job.service';
 
 @Component({
   selector: 'app-main-job-role.component',
@@ -72,7 +72,7 @@ export class MainJobRoleComponent extends QuestionComponent implements OnInit, O
   }
 
   private prefillForm(): void {
-    let savedMainJob = this.worker.mainJob;
+    const savedMainJob = this.worker.mainJob;
     if (savedMainJob) {
       this.form.setValue({ mainJob: savedMainJob.jobId });
       this.preFilledId = savedMainJob.jobId;
@@ -124,8 +124,9 @@ export class MainJobRoleComponent extends QuestionComponent implements OnInit, O
       this.next = this.determineConditionalRouting();
     } else {
       this.next = this.getRoutePath('mandatory-details');
+      this.workerService.setAddStaffRecordInProgress(true);
+      this.workerService.clearHasCompletedStaffRecordFlow();
     }
-    !this.editFlow && this.workerService.setAddStaffRecordInProgress(true);
   }
 
   protected addAlert(): void {

--- a/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
+++ b/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
@@ -2,9 +2,9 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { PermissionType } from '@core/model/permissions.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
@@ -22,13 +22,12 @@ import { render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
 import { MandatoryDetailsComponent } from './mandatory-details.component';
-import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 describe('MandatoryDetailsComponent', () => {
   const setup = async (canEditWorker = true, primaryUid = 123) => {
     const permissions = canEditWorker ? ['canEditWorker'] : [];
-    const { fixture, getByText, queryByText, getByTestId, queryByTestId } = await render(MandatoryDetailsComponent, {
-      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+    const setupTools = await render(MandatoryDetailsComponent, {
+      imports: [SharedModule, RouterModule, HttpClientTestingModule],
       declarations: [
         InsetTextComponent,
         BasicRecordComponent,
@@ -74,18 +73,18 @@ describe('MandatoryDetailsComponent', () => {
       ],
     });
 
-    const component = fixture.componentInstance;
+    const component = setupTools.fixture.componentInstance;
     const router = TestBed.inject(Router) as Router;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
 
+    const workerService = TestBed.inject(WorkerService) as WorkerService;
+    const clearHasCompletedStaffRecordFlowSpy = spyOn(workerService, 'clearHasCompletedStaffRecordFlow');
+
     return {
+      ...setupTools,
       component,
-      fixture,
-      getByText,
-      queryByText,
-      getByTestId,
-      queryByTestId,
       routerSpy,
+      clearHasCompletedStaffRecordFlowSpy,
     };
   };
 
@@ -113,7 +112,7 @@ describe('MandatoryDetailsComponent', () => {
 
   describe('edit name/id and contract', () => {
     it('should take you to the staff-details page when change link is clicked', async () => {
-      const { component, getByText, getByTestId } = await setup();
+      const { component, getByTestId } = await setup();
 
       const worker = component.worker;
 
@@ -126,7 +125,7 @@ describe('MandatoryDetailsComponent', () => {
     });
 
     it('should not show the change link if the user does not have edit permissions', async () => {
-      const { queryByText, getByTestId } = await setup(false);
+      const { getByTestId } = await setup(false);
 
       const nameSection = within(getByTestId('name-and-contract-section'));
       expect(nameSection.queryByText('Change')).toBeFalsy();
@@ -135,7 +134,7 @@ describe('MandatoryDetailsComponent', () => {
 
   describe('main job role', () => {
     it('should take you to the main-job-role page when change link is clicked', async () => {
-      const { component, getByText, getByTestId } = await setup();
+      const { component, getByTestId } = await setup();
 
       const worker = component.worker;
 
@@ -148,7 +147,7 @@ describe('MandatoryDetailsComponent', () => {
     });
 
     it('should not show the change link if the user does not have edit permissions', async () => {
-      const { queryByText, getByTestId } = await setup(false);
+      const { getByTestId } = await setup(false);
 
       const mainJobRoleSection = within(getByTestId('main-job-role-section'));
       expect(mainJobRoleSection.queryByText('Change')).toBeFalsy();
@@ -156,13 +155,19 @@ describe('MandatoryDetailsComponent', () => {
   });
 
   it('should submit and navigate to date of birth page when add details button clicked', async () => {
-    const { getByTestId, component, routerSpy } = await setup();
+    const { getByText, routerSpy } = await setup();
 
-    const submission = spyOn(component, 'onSubmit').and.callThrough();
-    const detailsButton = getByTestId('add-details-button');
+    const detailsButton = getByText('Add details to this record');
     detailsButton.click();
-    expect(submission).toHaveBeenCalled();
     expect(routerSpy).toHaveBeenCalledWith(['', 'date-of-birth']);
+  });
+
+  it('should clear hasCompletedStaffRecordFlow when add details button clicked', async () => {
+    const { getByText, clearHasCompletedStaffRecordFlowSpy } = await setup();
+
+    const detailsButton = getByText('Add details to this record');
+    detailsButton.click();
+    expect(clearHasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
   });
 
   it('should take you to to dashboard if adding a staff record to own establishment', async () => {

--- a/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
+++ b/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.spec.ts
@@ -77,14 +77,10 @@ describe('MandatoryDetailsComponent', () => {
     const router = TestBed.inject(Router) as Router;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
 
-    const workerService = TestBed.inject(WorkerService) as WorkerService;
-    const clearHasCompletedStaffRecordFlowSpy = spyOn(workerService, 'clearHasCompletedStaffRecordFlow');
-
     return {
       ...setupTools,
       component,
       routerSpy,
-      clearHasCompletedStaffRecordFlowSpy,
     };
   };
 
@@ -160,14 +156,6 @@ describe('MandatoryDetailsComponent', () => {
     const detailsButton = getByText('Add details to this record');
     detailsButton.click();
     expect(routerSpy).toHaveBeenCalledWith(['', 'date-of-birth']);
-  });
-
-  it('should clear hasCompletedStaffRecordFlow when add details button clicked', async () => {
-    const { getByText, clearHasCompletedStaffRecordFlowSpy } = await setup();
-
-    const detailsButton = getByText('Add details to this record');
-    detailsButton.click();
-    expect(clearHasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
   });
 
   it('should take you to to dashboard if adding a staff record to own establishment', async () => {

--- a/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.ts
+++ b/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.ts
@@ -40,12 +40,6 @@ export class MandatoryDetailsComponent implements OnInit, OnDestroy {
         this.worker = worker;
       }),
     );
-
-    this.setBackLink();
-  }
-
-  public setBackLink(): void {
-    this.backLinkService.showBackLink();
   }
 
   navigateToDashboard(event: Event): void {

--- a/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.ts
+++ b/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.ts
@@ -55,6 +55,8 @@ export class MandatoryDetailsComponent implements OnInit, OnDestroy {
 
   onSubmit(event: Event): void {
     event.preventDefault();
+    this.workerService.clearHasCompletedStaffRecordFlow();
+
     const urlArr = this.router.url.split('/');
     const url = urlArr.slice(0, urlArr.length - 1).join('/');
     this.router.navigate([url, 'date-of-birth']);

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.html
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.html
@@ -36,7 +36,7 @@
         </select>
       </div>
     </div>
-    <div class="govuk-grid-column-one-third" *ngIf="insideFlow && !insideOtherQualificationsLevelSummaryFlow">
+    <div class="govuk-grid-column-one-third" *ngIf="insideFlow">
       <div class="govuk-!-margin-left-8">
         <app-progress-bar
           data-testid="progress-bar-1"
@@ -47,8 +47,5 @@
     </div>
   </div>
 
-  <app-submit-button
-    [return]="!insideFlow || insideOtherQualificationsLevelSummaryFlow"
-    (clicked)="setSubmitAction($event)"
-  ></app-submit-button>
+  <app-submit-button [return]="!insideFlow" (clicked)="setSubmitAction($event)" callToAction="Save"></app-submit-button>
 </form>

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -60,16 +60,12 @@ describe('OtherQualificationsLevelComponent', () => {
     const alertService = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alertService, 'addAlert').and.stub();
 
-    const workerService = injector.inject(WorkerService) as WorkerService;
-    const hasCompletedStaffRecordFlowSpy = spyOnProperty(workerService, 'hasCompletedStaffRecordFlow', 'set');
-
     return {
       ...setupTools,
       component: setupTools.fixture.componentInstance,
       router,
       routerSpy,
       alertSpy,
-      hasCompletedStaffRecordFlowSpy,
     };
   }
 
@@ -252,18 +248,6 @@ describe('OtherQualificationsLevelComponent', () => {
       });
     });
 
-    it('should set hasCompletedStaffRecordFlow in worker service when submitting in flow', async () => {
-      const { getByText, getByLabelText, hasCompletedStaffRecordFlowSpy } = await setup(false);
-
-      const select = getByLabelText('Qualification level', { exact: false });
-      fireEvent.change(select, { target: { value: '1' } });
-
-      const saveButton = getByText('Save');
-      fireEvent.click(saveButton);
-
-      expect(hasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
-    });
-
     ['Skip this question', 'View this staff record'].forEach((link) => {
       it(`should add Staff record added alert when '${link}' is clicked`, async () => {
         const { getByText, alertSpy } = await setup(false);
@@ -274,14 +258,6 @@ describe('OtherQualificationsLevelComponent', () => {
           type: 'success',
           message: 'Staff record saved',
         });
-      });
-
-      it(`should set hasCompletedStaffRecordFlow in worker service when '${link}' is clicked`, async () => {
-        const { getByText, hasCompletedStaffRecordFlowSpy } = await setup(false);
-
-        fireEvent.click(getByText(link));
-
-        expect(hasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
       });
     });
 

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -7,10 +7,7 @@ import { QualificationService } from '@core/services/qualification.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
 import { MockQualificationService } from '@core/test-utils/MockQualificationsService';
-import {
-  MockWorkerServiceWithoutReturnUrl,
-  MockWorkerServiceWithUpdateWorker,
-} from '@core/test-utils/MockWorkerService';
+import { MockWorkerServiceWithoutReturnUrl, MockWorkerServiceWithUpdateWorker } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
@@ -60,12 +57,16 @@ describe('OtherQualificationsLevelComponent', () => {
     const alertService = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alertService, 'addAlert').and.stub();
 
+    const workerService = injector.inject(WorkerService) as WorkerService;
+    const hasCompletedStaffRecordFlowSpy = spyOnProperty(workerService, 'hasCompletedStaffRecordFlow', 'set');
+
     return {
       ...setupTools,
       component: setupTools.fixture.componentInstance,
       router,
       routerSpy,
       alertSpy,
+      hasCompletedStaffRecordFlowSpy,
     };
   }
 
@@ -232,7 +233,7 @@ describe('OtherQualificationsLevelComponent', () => {
     });
   });
 
-  describe('Displaying Staff record added banner', () => {
+  describe('Completing Add details to staff record flow', () => {
     it('should add Staff record added alert when submitting from flow', async () => {
       const { getByText, getByLabelText, alertSpy } = await setup(false);
 
@@ -246,6 +247,18 @@ describe('OtherQualificationsLevelComponent', () => {
         type: 'success',
         message: 'Staff record saved',
       });
+    });
+
+    it('should set hasCompletedStaffRecordFlow in worker service when submitting in flow', async () => {
+      const { getByText, getByLabelText, hasCompletedStaffRecordFlowSpy } = await setup(false);
+
+      const select = getByLabelText('Qualification level', { exact: false });
+      fireEvent.change(select, { target: { value: '1' } });
+
+      const saveButton = getByText('Save');
+      fireEvent.click(saveButton);
+
+      expect(hasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
     });
 
     it('should not add Staff record added alert when user submits but not in flow', async () => {

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AlertService } from '@core/services/alert.service';
 import { QualificationService } from '@core/services/qualification.service';
 import { WindowRef } from '@core/services/window.ref';
@@ -20,45 +19,41 @@ import { OtherQualificationsLevelComponent } from './other-qualifications-level.
 
 describe('OtherQualificationsLevelComponent', () => {
   async function setup(returnUrl = true) {
-    const { fixture, getByText, queryByTestId, getByLabelText, getByTestId } = await render(
-      OtherQualificationsLevelComponent,
-      {
-        imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkersModule],
-        providers: [
-          UntypedFormBuilder,
-          {
-            provide: ActivatedRoute,
-            useValue: {
-              parent: {
-                snapshot: {
-                  url: [{ path: returnUrl ? 'staff-record-summary' : 'staff-uid' }],
-                  data: {
-                    establishment: { uid: 'mocked-uid' },
-                    primaryWorkplace: {},
-                  },
+    const setupTools = await render(OtherQualificationsLevelComponent, {
+      imports: [SharedModule, RouterModule, HttpClientTestingModule, WorkersModule],
+      providers: [
+        UntypedFormBuilder,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            parent: {
+              snapshot: {
+                url: [{ path: returnUrl ? 'staff-record-summary' : 'staff-uid' }],
+                data: {
+                  establishment: { uid: 'mocked-uid' },
+                  primaryWorkplace: {},
                 },
               },
-              snapshot: {
-                params: {},
-              },
+            },
+            snapshot: {
+              params: {},
             },
           },
-          {
-            provide: WorkerService,
-            useClass: returnUrl ? MockWorkerServiceWithUpdateWorker : MockWorkerServiceWithoutReturnUrl,
-          },
-          {
-            provide: QualificationService,
-            useClass: MockQualificationService,
-          },
-          AlertService,
-          WindowRef,
-        ],
-      },
-    );
+        },
+        {
+          provide: WorkerService,
+          useClass: returnUrl ? MockWorkerServiceWithUpdateWorker : MockWorkerServiceWithoutReturnUrl,
+        },
+        {
+          provide: QualificationService,
+          useClass: MockQualificationService,
+        },
+        AlertService,
+        WindowRef,
+      ],
+    });
     const injector = getTestBed();
 
-    const component = fixture.componentInstance;
     const router = injector.inject(Router) as Router;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
 
@@ -66,14 +61,10 @@ describe('OtherQualificationsLevelComponent', () => {
     const alertSpy = spyOn(alertService, 'addAlert').and.stub();
 
     return {
-      component,
-      fixture,
+      ...setupTools,
+      component: setupTools.fixture.componentInstance,
       router,
       routerSpy,
-      getByText,
-      queryByTestId,
-      getByLabelText,
-      getByTestId,
       alertSpy,
     };
   }
@@ -93,10 +84,7 @@ describe('OtherQualificationsLevelComponent', () => {
 
   describe('submit buttons', () => {
     it('should render the page with a save button when the return value is null', async () => {
-      const { component, fixture, getByText } = await setup(false);
-
-      component.return = null;
-      fixture.detectChanges();
+      const { getByText } = await setup(false);
 
       const button = getByText('Save');
       const viewRecordLink = getByText('View this staff record');

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -123,7 +123,7 @@ describe('OtherQualificationsLevelComponent', () => {
   });
 
   describe('navigation', () => {
-    it('should navigate to confirm-staff-record page when submitting from flow', async () => {
+    it('should navigate to staff-record-summary page when submitting from flow', async () => {
       const { component, fixture, routerSpy, getByText, getByLabelText } = await setup(false);
 
       const workerId = component.worker.uid;
@@ -141,11 +141,11 @@ describe('OtherQualificationsLevelComponent', () => {
         workplaceId,
         'staff-record',
         workerId,
-        'confirm-staff-record',
+        'staff-record-summary',
       ]);
     });
 
-    it('should navigate to confirm-staff-record page when skipping the question in the flow', async () => {
+    it('should navigate to staff-record-summary page when skipping the question in the flow', async () => {
       const { component, routerSpy, getByText } = await setup(false);
 
       const workerId = component.worker.uid;
@@ -159,7 +159,7 @@ describe('OtherQualificationsLevelComponent', () => {
         workplaceId,
         'staff-record',
         workerId,
-        'confirm-staff-record',
+        'staff-record-summary',
       ]);
     });
 

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -6,7 +6,10 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { QualificationService } from '@core/services/qualification.service';
 import { WorkerService } from '@core/services/worker.service';
 import { MockQualificationService } from '@core/test-utils/MockQualificationsService';
-import { MockWorkerServiceWithoutReturnUrl, MockWorkerServiceWithUpdateWorker } from '@core/test-utils/MockWorkerService';
+import {
+  MockWorkerServiceWithoutReturnUrl,
+  MockWorkerServiceWithUpdateWorker,
+} from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
@@ -82,13 +85,13 @@ describe('OtherQualificationsLevelComponent', () => {
   });
 
   describe('submit buttons', () => {
-    it('should render the page with a save and continue button when there return value is null', async () => {
+    it('should render the page with a save button when the return value is null', async () => {
       const { component, fixture, getByText } = await setup(false);
 
       component.return = null;
       fixture.detectChanges();
 
-      const button = getByText('Save and continue');
+      const button = getByText('Save');
       const viewRecordLink = getByText('View this staff record');
 
       expect(button).toBeTruthy();
@@ -130,7 +133,7 @@ describe('OtherQualificationsLevelComponent', () => {
       const select = getByLabelText('Qualification level', { exact: false });
       fireEvent.change(select, { target: { value: '1' } });
 
-      const saveButton = getByText('Save and continue');
+      const saveButton = getByText('Save');
       fireEvent.click(saveButton);
       fixture.detectChanges();
 

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -7,7 +7,10 @@ import { QualificationService } from '@core/services/qualification.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
 import { MockQualificationService } from '@core/test-utils/MockQualificationsService';
-import { MockWorkerServiceWithoutReturnUrl, MockWorkerServiceWithUpdateWorker } from '@core/test-utils/MockWorkerService';
+import {
+  MockWorkerServiceWithoutReturnUrl,
+  MockWorkerServiceWithUpdateWorker,
+} from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
@@ -259,6 +262,27 @@ describe('OtherQualificationsLevelComponent', () => {
       fireEvent.click(saveButton);
 
       expect(hasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
+    });
+
+    ['Skip this question', 'View this staff record'].forEach((link) => {
+      it(`should add Staff record added alert when '${link}' is clicked`, async () => {
+        const { getByText, alertSpy } = await setup(false);
+
+        fireEvent.click(getByText(link));
+
+        expect(alertSpy).toHaveBeenCalledWith({
+          type: 'success',
+          message: 'Staff record saved',
+        });
+      });
+
+      it(`should set hasCompletedStaffRecordFlow in worker service when '${link}' is clicked`, async () => {
+        const { getByText, hasCompletedStaffRecordFlowSpy } = await setup(false);
+
+        fireEvent.click(getByText(link));
+
+        expect(hasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
+      });
     });
 
     it('should not add Staff record added alert when user submits but not in flow', async () => {

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { QualificationLevel } from '@core/model/qualification.model';
+import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -27,6 +28,7 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
     protected workerService: WorkerService,
     protected establishmentService: EstablishmentService,
     private qualificationService: QualificationService,
+    private alertService: AlertService,
   ) {
     super(formBuilder, router, route, backLinkService, errorSummaryService, workerService, establishmentService);
 
@@ -67,5 +69,14 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
       },
     };
     return props;
+  }
+
+  addAlert(): void {
+    if (this.insideFlow) {
+      this.alertService.addAlert({
+        type: 'success',
+        message: 'Staff record saved',
+      });
+    }
   }
 }

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -71,7 +71,9 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
     return props;
   }
 
-  addAlert(): void {
+  onSubmit(): void {
+    super.onSubmit();
+
     if (this.insideFlow) {
       this.workerService.hasCompletedStaffRecordFlow = true;
       this.alertService.addAlert({

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -44,7 +44,7 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
       this.prefill();
     }
 
-    this.next = this.getRoutePath('confirm-staff-record');
+    this.next = this.getRoutePath('staff-record-summary');
   }
 
   private prefill(): void {

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -73,6 +73,7 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
 
   addAlert(): void {
     if (this.insideFlow) {
+      this.workerService.hasCompletedStaffRecordFlow = true;
       this.alertService.addAlert({
         type: 'success',
         message: 'Staff record saved',

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -17,7 +17,6 @@ import { QuestionComponent } from '../question/question.component';
 export class OtherQualificationsLevelComponent extends QuestionComponent {
   public qualifications: QualificationLevel[];
   public section = 'Training and qualifications';
-  public insideOtherQualificationsLevelSummaryFlow: boolean;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -75,18 +75,17 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
     super.onSubmit();
 
     if (!this.submitted && this.insideFlow) {
-      this.setCompletedStaffFlowAndAddAlert();
+      this.addCompletedStaffFlowAlert();
     }
   }
 
   addAlert(): void {
     if (this.insideFlow) {
-      this.setCompletedStaffFlowAndAddAlert();
+      this.addCompletedStaffFlowAlert();
     }
   }
 
-  setCompletedStaffFlowAndAddAlert(): void {
-    this.workerService.hasCompletedStaffRecordFlow = true;
+  addCompletedStaffFlowAlert(): void {
     this.alertService.addAlert({
       type: 'success',
       message: 'Staff record saved',

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -74,12 +74,22 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
   onSubmit(): void {
     super.onSubmit();
 
-    if (this.insideFlow) {
-      this.workerService.hasCompletedStaffRecordFlow = true;
-      this.alertService.addAlert({
-        type: 'success',
-        message: 'Staff record saved',
-      });
+    if (!this.submitted && this.insideFlow) {
+      this.setCompletedStaffFlowAndAddAlert();
     }
+  }
+
+  addAlert(): void {
+    if (this.insideFlow) {
+      this.setCompletedStaffFlowAndAddAlert();
+    }
+  }
+
+  setCompletedStaffFlowAndAddAlert(): void {
+    this.workerService.hasCompletedStaffRecordFlow = true;
+    this.alertService.addAlert({
+      type: 'success',
+      message: 'Staff record saved',
+    });
   }
 }

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.html
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.html
@@ -45,5 +45,6 @@
     [summaryContinue]="true"
     [return]="!insideFlow"
     (clicked)="setSubmitAction($event)"
+    callToAction="Save"
   ></app-submit-button>
 </form>

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AlertService } from '@core/services/alert.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
@@ -19,8 +18,8 @@ describe('OtherQualificationsComponent', () => {
     const insideFlow = overrides.insideFlow ?? false;
     const workerOverrides = overrides.worker ?? { otherQualification: null };
 
-    const { fixture, getByText, getByTestId, queryByTestId } = await render(OtherQualificationsComponent, {
-      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkersModule],
+    const setupTools = await render(OtherQualificationsComponent, {
+      imports: [SharedModule, RouterModule, HttpClientTestingModule, WorkersModule],
       providers: [
         {
           provide: ActivatedRoute,
@@ -49,8 +48,6 @@ describe('OtherQualificationsComponent', () => {
       ],
     });
 
-    const component = fixture.componentInstance;
-
     const injector = getTestBed();
     const router = injector.inject(Router) as Router;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
@@ -62,13 +59,10 @@ describe('OtherQualificationsComponent', () => {
     const hasCompletedStaffRecordFlowSpy = spyOnProperty(workerService, 'hasCompletedStaffRecordFlow', 'set');
 
     return {
-      component,
-      fixture,
+      ...setupTools,
+      component: setupTools.fixture.componentInstance,
       routerSpy,
       router,
-      getByText,
-      getByTestId,
-      queryByTestId,
       alertSpy,
       hasCompletedStaffRecordFlowSpy,
     };

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -55,16 +55,12 @@ describe('OtherQualificationsComponent', () => {
     const alertService = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alertService, 'addAlert').and.stub();
 
-    const workerService = injector.inject(WorkerService) as WorkerService;
-    const hasCompletedStaffRecordFlowSpy = spyOnProperty(workerService, 'hasCompletedStaffRecordFlow', 'set');
-
     return {
       ...setupTools,
       component: setupTools.fixture.componentInstance,
       routerSpy,
       router,
       alertSpy,
-      hasCompletedStaffRecordFlowSpy,
     };
   }
 
@@ -134,14 +130,6 @@ describe('OtherQualificationsComponent', () => {
             message: 'Staff record saved',
           });
         });
-
-        it(`should set hasCompletedStaffRecordFlow in worker service when '${link}' is clicked`, async () => {
-          const { getByText, hasCompletedStaffRecordFlowSpy } = await setup({ insideFlow: true });
-
-          fireEvent.click(getByText(link));
-
-          expect(hasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
-        });
       });
 
       ['No', 'I do not know', null].forEach((answer) => {
@@ -180,19 +168,6 @@ describe('OtherQualificationsComponent', () => {
             type: 'success',
             message: 'Staff record saved',
           });
-        });
-
-        it(`should set hasCompletedStaffRecordFlow in worker service when '${answer}' is selected`, async () => {
-          const { getByText, hasCompletedStaffRecordFlowSpy } = await setup({ insideFlow: true });
-
-          if (!userClicksSaveWithoutSelecting) {
-            const button = getByText(answer);
-            fireEvent.click(button);
-          }
-
-          fireEvent.click(getByText('Save'));
-
-          expect(hasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
         });
       });
     });

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -120,36 +120,41 @@ describe('OtherQualificationsComponent', () => {
       ]);
     });
 
-    it(`should navigate with the 'confirm-staff-record' url when 'Skip this question' is clicked and in the flow`, async () => {
-      const { component, getByText, routerSpy } = await setup(true, 'Yes');
+    describe('Navigation in add worker details flow', () => {
+      ['Skip this question', 'View this staff record'].forEach((link) => {
+        it(`should navigate with the 'confirm-staff-record' url when '${link}' is clicked and in the flow`, async () => {
+          const { component, getByText, routerSpy } = await setup(true, 'Yes');
 
-      const button = getByText('Skip this question');
-      fireEvent.click(button);
+          fireEvent.click(getByText(link));
 
-      expect(routerSpy).toHaveBeenCalledWith([
-        '/workplace',
-        'mocked-uid',
-        'staff-record',
-        component.worker.uid,
-        'confirm-staff-record',
-      ]);
-    });
+          expect(routerSpy).toHaveBeenCalledWith([
+            '/workplace',
+            'mocked-uid',
+            'staff-record',
+            component.worker.uid,
+            'staff-record-summary',
+          ]);
+        });
+      });
 
-    it('should navigate to staff-record when View this staff record link is clicked', async () => {
-      const { component, routerSpy, getByText } = await setup();
+      ['No', 'I do not know'].forEach((answer) => {
+        it(`should navigate to 'staff-record-summary' url when '${answer}' is selected and in the flow`, async () => {
+          const { component, getByText, routerSpy } = await setup(true, 'Yes');
 
-      const workplaceUid = component.workplace.uid;
-      const workerUid = component.worker.uid;
-      const viewRecordLink = getByText('View this staff record');
-      fireEvent.click(viewRecordLink);
+          const button = getByText(answer);
+          fireEvent.click(button);
 
-      expect(routerSpy).toHaveBeenCalledWith([
-        '/workplace',
-        workplaceUid,
-        'staff-record',
-        workerUid,
-        'staff-record-summary',
-      ]);
+          fireEvent.click(getByText('Save'));
+
+          expect(routerSpy).toHaveBeenCalledWith([
+            '/workplace',
+            'mocked-uid',
+            'staff-record',
+            component.worker.uid,
+            'staff-record-summary',
+          ]);
+        });
+      });
     });
 
     it('should navigate to staff-summary-page page when pressing save and not know is entered', async () => {

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -146,6 +146,25 @@ describe('OtherQualificationsComponent', () => {
             'staff-record-summary',
           ]);
         });
+
+        it(`should add Staff record added alert when '${link}' is clicked`, async () => {
+          const { getByText, alertSpy } = await setup(true, 'Yes');
+
+          fireEvent.click(getByText(link));
+
+          expect(alertSpy).toHaveBeenCalledWith({
+            type: 'success',
+            message: 'Staff record saved',
+          });
+        });
+
+        it(`should set hasCompletedStaffRecordFlow in worker service when '${link}' is clicked`, async () => {
+          const { getByText, hasCompletedStaffRecordFlowSpy } = await setup(true, 'Yes');
+
+          fireEvent.click(getByText(link));
+
+          expect(hasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
+        });
       });
 
       ['No', 'I do not know'].forEach((answer) => {

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -89,10 +89,10 @@ describe('OtherQualificationsComponent', () => {
   });
 
   describe('submit buttons', () => {
-    it('should render the page with a save and continue button and view this staff record and Skip this question link', async () => {
+    it('should render the page with a save button, view this staff record and Skip this question link when in flow', async () => {
       const { getByText } = await setup();
 
-      expect(getByText('Save and continue')).toBeTruthy();
+      expect(getByText('Save')).toBeTruthy();
       expect(getByText('View this staff record')).toBeTruthy();
       expect(getByText('Skip this question')).toBeTruthy();
     });
@@ -107,7 +107,7 @@ describe('OtherQualificationsComponent', () => {
     it(`should run getRoutePath with a other-qualifications-level string when otherQualification is yes and in the flow`, async () => {
       const { component, getByText, routerSpy } = await setup(true, 'Yes');
 
-      const button = getByText('Save and continue');
+      const button = getByText('Save');
 
       fireEvent.click(button);
 

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -78,6 +78,9 @@ describe('OtherQualificationsComponent', () => {
     const alertService = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alertService, 'addAlert').and.stub();
 
+    const workerService = injector.inject(WorkerService) as WorkerService;
+    const hasCompletedStaffRecordFlowSpy = spyOnProperty(workerService, 'hasCompletedStaffRecordFlow', 'set');
+
     return {
       component,
       fixture,
@@ -87,6 +90,7 @@ describe('OtherQualificationsComponent', () => {
       getByTestId,
       queryByTestId,
       alertSpy,
+      hasCompletedStaffRecordFlowSpy,
     };
   }
 
@@ -174,6 +178,17 @@ describe('OtherQualificationsComponent', () => {
             type: 'success',
             message: 'Staff record saved',
           });
+        });
+
+        it(`should set hasCompletedStaffRecordFlow in worker service when '${answer}' is selected`, async () => {
+          const { getByText, hasCompletedStaffRecordFlowSpy } = await setup(true, 'Yes');
+
+          const button = getByText(answer);
+          fireEvent.click(button);
+
+          fireEvent.click(getByText('Save'));
+
+          expect(hasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
         });
       });
     });

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -74,8 +74,9 @@ export class OtherQualificationsComponent extends QuestionComponent {
 
   onSubmit(): void {
     super.onSubmit();
+    const { otherQualification } = this.form.value;
 
-    if (!this.submitted && this.insideFlow) {
+    if ((!this.submitted || !otherQualification) && this.insideFlow) {
       this.setCompletedStaffFlowAndAddAlert();
     }
   }

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -77,7 +77,7 @@ export class OtherQualificationsComponent extends QuestionComponent {
     const { otherQualification } = this.form.value;
 
     if ((!this.submitted || !otherQualification) && this.insideFlow) {
-      this.setCompletedStaffFlowAndAddAlert();
+      this.addCompletedStaffFlowAlert();
     }
   }
 
@@ -85,12 +85,11 @@ export class OtherQualificationsComponent extends QuestionComponent {
     const { otherQualification } = this.form.value;
 
     if (otherQualification !== 'Yes' && this.insideFlow) {
-      this.setCompletedStaffFlowAndAddAlert();
+      this.addCompletedStaffFlowAlert();
     }
   }
 
-  setCompletedStaffFlowAndAddAlert(): void {
-    this.workerService.hasCompletedStaffRecordFlow = true;
+  addCompletedStaffFlowAlert(): void {
     this.alertService.addAlert({
       type: 'success',
       message: 'Staff record saved',

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -39,7 +39,7 @@ export class OtherQualificationsComponent extends QuestionComponent {
     if (this.worker.otherQualification) {
       this.prefill();
     }
-    this.next = this.getRoutePath('confirm-staff-record');
+    this.next = this.getRoutePath('staff-record-summary');
   }
 
   private prefill(): void {
@@ -65,7 +65,7 @@ export class OtherQualificationsComponent extends QuestionComponent {
     if (otherQualification === 'Yes') {
       nextRoute.push('other-qualifications-level');
     } else if (this.insideFlow) {
-      nextRoute.push('confirm-staff-record');
+      nextRoute.push('staff-record-summary');
     }
     return nextRoute;
   }

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -79,6 +79,7 @@ export class OtherQualificationsComponent extends QuestionComponent {
   addAlert(): void {
     const { otherQualification } = this.form.value;
     if (otherQualification !== 'Yes' && this.insideFlow) {
+      this.workerService.hasCompletedStaffRecordFlow = true;
       this.alertService.addAlert({
         type: 'success',
         message: 'Staff record saved',

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -72,18 +72,21 @@ export class OtherQualificationsComponent extends QuestionComponent {
     return nextRoute;
   }
 
-  onSuccess(): void {
-    this.next = this.determineConditionalRouting();
-  }
+  onSubmit(): void {
+    super.onSubmit();
 
-  addAlert(): void {
     const { otherQualification } = this.form.value;
-    if (otherQualification !== 'Yes' && this.insideFlow) {
+
+    if ((otherQualification !== 'Yes' || !this.submitted) && this.insideFlow) {
       this.workerService.hasCompletedStaffRecordFlow = true;
       this.alertService.addAlert({
         type: 'success',
         message: 'Staff record saved',
       });
     }
+  }
+
+  onSuccess(): void {
+    this.next = this.determineConditionalRouting();
   }
 }

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -75,15 +75,25 @@ export class OtherQualificationsComponent extends QuestionComponent {
   onSubmit(): void {
     super.onSubmit();
 
+    if (!this.submitted && this.insideFlow) {
+      this.setCompletedStaffFlowAndAddAlert();
+    }
+  }
+
+  addAlert(): void {
     const { otherQualification } = this.form.value;
 
-    if ((otherQualification !== 'Yes' || !this.submitted) && this.insideFlow) {
-      this.workerService.hasCompletedStaffRecordFlow = true;
-      this.alertService.addAlert({
-        type: 'success',
-        message: 'Staff record saved',
-      });
+    if (otherQualification !== 'Yes' && this.insideFlow) {
+      this.setCompletedStaffFlowAndAddAlert();
     }
+  }
+
+  setCompletedStaffFlowAndAddAlert(): void {
+    this.workerService.hasCompletedStaffRecordFlow = true;
+    this.alertService.addAlert({
+      type: 'success',
+      message: 'Staff record saved',
+    });
   }
 
   onSuccess(): void {

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -27,6 +28,7 @@ export class OtherQualificationsComponent extends QuestionComponent {
     protected errorSummaryService: ErrorSummaryService,
     protected workerService: WorkerService,
     protected establishmentService: EstablishmentService,
+    protected alertService: AlertService,
   ) {
     super(formBuilder, router, route, backLinkService, errorSummaryService, workerService, establishmentService);
 
@@ -72,5 +74,15 @@ export class OtherQualificationsComponent extends QuestionComponent {
 
   onSuccess(): void {
     this.next = this.determineConditionalRouting();
+  }
+
+  addAlert(): void {
+    const { otherQualification } = this.form.value;
+    if (otherQualification !== 'Yes' && this.insideFlow) {
+      this.alertService.addAlert({
+        type: 'success',
+        message: 'Staff record saved',
+      });
+    }
   }
 }

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.html
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.html
@@ -77,7 +77,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
       <a
-        *ngIf="canEditWorker && worker.completed"
+        *ngIf="canEditWorker"
         class="govuk-button govuk-button--link govuk-!-padding-left-0"
         role="button"
         draggable="false"
@@ -92,8 +92,7 @@
     <ng-container *ngIf="!worker.completed && canEditWorker">
       <div class="govuk-grid-column-full">
         <div class="govuk-button-group govuk__flex govuk__justify-content-space-between govuk-!-margin-top-0">
-          <p>Check these details before you confirm them.</p>
-          <button type="button" class="govuk-button" (click)="saveAndComplete()">Confirm record details</button>
+          <button type="button" class="govuk-button" (click)="saveAndComplete()">Continue</button>
         </div>
       </div>
     </ng-container>
@@ -102,4 +101,8 @@
   <app-personal-details [workplace]="workplace" [worker]="worker"></app-personal-details>
   <app-employment [workplace]="workplace" [worker]="worker"></app-employment>
   <app-qualifications-and-training [workplace]="workplace" [worker]="worker"> </app-qualifications-and-training>
+
+  <ng-container *ngIf="!worker.completed && canEditWorker">
+    <button type="button" class="govuk-button govuk-!-margin-top-9" (click)="saveAndComplete()">Continue</button>
+  </ng-container>
 </ng-container>

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.html
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.html
@@ -89,7 +89,7 @@
     </div>
   </div>
   <div class="govuk-grid-row">
-    <ng-container *ngIf="!worker.completed && canEditWorker">
+    <ng-container *ngIf="hasCompletedStaffRecordFlow && canEditWorker">
       <div class="govuk-grid-column-full">
         <div class="govuk-button-group govuk__flex govuk__justify-content-space-between govuk-!-margin-top-0">
           <button type="button" class="govuk-button" (click)="saveAndComplete()">Continue</button>
@@ -102,7 +102,7 @@
   <app-employment [workplace]="workplace" [worker]="worker"></app-employment>
   <app-qualifications-and-training [workplace]="workplace" [worker]="worker"> </app-qualifications-and-training>
 
-  <ng-container *ngIf="!worker.completed && canEditWorker">
+  <ng-container *ngIf="hasCompletedStaffRecordFlow && canEditWorker">
     <button type="button" class="govuk-button govuk-!-margin-top-9" (click)="saveAndComplete()">Continue</button>
   </ng-container>
 </ng-container>

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.html
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.html
@@ -88,16 +88,12 @@
       </a>
     </div>
   </div>
-  <div class="govuk-grid-row">
-    <ng-container *ngIf="hasCompletedStaffRecordFlow && canEditWorker">
-      <div class="govuk-grid-column-full">
-        <div class="govuk-button-group govuk__flex govuk__justify-content-space-between govuk-!-margin-top-0">
-          <a type="button" class="govuk-button" [routerLink]="continueRoute">Continue</a>
-        </div>
-      </div>
-    </ng-container>
-  </div>
-  <app-basic-record [basicTitle]="'Mandatory information'" [workplace]="workplace" [worker]="worker"></app-basic-record>
+  <app-basic-record
+    [basicTitle]="'Mandatory information'"
+    [workplace]="workplace"
+    [worker]="worker"
+    [continueRoute]="continueRoute"
+  ></app-basic-record>
   <app-personal-details [workplace]="workplace" [worker]="worker"></app-personal-details>
   <app-employment [workplace]="workplace" [worker]="worker"></app-employment>
   <app-qualifications-and-training [workplace]="workplace" [worker]="worker"> </app-qualifications-and-training>

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.html
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.html
@@ -92,7 +92,7 @@
     <ng-container *ngIf="hasCompletedStaffRecordFlow && canEditWorker">
       <div class="govuk-grid-column-full">
         <div class="govuk-button-group govuk__flex govuk__justify-content-space-between govuk-!-margin-top-0">
-          <button type="button" class="govuk-button" (click)="saveAndComplete()">Continue</button>
+          <button type="button" class="govuk-button" (click)="navigateToAddAnotherStaffRecordPage()">Continue</button>
         </div>
       </div>
     </ng-container>
@@ -103,6 +103,8 @@
   <app-qualifications-and-training [workplace]="workplace" [worker]="worker"> </app-qualifications-and-training>
 
   <ng-container *ngIf="hasCompletedStaffRecordFlow && canEditWorker">
-    <button type="button" class="govuk-button govuk-!-margin-top-9" (click)="saveAndComplete()">Continue</button>
+    <button type="button" class="govuk-button govuk-!-margin-top-9" (click)="navigateToAddAnotherStaffRecordPage()">
+      Continue
+    </button>
   </ng-container>
 </ng-container>

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.html
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.html
@@ -30,7 +30,7 @@
       <h1 class="govuk-heading-l">Staff record</h1>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <div *ngIf="worker.completed" class="govuk-grid-row govuk-!-margin-top-0">
+      <div class="govuk-grid-row govuk-!-margin-top-0">
         <div class="govuk-button-group govuk__align-items-center govuk-util__float-right govuk-!-margin-top-0">
           <a
             class="govuk-button govuk-button--link"

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.html
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.html
@@ -92,7 +92,7 @@
     <ng-container *ngIf="hasCompletedStaffRecordFlow && canEditWorker">
       <div class="govuk-grid-column-full">
         <div class="govuk-button-group govuk__flex govuk__justify-content-space-between govuk-!-margin-top-0">
-          <button type="button" class="govuk-button" (click)="navigateToAddAnotherStaffRecordPage()">Continue</button>
+          <a type="button" class="govuk-button" [routerLink]="continueRoute">Continue</a>
         </div>
       </div>
     </ng-container>
@@ -103,8 +103,6 @@
   <app-qualifications-and-training [workplace]="workplace" [worker]="worker"> </app-qualifications-and-training>
 
   <ng-container *ngIf="hasCompletedStaffRecordFlow && canEditWorker">
-    <button type="button" class="govuk-button govuk-!-margin-top-9" (click)="navigateToAddAnotherStaffRecordPage()">
-      Continue
-    </button>
+    <a type="button" class="govuk-button govuk-!-margin-top-9" [routerLink]="continueRoute">Continue</a>
   </ng-container>
 </ng-container>

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -255,6 +255,20 @@ describe('StaffRecordComponent', () => {
         expect(updateWorkerSpy).toHaveBeenCalledWith(workplaceUid, workerUid, { completed: true });
       });
 
+      it('should not call updateWorker when completed is false for worker but hasCompletedStaffRecordFlow is not true', async () => {
+        const updateWorkerSpy = jasmine.createSpy('updateWorker').and.returnValue(of(true));
+
+        await setup({
+          workerService: {
+            hasCompletedStaffRecordFlow: null,
+            updateWorker: updateWorkerSpy,
+            worker: { completed: false },
+          },
+        });
+
+        expect(updateWorkerSpy).not.toHaveBeenCalled();
+      });
+
       it('should not call updateWorker when hasCompletedStaffRecordFlow but completed is true for worker', async () => {
         const updateWorkerSpy = jasmine.createSpy('updateWorker').and.returnValue(of(true));
 

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -111,49 +111,45 @@ describe('StaffRecordComponent', () => {
     expect(getAllByText(component.worker.nameOrId).length).toBe(2);
   });
 
-  it('should render the Complete record button and correct text when worker.completed is false and canEditWorker is true', async () => {
-    const { getByText } = await setup({ worker: { completed: false } });
+  it('should render a Continue button at top and bottom of page when worker.completed is false and canEditWorker is true', async () => {
+    const { getAllByText } = await setup({ worker: { completed: false } });
 
-    const button = getByText('Confirm record details');
-    const text = getByText(`Check these details before you confirm them.`);
+    const continueButtons = getAllByText('Continue');
 
-    expect(button).toBeTruthy();
-    expect(text).toBeTruthy();
+    expect(continueButtons.length).toEqual(2);
   });
 
-  it('should not render the Complete record button when worker.completed is false and canEditWorker is false', async () => {
+  it('should not render the Continue record button when worker.completed is false and canEditWorker is false', async () => {
     const { queryByText } = await setup({ worker: { completed: false }, permissions: [] });
 
-    const button = queryByText('Confirm record details');
-    const text = queryByText(`Check these details before you confirm them.`);
+    const button = queryByText('Continue');
     const flagLongTermAbsenceLink = queryByText('Flag long-term absence');
     const deleteRecordLink = queryByText('Delete staff record');
 
     expect(button).toBeFalsy();
-    expect(text).toBeFalsy();
     expect(flagLongTermAbsenceLink).toBeFalsy();
     expect(deleteRecordLink).toBeFalsy();
   });
 
-  it('should render the delete record link, add training link and flag long term absence link, and not correct text when worker.completed is true', async () => {
-    const { queryByText, getByText, getByTestId, getByRole, workplaceUid, workerUid } = await setup({
-      worker: { completed: true, longTermAbsence: null },
+  [true, false].forEach((completedValue) => {
+    it(`should render the delete record link, add training link and flag long term absence link, when worker.completed is ${completedValue}`, async () => {
+      const { queryByText, getByText, getByTestId, getByRole, workplaceUid, workerUid } = await setup({
+        worker: { completed: completedValue, longTermAbsence: null },
+      });
+
+      const button = queryByText('Confirm record details');
+      const flagLongTermAbsenceLink = getByText('Flag long-term absence');
+      const deleteRecordLink = getByRole('button', { name: 'Delete staff record' });
+      const trainingAndQualsLink = getByTestId('training-and-qualifications-link');
+
+      expect(button).toBeFalsy();
+      expect(flagLongTermAbsenceLink).toBeTruthy();
+      expect(deleteRecordLink).toBeTruthy();
+      expect(deleteRecordLink.getAttribute('href')).toEqual(
+        `/workplace/${workplaceUid}/staff-record/${workerUid}/delete-staff-record`,
+      );
+      expect(trainingAndQualsLink).toBeTruthy();
     });
-
-    const button = queryByText('Confirm record details');
-    const text = queryByText(`Check the record details you've added are correct.`);
-    const flagLongTermAbsenceLink = getByText('Flag long-term absence');
-    const deleteRecordLink = getByRole('button', { name: 'Delete staff record' });
-    const trainingAndQualsLink = getByTestId('training-and-qualifications-link');
-
-    expect(button).toBeFalsy();
-    expect(text).toBeFalsy();
-    expect(flagLongTermAbsenceLink).toBeTruthy();
-    expect(deleteRecordLink).toBeTruthy();
-    expect(deleteRecordLink.getAttribute('href')).toEqual(
-      `/workplace/${workplaceUid}/staff-record/${workerUid}/delete-staff-record`,
-    );
-    expect(trainingAndQualsLink).toBeTruthy();
   });
 
   it('should set returnTo$ in the worker service to the staff record page on init', async () => {
@@ -216,22 +212,22 @@ describe('StaffRecordComponent', () => {
   });
 
   describe('saveAndComplete', () => {
-    it('should call updateWorker on the worker service when button is clicked', async () => {
-      const { workerService, getByText, workplaceUid, workerUid } = await setup({ worker: { completed: false } });
+    it('should call updateWorker on the worker service when Continue button is clicked', async () => {
+      const { workerService, getAllByText, workplaceUid, workerUid } = await setup({ worker: { completed: false } });
 
       const updateWorkerSpy = spyOn(workerService, 'updateWorker').and.callThrough();
 
-      const button = getByText('Confirm record details');
-      fireEvent.click(button);
+      const continueButtons = getAllByText('Continue');
+      fireEvent.click(continueButtons[0]);
 
       expect(updateWorkerSpy).toHaveBeenCalledWith(workplaceUid, workerUid, { completed: true });
     });
 
-    it('should navigate to the "Add another staff record" page when worker is confirmed', async () => {
-      const { routerSpy, getByText, workplaceUid } = await setup({ worker: { completed: false } });
+    it('should navigate to the "Add another staff record" page when Continue button is clicked', async () => {
+      const { routerSpy, getAllByText, workplaceUid } = await setup({ worker: { completed: false } });
 
-      const button = getByText('Confirm record details');
-      fireEvent.click(button);
+      const continueButtons = getAllByText('Continue');
+      fireEvent.click(continueButtons[0]);
 
       expect(routerSpy).toHaveBeenCalledWith(['/workplace', workplaceUid, 'staff-record', 'add-another-staff-record']);
     });

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -112,17 +112,13 @@ describe('StaffRecordComponent', () => {
   });
 
   it('should render the Complete record button and correct text when worker.completed is false and canEditWorker is true', async () => {
-    const { getByText, queryByText } = await setup({ worker: { completed: false } });
+    const { getByText } = await setup({ worker: { completed: false } });
 
     const button = getByText('Confirm record details');
     const text = getByText(`Check these details before you confirm them.`);
-    const flagLongTermAbsenceLink = queryByText('Flag long-term absence');
-    const deleteRecordLink = queryByText('Delete staff record');
 
     expect(button).toBeTruthy();
     expect(text).toBeTruthy();
-    expect(flagLongTermAbsenceLink).toBeFalsy();
-    expect(deleteRecordLink).toBeFalsy();
   });
 
   it('should not render the Complete record button when worker.completed is false and canEditWorker is false', async () => {
@@ -160,7 +156,7 @@ describe('StaffRecordComponent', () => {
     expect(trainingAndQualsLink).toBeTruthy();
   });
 
-  it('should set returnTo$ in the worker service to the training and qualifications record page on init', async () => {
+  it('should set returnTo$ in the worker service to the staff record page on init', async () => {
     const { component, workerSpy, workplaceUid, workerUid } = await setup();
 
     component.setReturnTo();
@@ -256,12 +252,6 @@ describe('StaffRecordComponent', () => {
 
     it('should not show the link when the workplace is not a parent', async () => {
       const { queryByText } = await setup({ isParent: false, worker: { completed: true } });
-
-      expect(queryByText('Transfer staff record')).toBeFalsy();
-    });
-
-    it('should not show the link if the worker details have not been completed', async () => {
-      const { queryByText } = await setup({ worker: { completed: false } });
 
       expect(queryByText('Transfer staff record')).toBeFalsy();
     });

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -197,9 +197,9 @@ describe('StaffRecordComponent', () => {
 
   describe('Add details to worker flow', () => {
     describe('Continue buttons', () => {
-      it('should render a Continue button at top and bottom of page when hasCompletedStaffRecordFlow is true', async () => {
+      it('should render a Continue button at top and bottom of page when completed is false', async () => {
         const { getAllByText } = await setup({
-          workerService: { worker: { completed: false }, hasCompletedStaffRecordFlow: true },
+          workerService: { worker: { completed: false } },
         });
 
         const continueButtons = getAllByText('Continue');
@@ -207,10 +207,19 @@ describe('StaffRecordComponent', () => {
         expect(continueButtons.length).toEqual(2);
       });
 
-      it('should not render the Continue record button when hasCompletedStaffRecordFlow is false', async () => {
+      it('should render a Continue button at top and bottom of page when hasCompletedStaffRecordFlow is true', async () => {
+        const { getAllByText } = await setup({
+          workerService: { worker: { completed: true }, hasCompletedStaffRecordFlow: true },
+        });
+
+        const continueButtons = getAllByText('Continue');
+
+        expect(continueButtons.length).toEqual(2);
+      });
+
+      it('should not render the Continue record button when copmleted is true and hasCompletedStaffRecordFlow is false', async () => {
         const { queryByText } = await setup({
-          workerService: { worker: { completed: false } },
-          hasCompletedStaffRecordFlow: false,
+          workerService: { worker: { completed: true }, hasCompletedStaffRecordFlow: false },
         });
 
         const button = queryByText('Continue');
@@ -224,7 +233,7 @@ describe('StaffRecordComponent', () => {
       ].forEach((scenario) => {
         it(`should have "Add another staff record" href on Continue button at ${scenario.position} of page`, async () => {
           const { getAllByText, workplaceUid } = await setup({
-            workerService: { hasCompletedStaffRecordFlow: true, worker: { completed: false } },
+            workerService: { worker: { completed: false } },
           });
 
           const continueButtons = getAllByText('Continue');
@@ -238,7 +247,7 @@ describe('StaffRecordComponent', () => {
     });
 
     describe('Updating completed', () => {
-      it('should call updateWorker on load of page when hasCompletedStaffRecordFlow and completed is false for worker', async () => {
+      it('should call updateWorker on load of page when completed is false for worker', async () => {
         const updateWorkerSpy = jasmine.createSpy('updateWorker').and.returnValue(of(true));
 
         const { workplaceUid, workerUid } = await setup({
@@ -252,21 +261,7 @@ describe('StaffRecordComponent', () => {
         expect(updateWorkerSpy).toHaveBeenCalledWith(workplaceUid, workerUid, { completed: true });
       });
 
-      it('should not call updateWorker when completed is false for worker but hasCompletedStaffRecordFlow is not true', async () => {
-        const updateWorkerSpy = jasmine.createSpy('updateWorker').and.returnValue(of(true));
-
-        await setup({
-          workerService: {
-            hasCompletedStaffRecordFlow: null,
-            updateWorker: updateWorkerSpy,
-            worker: { completed: false },
-          },
-        });
-
-        expect(updateWorkerSpy).not.toHaveBeenCalled();
-      });
-
-      it('should not call updateWorker when hasCompletedStaffRecordFlow but completed is true for worker', async () => {
+      it('should not call updateWorker when completed is true for worker', async () => {
         const updateWorkerSpy = jasmine.createSpy('updateWorker').and.returnValue(of(true));
 
         await setup({

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -81,6 +81,8 @@ describe('StaffRecordComponent', () => {
     const workerSpy = spyOn(workerService, 'setReturnTo');
     workerSpy.and.callThrough();
 
+    const clearHasCompletedStaffRecordFlowSpy = spyOn(workerService, 'clearHasCompletedStaffRecordFlow');
+
     const workplaceUid = component.workplace.uid;
     const workerUid = component.worker.uid;
 
@@ -96,6 +98,7 @@ describe('StaffRecordComponent', () => {
       workplaceUid,
       workerUid,
       alertSpy,
+      clearHasCompletedStaffRecordFlowSpy,
     };
   }
 
@@ -264,6 +267,50 @@ describe('StaffRecordComponent', () => {
         });
 
         expect(updateWorkerSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Clearing hasCompletedStaffRecordFlow', () => {
+      it('should clear hasCompletedStaffRecordFlow when user clicks on link outside of Add/Change buttons', async () => {
+        const { getByText, clearHasCompletedStaffRecordFlowSpy } = await setup({
+          workerService: {
+            hasCompletedStaffRecordFlow: true,
+            worker: { completed: false },
+          },
+        });
+
+        const flagLongTermAbsenceLink = getByText('Flag long-term absence');
+        fireEvent.click(flagLongTermAbsenceLink);
+
+        expect(clearHasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
+      });
+
+      it('should not clear hasCompletedStaffRecordFlow page when user clicks on an Add/Change button', async () => {
+        const { getAllByText, clearHasCompletedStaffRecordFlowSpy } = await setup({
+          workerService: {
+            hasCompletedStaffRecordFlow: true,
+            worker: { completed: false },
+          },
+        });
+
+        const changeLinks = getAllByText('Change', { selector: 'a' });
+        fireEvent.click(changeLinks[0]);
+
+        expect(clearHasCompletedStaffRecordFlowSpy).not.toHaveBeenCalled();
+      });
+
+      it('should not clear hasCompletedStaffRecordFlow page when user clicks on Continue button', async () => {
+        const { getAllByText, clearHasCompletedStaffRecordFlowSpy } = await setup({
+          workerService: {
+            hasCompletedStaffRecordFlow: true,
+            worker: { completed: false },
+          },
+        });
+
+        const continueButtons = getAllByText('Continue');
+        fireEvent.click(continueButtons[0]);
+
+        expect(clearHasCompletedStaffRecordFlowSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -17,7 +17,6 @@ import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockWorkerServiceWithUpdateWorker, workerBuilder } from '@core/test-utils/MockWorkerService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
@@ -89,8 +88,6 @@ describe('StaffRecordComponent', () => {
     const alert = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alert, 'addAlert').and.callThrough();
 
-    const parentSubsidiaryViewService = injector.inject(ParentSubsidiaryViewService) as ParentSubsidiaryViewService;
-
     return {
       ...setupTools,
       component,
@@ -100,7 +97,6 @@ describe('StaffRecordComponent', () => {
       workplaceUid,
       workerUid,
       alertSpy,
-      parentSubsidiaryViewService,
     };
   }
 

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -222,20 +222,17 @@ describe('StaffRecordComponent', () => {
         { index: 0, position: 'top' },
         { index: 1, position: 'bottom' },
       ].forEach((scenario) => {
-        it(`should navigate to the "Add another staff record" page when Continue button at ${scenario.position} of page is clicked`, async () => {
-          const { routerSpy, getAllByText, workplaceUid } = await setup({
+        it(`should have "Add another staff record" href on Continue button at ${scenario.position} of page`, async () => {
+          const { getAllByText, workplaceUid } = await setup({
             workerService: { hasCompletedStaffRecordFlow: true, worker: { completed: false } },
           });
 
           const continueButtons = getAllByText('Continue');
           fireEvent.click(continueButtons[scenario.index]);
 
-          expect(routerSpy).toHaveBeenCalledWith([
-            '/workplace',
-            workplaceUid,
-            'staff-record',
-            'add-another-staff-record',
-          ]);
+          expect(continueButtons[scenario.index].getAttribute('href')).toEqual(
+            `/workplace/${workplaceUid}/staff-record/add-another-staff-record`,
+          );
         });
       });
     });

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -109,24 +109,25 @@ describe('StaffRecordComponent', () => {
     expect(getAllByText(component.worker.nameOrId).length).toBe(2);
   });
 
-  it('should render a Continue button at top and bottom of page when worker.completed is false and canEditWorker is true', async () => {
-    const { getAllByText } = await setup({ workerService: { worker: { completed: false } } });
+  it('should render a Continue button at top and bottom of page when hasCompletedStaffRecordFlow is true', async () => {
+    const { getAllByText } = await setup({
+      workerService: { worker: { completed: false }, hasCompletedStaffRecordFlow: true },
+    });
 
     const continueButtons = getAllByText('Continue');
 
     expect(continueButtons.length).toEqual(2);
   });
 
-  it('should not render the Continue record button when worker.completed is false and canEditWorker is false', async () => {
-    const { queryByText } = await setup({ workerService: { worker: { completed: false } }, permissions: [] });
+  it('should not render the Continue record button when hasCompletedStaffRecordFlow is false', async () => {
+    const { queryByText } = await setup({
+      workerService: { worker: { completed: false } },
+      hasCompletedStaffRecordFlow: false,
+    });
 
     const button = queryByText('Continue');
-    const flagLongTermAbsenceLink = queryByText('Flag long-term absence');
-    const deleteRecordLink = queryByText('Delete staff record');
 
     expect(button).toBeFalsy();
-    expect(flagLongTermAbsenceLink).toBeFalsy();
-    expect(deleteRecordLink).toBeFalsy();
   });
 
   [true, false].forEach((completedValue) => {
@@ -162,7 +163,7 @@ describe('StaffRecordComponent', () => {
   });
 
   it('should render the training and qualifications link with the correct href', async () => {
-    const { getByTestId, workplaceUid, workerUid } = await setup({ workerService: { worker: { completed: true } } });
+    const { getByTestId, workplaceUid, workerUid } = await setup();
 
     const link = getByTestId('training-and-qualifications-link');
     expect(link.getAttribute('href')).toEqual(
@@ -214,7 +215,7 @@ describe('StaffRecordComponent', () => {
   describe('saveAndComplete', () => {
     it('should call updateWorker on the worker service when Continue button is clicked', async () => {
       const { workerService, getAllByText, workplaceUid, workerUid } = await setup({
-        workerService: { worker: { completed: false } },
+        workerService: { hasCompletedStaffRecordFlow: true, worker: { completed: false } },
       });
 
       const updateWorkerSpy = spyOn(workerService, 'updateWorker').and.callThrough();
@@ -227,7 +228,7 @@ describe('StaffRecordComponent', () => {
 
     it('should navigate to the "Add another staff record" page when Continue button is clicked', async () => {
       const { routerSpy, getAllByText, workplaceUid } = await setup({
-        workerService: { worker: { completed: false } },
+        workerService: { hasCompletedStaffRecordFlow: true, worker: { completed: false } },
       });
 
       const continueButtons = getAllByText('Continue');
@@ -239,19 +240,19 @@ describe('StaffRecordComponent', () => {
 
   describe('transfer staff record link', () => {
     it('should show the link when the primary workplace is a parent and has canEdit permissions', async () => {
-      const { getByText } = await setup({ workerService: { worker: { completed: true } } });
+      const { getByText } = await setup({ isParent: true });
 
       expect(getByText('Transfer staff record')).toBeTruthy();
     });
 
     it('should not show the link when there are no canEditWorker permissions', async () => {
-      const { queryByText } = await setup({ worker: { completed: true }, permissions: [] });
+      const { queryByText } = await setup({ permissions: [] });
 
       expect(queryByText('Transfer staff record')).toBeFalsy();
     });
 
     it('should not show the link when the workplace is not a parent', async () => {
-      const { queryByText } = await setup({ isParent: false, workerService: { worker: { completed: true } } });
+      const { queryByText } = await setup({ isParent: false });
 
       expect(queryByText('Transfer staff record')).toBeFalsy();
     });

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -1,13 +1,13 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
-import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
+import { Worker } from '@core/model/worker.model';
 import { AlertService } from '@core/services/alert.service';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
@@ -15,7 +15,7 @@ import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
 import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
-import { MockWorkerServiceWithUpdateWorker } from '@core/test-utils/MockWorkerService';
+import { MockWorkerServiceWithUpdateWorker, workerBuilder } from '@core/test-utils/MockWorkerService';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { SharedModule } from '@shared/shared.module';
@@ -23,13 +23,17 @@ import { fireEvent, render } from '@testing-library/angular';
 
 import { WorkersModule } from '../workers.module';
 import { StaffRecordComponent } from './staff-record.component';
-import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 describe('StaffRecordComponent', () => {
-  async function setup(isParent = true, ownWorkplace = true) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function setup(overrides: any = {}) {
+    const isParent = overrides.isParent ?? true;
+    const worker = { ...workerBuilder(), ...overrides.worker } as Worker;
+    const permissions = overrides.permissions ?? ['canEditWorker', 'canDeleteWorker'];
+
     const workplace = establishmentBuilder() as Establishment;
     const setupTools = await render(StaffRecordComponent, {
-      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, WorkersModule],
+      imports: [SharedModule, RouterModule, HttpClientTestingModule, WorkersModule],
       providers: [
         AlertService,
         WindowRef,
@@ -43,7 +47,7 @@ describe('StaffRecordComponent', () => {
                 data: {
                   establishment: workplace,
                 },
-                url: [{ path: ownWorkplace ? 'staff-record-summary' : '' }],
+                url: [{ path: 'staff-record-summary' }],
               },
             },
             snapshot: {},
@@ -51,26 +55,24 @@ describe('StaffRecordComponent', () => {
         },
         {
           provide: WorkerService,
-          useClass: MockWorkerServiceWithUpdateWorker,
+          useFactory: MockWorkerServiceWithUpdateWorker.factory(worker),
         },
         {
           provide: EstablishmentService,
           useValue: {
             establishmentId: 'mock-uid',
-            isOwnWorkplace: () => ownWorkplace,
             primaryWorkplace: {
               isParent,
             },
           },
         },
         { provide: BreadcrumbService, useClass: MockBreadcrumbService },
-        { provide: PermissionsService, useClass: MockPermissionsService },
+        { provide: PermissionsService, useFactory: MockPermissionsService.factory(permissions) },
         { provide: FeatureFlagsService, useClass: MockFeatureFlagsService },
       ],
     });
 
-    const fixture = setupTools.fixture;
-    const component = fixture.componentInstance;
+    const component = setupTools.fixture.componentInstance;
 
     const injector = getTestBed();
     const router = injector.inject(Router) as Router;
@@ -90,8 +92,8 @@ describe('StaffRecordComponent', () => {
     const parentSubsidiaryViewService = injector.inject(ParentSubsidiaryViewService) as ParentSubsidiaryViewService;
 
     return {
+      ...setupTools,
       component,
-      fixture,
       routerSpy,
       workerService,
       workerSpy,
@@ -99,7 +101,6 @@ describe('StaffRecordComponent', () => {
       workerUid,
       alertSpy,
       parentSubsidiaryViewService,
-      ...setupTools,
     };
   }
 
@@ -115,10 +116,8 @@ describe('StaffRecordComponent', () => {
   });
 
   it('should render the Complete record button and correct text when worker.completed is false and canEditWorker is true', async () => {
-    const { component, fixture, getByText, queryByText } = await setup();
-    component.canEditWorker = true;
-    component.worker.completed = false;
-    fixture.detectChanges();
+    const { getByText, queryByText } = await setup({ worker: { completed: false } });
+
     const button = getByText('Confirm record details');
     const text = getByText(`Check these details before you confirm them.`);
     const flagLongTermAbsenceLink = queryByText('Flag long-term absence');
@@ -131,10 +130,8 @@ describe('StaffRecordComponent', () => {
   });
 
   it('should not render the Complete record button when worker.completed is false and canEditWorker is false', async () => {
-    const { component, fixture, queryByText } = await setup();
+    const { queryByText } = await setup({ worker: { completed: false }, permissions: [] });
 
-    component.worker.completed = false;
-    fixture.detectChanges();
     const button = queryByText('Confirm record details');
     const text = queryByText(`Check these details before you confirm them.`);
     const flagLongTermAbsenceLink = queryByText('Flag long-term absence');
@@ -147,15 +144,9 @@ describe('StaffRecordComponent', () => {
   });
 
   it('should render the delete record link, add training link and flag long term absence link, and not correct text when worker.completed is true', async () => {
-    const { component, fixture, queryByText, getByText, getByTestId, getByRole, workplaceUid, workerUid } =
-      await setup();
-
-    component.canEditWorker = true;
-    component.canDeleteWorker = true;
-    component.worker.longTermAbsence = null;
-    component.worker.completed = true;
-
-    fixture.detectChanges();
+    const { queryByText, getByText, getByTestId, getByRole, workplaceUid, workerUid } = await setup({
+      worker: { completed: true, longTermAbsence: null },
+    });
 
     const button = queryByText('Confirm record details');
     const text = queryByText(`Check the record details you've added are correct.`);
@@ -185,14 +176,8 @@ describe('StaffRecordComponent', () => {
   });
 
   it('should render the training and qualifications link with the correct href', async () => {
-    const { getByTestId, component, fixture } = await setup();
+    const { getByTestId, workplaceUid, workerUid } = await setup({ worker: { completed: true } });
 
-    component.canEditWorker = true;
-    component.worker.completed = true;
-    fixture.detectChanges();
-
-    const workplaceUid = component.workplace.uid;
-    const workerUid = component.worker.uid;
     const link = getByTestId('training-and-qualifications-link');
     expect(link.getAttribute('href')).toEqual(
       `/workplace/${workplaceUid}/training-and-qualifications-record/${workerUid}/training`,
@@ -201,22 +186,16 @@ describe('StaffRecordComponent', () => {
 
   describe('Long-Term Absence', () => {
     it('should display the Long-Term Absence if the worker is currently flagged as long term absent', async () => {
-      const { component, fixture, getByText, queryByText } = await setup();
-
-      component.worker.completed = true;
-      component.worker.longTermAbsence = 'Illness';
-      fixture.detectChanges();
+      const { getByText, queryByText } = await setup({ worker: { completed: true, longTermAbsence: 'Illness' } });
 
       expect(getByText('Long-term absent')).toBeTruthy();
       expect(queryByText('Flag long-term absence')).toBeFalsy();
     });
 
     it('should navigate to `long-term-absence` when pressing the "view" button', async () => {
-      const { component, fixture, getByTestId, workplaceUid, workerUid } = await setup();
-
-      component.worker.completed = true;
-      component.worker.longTermAbsence = 'Illness';
-      fixture.detectChanges();
+      const { getByTestId, workplaceUid, workerUid } = await setup({
+        worker: { completed: true, longTermAbsence: 'Illness' },
+      });
 
       const longTermAbsenceLink = getByTestId('longTermAbsence');
       expect(longTermAbsenceLink.getAttribute('href')).toBe(
@@ -227,23 +206,15 @@ describe('StaffRecordComponent', () => {
 
   describe('Flag long-term absence', () => {
     it('should display the "Flag long-term absence" link if the worker is not currently flagged as long term absent', async () => {
-      const { component, fixture, getByText } = await setup();
-
-      component.worker.longTermAbsence = null;
-      component.canEditWorker = true;
-      component.worker.completed = true;
-      fixture.detectChanges();
+      const { getByText } = await setup({ worker: { completed: true, longTermAbsence: null } });
 
       expect(getByText('Flag long-term absence')).toBeTruthy();
     });
 
     it('should navigate to `./long-term-absence` when pressing the "Flag long-term absence" button', async () => {
-      const { component, fixture, getByTestId, workplaceUid, workerUid } = await setup();
-
-      component.worker.longTermAbsence = null;
-      component.canEditWorker = true;
-      component.worker.completed = true;
-      fixture.detectChanges();
+      const { getByTestId, workplaceUid, workerUid } = await setup({
+        worker: { completed: true, longTermAbsence: null },
+      });
 
       const flagLongTermAbsenceLink = getByTestId('flagLongTermAbsence');
       expect(flagLongTermAbsenceLink.getAttribute('href')).toBe(
@@ -254,15 +225,9 @@ describe('StaffRecordComponent', () => {
 
   describe('saveAndComplete', () => {
     it('should call updateWorker on the worker service when button is clicked', async () => {
-      const { component, fixture, workerService, getByText } = await setup();
-
-      component.canEditWorker = true;
-      component.worker.completed = false;
-      fixture.detectChanges();
+      const { workerService, getByText, workplaceUid, workerUid } = await setup({ worker: { completed: false } });
 
       const updateWorkerSpy = spyOn(workerService, 'updateWorker').and.callThrough();
-      const workplaceUid = component.workplace.uid;
-      const workerUid = component.worker.uid;
 
       const button = getByText('Confirm record details');
       fireEvent.click(button);
@@ -270,81 +235,39 @@ describe('StaffRecordComponent', () => {
       expect(updateWorkerSpy).toHaveBeenCalledWith(workplaceUid, workerUid, { completed: true });
     });
 
-    it('should navigate to the "Add another workplace" page when worker is confirmed if workplace and establishment are the same', async () => {
-      const { component, fixture, routerSpy, getByText } = await setup();
-
-      component.canEditWorker = true;
-      component.workplace.uid = 'mock-uid';
-      component.worker.completed = false;
-      fixture.detectChanges();
+    it('should navigate to the "Add another staff record" page when worker is confirmed', async () => {
+      const { routerSpy, getByText, workplaceUid } = await setup({ worker: { completed: false } });
 
       const button = getByText('Confirm record details');
       fireEvent.click(button);
 
-      expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mock-uid', 'staff-record', 'add-another-staff-record']);
+      expect(routerSpy).toHaveBeenCalledWith(['/workplace', workplaceUid, 'staff-record', 'add-another-staff-record']);
     });
-
   });
 
   describe('transfer staff record link', () => {
     it('should show the link when the primary workplace is a parent and has canEdit permissions', async () => {
-      const { component, fixture, getByText } = await setup();
-
-      component.worker.completed = true;
-      component.canEditWorker = true;
-      fixture.detectChanges();
+      const { getByText } = await setup({ worker: { completed: true } });
 
       expect(getByText('Transfer staff record')).toBeTruthy();
     });
 
     it('should not show the link when there are no canEditWorker permissions', async () => {
-      const { component, fixture, queryByText } = await setup();
-
-      component.worker.completed = true;
-      component.canEditWorker = false;
-      fixture.detectChanges();
+      const { queryByText } = await setup({ worker: { completed: true }, permissions: [] });
 
       expect(queryByText('Transfer staff record')).toBeFalsy();
     });
 
     it('should not show the link when the workplace is not a parent', async () => {
-      const { component, fixture, queryByText } = await setup(false);
-
-      component.worker.completed = true;
-      component.canEditWorker = true;
-      fixture.detectChanges();
+      const { queryByText } = await setup({ isParent: false, worker: { completed: true } });
 
       expect(queryByText('Transfer staff record')).toBeFalsy();
     });
 
     it('should not show the link if the worker details have not been completed', async () => {
-      const { component, fixture, queryByText } = await setup();
-
-      component.worker.completed = false;
-      component.canEditWorker = true;
-      fixture.detectChanges();
+      const { queryByText } = await setup({ worker: { completed: false } });
 
       expect(queryByText('Transfer staff record')).toBeFalsy();
-    });
-  });
-
-  describe('Breadcrumbs', async () => {
-    it('getBreadcrumbsJourney should return my workplace journey when viewing sub as parent', async () => {
-      const { component, parentSubsidiaryViewService } = await setup(false, false);
-      spyOn(parentSubsidiaryViewService, 'getViewingSubAsParent').and.returnValue(true);
-      expect(component.getBreadcrumbsJourney()).toBe(JourneyType.MY_WORKPLACE);
-    });
-
-    it('getBreadcrumbsJourney should return main workplace journey when is own workplace', async () => {
-      const { component } = await setup();
-
-      expect(component.getBreadcrumbsJourney()).toBe(JourneyType.MY_WORKPLACE);
-    });
-
-    it('getBreadcrumbsJourney should return all workplaces journey when is not own workplace and not in parent sub view', async () => {
-      const { component } = await setup(false, false);
-
-      expect(component.getBreadcrumbsJourney()).toBe(JourneyType.ALL_WORKPLACES);
     });
   });
 });

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';
@@ -46,6 +46,10 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     this.hasCompletedStaffRecordFlow = this.workerService.hasCompletedStaffRecordFlow;
     this.workplace = this.route.parent.snapshot.data.establishment;
     this.isParent = this.establishmentService.primaryWorkplace.isParent;
+
+    if (this.hasCompletedStaffRecordFlow) {
+      this.trackNavigationToClearHasCompletedStaffRecordFlow();
+    }
 
     this.subscriptions.add(
       this.workerService.worker$.pipe(take(1)).subscribe((worker) => {
@@ -105,6 +109,18 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
           console.log(error);
         },
       ),
+    );
+  }
+
+  private trackNavigationToClearHasCompletedStaffRecordFlow(): void {
+    this.subscriptions.add(
+      this.router.events.subscribe((event) => {
+        if (event instanceof NavigationStart) {
+          if (!event.url?.includes('staff-record-summary') || event.url?.includes('add-another-staff-record')) {
+            this.workerService.clearHasCompletedStaffRecordFlow();
+          }
+        }
+      }),
     );
   }
 

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -49,15 +49,17 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     this.isParent = this.establishmentService.primaryWorkplace.isParent;
 
     if (this.hasCompletedStaffRecordFlow) {
-      this.continueRoute = ['/workplace', this.workplace.uid, 'staff-record', 'add-another-staff-record'];
-      this.trackNavigationToClearHasCompletedStaffRecordFlow();
+      this.showContinueButtons();
     }
 
     this.subscriptions.add(
       this.workerService.worker$.pipe(take(1)).subscribe((worker) => {
         this.worker = worker;
-        if (!this.worker?.completed && this.hasCompletedStaffRecordFlow) {
+        if (!this.worker?.completed) {
+          this.workerService.hasCompletedStaffRecordFlow = true;
+          this.hasCompletedStaffRecordFlow = true;
           this.updateCompleted();
+          this.showContinueButtons();
         }
       }),
     );
@@ -74,6 +76,11 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
 
     this.canDeleteWorker = this.permissionsService.can(this.workplace.uid, 'canDeleteWorker');
     this.canEditWorker = this.permissionsService.can(this.workplace.uid, 'canEditWorker');
+  }
+
+  private showContinueButtons(): void {
+    this.continueRoute = ['/workplace', this.workplace.uid, 'staff-record', 'add-another-staff-record'];
+    this.trackNavigationToClearHasCompletedStaffRecordFlow();
   }
 
   public backLinkNavigation(): URLStructure {

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -50,6 +50,9 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.workerService.worker$.pipe(take(1)).subscribe((worker) => {
         this.worker = worker;
+        if (!this.worker?.completed) {
+          this.updateCompleted();
+        }
       }),
     );
 
@@ -84,7 +87,11 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     });
   }
 
-  public saveAndComplete(): void {
+  public navigateToAddAnotherStaffRecordPage(): void {
+    this.router.navigate(['/workplace', this.workplace.uid, 'staff-record', 'add-another-staff-record']);
+  }
+
+  private updateCompleted(): void {
     const props = {
       completed: true,
     };
@@ -93,7 +100,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
       this.workerService.updateWorker(this.workplace.uid, this.worker.uid, props).subscribe(
         (data) => {
           this.workerService.setState({ ...this.worker, ...data });
-          this.router.navigate(['/workplace', this.workplace.uid, 'staff-record', 'add-another-staff-record']);
         },
         (error) => {
           console.log(error);

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -27,7 +27,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
   public returnToRecord: URLStructure;
   public worker: Worker;
   public workplace: Establishment;
-  public insideFlow: boolean;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -43,8 +42,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.insideFlow = this.route.parent.snapshot.url[0].path !== 'staff-record-summary';
-
     this.workplace = this.route.parent.snapshot.data.establishment;
     this.isParent = this.establishmentService.primaryWorkplace.isParent;
 

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -57,7 +57,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     );
 
     if (!this.insideFlow) {
-      this.breadcrumbService.show(this.getBreadcrumbsJourney());
+      this.breadcrumbService.show(JourneyType.MY_WORKPLACE);
     } else {
       this.backLinkService.showBackLink();
     }
@@ -115,12 +115,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
       fragment: 'staff-record',
     };
     this.workerService.setReturnTo(this.returnToRecord);
-  }
-
-  public getBreadcrumbsJourney(): JourneyType {
-    return this.parentSubsidiaryViewService.getViewingSubAsParent() || this.establishmentService.isOwnWorkplace()
-      ? JourneyType.MY_WORKPLACE
-      : JourneyType.ALL_WORKPLACES;
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -54,7 +54,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.workerService.worker$.pipe(take(1)).subscribe((worker) => {
         this.worker = worker;
-        if (!this.worker?.completed) {
+        if (!this.worker?.completed && this.hasCompletedStaffRecordFlow) {
           this.updateCompleted();
         }
       }),
@@ -116,7 +116,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.router.events.subscribe((event) => {
         if (event instanceof NavigationStart) {
-          if (!event.url?.includes('staff-record-summary') || event.url?.includes('add-another-staff-record')) {
+          if (!event.url?.includes('staff-record-summary') && !event.url?.includes('add-another-staff-record')) {
             this.workerService.clearHasCompletedStaffRecordFlow();
           }
         }

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -11,7 +11,6 @@ import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { WorkerService } from '@core/services/worker.service';
-import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -41,7 +40,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     private workerService: WorkerService,
     protected backLinkService: BackLinkService,
     public breadcrumbService: BreadcrumbService,
-    private parentSubsidiaryViewService: ParentSubsidiaryViewService,
   ) {}
 
   ngOnInit(): void {

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -54,11 +54,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
       }),
     );
 
-    if (!this.insideFlow) {
-      this.breadcrumbService.show(JourneyType.MY_WORKPLACE);
-    } else {
-      this.backLinkService.showBackLink();
-    }
+    this.breadcrumbService.show(JourneyType.STAFF_RECORDS_TAB);
 
     this.subscriptions.add(
       this.workerService.alert$.subscribe((alert) => {

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -28,6 +28,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
   public worker: Worker;
   public workplace: Establishment;
   public hasCompletedStaffRecordFlow: boolean;
+  public continueRoute: string[];
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -48,6 +49,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     this.isParent = this.establishmentService.primaryWorkplace.isParent;
 
     if (this.hasCompletedStaffRecordFlow) {
+      this.continueRoute = ['/workplace', this.workplace.uid, 'staff-record', 'add-another-staff-record'];
       this.trackNavigationToClearHasCompletedStaffRecordFlow();
     }
 
@@ -89,10 +91,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
         ? this.route.parent.snapshot.data.primaryWorkplace.uid
         : null,
     });
-  }
-
-  public navigateToAddAnotherStaffRecordPage(): void {
-    this.router.navigate(['/workplace', this.workplace.uid, 'staff-record', 'add-another-staff-record']);
   }
 
   private updateCompleted(): void {

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -27,6 +27,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
   public returnToRecord: URLStructure;
   public worker: Worker;
   public workplace: Establishment;
+  public hasCompletedStaffRecordFlow: boolean;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -42,6 +43,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.hasCompletedStaffRecordFlow = this.workerService.hasCompletedStaffRecordFlow;
     this.workplace = this.route.parent.snapshot.data.establishment;
     this.isParent = this.establishmentService.primaryWorkplace.isParent;
 

--- a/frontend/src/app/features/workers/workers-routing.module.ts
+++ b/frontend/src/app/features/workers/workers-routing.module.ts
@@ -45,6 +45,7 @@ import { ContractWithZeroHoursComponent } from './contract-with-zero-hours/contr
 import { CountryOfBirthComponent } from './country-of-birth/country-of-birth.component';
 import { DateOfBirthComponent } from './date-of-birth/date-of-birth.component';
 import { DaysOfSicknessComponent } from './days-of-sickness/days-of-sickness.component';
+import { DeleteAnotherStaffRecordComponent } from './delete-another-staff-record/delete-another-staff-record.component';
 import { DeleteStaffRecordComponent } from './delete-staff-record/delete-staff-record.component';
 import { DisabilityComponent } from './disability/disability.component';
 import { EditWorkerComponent } from './edit-worker/edit-worker.component';
@@ -85,7 +86,6 @@ import {
 } from './update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component';
 import { WeeklyContractedHoursComponent } from './weekly-contracted-hours/weekly-contracted-hours.component';
 import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.component';
-import { DeleteAnotherStaffRecordComponent } from './delete-another-staff-record/delete-another-staff-record.component';
 
 const routes: Routes = [
   {
@@ -167,7 +167,7 @@ const routes: Routes = [
     path: 'add-another-staff-record',
     component: AddAnotherStaffRecordComponent,
   },
-    {
+  {
     path: 'delete-another-staff-record',
     component: DeleteAnotherStaffRecordComponent,
   },
@@ -470,11 +470,6 @@ const routes: Routes = [
             data: { title: 'Flag long term absence' },
           },
         ],
-      },
-      {
-        path: 'confirm-staff-record',
-        component: StaffRecordComponent,
-        data: { title: 'Confirm Staff Record' },
       },
       {
         path: 'staff-details',

--- a/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.html
@@ -1,4 +1,14 @@
-<h2 class="govuk-heading-m">{{ basicTitle }}</h2>
+<div class="govuk-grid-row govuk__flex govuk__align-items-flex-end govuk-!-margin-bottom-0">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-4">{{ basicTitle }}</h2>
+  </div>
+  <div class="govuk-grid-column-one-third govuk-util__align-right">
+    <a *ngIf="continueRoute" type="button" class="govuk-button govuk-!-margin-bottom-6" [routerLink]="continueRoute"
+      >Continue</a
+    >
+  </div>
+</div>
+
 <dl
   class="govuk-summary-list govuk-summary-list--no-border asc-summarylist-border-top govuk-summary-list--wide-key govuk-!-margin-bottom-0"
   data-testid="name-and-contract-section"

--- a/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.spec.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
+import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
@@ -13,11 +14,11 @@ import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 
 import { BasicRecordComponent } from './basic-record.component';
-import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
 describe('BasicRecordComponent', () => {
-  async function setup(mandatoryDetailsPage = false) {
-    const { fixture, getByText, getByTestId } = await render(BasicRecordComponent, {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function setup(overrides: any = {}) {
+    const setupTools = await render(BasicRecordComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
       declarations: [SummaryRecordChangeComponent],
       providers: [
@@ -30,19 +31,16 @@ describe('BasicRecordComponent', () => {
       ],
       componentProperties: {
         canEditWorker: true,
-        mandatoryDetailsPage,
+        mandatoryDetailsPage: false,
         workplace: establishmentBuilder() as Establishment,
         worker: workerWithWdf() as Worker,
+        ...overrides,
       },
     });
 
-    const component = fixture.componentInstance;
-
     return {
-      component,
-      fixture,
-      getByText,
-      getByTestId,
+      ...setupTools,
+      component: setupTools.fixture.componentInstance,
     };
   }
 
@@ -52,7 +50,7 @@ describe('BasicRecordComponent', () => {
   });
 
   it('should render the change link with the staff-record-summary/staff-details url when not on the mandatory details page', async () => {
-    const { component, getByText, getByTestId } = await setup();
+    const { component, getByTestId } = await setup();
 
     const nameSection = within(getByTestId('name-and-contract-section'));
     const changeLink = nameSection.getByText('Change');
@@ -63,7 +61,7 @@ describe('BasicRecordComponent', () => {
   });
 
   it('should render the change link with the staff-record-summary/main-job-role url when not on the mandatory details page', async () => {
-    const { component, getByText, getByTestId } = await setup();
+    const { component, getByTestId } = await setup();
 
     const mainJobRoleSection = within(getByTestId('main-job-role-section'));
     const changeLink = mainJobRoleSection.getByText('Change');
@@ -74,7 +72,7 @@ describe('BasicRecordComponent', () => {
   });
 
   it('should render the change link with the mandatory-details/staff-details url when on the mandatory details page', async () => {
-    const { component, getByText, getByTestId } = await setup(true);
+    const { component, getByTestId } = await setup({ mandatoryDetailsPage: true });
 
     const nameSection = within(getByTestId('name-and-contract-section'));
     const changeLink = nameSection.getByText('Change');
@@ -85,7 +83,7 @@ describe('BasicRecordComponent', () => {
   });
 
   it('should render the change link with the mandatory-details/main-job-role url when on the mandatory details page', async () => {
-    const { component, getByText, getByTestId } = await setup(true);
+    const { component, getByTestId } = await setup({ mandatoryDetailsPage: true });
 
     const mainJobRoleSection = within(getByTestId('main-job-role-section'));
     const changeLink = mainJobRoleSection.getByText('Change');
@@ -93,5 +91,28 @@ describe('BasicRecordComponent', () => {
     expect(changeLink.getAttribute('href')).toBe(
       `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/mandatory-details/main-job-role`,
     );
+  });
+
+  describe('Continue button', () => {
+    it('should not be rendered when no route passed in', async () => {
+      const { queryByText } = await setup();
+
+      const continueButton = queryByText('Continue');
+
+      expect(continueButton).toBeFalsy();
+    });
+
+    it('should be rendered with link to route passed in', async () => {
+      const { queryByText } = await setup({
+        continueRoute: ['/workplace', 'workplaceUid', 'staff-record', 'add-another-staff-record'],
+      });
+
+      const continueButton = queryByText('Continue');
+
+      expect(continueButton).toBeTruthy();
+      expect(continueButton.getAttribute('href')).toEqual(
+        '/workplace/workplaceUid/staff-record/add-another-staff-record',
+      );
+    });
   });
 });

--- a/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/basic-record/basic-record.component.ts
@@ -12,6 +12,7 @@ export class BasicRecordComponent extends StaffRecordSummaryComponent {
   @Input() public overallWdfEligibility: boolean;
   @Input() public canEditWorker: boolean;
   @Input() public mandatoryDetailsPage = false;
+  @Input() public continueRoute: string[] = null;
 
   public showWdfConfirmations: any = {
     contract: null,

--- a/frontend/src/app/shared/components/submit-button/submit-button.component.html
+++ b/frontend/src/app/shared/components/submit-button/submit-button.component.html
@@ -17,7 +17,7 @@
   <ng-template #staffRecordButtonLogic>
     <ng-container *ngIf="!return; else summary">
       <div class="govuk-grid-column-two-thirds govuk__flex govuk-!-padding-left-0">
-        <div>
+        <div style="width: 250px">
           <button type="submit" class="govuk-button govuk-!-margin-right-9" (click)="onButtonClick('continue', true)">
             {{ callToAction }}
           </button>

--- a/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
+++ b/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
@@ -46,6 +46,7 @@ export class StaffSummaryDirective implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.workerService.clearHasCompletedStaffRecordFlow();
     this.totalWorkerCount = this.workerCount;
     this.paginatedWorkers = this.workers;
     this.canViewWorker = this.permissionsService.can(this.workplace.uid, 'canViewWorker');


### PR DESCRIPTION
#### Work done
- Changed Confirm button to two Continue buttons on staff record after completing flow
- Changed to update completed (used for showing add details link) as soon as user completes flow
- Store state of `hasCompletedStaffRecordFlow` so Continue buttons persist when updating answers to questions/going back from Add another staff record
- Updated breadcrumbs on individual staff records

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
