### PR TITLE
Fix/update workplace summary banner changes

### DIFF
--- a/frontend/src/app/core/services/update-workplace-after-staff-changes.service.spec.ts
+++ b/frontend/src/app/core/services/update-workplace-after-staff-changes.service.spec.ts
@@ -69,4 +69,52 @@ describe('UpdateWorkplaceAfterStaffChangesService', () => {
       expect(service.allUpdatePagesVisited(WorkplaceUpdateFlowType.DELETE)).toBeTrue();
     });
   });
+
+  describe('allUpdatePagesSubmitted', () => {
+    [
+      [],
+      [WorkplaceUpdatePage.TOTAL_STAFF],
+      [WorkplaceUpdatePage.TOTAL_STAFF, WorkplaceUpdatePage.UPDATE_VACANCIES],
+    ].forEach((submittedPages) => {
+      it(`should return false when not all add pages in submittedPages when ADD passed in (${submittedPages})`, async () => {
+        submittedPages.forEach((page) => {
+          service.addToSubmittedPages(page);
+        });
+
+        expect(service.allUpdatePagesSubmitted(WorkplaceUpdateFlowType.ADD)).toBeFalse();
+      });
+
+      it(`should return false when not all delete pages in submittedPages when DELETE passed in (${submittedPages})`, async () => {
+        submittedPages.forEach((page) => {
+          service.addToSubmittedPages(page);
+        });
+
+        expect(service.allUpdatePagesSubmitted(WorkplaceUpdateFlowType.DELETE)).toBeFalse();
+      });
+    });
+
+    it('should return true when all pages in submittedPages for add flow', async () => {
+      [
+        WorkplaceUpdatePage.TOTAL_STAFF,
+        WorkplaceUpdatePage.UPDATE_VACANCIES,
+        WorkplaceUpdatePage.UPDATE_STARTERS,
+      ].forEach((page) => {
+        service.addToSubmittedPages(page);
+      });
+
+      expect(service.allUpdatePagesSubmitted(WorkplaceUpdateFlowType.ADD)).toBeTrue();
+    });
+
+    it('should return true when all pages in submittedPages for delete flow', async () => {
+      [
+        WorkplaceUpdatePage.TOTAL_STAFF,
+        WorkplaceUpdatePage.UPDATE_VACANCIES,
+        WorkplaceUpdatePage.UPDATE_LEAVERS,
+      ].forEach((page) => {
+        service.addToSubmittedPages(page);
+      });
+
+      expect(service.allUpdatePagesSubmitted(WorkplaceUpdateFlowType.DELETE)).toBeTrue();
+    });
+  });
 });

--- a/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
+++ b/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
@@ -12,6 +12,7 @@ export class UpdateWorkplaceAfterStaffChangesService {
   private _selectedVacancies: Vacancy[] = null;
   private _selectedStarters: Starter[] = null;
   private _selectedLeavers: Leaver[] = null;
+  private _hasViewedSavedBanner: boolean = false;
 
   public addToVisitedPages(page: WorkplaceUpdatePage): void {
     this.visitedPages.add(page);
@@ -72,6 +73,14 @@ export class UpdateWorkplaceAfterStaffChangesService {
 
   set selectedLeavers(updatedLeavers: Leaver[]) {
     this._selectedLeavers = updatedLeavers;
+  }
+
+  get hasViewedSavedBanner(): boolean {
+    return this._hasViewedSavedBanner;
+  }
+
+  set hasViewedSavedBanner(hasViewed: boolean) {
+    this._hasViewedSavedBanner = hasViewed;
   }
 }
 

--- a/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
+++ b/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
@@ -8,16 +8,13 @@ export class UpdateWorkplaceAfterStaffChangesService {
   constructor() {}
 
   private visitedPages: Set<WorkplaceUpdatePage> = new Set();
+  private submittedPages: Set<WorkplaceUpdatePage> = new Set();
   private _selectedVacancies: Vacancy[] = null;
   private _selectedStarters: Starter[] = null;
   private _selectedLeavers: Leaver[] = null;
 
   public addToVisitedPages(page: WorkplaceUpdatePage): void {
     this.visitedPages.add(page);
-  }
-
-  public resetVisitedPages(): void {
-    this.visitedPages.clear();
   }
 
   public allUpdatePagesVisited(flowType: WorkplaceUpdateFlowType): boolean {
@@ -27,6 +24,24 @@ export class UpdateWorkplaceAfterStaffChangesService {
     return pages.every((page) => {
       return this.visitedPages.has(page);
     });
+  }
+
+  public addToSubmittedPages(page: WorkplaceUpdatePage): void {
+    this.submittedPages.add(page);
+  }
+
+  public allUpdatePagesSubmitted(flowType: WorkplaceUpdateFlowType): boolean {
+    const pages =
+      flowType === WorkplaceUpdateFlowType.ADD ? addStaffWorkplaceUpdatePages : deleteStaffWorkplaceUpdatePages;
+
+    return pages.every((page) => {
+      return this.submittedPages.has(page);
+    });
+  }
+
+  public resetVisitedAndSubmittedPages(): void {
+    this.visitedPages.clear();
+    this.submittedPages.clear();
   }
 
   public clearAllSelectedJobRoles() {

--- a/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
+++ b/frontend/src/app/core/services/update-workplace-after-staff-changes.service.ts
@@ -43,6 +43,7 @@ export class UpdateWorkplaceAfterStaffChangesService {
   public resetVisitedAndSubmittedPages(): void {
     this.visitedPages.clear();
     this.submittedPages.clear();
+    this._hasViewedSavedBanner = false;
   }
 
   public clearAllSelectedJobRoles() {

--- a/frontend/src/app/features/workers/add-another-staff-record/add-another-staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/add-another-staff-record/add-another-staff-record.component.spec.ts
@@ -2,9 +2,10 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockUpdateWorkplaceAfterStaffChangesService } from '@core/test-utils/MockUpdateWorkplaceAfterStaffChangesService';
 import { render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
@@ -12,13 +13,21 @@ import { AddAnotherStaffRecordComponent } from './add-another-staff-record.compo
 
 describe('AddAnotherStaffRecordComponent', () => {
   async function setup() {
+    const resetVisitedAndSubmittedPagesSpy = jasmine.createSpy('resetVisitedAndSubmittedPages');
+
     const setupTools = await render(AddAnotherStaffRecordComponent, {
-      imports: [RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+      imports: [HttpClientTestingModule, ReactiveFormsModule],
       providers: [
         UntypedFormBuilder,
         {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
+        },
+        {
+          provide: UpdateWorkplaceAfterStaffChangesService,
+          useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({
+            resetVisitedAndSubmittedPages: resetVisitedAndSubmittedPagesSpy,
+          }),
         },
       ],
     });
@@ -33,6 +42,7 @@ describe('AddAnotherStaffRecordComponent', () => {
       ...setupTools,
       component,
       navigateSpy,
+      resetVisitedAndSubmittedPagesSpy,
     };
   }
 
@@ -114,6 +124,14 @@ describe('AddAnotherStaffRecordComponent', () => {
         'staff-record',
         'update-workplace-details-after-adding-staff',
       ]);
+    });
+
+    it('should call resetVisitedAndSubmittedPages when navigating to update-workplace-details-after-adding-staff', async () => {
+      const { getByText, resetVisitedAndSubmittedPagesSpy } = await setup();
+
+      userEvent.click(getByText('Continue'));
+
+      expect(resetVisitedAndSubmittedPagesSpy).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/app/features/workers/add-another-staff-record/add-another-staff-record.component.ts
+++ b/frontend/src/app/features/workers/add-another-staff-record/add-another-staff-record.component.ts
@@ -3,6 +3,7 @@ import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BackLinkService } from '@core/services/backLink.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
 
 @Component({
   selector: 'app-add-another-staff-record',
@@ -13,10 +14,11 @@ export class AddAnotherStaffRecordComponent implements OnInit {
   private workplaceUid: string;
 
   constructor(
-    protected backLinkService: BackLinkService,
-    protected formBuilder: UntypedFormBuilder,
-    protected router: Router,
-    protected establishmentService: EstablishmentService,
+    private backLinkService: BackLinkService,
+    private formBuilder: UntypedFormBuilder,
+    private router: Router,
+    private establishmentService: EstablishmentService,
+    private updateWorkplaceAfterStaffChangesService: UpdateWorkplaceAfterStaffChangesService,
   ) {
     this.form = this.formBuilder.group({
       addAnotherStaffRecord: null,
@@ -31,6 +33,7 @@ export class AddAnotherStaffRecordComponent implements OnInit {
     if (this.form.controls['addAnotherStaffRecord'].value === 'YES') {
       this.router.navigate(['/workplace', this.workplaceUid, 'staff-record', 'create-staff-record', 'staff-details']);
     } else {
+      this.updateWorkplaceAfterStaffChangesService.resetVisitedAndSubmittedPages();
       this.router.navigate([
         '/workplace',
         this.workplaceUid,

--- a/frontend/src/app/features/workers/delete-another-staff-record/delete-another-staff-record.component.ts
+++ b/frontend/src/app/features/workers/delete-another-staff-record/delete-another-staff-record.component.ts
@@ -3,20 +3,22 @@ import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BackLinkService } from '@core/services/backLink.service';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
 
 @Component({
   selector: 'app-delete-add-another-staff-record',
   templateUrl: './delete-another-staff-record.component.html',
 })
-export class DeleteAnotherStaffRecordComponent implements OnInit{
+export class DeleteAnotherStaffRecordComponent implements OnInit {
   public form: UntypedFormGroup;
   private workplaceUid: string;
 
   constructor(
-    protected backLinkService: BackLinkService,
-    protected formBuilder: UntypedFormBuilder,
-    protected router: Router,
-    protected establishmentService: EstablishmentService,
+    private backLinkService: BackLinkService,
+    private formBuilder: UntypedFormBuilder,
+    private router: Router,
+    private establishmentService: EstablishmentService,
+    private updateWorkplaceAfterStaffChangesService: UpdateWorkplaceAfterStaffChangesService,
   ) {
     this.form = this.formBuilder.group({
       deleteAnotherStaffRecord: null,
@@ -29,11 +31,15 @@ export class DeleteAnotherStaffRecordComponent implements OnInit{
 
   public onSubmit(): void {
     if (this.form.controls['deleteAnotherStaffRecord'].value === 'YES') {
-      this.router.navigate(['/dashboard'], {fragment: 'staff-records'});
+      this.router.navigate(['/dashboard'], { fragment: 'staff-records' });
     } else {
-      this.router.navigate(['/workplace', this.workplaceUid, 'staff-record', 'update-workplace-details-after-deleting-staff']);
+      this.updateWorkplaceAfterStaffChangesService.resetVisitedAndSubmittedPages();
+      this.router.navigate([
+        '/workplace',
+        this.workplaceUid,
+        'staff-record',
+        'update-workplace-details-after-deleting-staff',
+      ]);
     }
   }
-
-
 }

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.spec.ts
@@ -72,6 +72,7 @@ describe('UpdateLeaversComponent', () => {
     const selectedLeavers = override.leaversFromSelectJobRolePages ?? null;
     const workplace = override.workplace ?? mockWorkplace;
     const addToVisitedPagesSpy = jasmine.createSpy('addToVisitedPages');
+    const addToSubmittedPagesSpy = jasmine.createSpy('addToSubmittedPages');
 
     const setupTools = await render(UpdateLeaversComponent, {
       imports: [SharedModule, RouterModule, ReactiveFormsModule, HttpClientTestingModule],
@@ -88,6 +89,7 @@ describe('UpdateLeaversComponent', () => {
           useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({
             selectedLeavers,
             addToVisitedPages: addToVisitedPagesSpy,
+            addToSubmittedPages: addToSubmittedPagesSpy,
           }),
         },
         {
@@ -120,6 +122,7 @@ describe('UpdateLeaversComponent', () => {
       updateWorkplaceAfterStaffChangesService,
       updateJobsSpy,
       addToVisitedPagesSpy,
+      addToSubmittedPagesSpy,
     };
   };
 
@@ -384,6 +387,16 @@ describe('UpdateLeaversComponent', () => {
           leavers: jobOptionsEnum[label],
         });
       });
+    });
+
+    it('should add leavers page to submittedPages in UpdateWorkplaceAfterStaffChangesService', async () => {
+      const { getByRole, addToSubmittedPagesSpy } = await setup({
+        workplace: mockWorkplace,
+        leaversFromSelectJobRolePages: selectedJobRoles,
+      });
+
+      userEvent.click(getByRole('button', { name: 'Save and return' }));
+      expect(addToSubmittedPagesSpy).toHaveBeenCalledWith(WorkplaceUpdatePage.UPDATE_LEAVERS);
     });
   });
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.spec.ts
@@ -61,6 +61,7 @@ describe('UpdateStartersComponent', () => {
     const workplace = override.workplace ?? mockWorkplaceWithNoStarters;
     const selectedStarters = override.startersFromSelectJobRolePages ?? null;
     const addToVisitedPagesSpy = jasmine.createSpy('addToVisitedPages');
+    const addToSubmittedPagesSpy = jasmine.createSpy('addToSubmittedPages');
 
     const setupTools = await render(UpdateStartersComponent, {
       imports: [SharedModule, RouterModule, ReactiveFormsModule, HttpClientTestingModule],
@@ -71,6 +72,7 @@ describe('UpdateStartersComponent', () => {
           useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({
             selectedStarters,
             addToVisitedPages: addToVisitedPagesSpy,
+            addToSubmittedPages: addToSubmittedPagesSpy,
           }),
         },
         {
@@ -110,6 +112,7 @@ describe('UpdateStartersComponent', () => {
       setStateSpy,
       updateWorkplaceAfterStaffChangesService,
       addToVisitedPagesSpy,
+      addToSubmittedPagesSpy,
     };
   };
 
@@ -504,6 +507,13 @@ describe('UpdateStartersComponent', () => {
 
       userEvent.click(getByRole('button', { name: 'Save and return' }));
       expect(updateWorkplaceAfterStaffChangesService.selectedStarters).toEqual(null);
+    });
+
+    it('should add starters page to submittedPages in UpdateWorkplaceAfterStaffChangesService', async () => {
+      const { getByRole, addToSubmittedPagesSpy } = await setup();
+
+      userEvent.click(getByRole('button', { name: 'Save and return' }));
+      expect(addToSubmittedPagesSpy).toHaveBeenCalledWith(WorkplaceUpdatePage.UPDATE_STARTERS);
     });
 
     describe('validation', () => {

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component.spec.ts
@@ -27,6 +27,7 @@ describe('UpdateTotalNumberOfStaffComponent', () => {
   const setup = async (overrides: any = {}) => {
     const numberOfStaff = overrides?.numberOfStaff ?? 10;
     const addToVisitedPagesSpy = jasmine.createSpy('addToVisitedPages');
+    const addToSubmittedPagesSpy = jasmine.createSpy('addToSubmittedPages');
 
     const setupTools = await render(UpdateTotalNumberOfStaffComponent, {
       imports: [SharedModule, RouterModule, HttpClientTestingModule, ReactiveFormsModule],
@@ -59,6 +60,7 @@ describe('UpdateTotalNumberOfStaffComponent', () => {
           provide: UpdateWorkplaceAfterStaffChangesService,
           useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({
             addToVisitedPages: addToVisitedPagesSpy,
+            addToSubmittedPages: addToSubmittedPagesSpy,
           }),
         },
       ],
@@ -81,6 +83,7 @@ describe('UpdateTotalNumberOfStaffComponent', () => {
       mockEstablishment,
       establishmentService,
       addToVisitedPagesSpy,
+      addToSubmittedPagesSpy,
     };
   };
 
@@ -168,6 +171,14 @@ describe('UpdateTotalNumberOfStaffComponent', () => {
       fixture.detectChanges();
 
       expect(postStaffSpy).toHaveBeenCalledWith(mockEstablishment.uid, 10);
+    });
+
+    it('should add total staff page to submittedPages in UpdateWorkplaceAfterStaffChangesService when successful', async () => {
+      const { addToSubmittedPagesSpy } = await setup();
+
+      await fillInNumberAndSubmitForm('10');
+
+      expect(addToSubmittedPagesSpy).toHaveBeenCalledWith(WorkplaceUpdatePage.TOTAL_STAFF);
     });
 
     it('should update numberOfStaff in establishment service if backend call is successful', async () => {

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component.ts
@@ -97,6 +97,8 @@ export class UpdateTotalNumberOfStaffComponent implements OnInit, OnDestroy, Aft
 
   onSuccess(data: { numberOfStaff: number }): void {
     this.updateWorkplaceState(data.numberOfStaff);
+    this.updateWorkplaceAfterStaffChangesService.addToSubmittedPages(WorkplaceUpdatePage.TOTAL_STAFF);
+
     this.returnToPreviousPage();
   }
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.spec.ts
@@ -50,6 +50,7 @@ describe('UpdateVacanciesComponent', () => {
     const workplace = override.workplace ?? mockWorkplaceWithNoVacancies;
     const selectedVacancies = override.vacanciesFromSelectJobRolePages ?? null;
     const addToVisitedPagesSpy = jasmine.createSpy('addToVisitedPages');
+    const addToSubmittedPagesSpy = jasmine.createSpy('addToSubmittedPages');
 
     const setupTools = await render(UpdateVacanciesComponent, {
       imports: [SharedModule, RouterModule, ReactiveFormsModule, HttpClientTestingModule],
@@ -60,6 +61,7 @@ describe('UpdateVacanciesComponent', () => {
           useFactory: MockUpdateWorkplaceAfterStaffChangesService.factory({
             selectedVacancies,
             addToVisitedPages: addToVisitedPagesSpy,
+            addToSubmittedPages: addToSubmittedPagesSpy,
           }),
         },
         {
@@ -98,6 +100,7 @@ describe('UpdateVacanciesComponent', () => {
       setStateSpy,
       updateWorkplaceAfterStaffChangesService,
       addToVisitedPagesSpy,
+      addToSubmittedPagesSpy,
       ...setupTools,
     };
   };
@@ -491,6 +494,13 @@ describe('UpdateVacanciesComponent', () => {
 
       userEvent.click(getByRole('button', { name: 'Save and return' }));
       expect(updateWorkplaceAfterStaffChangesService.selectedVacancies).toEqual(null);
+    });
+
+    it('should add vacancies page to submittedPages in UpdateWorkplaceAfterStaffChangesService', async () => {
+      const { getByRole, addToSubmittedPagesSpy } = await setup();
+
+      userEvent.click(getByRole('button', { name: 'Save and return' }));
+      expect(addToSubmittedPagesSpy).toHaveBeenCalledWith(WorkplaceUpdatePage.UPDATE_VACANCIES);
     });
 
     describe('validation', () => {

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -82,63 +82,91 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
     expect(clearJobRolesSpy).toHaveBeenCalled();
   });
 
-  describe('Views when user has visited pages', () => {
-    it('should display warning text when user has not visited all of the update question pages in add view', async () => {
-      const { getByText } = await setup({
-        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisited: () => false },
+  describe('Views when user has visited/submitted on update pages', () => {
+    describe('Warning text', () => {
+      it('should display when user has not visited all of the update question pages in add view', async () => {
+        const { getByText } = await setup({
+          updateWorkplaceAfterStaffChangesService: {
+            allUpdatePagesVisited: () => false,
+            allUpdatePagesSubmitted: () => false,
+          },
+        });
+
+        expect(
+          getByText('This data does not update automatically when you add staff records.', { exact: false }),
+        ).toBeTruthy();
+        expect(getByText('You need to check and change these yourself.', { exact: false })).toBeTruthy();
       });
 
-      expect(
-        getByText('This data does not update automatically when you add staff records.', { exact: false }),
-      ).toBeTruthy();
-      expect(getByText('You need to check and change these yourself.', { exact: false })).toBeTruthy();
-    });
+      it('should display when user has not visited all of the update question pages in delete view', async () => {
+        const { getByText } = await setup({
+          flowType: WorkplaceUpdateFlowType.DELETE,
+          updateWorkplaceAfterStaffChangesService: {
+            allUpdatePagesVisited: () => false,
+            allUpdatePagesSubmitted: () => false,
+          },
+        });
 
-    it('should display warning text when user has not visited all of the update question pages in delete view', async () => {
-      const { getByText } = await setup({
-        flowType: WorkplaceUpdateFlowType.DELETE,
-        updateWorkplaceAfterStaffChangesService: {
-          allUpdatePagesVisited: () => false,
-        },
+        expect(
+          getByText('This data does not update automatically when you delete staff records.', { exact: false }),
+        ).toBeTruthy();
+        expect(getByText('You need to check and change these yourself.', { exact: false })).toBeTruthy();
       });
 
-      expect(
-        getByText('This data does not update automatically when you delete staff records.', { exact: false }),
-      ).toBeTruthy();
-      expect(getByText('You need to check and change these yourself.', { exact: false })).toBeTruthy();
-    });
+      it('should not display when user has visited all of the update question pages', async () => {
+        const { queryByText } = await setup({
+          updateWorkplaceAfterStaffChangesService: {
+            allUpdatePagesVisited: () => true,
+            allUpdatePagesSubmitted: () => false,
+          },
+        });
 
-    it('should not display warning text when user has visited all of the update question pages', async () => {
-      const { queryByText } = await setup({
-        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisited: () => true },
-      });
-
-      expect(
-        queryByText('This data does not update automatically when you add staff records.', { exact: false }),
-      ).toBeFalsy();
-      expect(queryByText('You need to check and change these yourself.', { exact: false })).toBeFalsy();
-    });
-
-    it('should add alert with starters in message when user has visited all update question pages from add version', async () => {
-      const { alertSpy } = await setup({
-        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisited: () => true },
-      });
-
-      expect(alertSpy).toHaveBeenCalledWith({
-        type: 'success',
-        message: 'Total number of staff, vacancies and starters information saved',
+        expect(
+          queryByText('This data does not update automatically when you add staff records.', { exact: false }),
+        ).toBeFalsy();
+        expect(queryByText('You need to check and change these yourself.', { exact: false })).toBeFalsy();
       });
     });
 
-    it('should add alert with leavers in message when user has visited all update question pages from delete version', async () => {
-      const { alertSpy } = await setup({
-        flowType: WorkplaceUpdateFlowType.DELETE,
-        updateWorkplaceAfterStaffChangesService: { allUpdatePagesVisited: () => true },
+    describe('Saved banner', () => {
+      it('should add alert with starters in message when user has submitted on all update question pages from add version', async () => {
+        const { alertSpy } = await setup({
+          updateWorkplaceAfterStaffChangesService: {
+            allUpdatePagesVisited: () => true,
+            allUpdatePagesSubmitted: () => true,
+          },
+        });
+
+        expect(alertSpy).toHaveBeenCalledWith({
+          type: 'success',
+          message: 'Total number of staff, vacancies and starters information saved',
+        });
       });
 
-      expect(alertSpy).toHaveBeenCalledWith({
-        type: 'success',
-        message: 'Total number of staff, vacancies and leavers information saved',
+      it('should add alert with leavers in message when user has submitted on all update question pages from delete version', async () => {
+        const { alertSpy } = await setup({
+          flowType: WorkplaceUpdateFlowType.DELETE,
+          updateWorkplaceAfterStaffChangesService: {
+            allUpdatePagesVisited: () => true,
+            allUpdatePagesSubmitted: () => true,
+          },
+        });
+
+        expect(alertSpy).toHaveBeenCalledWith({
+          type: 'success',
+          message: 'Total number of staff, vacancies and leavers information saved',
+        });
+      });
+
+      it('should not add alert when user has visited but not submitted on all update question pages', async () => {
+        const { alertSpy } = await setup({
+          updateWorkplaceAfterStaffChangesService: {
+            allUpdatePagesVisited: () => true,
+            allUpdatePagesSubmitted: () => false,
+          },
+        });
+
+        expect(alertSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -168,6 +168,18 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
 
         expect(alertSpy).not.toHaveBeenCalled();
       });
+
+      it('should not add alert when user has submitted on all update question pages but has already seen banner', async () => {
+        const { alertSpy } = await setup({
+          updateWorkplaceAfterStaffChangesService: {
+            allUpdatePagesVisited: () => true,
+            allUpdatePagesSubmitted: () => true,
+            hasViewedSavedBanner: true,
+          },
+        });
+
+        expect(alertSpy).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { AlertService } from '@core/services/alert.service';
@@ -13,7 +13,7 @@ import {
   selector: 'app-update-workplace-details-after-staff-changes',
   templateUrl: './update-workplace-details-after-staff-changes.component.html',
 })
-export class UpdateWorkplaceDetailsAfterStaffChangesComponent {
+export class UpdateWorkplaceDetailsAfterStaffChangesComponent implements OnInit {
   constructor(
     private establishmentService: EstablishmentService,
     private router: Router,
@@ -25,6 +25,7 @@ export class UpdateWorkplaceDetailsAfterStaffChangesComponent {
 
   public workplace: Establishment;
   public allPagesVisited: boolean;
+  public allPagesSubmitted: boolean;
   public WorkplaceUpdateFlowType = WorkplaceUpdateFlowType;
   public flowType: WorkplaceUpdateFlowType;
 
@@ -32,10 +33,12 @@ export class UpdateWorkplaceDetailsAfterStaffChangesComponent {
     this.flowType = this.route.snapshot?.data?.flowType;
     this.workplace = this.establishmentService.establishment;
     this.allPagesVisited = this.updateWorkplaceAfterStaffChangesService.allUpdatePagesVisited(this.flowType);
+    this.allPagesSubmitted = this.updateWorkplaceAfterStaffChangesService.allUpdatePagesSubmitted(this.flowType);
+
     this.updateWorkplaceAfterStaffChangesService.clearAllSelectedJobRoles();
     this.backLinkService.showBackLink();
 
-    if (this.allPagesVisited) {
+    if (this.allPagesSubmitted) {
       this.alertService.addAlert({
         type: 'success',
         message: `Total number of staff, vacancies and ${
@@ -45,7 +48,7 @@ export class UpdateWorkplaceDetailsAfterStaffChangesComponent {
     }
   }
 
-  public isArray(variable: any): boolean {
+  public isArray(variable: unknown): boolean {
     return Array.isArray(variable);
   }
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
@@ -38,13 +38,15 @@ export class UpdateWorkplaceDetailsAfterStaffChangesComponent implements OnInit 
     this.updateWorkplaceAfterStaffChangesService.clearAllSelectedJobRoles();
     this.backLinkService.showBackLink();
 
-    if (this.allPagesSubmitted) {
+    if (this.allPagesSubmitted && !this.updateWorkplaceAfterStaffChangesService.hasViewedSavedBanner) {
       this.alertService.addAlert({
         type: 'success',
         message: `Total number of staff, vacancies and ${
           this.flowType === WorkplaceUpdateFlowType.ADD ? 'starters' : 'leavers'
         } information saved`,
       });
+
+      this.updateWorkplaceAfterStaffChangesService.hasViewedSavedBanner = true;
     }
   }
 

--- a/frontend/src/app/shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive.ts
@@ -20,9 +20,7 @@ import {
   WorkplaceUpdatePage,
 } from '@core/services/update-workplace-after-staff-changes.service';
 import { FormatUtil } from '@core/utils/format-util';
-import {
-  NumberInputWithButtonsComponent,
-} from '@shared/components/number-input-with-buttons/number-input-with-buttons.component';
+import { NumberInputWithButtonsComponent } from '@shared/components/number-input-with-buttons/number-input-with-buttons.component';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
 import lodash from 'lodash';
 
@@ -310,6 +308,8 @@ export class UpdateStartersLeaversVacanciesDirective implements OnInit, AfterVie
 
   private onSuccess(): void {
     this.updateWorkplaceAfterStaffChangesService.clearAllSelectedJobRoles();
+    this.updateWorkplaceAfterStaffChangesService.addToSubmittedPages(this.updatePage);
+
     this.returnToPreviousPage();
   }
 


### PR DESCRIPTION
#### Work done
- Updated logic for displaying the update pages saved banner so it only displays on submission and still clear warning text after user has visited pages
- Added clearing of above state on entry to update summary pages to ensure no side effects from previous visits

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
