### PR TITLE
undo change to alert service

### DIFF
--- a/frontend/src/app/core/services/alert.service.spec.ts
+++ b/frontend/src/app/core/services/alert.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import { AlertService } from './alert.service';
-import { NavigationEnd, Router } from '@angular/router';
+import { NavigationStart, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { WindowRef } from './window.ref';
 
@@ -26,7 +26,7 @@ describe('AlertService', () => {
     const removeAlertSpy = spyOn(service, 'removeAlert');
 
     const routerEvent$ = router.events as BehaviorSubject<any>;
-    routerEvent$.next(new NavigationEnd(1, '/test/mock/page/url', '/test/mock/page/url'));
+    routerEvent$.next(new NavigationStart(1, '/test/mock/page/url'));
 
     expect(removeAlertSpy).toHaveBeenCalled();
   });

--- a/frontend/src/app/core/services/alert.service.ts
+++ b/frontend/src/app/core/services/alert.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { NavigationEnd, Router } from '@angular/router';
+import { NavigationStart, Router } from '@angular/router';
 import { Alert } from '@core/model/alert.model';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -13,7 +13,7 @@ export class AlertService {
   private _alert$: BehaviorSubject<Alert> = new BehaviorSubject(null);
 
   constructor(private router: Router, private windowRef: WindowRef) {
-    this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+    this.router.events.pipe(filter((event) => event instanceof NavigationStart)).subscribe(() => {
       this.removeAlert();
     });
   }


### PR DESCRIPTION
#### Work done
- undo the recent change to alert service

A previous PR changed removeAlert subscription to listen to NavigationEnd event to solve an issue of alert disappeared before page change.
However, we found that the change doesn't go well with some existing usage of AlertService.
This PR will undo the change from feature branch, so that we can work on AlertService in a separate branch.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
