### PR TITLE
Fix/1688 fix layout of change password page

### DIFF
--- a/frontend/src/app/features/account-management/change-password/edit/edit.component.html
+++ b/frontend/src/app/features/account-management/change-password/edit/edit.component.html
@@ -33,10 +33,10 @@
         <div [formGroupName]="'passwordGroup'">
           <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && getCreatePasswordInput.errors">
             <label class="govuk-label" for="createPasswordInput">New password</label>
-            <span id="createPasswordInput-hint" class="govuk-hint">
+            <div id="createPasswordInput-hint" class="govuk-hint">
               Must be at least 8 characters long and have uppercase letters, lowercase letters, numbers and special
               characters like !, £.
-            </span>
+            </div>
             <span
               *ngIf="submitted && getCreatePasswordInput.errors"
               id="passwordGroup-createPasswordInput-error"

--- a/frontend/src/app/features/reset-password/edit/edit.component.html
+++ b/frontend/src/app/features/reset-password/edit/edit.component.html
@@ -17,10 +17,10 @@
         <div [formGroupName]="'passwordGroup'">
           <div class="govuk-form-group" [class.govuk-form-group--error]="submitted && getPasswordInput.errors">
             <label class="govuk-label" for="createPasswordInput"> Password </label>
-            <span id="createPasswordInput-hint" class="govuk-hint">
+            <div id="createPasswordInput-hint" class="govuk-hint">
               Must be at least 8 characters long and have uppercase letters, lowercase letters, numbers and special
               characters like !, £.
-            </span>
+            </div>
             <span *ngIf="submitted" id="createPasswordInput-error" class="govuk-error-message">
               <span class="govuk-visually-hidden">Error:</span>
               <span *ngIf="getPasswordInput.hasError('required')">


### PR DESCRIPTION
#### Work done
- Replace `<span>` tag with `<div>` tag in password pages

Seems that the layout issue is related to a [previous change](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#update-the-html-for-hints ) in govuk CSS, where `display: block` was removed from  `govuk-hint` class.

Change password page after fix:
![password page after fix](https://github.com/user-attachments/assets/ccfe9646-5e59-4cac-a8e4-f8f052d238c1)


#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
