### PR TITLE
Fix/Job role titles in error message should not show abbreviation as lowercase

### DIFF
--- a/frontend/src/app/features/workplace/how-many-leavers/how-many-leavers.component.spec.ts
+++ b/frontend/src/app/features/workplace/how-many-leavers/how-many-leavers.component.spec.ts
@@ -290,6 +290,21 @@ describe('HowManyLeaversComponent', () => {
 
         expect(updateJobsSpy).not.toHaveBeenCalled();
       });
+
+      it('should show the error message without converting abbreviation in job titles to lower case', async () => {
+        const { fixture, getByText, getByRole } = await setup({
+          selectedJobRoles: [{ jobId: 36, title: 'IT manager', total: 1 }],
+        });
+
+        await fillInValueForJobRole('IT manager', '0');
+        userEvent.click(getByRole('button', { name: 'Save and continue' }));
+        fixture.detectChanges();
+
+        const errorSummaryBox = getByText('There is a problem').parentElement;
+        expect(
+          within(errorSummaryBox).getByText('Number of leavers must be between 1 and 999 (IT manager)'),
+        ).toBeTruthy();
+      });
     });
   });
 

--- a/frontend/src/app/features/workplace/how-many-starters/how-many-starters.component.spec.ts
+++ b/frontend/src/app/features/workplace/how-many-starters/how-many-starters.component.spec.ts
@@ -306,6 +306,21 @@ describe('HowManyStartersComponent', () => {
 
         expect(updateJobsSpy).not.toHaveBeenCalled();
       });
+
+      it('should show the error message without converting abbreviation in job titles to lower case', async () => {
+        const { fixture, getByText, getByRole } = await setup({
+          selectedJobRoles: [{ jobId: 36, title: 'IT manager', total: 1 }],
+        });
+
+        await fillInValueForJobRole('IT manager', '0');
+        userEvent.click(getByRole('button', { name: 'Save and continue' }));
+        fixture.detectChanges();
+
+        const errorSummaryBox = getByText('There is a problem').parentElement;
+        expect(
+          within(errorSummaryBox).getByText('Number of starters must be between 1 and 999 (IT manager)'),
+        ).toBeTruthy();
+      });
     });
   });
 

--- a/frontend/src/app/features/workplace/how-many-vacancies/how-many-vacancies.component.spec.ts
+++ b/frontend/src/app/features/workplace/how-many-vacancies/how-many-vacancies.component.spec.ts
@@ -302,6 +302,21 @@ describe('HowManyVacanciesComponent', () => {
 
         expect(updateJobsSpy).not.toHaveBeenCalled();
       });
+
+      it('should show the error message without converting abbreviation in job titles to lower case', async () => {
+        const { fixture, getByText, getByRole } = await setup({
+          selectedJobRoles: [{ jobId: 36, title: 'IT manager', total: 1 }],
+        });
+
+        await fillInValueForJobRole('IT manager', '0');
+        userEvent.click(getByRole('button', { name: 'Save and continue' }));
+        fixture.detectChanges();
+
+        const errorSummaryBox = getByText('There is a problem').parentElement;
+        expect(
+          within(errorSummaryBox).getByText('Number of vacancies must be between 1 and 999 (IT manager)'),
+        ).toBeTruthy();
+      });
     });
   });
 

--- a/frontend/src/app/features/workplace/vacancies-and-turnover/how-many-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/features/workplace/vacancies-and-turnover/how-many-starters-leavers-vacancies.directive.ts
@@ -10,6 +10,7 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { VacanciesAndTurnoverService } from '../../../core/services/vacancies-and-turnover.service';
 import { JobRoleNumbersTableComponent } from '@shared/components/job-role-numbers-table/job-role-numbers-table.component';
+import { FormatUtil } from '@core/utils/format-util';
 
 @Directive()
 export class HowManyStartersLeaversVacanciesDirective extends Question implements OnInit, OnDestroy {
@@ -161,25 +162,25 @@ export class HowManyStartersLeaversVacanciesDirective extends Question implement
     this.formErrorsMap = [];
 
     this.jobRoleNumbers.controls.forEach((_, index) => {
-      const jobRoleTitle = this.selectedJobRoles[index].title.toLowerCase();
+      const jobRoleTitleInLowerCase = FormatUtil.formatToLowercaseExcludingAcronyms(this.selectedJobRoles[index].title);
       this.formErrorsMap.push({
         item: `jobRoleNumbers.${index}`,
         type: [
           {
             name: 'required',
-            message: this.getErrorMessage('required', jobRoleTitle),
+            message: this.getErrorMessage('required', jobRoleTitleInLowerCase),
           },
           {
             name: 'min',
-            message: this.getErrorMessage('min', jobRoleTitle),
+            message: this.getErrorMessage('min', jobRoleTitleInLowerCase),
           },
           {
             name: 'max',
-            message: this.getErrorMessage('max', jobRoleTitle),
+            message: this.getErrorMessage('max', jobRoleTitleInLowerCase),
           },
           {
             name: 'pattern',
-            message: this.getErrorMessage('pattern', jobRoleTitle),
+            message: this.getErrorMessage('pattern', jobRoleTitleInLowerCase),
           },
         ],
       });

--- a/frontend/src/app/shared/components/update-starters-leavers-vacancies/update-leavers/update-leavers.component.spec.ts
+++ b/frontend/src/app/shared/components/update-starters-leavers-vacancies/update-leavers/update-leavers.component.spec.ts
@@ -333,7 +333,7 @@ describe('UpdateLeaversComponent', () => {
     }) as Establishment;
 
     it('should call updateJobs to save selected job roles', async () => {
-      const { getByRole, component, fixture, routerSpy, vacanciesAndTurnoverService, updateJobsSpy } = await setup({
+      const { getByRole, fixture, vacanciesAndTurnoverService, updateJobsSpy } = await setup({
         workplace: mockWorkplace,
         leaversFromSelectJobRolePages: selectedJobRoles,
         snapshot: { staffUpdatesView: true },
@@ -565,6 +565,32 @@ describe('UpdateLeaversComponent', () => {
       expect(errorMessage1).toBeTruthy();
       expect(errorMessage1WithJobRole).toBeTruthy();
       expect(errorMessage2.length).toEqual(2);
+    });
+
+    it('should show the error message without converting abbreviation in job titles to lower case', async () => {
+      const { fixture, getByRole, updateJobsSpy, getByLabelText, getByText } = await setup({
+        leaversFromSelectJobRolePages: [{ jobId: 36, title: 'IT manager', total: 1 }],
+      });
+
+      const numberInputForJobRole = getByLabelText('IT manager') as HTMLInputElement;
+      userEvent.clear(numberInputForJobRole);
+      userEvent.type(numberInputForJobRole, '0');
+
+      userEvent.click(getByRole('button', { name: 'Save and return' }));
+
+      fixture.detectChanges();
+
+      const expectedErrorMessage = {
+        summaryBox: 'Number of leavers must be between 1 and 999 (IT manager)',
+        inline: 'Number of leavers must be between 1 and 999',
+      };
+
+      fixture.detectChanges();
+
+      expect(getByText(expectedErrorMessage.summaryBox)).toBeTruthy();
+      expect(getByText(expectedErrorMessage.inline)).toBeTruthy();
+
+      expect(updateJobsSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/app/shared/components/update-starters-leavers-vacancies/update-starters/update-starters.component.spec.ts
+++ b/frontend/src/app/shared/components/update-starters-leavers-vacancies/update-starters/update-starters.component.spec.ts
@@ -610,6 +610,26 @@ describe('UpdateStartersComponent', () => {
         });
       });
 
+      it('should show the error message without converting abbreviation in job titles to lower case', async () => {
+        const { fixture, getByRole, updateJobsSpy } = await setup({
+          startersFromSelectJobRolePages: [{ jobId: 36, title: 'IT manager', total: 1 }],
+        });
+
+        await fillInValueForJobRole('IT manager', '0');
+
+        userEvent.click(getByRole('button', { name: 'Save and return' }));
+
+        const expectedErrorMessage = {
+          summaryBox: 'Number of starters must be between 1 and 999 (IT manager)',
+          inline: 'Number of starters must be between 1 and 999',
+        };
+
+        fixture.detectChanges();
+
+        expectErrorMessageAppears(expectedErrorMessage.summaryBox, expectedErrorMessage.inline);
+        expect(updateJobsSpy).not.toHaveBeenCalled();
+      });
+
       it('should still show the correct error messages even if some job roles were removed before submit', async () => {
         const { fixture, getByRole } = await setup({
           startersFromSelectJobRolePages: [{ jobId: 10, title: 'Care worker', total: 3 }, ...mockStarters],

--- a/frontend/src/app/shared/components/update-starters-leavers-vacancies/update-vacancies/update-vacancies.component.spec.ts
+++ b/frontend/src/app/shared/components/update-starters-leavers-vacancies/update-vacancies/update-vacancies.component.spec.ts
@@ -585,7 +585,7 @@ describe('UpdateVacanciesComponent', () => {
       testCases.forEach(({ inputValue, expectedErrorMessage }) => {
         it(`should show an error when user input "${inputValue}" for a job role`, async () => {
           const { fixture, getByRole, updateJobsSpy } = await setup({
-            vacanciesFromSelectJobRolePages: [{ jobId: 10, title: 'Care worker', total: 1 }],
+            vacanciesFromSelectJobRolePages: [{ jobId: 36, title: 'Care worker', total: 1 }],
           });
 
           await fillInValueForJobRole('Care worker', inputValue);
@@ -597,6 +597,26 @@ describe('UpdateVacanciesComponent', () => {
           expectErrorMessageAppears(expectedErrorMessage.summaryBox, expectedErrorMessage.inline);
           expect(updateJobsSpy).not.toHaveBeenCalled();
         });
+      });
+
+      it('should show the error message without converting abbreviation in job titles to lower case', async () => {
+        const { fixture, getByRole, updateJobsSpy } = await setup({
+          vacanciesFromSelectJobRolePages: [{ jobId: 36, title: 'IT manager', total: 1 }],
+        });
+
+        await fillInValueForJobRole('IT manager', '0');
+
+        userEvent.click(getByRole('button', { name: 'Save and return' }));
+
+        const expectedErrorMessage = {
+          summaryBox: 'Number of vacancies must be between 1 and 999 (IT manager)',
+          inline: 'Number of vacancies must be between 1 and 999',
+        };
+
+        fixture.detectChanges();
+
+        expectErrorMessageAppears(expectedErrorMessage.summaryBox, expectedErrorMessage.inline);
+        expect(updateJobsSpy).not.toHaveBeenCalled();
       });
 
       it('should still show the correct error messages even if some job roles were removed before submit', async () => {


### PR DESCRIPTION
#### Work done
- Add unit tests to `how-many-SLV` pages and `update-SLV` pages to ensure job role titles in error message are correct
(abbreviations should not be in lowercase)
- Use the special lowercase function from FormatUtil for job role titles instead of `.toLowerCase()`

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
