### PR TITLE
Fix/1687 total number of staff

### DIFF
--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.html
@@ -30,7 +30,7 @@
               <app-summary-record-change
                 [explanationText]="' total number of staff'"
                 [link]="['update-total-staff']"
-                [hasData]="workplace.numberOfStaff"
+                [hasData]="workplace.numberOfStaff | hasValue"
               ></app-summary-record-change>
             </dd>
           </div>

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -14,7 +14,7 @@ import userEvent from '@testing-library/user-event';
 
 import { UpdateWorkplaceDetailsAfterStaffChangesComponent } from './update-workplace-details-after-staff-changes.component';
 
-fdescribe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
+describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   async function setup(overrides: any = {}) {
     const workplace = { ...establishmentBuilder(), ...overrides.workplace };

--- a/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
+++ b/frontend/src/app/features/workers/update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component.spec.ts
@@ -14,7 +14,7 @@ import userEvent from '@testing-library/user-event';
 
 import { UpdateWorkplaceDetailsAfterStaffChangesComponent } from './update-workplace-details-after-staff-changes.component';
 
-describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
+fdescribe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   async function setup(overrides: any = {}) {
     const workplace = { ...establishmentBuilder(), ...overrides.workplace };
@@ -227,6 +227,16 @@ describe('UpdateWorkplaceDetailsAfterStaffChangesComponent', () => {
 
       expect(addLink.getAttribute('ng-reflect-router-link')).toEqual('update-total-staff');
       expect(within(numberOfStaffRow).queryByText('-')).toBeTruthy();
+    });
+
+    it('should display 0 and a Change link if the number of staff is 0', async () => {
+      const { queryByTestId } = await setup({ workplace: { numberOfStaff: 0 } });
+
+      const numberOfStaffRow = queryByTestId('numberOfStaff');
+      const changeLink = within(numberOfStaffRow).queryByText('Change');
+
+      expect(changeLink.getAttribute('ng-reflect-router-link')).toEqual('update-total-staff');
+      expect(within(numberOfStaffRow).queryByText('0')).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -160,7 +160,7 @@
             <app-summary-record-change
               [explanationText]="' total number of staff'"
               [link]="['/workplace', workplace.uid, 'total-staff']"
-              [hasData]="workplace.numberOfStaff"
+              [hasData]="workplace.numberOfStaff | hasValue"
               (setReturnClicked)="this.setReturn()"
             ></app-summary-record-change>
           </dd>

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -2,8 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter, Router, RouterModule } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { PermissionType } from '@core/model/permissions.model';
 import { CqcStatusChangeService } from '@core/services/cqc-status-change.service';
@@ -31,7 +30,7 @@ describe('NewWorkplaceSummaryComponent', () => {
     hasQuestions = true,
   ) => {
     const { fixture, getByText, queryByText, getByTestId, queryByTestId } = await render(NewWorkplaceSummaryComponent, {
-      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule, ReactiveFormsModule],
+      imports: [SharedModule, RouterModule, HttpClientTestingModule, ReactiveFormsModule],
       providers: [
         {
           provide: PermissionsService,
@@ -50,6 +49,7 @@ describe('NewWorkplaceSummaryComponent', () => {
           provide: VacanciesAndTurnoverService,
           useClass: MockVacanciesAndTurnoverService,
         },
+        provideRouter([]),
       ],
       componentProperties: {
         workplace: establishmentWithShareWith(shareWith) as Establishment,
@@ -172,6 +172,22 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(within(numberOfStaffRow).queryByTestId('number-of-staff-top-row').getAttribute('class')).not.toContain(
           'govuk-summary-list__row--no-bottom-border govuk-summary-list__row--no-bottom-padding',
         );
+      });
+
+      it('should render 0 and an Change link if the number of staff is 0', async () => {
+        const { component, fixture } = await setup();
+
+        component.canEditEstablishment = true;
+        component.workplace.numberOfStaff = 0;
+
+        fixture.detectChanges();
+
+        const numberOfStaffRow = within(document.body).queryByTestId('numberOfStaff');
+        const link = within(numberOfStaffRow).queryByText('Change');
+
+        expect(link).toBeTruthy();
+        expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/total-staff`);
+        expect(within(numberOfStaffRow).queryByText('0')).toBeTruthy();
       });
 
       it('should render a dash and an Add link if there is not a value for number of staff', async () => {

--- a/frontend/src/app/shared/pipes/has-value.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/has-value.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { HasValuePipe } from './has-value.pipe';
 
-fdescribe('HasValuePipe', () => {
+describe('HasValuePipe', () => {
   it('create an instance', () => {
     const pipe = new HasValuePipe();
     expect(pipe).toBeTruthy();

--- a/frontend/src/app/shared/pipes/has-value.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/has-value.pipe.spec.ts
@@ -1,0 +1,43 @@
+import { HasValuePipe } from './has-value.pipe';
+
+fdescribe('HasValuePipe', () => {
+  it('create an instance', () => {
+    const pipe = new HasValuePipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it('return false when the given value is undefined', async () => {
+    const pipe = new HasValuePipe();
+    const inputValue = undefined;
+    const expected = false;
+
+    expect(pipe.transform(inputValue)).toEqual(expected);
+  });
+
+  it('return false when the given value is null', async () => {
+    const pipe = new HasValuePipe();
+    const inputValue = null;
+    const expected = false;
+
+    expect(pipe.transform(inputValue)).toEqual(expected);
+  });
+
+  it('return true when the given value is 0', async () => {
+    const pipe = new HasValuePipe();
+    const inputValue = 0;
+    const expected = true;
+
+    expect(pipe.transform(inputValue)).toEqual(expected);
+  });
+
+  const testCases = [10, '', 'a string', {}, { an: 'object' }, [], [1, 2, 3]];
+
+  testCases.forEach((inputValue) => {
+    it(`return true when the given value is ${inputValue}`, async () => {
+      const pipe = new HasValuePipe();
+      const expected = true;
+
+      expect(pipe.transform(inputValue)).toEqual(expected);
+    });
+  });
+});

--- a/frontend/src/app/shared/pipes/has-value.pipe.ts
+++ b/frontend/src/app/shared/pipes/has-value.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { isNull } from 'lodash';
+
+@Pipe({
+  name: 'hasValue',
+})
+export class HasValuePipe implements PipeTransform {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transform(value: any): boolean {
+    if (isNull(value) || value === undefined) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -142,6 +142,7 @@ import { WorkerDaysPipe } from './pipes/worker-days.pipe';
 import { WorkerPayPipe } from './pipes/worker-pay.pipe';
 import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-bearer.pipe';
 import { JobRoleNumbersTableComponent } from './components/job-role-numbers-table/job-role-numbers-table.component';
+import { HasValuePipe } from './pipes/has-value.pipe';
 
 @NgModule({
   imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, OverlayModule],
@@ -285,6 +286,7 @@ import { JobRoleNumbersTableComponent } from './components/job-role-numbers-tabl
     SelectJobRolesToAddComponent,
     NumberInputWithButtonsComponent,
     JobRoleNumbersTableComponent,
+    HasValuePipe,
   ],
   exports: [
     AbsoluteNumberPipe,
@@ -418,8 +420,8 @@ import { JobRoleNumbersTableComponent } from './components/job-role-numbers-tabl
     HelpContentComponent,
     FormatStartersLeaversVacanciesPipe,
     NumberInputWithButtonsComponent,
-    NumberInputWithButtonsComponent,
     JobRoleNumbersTableComponent,
+    HasValuePipe,
   ],
   providers: [DialogService, TotalStaffComponent, ArticleListResolver, PageResolver, QuestionsAndAnswersResolver],
 })


### PR DESCRIPTION
#### Work done
- Amend update-workplace-details-after-staff-changes component and the workplace summary to show "Change" link instead of "Add" when total number of staff is 0

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
