### PR TITLE
Fix/skip delete another staff record when no records

### DIFF
--- a/frontend/src/app/features/workers/delete-staff-record/delete-staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/delete-staff-record/delete-staff-record.component.spec.ts
@@ -23,7 +23,7 @@ import { DeleteStaffRecordComponent } from './delete-staff-record.component';
 describe('DeleteStaffRecordComponent', () => {
   const mockWorker = workerBuilder() as Worker;
 
-  const setup = async () => {
+  const setup = async (overrides: any = {}) => {
     const setupTools = await render(DeleteStaffRecordComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
@@ -40,7 +40,7 @@ describe('DeleteStaffRecordComponent', () => {
           provide: ActivatedRoute,
           useValue: {
             snapshot: {
-              data: { reasonsForLeaving: mockLeaveReasons },
+              data: { reasonsForLeaving: mockLeaveReasons, totalNumberOfStaff: 2, ...overrides.snapshot },
             },
           },
         },
@@ -170,7 +170,7 @@ describe('DeleteStaffRecordComponent', () => {
       });
     });
 
-    it('should navigate to staff record page and show an alert when worker is successfully deleted', async () => {
+    it('should navigate to staff record page and show an alert when worker is successfully deleted and more than one staff record', async () => {
       const { component, getByRole, routerSpy, alertServiceSpy } = await setup();
 
       userEvent.click(getByRole('checkbox', { name: /I know that/ }));
@@ -181,6 +181,26 @@ describe('DeleteStaffRecordComponent', () => {
         'mocked-uid',
         'staff-record',
         'delete-another-staff-record',
+      ]);
+
+      await routerSpy.calls.mostRecent().returnValue;
+      expect(alertServiceSpy).toHaveBeenCalledWith({
+        type: 'success',
+        message: `Staff record deleted (${component.worker.nameOrId})`,
+      });
+    });
+
+    it('should navigate to check this information page and show an alert when worker is successfully deleted and is last staff record', async () => {
+      const { component, getByRole, routerSpy, alertServiceSpy } = await setup({ snapshot: { totalNumberOfStaff: 1 } });
+
+      userEvent.click(getByRole('checkbox', { name: /I know that/ }));
+      userEvent.click(getByRole('button', { name: 'Delete this staff record' }));
+
+      expect(routerSpy).toHaveBeenCalledWith([
+        '/workplace',
+        'mocked-uid',
+        'staff-record',
+        'update-workplace-details-after-deleting-staff',
       ]);
 
       await routerSpy.calls.mostRecent().returnValue;

--- a/frontend/src/app/features/workers/delete-staff-record/delete-staff-record.component.ts
+++ b/frontend/src/app/features/workers/delete-staff-record/delete-staff-record.component.ts
@@ -32,6 +32,7 @@ export class DeleteStaffRecordComponent implements OnInit, AfterViewInit, OnDest
   public otherReasonDetailMaxLength = 500;
   public confirmationMissingErrorMessage =
     'Confirm that you know this action will permanently delete this staff record and any training and qualification records (and certificates) related to it';
+  public totalNumberOfStaffBeforeDelete: number;
 
   private subscriptions: Subscription = new Subscription();
 
@@ -51,6 +52,7 @@ export class DeleteStaffRecordComponent implements OnInit, AfterViewInit, OnDest
     this.worker = this.workerService.worker;
     this.workplace = this.establishmentService.establishment;
     this.reasons = this.route.snapshot.data?.reasonsForLeaving;
+    this.totalNumberOfStaffBeforeDelete = this.route.snapshot.data?.totalNumberOfStaff;
 
     this.setupForm();
     this.setupFormErrorsMap();
@@ -141,7 +143,13 @@ export class DeleteStaffRecordComponent implements OnInit, AfterViewInit, OnDest
 
   private onSuccess(): void {
     this.updateWorkplaceAfterStaffChangesService.clearDoYouWantToAddOrDeleteAnswer();
-    this.router.navigate(['/workplace', this.workplace.uid, 'staff-record', 'delete-another-staff-record']).then(() =>
+
+    const nextPage =
+      this.totalNumberOfStaffBeforeDelete > 1
+        ? 'delete-another-staff-record'
+        : 'update-workplace-details-after-deleting-staff';
+
+    this.router.navigate(['/workplace', this.workplace.uid, 'staff-record', nextPage]).then(() =>
       this.alertService.addAlert({
         type: 'success',
         message: `Staff record deleted (${this.worker.nameOrId})`,

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -22,7 +22,9 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
   async function setup(overrides: any = {}) {
     const workplace = { ...establishmentBuilder(), ...overrides.workplace };
     const flowType = overrides?.flowType || WorkplaceUpdateFlowType.ADD;
+    const totalNumberOfStaff = overrides?.totalNumberOfStaff ?? 10;
     const alertSpy = jasmine.createSpy('addAlert').and.returnValue(Promise.resolve(true));
+    const showBackLinkSpy = jasmine.createSpy('setBacklink').and.returnValue(Promise.resolve(true));
 
     const setupTools = await render(UpdateWorkplaceDetailsAfterStaffChangesComponent, {
       imports: [SharedModule, RouterModule, HttpClientTestingModule, ReactiveFormsModule],
@@ -45,11 +47,16 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
           provide: ActivatedRoute,
           useValue: {
             snapshot: {
-              data: { flowType },
+              data: { flowType, totalNumberOfStaff },
             },
           },
         },
-        BackLinkService,
+        {
+          provide: BackLinkService,
+          useValue: {
+            showBackLink: showBackLinkSpy,
+          },
+        },
       ],
     });
 
@@ -65,6 +72,7 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
       workplace,
       routerSpy,
       alertSpy,
+      showBackLinkSpy,
     };
   }
 
@@ -468,6 +476,20 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
 
     expect(routerSpy).toHaveBeenCalledWith(['/dashboard'], {
       fragment: 'staff-records',
+    });
+  });
+
+  describe('Displaying back link', () => {
+    it('should display back link when there is at least 1 staff record', async () => {
+      const { showBackLinkSpy } = await setup({ totalNumberOfStaff: 1 });
+
+      expect(showBackLinkSpy).toHaveBeenCalled();
+    });
+
+    it('should not display a back link when there are no staff records (come to page directly from delete)', async () => {
+      const { showBackLinkSpy } = await setup({ totalNumberOfStaff: 0 });
+
+      expect(showBackLinkSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.ts
@@ -28,15 +28,17 @@ export class UpdateWorkplaceDetailsAfterStaffChangesComponent implements OnInit 
   public allPagesSubmitted: boolean;
   public WorkplaceUpdateFlowType = WorkplaceUpdateFlowType;
   public flowType: WorkplaceUpdateFlowType;
+  private totalNumberOfStaff: number;
 
   ngOnInit(): void {
     this.flowType = this.route.snapshot?.data?.flowType;
+    this.totalNumberOfStaff = this.route.snapshot?.data?.totalNumberOfStaff;
     this.workplace = this.establishmentService.establishment;
     this.allPagesVisited = this.updateWorkplaceAfterStaffChangesService.allUpdatePagesVisited(this.flowType);
     this.allPagesSubmitted = this.updateWorkplaceAfterStaffChangesService.allUpdatePagesSubmitted(this.flowType);
 
     this.updateWorkplaceAfterStaffChangesService.clearAllSelectedJobRoles();
-    this.backLinkService.showBackLink();
+    this.showBackLink();
 
     if (this.allPagesSubmitted && !this.updateWorkplaceAfterStaffChangesService.hasViewedSavedBanner) {
       this.alertService.addAlert({
@@ -57,5 +59,11 @@ export class UpdateWorkplaceDetailsAfterStaffChangesComponent implements OnInit 
   public clickContinue(event: Event): void {
     event.preventDefault();
     this.router.navigate(['/dashboard'], { fragment: 'staff-records' });
+  }
+
+  private showBackLink(): void {
+    if (this.totalNumberOfStaff > 0) {
+      this.backLinkService.showBackLink();
+    }
   }
 }

--- a/frontend/src/app/features/workers/workers-routing.module.ts
+++ b/frontend/src/app/features/workers/workers-routing.module.ts
@@ -95,6 +95,9 @@ const routes: Routes = [
           title: 'Update workplace details',
           flowType: WorkplaceUpdateFlowType.ADD,
         },
+        resolve: {
+          totalNumberOfStaff: TotalStaffRecordsResolver,
+        },
       },
       {
         path: 'update-total-staff',
@@ -147,6 +150,9 @@ const routes: Routes = [
         data: {
           title: 'Update workplace details',
           flowType: WorkplaceUpdateFlowType.DELETE,
+        },
+        resolve: {
+          totalNumberOfStaff: TotalStaffRecordsResolver,
         },
       },
       {

--- a/frontend/src/app/features/workers/workers-routing.module.ts
+++ b/frontend/src/app/features/workers/workers-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CheckPermissionsGuard } from '@core/guards/permissions/check-permissions/check-permissions.guard';
 import { AvailableQualificationsResolver } from '@core/resolvers/available-qualification.resolver';
+import { TotalStaffRecordsResolver } from '@core/resolvers/dashboard/total-staff-records.resolver';
 import { ExpiresSoonAlertDatesResolver } from '@core/resolvers/expiresSoonAlertDates.resolver';
 import { JobsResolver } from '@core/resolvers/jobs.resolver';
 import { LongTermAbsenceResolver } from '@core/resolvers/long-term-absence.resolver';
@@ -14,26 +15,14 @@ import { TrainingRecordsForCategoryResolver } from '@core/resolvers/training-rec
 import { WorkerReasonsForLeavingResolver } from '@core/resolvers/worker-reasons-for-leaving.resolver';
 import { WorkerResolver } from '@core/resolvers/worker.resolver';
 import { WorkplaceUpdateFlowType } from '@core/services/update-workplace-after-staff-changes.service';
-import {
-  SelectQualificationTypeComponent,
-} from '@features/training-and-qualifications/add-edit-qualification/select-qualification-type/select-qualification-type.component';
-import {
-  SelectTrainingCategoryComponent,
-} from '@features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component';
-import {
-  ViewTrainingComponent,
-} from '@shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component';
+import { SelectQualificationTypeComponent } from '@features/training-and-qualifications/add-edit-qualification/select-qualification-type/select-qualification-type.component';
+import { SelectTrainingCategoryComponent } from '@features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component';
+import { ViewTrainingComponent } from '@shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component';
 
-import {
-  AddEditQualificationComponent,
-} from '../training-and-qualifications/add-edit-qualification/add-edit-qualification.component';
+import { AddEditQualificationComponent } from '../training-and-qualifications/add-edit-qualification/add-edit-qualification.component';
 import { AddEditTrainingComponent } from '../training-and-qualifications/add-edit-training/add-edit-training.component';
-import {
-  DeleteRecordComponent,
-} from '../training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component';
-import {
-  NewTrainingAndQualificationsRecordComponent,
-} from '../training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component';
+import { DeleteRecordComponent } from '../training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component';
+import { NewTrainingAndQualificationsRecordComponent } from '../training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component';
 import { AddAnotherStaffRecordComponent } from './add-another-staff-record/add-another-staff-record.component';
 import { AdultSocialCareStartedComponent } from './adult-social-care-started/adult-social-care-started.component';
 import { ApprenticeshipTrainingComponent } from './apprenticeship-training/apprenticeship-training.component';
@@ -54,9 +43,7 @@ import { EthnicityComponent } from './ethnicity/ethnicity.component';
 import { GenderComponent } from './gender/gender.component';
 import { HealthAndCareVisaComponent } from './health-and-care-visa/health-and-care-visa.component';
 import { HomePostcodeComponent } from './home-postcode/home-postcode.component';
-import {
-  Level2AdultSocialCareCertificateComponent,
-} from './level-2-adult-social-care-certificate/level-2-adult-social-care-certificate.component';
+import { Level2AdultSocialCareCertificateComponent } from './level-2-adult-social-care-certificate/level-2-adult-social-care-certificate.component';
 import { LongTermAbsenceComponent } from './long-term-absence/long-term-absence.component';
 import { MainJobRoleComponent } from './main-job-role/main-job-role.component';
 import { MainJobStartDateComponent } from './main-job-start-date/main-job-start-date.component';
@@ -71,9 +58,7 @@ import { OtherQualificationsComponent } from './other-qualifications/other-quali
 import { RecruitedFromComponent } from './recruited-from/recruited-from.component';
 import { SalaryComponent } from './salary/salary.component';
 import { SelectRecordTypeComponent } from './select-record-type/select-record-type.component';
-import {
-  SocialCareQualificationLevelComponent,
-} from './social-care-qualification-level/social-care-qualification-level.component';
+import { SocialCareQualificationLevelComponent } from './social-care-qualification-level/social-care-qualification-level.component';
 import { SocialCareQualificationComponent } from './social-care-qualification/social-care-qualification.component';
 import { StaffDetailsComponent } from './staff-details/staff-details.component';
 import { StaffRecordComponent } from './staff-record/staff-record.component';
@@ -82,21 +67,13 @@ import {
   JobRoleType,
   SelectJobRolesToAddComponent,
 } from './update-workplace-details-after-staff-changes/select-job-roles-to-add/select-job-roles-to-add.component';
-import {
-  UpdateStartersComponent,
-} from './update-workplace-details-after-staff-changes/update-starters/update-starters.component';
-import {
-  UpdateTotalNumberOfStaffComponent,
-} from './update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component';
-import {
-  UpdateVacanciesComponent,
-} from './update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component';
-import {
-  UpdateWorkplaceDetailsAfterStaffChangesComponent,
-} from './update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component';
+import { UpdateLeaversComponent } from './update-workplace-details-after-staff-changes/update-leavers/update-leavers.component';
+import { UpdateStartersComponent } from './update-workplace-details-after-staff-changes/update-starters/update-starters.component';
+import { UpdateTotalNumberOfStaffComponent } from './update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component';
+import { UpdateVacanciesComponent } from './update-workplace-details-after-staff-changes/update-vacancies/update-vacancies.component';
+import { UpdateWorkplaceDetailsAfterStaffChangesComponent } from './update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component';
 import { WeeklyContractedHoursComponent } from './weekly-contracted-hours/weekly-contracted-hours.component';
 import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.component';
-import { UpdateLeaversComponent } from './update-workplace-details-after-staff-changes/update-leavers/update-leavers.component';
 
 const routes: Routes = [
   {
@@ -841,6 +818,7 @@ const routes: Routes = [
         component: DeleteStaffRecordComponent,
         resolve: {
           reasonsForLeaving: WorkerReasonsForLeavingResolver,
+          totalNumberOfStaff: TotalStaffRecordsResolver,
         },
         data: {
           permissions: ['canDeleteWorker'],


### PR DESCRIPTION
#### Work done
- Added logic to prevent user seeing _Delete another staff record_ page when they have no staff records left
- Added logic to stop showing the back link on the _Check this information_ page when user has come directly from deleting their last staff record

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
