### PR TITLE
Fix/update slv validations and alert

### DIFF
--- a/frontend/src/app/core/services/alert.service.spec.ts
+++ b/frontend/src/app/core/services/alert.service.spec.ts
@@ -5,7 +5,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { WindowRef } from './window.ref';
 
-fdescribe('BackLinkService', () => {
+describe('BackLinkService', () => {
   let service: AlertService;
   let router: Router;
 

--- a/frontend/src/app/core/services/alert.service.spec.ts
+++ b/frontend/src/app/core/services/alert.service.spec.ts
@@ -5,7 +5,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { WindowRef } from './window.ref';
 
-describe('BackLinkService', () => {
+describe('AlertService', () => {
   let service: AlertService;
   let router: Router;
 

--- a/frontend/src/app/core/services/alert.service.spec.ts
+++ b/frontend/src/app/core/services/alert.service.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AlertService } from './alert.service';
+import { NavigationEnd, Router } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { WindowRef } from './window.ref';
+
+fdescribe('BackLinkService', () => {
+  let service: AlertService;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [AlertService, WindowRef, Router],
+    });
+    service = TestBed.inject(AlertService);
+    router = TestBed.inject(Router);
+  });
+
+  it('should create the service', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should remove existing alert on page change', async () => {
+    const removeAlertSpy = spyOn(service, 'removeAlert');
+
+    const routerEvent$ = router.events as BehaviorSubject<any>;
+    routerEvent$.next(new NavigationEnd(1, '/test/mock/page/url', '/test/mock/page/url'));
+
+    expect(removeAlertSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/core/services/alert.service.ts
+++ b/frontend/src/app/core/services/alert.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { NavigationStart, Router } from '@angular/router';
+import { NavigationEnd, Router } from '@angular/router';
 import { Alert } from '@core/model/alert.model';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -13,7 +13,7 @@ export class AlertService {
   private _alert$: BehaviorSubject<Alert> = new BehaviorSubject(null);
 
   constructor(private router: Router, private windowRef: WindowRef) {
-    this.router.events.pipe(filter((event) => event instanceof NavigationStart)).subscribe(() => {
+    this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
       this.removeAlert();
     });
   }

--- a/frontend/src/app/features/workers/delete-another-staff-record/delete-another-staff-record.component.ts
+++ b/frontend/src/app/features/workers/delete-another-staff-record/delete-another-staff-record.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
-import { BackLinkService } from '@core/services/backLink.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { UpdateWorkplaceAfterStaffChangesService } from '@core/services/update-workplace-after-staff-changes.service';
 
@@ -14,7 +13,6 @@ export class DeleteAnotherStaffRecordComponent implements OnInit {
   private workplaceUid: string;
 
   constructor(
-    private backLinkService: BackLinkService,
     private formBuilder: UntypedFormBuilder,
     private router: Router,
     private establishmentService: EstablishmentService,
@@ -25,7 +23,6 @@ export class DeleteAnotherStaffRecordComponent implements OnInit {
     });
   }
   ngOnInit(): void {
-    this.backLinkService.showBackLink();
     this.workplaceUid = this.establishmentService.establishment.uid;
   }
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.spec.ts
@@ -19,7 +19,7 @@ import { of, throwError } from 'rxjs';
 
 import { UpdateLeaversComponent } from './update-leavers.component';
 
-describe('UpdateLeaversComponent', () => {
+fdescribe('UpdateLeaversComponent', () => {
   const today = new Date();
   today.setFullYear(today.getFullYear() - 1);
 
@@ -62,7 +62,7 @@ describe('UpdateLeaversComponent', () => {
   const totalJobRoles = (jobRoles: any) => {
     let total = 0;
 
-    for (let i in jobRoles) {
+    for (const i in jobRoles) {
       total += jobRoles[i].total;
     }
     return total;
@@ -409,7 +409,7 @@ describe('UpdateLeaversComponent', () => {
       fixture.detectChanges();
 
       const errorMessage1 = getAllByText('Add a job role');
-      const errorMessage2 = getAllByText('Select there are no leavers or do not know');
+      const errorMessage2 = getAllByText('Select no staff left or do not know');
 
       expect(errorMessage1.length).toEqual(2);
       expect(errorMessage2.length).toEqual(2);
@@ -432,7 +432,7 @@ describe('UpdateLeaversComponent', () => {
       const errorMessage1Text = 'Enter the number of leavers or remove';
 
       const errorMessage1 = getAllByText(`${errorMessage1Text} ${jobRole.toLowerCase()}`);
-      const errorMessage2 = getAllByText('Select there are no leavers or do not know');
+      const errorMessage2 = getAllByText('Select no staff left or do not know');
 
       expect(errorMessage1.length).toEqual(2);
       expect(errorMessage2.length).toEqual(2);
@@ -455,7 +455,7 @@ describe('UpdateLeaversComponent', () => {
       const errorMessage1Text = 'Number of leavers must be between 1 and 999';
       const errorMessage1 = getByText(errorMessage1Text);
       const errorMessage1WithJobRole = getByText(`${errorMessage1Text} (${jobRole.toLowerCase()})`);
-      const errorMessage2 = getAllByText('Select there are no leavers or do not know');
+      const errorMessage2 = getAllByText('Select no staff left or do not know');
 
       expect(errorMessage1).toBeTruthy();
       expect(errorMessage1WithJobRole).toBeTruthy();

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.spec.ts
@@ -19,7 +19,7 @@ import { of, throwError } from 'rxjs';
 
 import { UpdateLeaversComponent } from './update-leavers.component';
 
-fdescribe('UpdateLeaversComponent', () => {
+describe('UpdateLeaversComponent', () => {
   const today = new Date();
   today.setFullYear(today.getFullYear() - 1);
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-leavers/update-leavers.component.ts
@@ -1,9 +1,7 @@
 import { Component } from '@angular/core';
 import { jobOptionsEnum } from '@core/model/establishment.model';
 import { WorkplaceUpdatePage } from '@core/services/update-workplace-after-staff-changes.service';
-import {
-  UpdateStartersLeaversVacanciesDirective,
-} from '@shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive';
+import { UpdateStartersLeaversVacanciesDirective } from '@shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive';
 
 @Component({
   selector: 'app-update-leavers',
@@ -19,7 +17,7 @@ export class UpdateLeaversComponent extends UpdateStartersLeaversVacanciesDirect
     'To show DHSC and the government the size of staff retention issues and help them make national and local policy and funding decisions.';
   public tableTitle = 'Leavers in the last 12 months';
   public totalNumberDescription = 'Total number of leavers';
-  public noOrDoNotKnowErrorMessage = 'Select there are no leavers or do not know';
+  public noOrDoNotKnowErrorMessage = 'Select no staff left or do not know';
   public numberRequiredErrorMessage = 'Enter the number of leavers or remove';
   public validNumberErrorMessage = 'Number of leavers must be between 1 and 999';
   public serverErrorMessage = 'Failed to update leavers';

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.spec.ts
@@ -19,7 +19,7 @@ import { of, throwError } from 'rxjs';
 
 import { UpdateStartersComponent } from './update-starters.component';
 
-fdescribe('UpdateStartersComponent', () => {
+describe('UpdateStartersComponent', () => {
   const today = new Date();
   today.setFullYear(today.getFullYear() - 1);
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.spec.ts
@@ -19,7 +19,7 @@ import { of, throwError } from 'rxjs';
 
 import { UpdateStartersComponent } from './update-starters.component';
 
-describe('UpdateStartersComponent', () => {
+fdescribe('UpdateStartersComponent', () => {
   const today = new Date();
   today.setFullYear(today.getFullYear() - 1);
 
@@ -610,7 +610,7 @@ describe('UpdateStartersComponent', () => {
           workplace: mockFreshWorkplace,
         });
         const expectedErrorMessage1 = 'Add a job role';
-        const expectedErrorMessage2 = 'Select there are no starters or do not know';
+        const expectedErrorMessage2 = 'Select no staff started or do not know';
 
         userEvent.click(getByRole('button', { name: 'Save and return' }));
 
@@ -644,7 +644,7 @@ describe('UpdateStartersComponent', () => {
           'Number of starters must be between 1 and 999 (care worker)',
           'Number of starters must be between 1 and 999',
         );
-        expectErrorMessageAppears('Select there are no starters or do not know');
+        expectErrorMessageAppears('Select no staff started or do not know');
         expect(queryByText('Add a job role')).toBeFalsy();
 
         expect(updateJobsSpy).not.toHaveBeenCalled();
@@ -667,7 +667,7 @@ describe('UpdateStartersComponent', () => {
 
         fixture.detectChanges();
 
-        expect(queryByText('Select there are no starters or do not know')).toBeFalsy();
+        expect(queryByText('Select no staff started or do not know')).toBeFalsy();
         expect(updateJobsSpy).not.toHaveBeenCalled();
       });
 
@@ -688,7 +688,7 @@ describe('UpdateStartersComponent', () => {
 
         fixture.detectChanges();
 
-        expectErrorMessageAppears('Select there are no starters or do not know');
+        expectErrorMessageAppears('Select no staff started or do not know');
 
         await fillInValueForJobRole('Care worker', '1');
         await fillInValueForJobRole('Registered nurse', '2');
@@ -697,7 +697,7 @@ describe('UpdateStartersComponent', () => {
 
         fixture.detectChanges();
 
-        expect(queryByText('Select there are no starters or do not know')).toBeFalsy();
+        expect(queryByText('Select no staff started or do not know')).toBeFalsy();
         expect(updateJobsSpy).toHaveBeenCalledWith(mockWorkplace.uid, {
           starters: [
             { jobId: 10, total: 1 },

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-starters/update-starters.component.ts
@@ -1,9 +1,7 @@
 import { Component } from '@angular/core';
 import { jobOptionsEnum } from '@core/model/establishment.model';
 import { WorkplaceUpdatePage } from '@core/services/update-workplace-after-staff-changes.service';
-import {
-  UpdateStartersLeaversVacanciesDirective,
-} from '@shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive';
+import { UpdateStartersLeaversVacanciesDirective } from '@shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive';
 
 @Component({
   selector: 'app-update-starters',
@@ -19,7 +17,7 @@ export class UpdateStartersComponent extends UpdateStartersLeaversVacanciesDirec
     "To see if the care sector is attracting new workers and see whether DHSC and the government's national and local recruitment plans are working.";
 
   public serverErrorMessage = 'Failed to update starters';
-  public noOrDoNotKnowErrorMessage = 'Select there are no starters or do not know';
+  public noOrDoNotKnowErrorMessage = 'Select no staff started or do not know';
   public numberRequiredErrorMessage = 'Enter the number of starters or remove';
   public validNumberErrorMessage = 'Number of starters must be between 1 and 999';
 

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.spec.ts
@@ -18,7 +18,7 @@ import { of, throwError } from 'rxjs';
 
 import { UpdateVacanciesComponent } from './update-vacancies.component';
 
-describe('UpdateVacanciesComponent', () => {
+fdescribe('UpdateVacanciesComponent', () => {
   const radioButtonLabels = {
     No: 'There are no current staff vacancies',
     DoNotKnow: 'I do not know if there are any current staff vacancies',
@@ -570,6 +570,31 @@ describe('UpdateVacanciesComponent', () => {
           'Number of vacancies must be between 1 and 999',
         );
         expectErrorMessageAppears('Enter the number of current staff vacancies or remove social worker');
+      });
+
+      it('should not show any error message when some error message is appearing and user selected "There are no current staff vacancies"', async () => {
+        const { fixture, getByRole, getByLabelText, queryByText } = await setup({
+          vacanciesFromSelectJobRolePages: mockVacancies,
+        });
+
+        await fillInValueForJobRole('Registered nurse', '9999');
+        await fillInValueForJobRole('Social worker', '');
+
+        userEvent.click(getByRole('button', { name: 'Save and return' }));
+
+        fixture.detectChanges();
+
+        expectErrorMessageAppears(
+          'Number of vacancies must be between 1 and 999 (registered nurse)',
+          'Number of vacancies must be between 1 and 999',
+        );
+
+        userEvent.click(getByLabelText(radioButtonLabels.No));
+
+        fixture.detectChanges();
+
+        expect(queryByText('There is a problem')).toBeFalsy();
+        expect(queryByText('Select there are no current staff vacancies or do not know')).toBeFalsy();
       });
 
       it('should still show the correct error messages even if some job roles were removed after submit', async () => {

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component.spec.ts
@@ -18,7 +18,7 @@ import { of, throwError } from 'rxjs';
 
 import { UpdateVacanciesComponent } from './update-vacancies.component';
 
-fdescribe('UpdateVacanciesComponent', () => {
+describe('UpdateVacanciesComponent', () => {
   const radioButtonLabels = {
     No: 'There are no current staff vacancies',
     DoNotKnow: 'I do not know if there are any current staff vacancies',

--- a/frontend/src/app/shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive.ts
@@ -258,6 +258,7 @@ export class UpdateStartersLeaversVacanciesDirective implements OnInit, AfterVie
 
   public handleClickedNoOrDoNotKnow = (value: jobOptionsEnum): void => {
     this.selectedNoOrDoNotKnow = value;
+    this.form.patchValue({ noOrDoNotKnow: value });
     this.removeAllSelectedJobRoles();
   };
 


### PR DESCRIPTION
#### Work done
- Fix a bug on update SLV validation when user clicked radio button during an error
- Update validation message for starters and leavers ("Select there are no starters or..." --> "Select no staff started or...")
- Remove backlink on "Do you want to delete another worker" page
- Change alert service to remove existing alert on NavigationEnd (instead of NavigationStart)

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
