### PR TITLE
Fix/track page views of update pages to show banner

### DIFF
--- a/frontend/src/app/core/services/update-workplace-after-staff-changes.service.spec.ts
+++ b/frontend/src/app/core/services/update-workplace-after-staff-changes.service.spec.ts
@@ -2,10 +2,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import {
-  AddStaffWorkplaceUpdatePage,
-  DeleteStaffWorkplaceUpdatePage,
   UpdateWorkplaceAfterStaffChangesService,
   WorkplaceUpdateFlowType,
+  WorkplaceUpdatePage,
 } from './update-workplace-after-staff-changes.service';
 
 describe('UpdateWorkplaceAfterStaffChangesService', () => {
@@ -26,8 +25,8 @@ describe('UpdateWorkplaceAfterStaffChangesService', () => {
   describe('allUpdatePagesVisited', () => {
     [
       [],
-      [AddStaffWorkplaceUpdatePage.TOTAL_STAFF],
-      [AddStaffWorkplaceUpdatePage.TOTAL_STAFF, AddStaffWorkplaceUpdatePage.UPDATE_VACANCIES],
+      [WorkplaceUpdatePage.TOTAL_STAFF],
+      [WorkplaceUpdatePage.TOTAL_STAFF, WorkplaceUpdatePage.UPDATE_VACANCIES],
     ].forEach((visitedPages) => {
       it(`should return false when not all add pages in visitedPages when ADD passed in (${visitedPages})`, async () => {
         visitedPages.forEach((page) => {
@@ -48,9 +47,9 @@ describe('UpdateWorkplaceAfterStaffChangesService', () => {
 
     it('should return true when all pages in visitedPages for add flow', async () => {
       [
-        AddStaffWorkplaceUpdatePage.TOTAL_STAFF,
-        AddStaffWorkplaceUpdatePage.UPDATE_VACANCIES,
-        AddStaffWorkplaceUpdatePage.UPDATE_STARTERS,
+        WorkplaceUpdatePage.TOTAL_STAFF,
+        WorkplaceUpdatePage.UPDATE_VACANCIES,
+        WorkplaceUpdatePage.UPDATE_STARTERS,
       ].forEach((page) => {
         service.addToVisitedPages(page);
       });
@@ -60,9 +59,9 @@ describe('UpdateWorkplaceAfterStaffChangesService', () => {
 
     it('should return true when all pages in visitedPages for delete flow', async () => {
       [
-        DeleteStaffWorkplaceUpdatePage.TOTAL_STAFF,
-        DeleteStaffWorkplaceUpdatePage.UPDATE_VACANCIES,
-        DeleteStaffWorkplaceUpdatePage.UPDATE_LEAVERS,
+        WorkplaceUpdatePage.TOTAL_STAFF,
+        WorkplaceUpdatePage.UPDATE_VACANCIES,
+        WorkplaceUpdatePage.UPDATE_LEAVERS,
       ].forEach((page) => {
         service.addToVisitedPages(page);
       });

--- a/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
+++ b/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Starter, Vacancy, Leaver } from '@core/model/establishment.model';
+import { Leaver, Starter, Vacancy } from '@core/model/establishment.model';
 
 @Injectable({
   providedIn: 'root',
@@ -22,9 +22,9 @@ export class UpdateWorkplaceAfterStaffChangesService {
 
   public allUpdatePagesVisited(flowType: WorkplaceUpdateFlowType): boolean {
     const pages =
-      flowType === WorkplaceUpdateFlowType.ADD ? AddStaffWorkplaceUpdatePage : DeleteStaffWorkplaceUpdatePage;
+      flowType === WorkplaceUpdateFlowType.ADD ? addStaffWorkplaceUpdatePages : deleteStaffWorkplaceUpdatePages;
 
-    return Object.values(pages).every((page) => {
+    return pages.every((page) => {
       return this.visitedPages.has(page);
     });
   }
@@ -60,19 +60,24 @@ export class UpdateWorkplaceAfterStaffChangesService {
   }
 }
 
-export enum AddStaffWorkplaceUpdatePage {
+export enum WorkplaceUpdatePage {
   TOTAL_STAFF = 'update-total-staff',
   UPDATE_VACANCIES = 'update-vacancies',
   UPDATE_STARTERS = 'update-starters',
-}
-
-export enum DeleteStaffWorkplaceUpdatePage {
-  TOTAL_STAFF = 'update-total-staff',
-  UPDATE_VACANCIES = 'update-vacancies',
   UPDATE_LEAVERS = 'update-leavers',
 }
 
-type WorkplaceUpdatePage = AddStaffWorkplaceUpdatePage | DeleteStaffWorkplaceUpdatePage;
+const addStaffWorkplaceUpdatePages = [
+  WorkplaceUpdatePage.TOTAL_STAFF,
+  WorkplaceUpdatePage.UPDATE_VACANCIES,
+  WorkplaceUpdatePage.UPDATE_STARTERS,
+];
+
+const deleteStaffWorkplaceUpdatePages = [
+  WorkplaceUpdatePage.TOTAL_STAFF,
+  WorkplaceUpdatePage.UPDATE_VACANCIES,
+  WorkplaceUpdatePage.UPDATE_LEAVERS,
+];
 
 export enum WorkplaceUpdateFlowType {
   ADD = 'ADD',

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 import { jobOptionsEnum } from '@core/model/establishment.model';
-import { UpdateStartersLeaversVacanciesDirective } from '@shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive';
+import { WorkplaceUpdatePage } from '@core/services/update-workplace-after-staff-changes.service';
+import {
+  UpdateStartersLeaversVacanciesDirective,
+} from '@shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive';
 
 @Component({
   selector: 'app-update-leavers',
@@ -20,6 +23,8 @@ export class UpdateLeaversComponent extends UpdateStartersLeaversVacanciesDirect
   public numberRequiredErrorMessage = 'Enter the number of leavers or remove';
   public validNumberErrorMessage = 'Number of leavers must be between 1 and 999';
   public serverErrorMessage = 'Failed to update leavers';
+
+  protected updatePage = WorkplaceUpdatePage.UPDATE_LEAVERS;
 
   protected setupTexts(): void {
     const todayOneYearAgo = this.getDateForOneYearAgo();

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.spec.ts
@@ -5,16 +5,19 @@ import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { Establishment, jobOptionsEnum, Starter } from '@core/model/establishment.model';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
+import {
+  UpdateWorkplaceAfterStaffChangesService,
+  WorkplaceUpdatePage,
+} from '@core/services/update-workplace-after-staff-changes.service';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockUpdateWorkplaceAfterStaffChangesService } from '@core/test-utils/MockUpdateWorkplaceAfterStaffChangesService';
+import { FormatUtil } from '@core/utils/format-util';
 import { SharedModule } from '@shared/shared.module';
 import { render, screen, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { of, throwError } from 'rxjs';
 
 import { UpdateStartersComponent } from './update-starters.component';
-import { FormatUtil } from '@core/utils/format-util';
 
 describe('UpdateStartersComponent', () => {
   const today = new Date();
@@ -57,6 +60,7 @@ describe('UpdateStartersComponent', () => {
   const setup = async (override: any = {}) => {
     const workplace = override.workplace ?? mockWorkplaceWithNoStarters;
     const selectedStarters = override.startersFromSelectJobRolePages ?? null;
+    const addToVisitedPagesSpy = jasmine.createSpy('addToVisitedPages');
 
     const setupTools = await render(UpdateStartersComponent, {
       imports: [SharedModule, RouterModule, ReactiveFormsModule, HttpClientTestingModule],
@@ -64,7 +68,10 @@ describe('UpdateStartersComponent', () => {
         UntypedFormBuilder,
         {
           provide: UpdateWorkplaceAfterStaffChangesService,
-          useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({ selectedStarters }),
+          useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({
+            selectedStarters,
+            addToVisitedPages: addToVisitedPagesSpy,
+          }),
         },
         {
           provide: EstablishmentService,
@@ -102,12 +109,19 @@ describe('UpdateStartersComponent', () => {
       updateJobsSpy,
       setStateSpy,
       updateWorkplaceAfterStaffChangesService,
+      addToVisitedPagesSpy,
     };
   };
 
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should add page to visitedPages in updateWorkplaceAfterStaffChangesService', async () => {
+    const { addToVisitedPagesSpy } = await setup();
+
+    expect(addToVisitedPagesSpy).toHaveBeenCalledWith(WorkplaceUpdatePage.UPDATE_STARTERS);
   });
 
   describe('rendering', () => {

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 import { jobOptionsEnum } from '@core/model/establishment.model';
-import { UpdateStartersLeaversVacanciesDirective } from '@shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive';
+import { WorkplaceUpdatePage } from '@core/services/update-workplace-after-staff-changes.service';
+import {
+  UpdateStartersLeaversVacanciesDirective,
+} from '@shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive';
 
 @Component({
   selector: 'app-update-starters',
@@ -22,6 +25,7 @@ export class UpdateStartersComponent extends UpdateStartersLeaversVacanciesDirec
 
   protected slvField = 'starters';
   protected selectedField = 'selectedStarters';
+  protected updatePage = WorkplaceUpdatePage.UPDATE_STARTERS;
 
   protected setupTexts(): void {
     const todayOneYearAgo = this.getDateForOneYearAgo();

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component.spec.ts
@@ -1,6 +1,3 @@
-import lodash from 'lodash';
-import { of, throwError } from 'rxjs';
-
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
@@ -8,14 +5,20 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import {
+  UpdateWorkplaceAfterStaffChangesService,
+  WorkplaceUpdatePage,
+} from '@core/services/update-workplace-after-staff-changes.service';
 import { MockActivatedRoute } from '@core/test-utils/MockActivatedRoute';
 import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService';
+import { MockUpdateWorkplaceAfterStaffChangesService } from '@core/test-utils/MockUpdateWorkplaceAfterStaffChangesService';
 import { SharedModule } from '@shared/shared.module';
 import { render, screen, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+import lodash from 'lodash';
+import { of, throwError } from 'rxjs';
 
 import { UpdateTotalNumberOfStaffComponent } from './update-total-number-of-staff.component';
-import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
 
 describe('UpdateTotalNumberOfStaffComponent', () => {
   const mockEstablishment = establishmentBuilder() as Establishment;
@@ -23,9 +26,7 @@ describe('UpdateTotalNumberOfStaffComponent', () => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const setup = async (overrides: any = {}) => {
     const numberOfStaff = overrides?.numberOfStaff ?? 10;
-    const returnTo = {
-      url: ['workplace', mockEstablishment.uid, 'staff-record', 'update-workplace-details-after-staff-changes'],
-    };
+    const addToVisitedPagesSpy = jasmine.createSpy('addToVisitedPages');
 
     const setupTools = await render(UpdateTotalNumberOfStaffComponent, {
       imports: [SharedModule, RouterModule, HttpClientTestingModule, ReactiveFormsModule],
@@ -56,7 +57,9 @@ describe('UpdateTotalNumberOfStaffComponent', () => {
         },
         {
           provide: UpdateWorkplaceAfterStaffChangesService,
-          useValue: { returnTo },
+          useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({
+            addToVisitedPages: addToVisitedPagesSpy,
+          }),
         },
       ],
     });
@@ -77,12 +80,19 @@ describe('UpdateTotalNumberOfStaffComponent', () => {
       routerSpy,
       mockEstablishment,
       establishmentService,
+      addToVisitedPagesSpy,
     };
   };
 
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should add page to visitedPages in updateWorkplaceAfterStaffChangesService', async () => {
+    const { addToVisitedPagesSpy } = await setup();
+
+    expect(addToVisitedPagesSpy).toHaveBeenCalledWith(WorkplaceUpdatePage.TOTAL_STAFF);
   });
 
   describe('rendering', () => {

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component.ts
@@ -1,5 +1,3 @@
-import { Subscription } from 'rxjs';
-
 import { HttpErrorResponse } from '@angular/common/http';
 import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
@@ -10,6 +8,11 @@ import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { TotalStaffConstraints, TotalStaffFormService } from '@core/services/total-staff-form.service';
+import {
+  UpdateWorkplaceAfterStaffChangesService,
+  WorkplaceUpdatePage,
+} from '@core/services/update-workplace-after-staff-changes.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-update-total-number-of-staff',
@@ -35,6 +38,7 @@ export class UpdateTotalNumberOfStaffComponent implements OnInit, OnDestroy, Aft
     private establishmentService: EstablishmentService,
     private backLinkService: BackLinkService,
     private errorSummaryService: ErrorSummaryService,
+    private updateWorkplaceAfterStaffChangesService: UpdateWorkplaceAfterStaffChangesService,
   ) {}
 
   ngOnInit(): void {
@@ -44,6 +48,7 @@ export class UpdateTotalNumberOfStaffComponent implements OnInit, OnDestroy, Aft
     this.setupFormError();
     this.setBackLink();
     this.prefill();
+    this.updateWorkplaceAfterStaffChangesService.addToVisitedPages(WorkplaceUpdatePage.TOTAL_STAFF);
   }
 
   private setupForm(): void {

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.spec.ts
@@ -5,7 +5,10 @@ import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { Establishment, jobOptionsEnum, Vacancy } from '@core/model/establishment.model';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
+import {
+  UpdateWorkplaceAfterStaffChangesService,
+  WorkplaceUpdatePage,
+} from '@core/services/update-workplace-after-staff-changes.service';
 import { establishmentBuilder, MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockUpdateWorkplaceAfterStaffChangesService } from '@core/test-utils/MockUpdateWorkplaceAfterStaffChangesService';
 import { SharedModule } from '@shared/shared.module';
@@ -46,6 +49,7 @@ describe('UpdateVacanciesComponent', () => {
   const setup = async (override: any = {}) => {
     const workplace = override.workplace ?? mockWorkplaceWithNoVacancies;
     const selectedVacancies = override.vacanciesFromSelectJobRolePages ?? null;
+    const addToVisitedPagesSpy = jasmine.createSpy('addToVisitedPages');
 
     const setupTools = await render(UpdateVacanciesComponent, {
       imports: [SharedModule, RouterModule, ReactiveFormsModule, HttpClientTestingModule],
@@ -53,7 +57,10 @@ describe('UpdateVacanciesComponent', () => {
         UntypedFormBuilder,
         {
           provide: UpdateWorkplaceAfterStaffChangesService,
-          useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({ selectedVacancies }),
+          useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({
+            selectedVacancies,
+            addToVisitedPages: addToVisitedPagesSpy,
+          }),
         },
         {
           provide: EstablishmentService,
@@ -90,6 +97,7 @@ describe('UpdateVacanciesComponent', () => {
       updateJobsSpy,
       setStateSpy,
       updateWorkplaceAfterStaffChangesService,
+      addToVisitedPagesSpy,
       ...setupTools,
     };
   };
@@ -97,6 +105,12 @@ describe('UpdateVacanciesComponent', () => {
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should add page to visitedPages in updateWorkplaceAfterStaffChangesService', async () => {
+    const { addToVisitedPagesSpy } = await setup();
+
+    expect(addToVisitedPagesSpy).toHaveBeenCalledWith(WorkplaceUpdatePage.UPDATE_VACANCIES);
   });
 
   describe('rendering', () => {

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { jobOptionsEnum } from '@core/model/establishment.model';
+import { WorkplaceUpdatePage } from '@core/services/update-workplace-after-staff-changes.service';
 import {
   UpdateStartersLeaversVacanciesDirective,
 } from '@shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive';
@@ -41,6 +42,7 @@ export class UpdateVacanciesComponent extends UpdateStartersLeaversVacanciesDire
 
   protected slvField = 'vacancies';
   protected selectedField = 'selectedVacancies';
+  protected updatePage = WorkplaceUpdatePage.UPDATE_VACANCIES;
 
   protected setupTexts(): void {
     if (!this.questionPreviouslyAnswered) {

--- a/frontend/src/app/shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive.ts
@@ -15,9 +15,14 @@ import { jobOptionsEnum, StarterLeaverVacancy, UpdateJobsRequest } from '@core/m
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
+import {
+  UpdateWorkplaceAfterStaffChangesService,
+  WorkplaceUpdatePage,
+} from '@core/services/update-workplace-after-staff-changes.service';
 import { FormatUtil } from '@core/utils/format-util';
-import { NumberInputWithButtonsComponent } from '@shared/components/number-input-with-buttons/number-input-with-buttons.component';
+import {
+  NumberInputWithButtonsComponent,
+} from '@shared/components/number-input-with-buttons/number-input-with-buttons.component';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
 import lodash from 'lodash';
 
@@ -55,6 +60,7 @@ export class UpdateStartersLeaversVacanciesDirective implements OnInit, AfterVie
 
   protected slvField: string;
   protected selectedField: string;
+  protected updatePage: WorkplaceUpdatePage;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -73,6 +79,7 @@ export class UpdateStartersLeaversVacanciesDirective implements OnInit, AfterVie
     this.setupFormErrorsMap();
     this.setupTexts();
     this.setBackLink();
+    this.updateWorkplaceAfterStaffChangesService.addToVisitedPages(this.updatePage);
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
#### Work done
- Added logic to add to visited pages on load of all update pages, which allows the display of a success banner on the summary page after user has visited all pages in the summary.

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
