### PR TITLE
spike/1658-remove-canmanagewdfclaims-columns-from-database

### DIFF
--- a/backend/migrations/20250402130009-removeWdfUserConstraintToNoneRole.js
+++ b/backend/migrations/20250402130009-removeWdfUserConstraintToNoneRole.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    return queryInterface.sequelize.query('ALTER TABLE cqc."User" DROP CONSTRAINT none_role_must_be_wdf_user');
+  },
+};

--- a/backend/migrations/20250402134600-removeCanManageWdfClaimsColumns.js
+++ b/backend/migrations/20250402134600-removeCanManageWdfClaimsColumns.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const table = { tableName: 'User', schema: 'cqc' };
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.transaction((transaction) => {
+      return Promise.all([
+        queryInterface.removeColumn(table, 'CanManageWdfClaimsValue', { transaction }),
+        queryInterface.removeColumn(table, 'CanManageWdfClaimsSavedAt', { transaction }),
+        queryInterface.removeColumn(table, 'CanManageWdfClaimsChangedAt', { transaction }),
+        queryInterface.removeColumn(table, 'CanManageWdfClaimsSavedBy', { transaction }),
+        queryInterface.removeColumn(table, 'CanManageWdfClaimsChangedBy', { transaction }),
+      ]);
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((transaction) => {
+      return Promise.all([
+        queryInterface.addColumn(
+          table,
+          'CanManageWdfClaimsValue',
+          {
+            type: Sequelize.DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          { transaction },
+        ),
+        queryInterface.addColumn(
+          table,
+          'CanManageWdfClaimsSavedAt',
+          {
+            type: Sequelize.DataTypes.DATE,
+            allowNull: true,
+          },
+          { transaction },
+        ),
+        queryInterface.addColumn(
+          table,
+          'CanManageWdfClaimsChangedAt',
+          {
+            type: Sequelize.DataTypes.DATE,
+            allowNull: true,
+          },
+          { transaction },
+        ),
+        queryInterface.addColumn(
+          table,
+          'CanManageWdfClaimsSavedBy',
+          {
+            type: Sequelize.DataTypes.TEXT,
+            allowNull: true,
+          },
+          { transaction },
+        ),
+        queryInterface.addColumn(
+          table,
+          'CanManageWdfClaimsChangedBy',
+          {
+            type: Sequelize.DataTypes.TEXT,
+            allowNull: true,
+          },
+          { transaction },
+        ),
+      ])
+    });
+  },
+};


### PR DESCRIPTION
#### Work done
- Add migrations to remove CanManageWdfClaims columns

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
