### PR TITLE
Fix/no capitalising acronyms for slv messages

### DIFF
--- a/frontend/src/app/core/utils/format-util.spec.ts
+++ b/frontend/src/app/core/utils/format-util.spec.ts
@@ -68,4 +68,31 @@ describe('FormatUtil', () => {
       expect(FormatUtil.formatPercent(0.5)).toEqual('50%');
     });
   });
+
+  describe('formatToLowercaseExcludingAcronyms', () => {
+    it('should put text with no acronyms to lower case', () => {
+      const testCases: { input: string; expected: string }[] = [
+        { input: 'Software engineer', expected: 'software engineer' },
+        { input: 'Support Worker', expected: 'support worker' },
+        { input: 'People and HR manager', expected: 'people and HR manager' },
+      ];
+
+      testCases.forEach(({ input, expected }) => {
+        expect(FormatUtil.formatToLowercaseExcludingAcronyms(input)).toEqual(expected);
+      });
+    });
+
+    it('should not put acronyms to lower case', () => {
+      const testCases: { input: string; expected: string }[] = [
+        { input: 'IT manager', expected: 'IT manager' },
+        { input: 'Manager of IT', expected: 'manager of IT' },
+        { input: 'People and HR manager', expected: 'people and HR manager' },
+        { input: 'ABC Acronym', expected: 'ABC acronym' },
+      ];
+
+      testCases.forEach(({ input, expected }) => {
+        expect(FormatUtil.formatToLowercaseExcludingAcronyms(input)).toEqual(expected);
+      });
+    });
+  });
 });

--- a/frontend/src/app/core/utils/format-util.ts
+++ b/frontend/src/app/core/utils/format-util.ts
@@ -23,4 +23,13 @@ export class FormatUtil {
   public static formatDateToLocaleDateString(date): string {
     return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
   }
+
+  public static formatToLowercaseExcludingAcronyms(text: string): string {
+    return text
+      .split(' ')
+      .map((word) => {
+        return /^[A-Z]{2,}/.test(word) ? word : word.toLowerCase();
+      })
+      .join(' ');
+  }
 }

--- a/frontend/src/app/shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/shared/directives/update-starters-leavers-vacancies/update-starters-leavers-vacancies.directive.ts
@@ -20,7 +20,9 @@ import {
   WorkplaceUpdatePage,
 } from '@core/services/update-workplace-after-staff-changes.service';
 import { FormatUtil } from '@core/utils/format-util';
-import { NumberInputWithButtonsComponent } from '@shared/components/number-input-with-buttons/number-input-with-buttons.component';
+import {
+  NumberInputWithButtonsComponent,
+} from '@shared/components/number-input-with-buttons/number-input-with-buttons.component';
 import { CustomValidators } from '@shared/validators/custom-form-validators';
 import lodash from 'lodash';
 
@@ -197,7 +199,7 @@ export class UpdateStartersLeaversVacanciesDirective implements OnInit, AfterVie
     errorType: string,
     inline: boolean = false,
   ): string {
-    const jobRoleTitleInLowerCase = jobRole.title.toLowerCase();
+    const jobRoleTitleInLowerCase = FormatUtil.formatToLowercaseExcludingAcronyms(jobRole.title);
 
     switch (errorType) {
       case 'required': {

--- a/frontend/src/app/shared/pipes/format-starters-leavers-vacancies.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/format-starters-leavers-vacancies.pipe.spec.ts
@@ -37,4 +37,18 @@ describe('FormatStartersLeaversVacanciesPipe', () => {
     expect(pipe.transform({ ...jobRole, other: null })).toEqual(expected);
     expect(pipe.transform({ ...jobRole, other: undefined })).toEqual(expected);
   });
+
+  it('should not put acronyms to lower case', () => {
+    const testCases: { expected: string; jobRole: Vacancy }[] = [
+      { jobRole: { jobId: 10, title: 'IT manager', total: 2 }, expected: '2 x IT manager' },
+      { jobRole: { jobId: 11, title: 'Manager of IT', total: 2 }, expected: '2 x manager of IT' },
+      { jobRole: { jobId: 12, title: 'People and HR manager', total: 4 }, expected: '4 x people and HR manager' },
+    ];
+
+    const pipe = new FormatStartersLeaversVacanciesPipe();
+
+    testCases.forEach(({ jobRole, expected }) => {
+      expect(pipe.transform(jobRole)).toEqual(expected);
+    });
+  });
 });

--- a/frontend/src/app/shared/pipes/format-starters-leavers-vacancies.pipe.ts
+++ b/frontend/src/app/shared/pipes/format-starters-leavers-vacancies.pipe.ts
@@ -1,12 +1,13 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { Leaver, Starter, Vacancy } from '@core/model/establishment.model';
+import { FormatUtil } from '@core/utils/format-util';
 
 @Pipe({
   name: 'formatSLV',
 })
 export class FormatStartersLeaversVacanciesPipe implements PipeTransform {
   transform(jobRole: Starter | Leaver | Vacancy): string {
-    const lowerCaseTitle = jobRole.title?.toLowerCase();
+    const lowerCaseTitle = FormatUtil.formatToLowercaseExcludingAcronyms(jobRole.title);
     if (jobRole.other?.length > 0) {
       return `${jobRole.total} x ${lowerCaseTitle}: ${jobRole.other?.toLowerCase()}`;
     }


### PR DESCRIPTION
#### Work done
- Created a util to put text to lower case but ignore acronyms
- Updated the error messaging and display of job roles for starters, leavers and vacancies to use util to resolve issue with acronyms in job roles being put to lower case

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
