### PR TITLE
Fix/backlink in repeat training question page

### DIFF
--- a/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.spec.ts
+++ b/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.spec.ts
@@ -3,22 +3,19 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
-import {
-  StaffRecruitmentCaptureTrainingRequirementComponent,
-} from './staff-recruitment-capture-training-requirement.component';
+import { StaffRecruitmentCaptureTrainingRequirementComponent } from './staff-recruitment-capture-training-requirement.component';
 
-describe('StaffRecruitmentCaptureTrainingRequirement', () => {
+fdescribe('StaffRecruitmentCaptureTrainingRequirement', () => {
   async function setup(returnUrl = true, repeatTraining = undefined) {
     const { fixture, getByText, getByLabelText, getByTestId, queryByTestId, queryByText } = await render(
       StaffRecruitmentCaptureTrainingRequirementComponent,
       {
-        imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+        imports: [SharedModule, RouterModule, HttpClientTestingModule, ReactiveFormsModule],
         providers: [
           UntypedFormBuilder,
           {
@@ -272,10 +269,10 @@ describe('StaffRecruitmentCaptureTrainingRequirement', () => {
   });
 
   describe('Back button', () => {
-    it('should set the back link to service-users', async () => {
+    it('should set the back link to how-many-leavers page', async () => {
       const { component } = await setup(false);
 
-      expect(component.previousRoute).toEqual(['/workplace', component.establishment.uid, 'service-users']);
+      expect(component.previousRoute).toEqual(['/workplace', component.establishment.uid, 'how-many-leavers']);
     });
   });
 });

--- a/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.spec.ts
+++ b/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.spec.ts
@@ -10,7 +10,7 @@ import { fireEvent, render } from '@testing-library/angular';
 
 import { StaffRecruitmentCaptureTrainingRequirementComponent } from './staff-recruitment-capture-training-requirement.component';
 
-fdescribe('StaffRecruitmentCaptureTrainingRequirement', () => {
+describe('StaffRecruitmentCaptureTrainingRequirement', () => {
   async function setup(returnUrl = true, repeatTraining = undefined) {
     const { fixture, getByText, getByLabelText, getByTestId, queryByTestId, queryByText } = await render(
       StaffRecruitmentCaptureTrainingRequirementComponent,

--- a/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.ts
+++ b/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.ts
@@ -53,7 +53,7 @@ export class StaffRecruitmentCaptureTrainingRequirementComponent extends Questio
   }
 
   private setPreviousRoute(): void {
-    this.previousRoute = ['/workplace', `${this.establishment.uid}`, 'how-many-leavers'];
+    this.previousRoute = ['/workplace', this.establishment.uid, 'how-many-leavers'];
   }
 
   private setupForm(): void {

--- a/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.ts
+++ b/frontend/src/app/features/workplace/staff-recruitment-capture-training-requirement/staff-recruitment-capture-training-requirement.component.ts
@@ -53,7 +53,7 @@ export class StaffRecruitmentCaptureTrainingRequirementComponent extends Questio
   }
 
   private setPreviousRoute(): void {
-    this.previousRoute = ['/workplace', `${this.establishment.uid}`, 'service-users'];
+    this.previousRoute = ['/workplace', `${this.establishment.uid}`, 'how-many-leavers'];
   }
 
   private setupForm(): void {


### PR DESCRIPTION
#### Work done
- Fix the backlink in repeat training question page

When in the flow, the page after leavers question is "Do new care workers have to repeat training..." question page, but the backlink of that page is pointing to "Who are your service users?" page instead of leavers page. This PR fix the issue


#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
