### PR TITLE
Fix: Add link on training actions list not working

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -4,8 +4,8 @@
       <p class="govuk-tag govuk-tag--grey asc-tag govuk-!-margin-bottom-0">
         Long-term absent
         <a
-          (click)="navigateToLongTermAbsence()"
-          href="javascript:void(0)"
+          (click)="navigateToLongTermAbsence($event)"
+          href="#"
           data-testid="longTermAbsence"
           class="govuk-link govuk-link--no-visited-state govuk-!-padding-left-1"
         >
@@ -32,9 +32,9 @@
         *ngIf="canEditWorker && worker.longTermAbsence === null"
         draggable="false"
         role="button"
-        href="javascript:void(0)"
+        href="#"
         data-testid="flagLongTermAbsence"
-        (click)="navigateToLongTermAbsence()"
+        (click)="navigateToLongTermAbsence($event)"
         >Flag long-term absence</a
       >
     </div>
@@ -141,8 +141,8 @@
             <a
               *ngIf="canEditWorker"
               class="govuk-link--no-visited-state govuk-util__float-right"
-              (click)="actionsListNavigate(actionListItem)"
-              href="javascript:void(0)"
+              (click)="actionsListNavigate($event, actionListItem)"
+              href="#"
               >{{ actionListItem.trainingStatus !== trainingStatusService.MISSING ? 'Update' : 'Add' }}</a
             >
           </td>
@@ -162,8 +162,8 @@
       <a
         class="govuk-tabs__tab asc-tabs__link"
         role="tab"
-        href="javascript:void(0)"
-        (click)="navigateToNewTab('all-records')"
+        href="#"
+        (click)="navigateToNewTab($event, 'all-records')"
         data-testid="allRecordsTabLink"
         [class.asc-tabs__link--active]="currentFragment === fragmentsObject.allRecords"
         >All records</a
@@ -177,8 +177,8 @@
       <a
         class="govuk-tabs__tab asc-tabs__link"
         role="tab"
-        href="javascript:void(0)"
-        (click)="navigateToNewTab('mandatory-training')"
+        href="#"
+        (click)="navigateToNewTab($event, 'mandatory-training')"
         data-testid="mandatoryTrainingTabLink"
         [class.asc-tabs__link--active]="currentFragment === fragmentsObject.mandatoryTraining"
         >Mandatory training</a
@@ -192,8 +192,8 @@
       <a
         class="govuk-tabs__tab asc-tabs__link"
         role="tab"
-        href="javascript:void(0)"
-        (click)="navigateToNewTab('non-mandatory-training')"
+        href="#"
+        (click)="navigateToNewTab($event, 'non-mandatory-training')"
         data-testid="nonMandatoryTrainingTabLink"
         [class.asc-tabs__link--active]="currentFragment === fragmentsObject.nonMandatoryTraining"
         >Non-mandatory training</a
@@ -208,8 +208,8 @@
         class="govuk-tabs__tab asc-tabs__link"
         role="tab"
         data-testid="qualificationsTabLink"
-        href="javascript:void(0)"
-        (click)="navigateToNewTab('qualifications')"
+        href="#"
+        (click)="navigateToNewTab($event, 'qualifications')"
         [class.asc-tabs__link--active]="currentFragment === fragmentsObject.qualifications"
         >Qualifications</a
       >

--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.ts
@@ -1,6 +1,3 @@
-import { from, merge, Subscription } from 'rxjs';
-import { mergeMap, tap, toArray } from 'rxjs/operators';
-
 import { Component, OnDestroy, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
@@ -25,6 +22,8 @@ import { WorkerService } from '@core/services/worker.service';
 import { FileUtil } from '@core/utils/file-util';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
+import { from, merge, Subscription } from 'rxjs';
+import { mergeMap, toArray } from 'rxjs/operators';
 
 @Component({
   selector: 'app-new-training-and-qualifications-record',
@@ -295,7 +294,8 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     });
   }
 
-  public actionsListNavigate(actionListItem): void {
+  public actionsListNavigate(event: Event, actionListItem): void {
+    event.preventDefault();
     const url = actionListItem.uid
       ? [
           'workplace',
@@ -315,7 +315,8 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     );
   }
 
-  public navigateToNewTab(fragmentString): void {
+  public navigateToNewTab(event: Event, fragmentString: string): void {
+    event.preventDefault();
     this.router
       .navigate(['workplace', this.workplace.uid, 'training-and-qualifications-record', this.worker.uid, 'training'], {
         fragment: fragmentString,
@@ -332,7 +333,8 @@ export class NewTrainingAndQualificationsRecordComponent implements OnInit, OnDe
     );
   }
 
-  public navigateToLongTermAbsence(): void {
+  public navigateToLongTermAbsence(event: Event): void {
+    event.preventDefault();
     this.router.navigate(
       ['/workplace', this.workplace.uid, 'training-and-qualifications-record', this.worker.uid, 'long-term-absence'],
       { queryParams: { returnToTrainingAndQuals: 'true' } },


### PR DESCRIPTION
#### Issue
Users have called the support team to say that they can't click on the Add links on the action list on the individual staff training and quals page. However, the links are working correctly for other users and admins accessing the same page. Without being able to replicate the issue, I suspect that it could be linked to using `javascript:void(0)` for those links and potentially users' browsers/firewalls stopping it so this is an attempted fix.  

#### Work done
- Updated training-and-qualifications-record to use event prevent default instead of javascript:void(0)

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
