### PR TITLE
Fix: Unable to click links on staff training and quals page

### DIFF
--- a/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
+++ b/frontend/src/app/features/training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component.html
@@ -216,38 +216,40 @@
     </li>
   </ul>
 </div>
-<div class="govuk-grid-column-full">
-  <app-new-training
-    *ngIf="currentFragment === fragmentsObject.allRecords || currentFragment === fragmentsObject.mandatoryTraining"
-    [trainingCategories]="mandatoryTraining"
-    [trainingType]="'Mandatory training'"
-    [isMandatoryTraining]="true"
-    [canEditWorker]="canEditWorker"
-    [setReturnRoute]="setReturnRoute"
-    [missingMandatoryTraining]="missingMandatoryTraining.length > 0"
-    (downloadFile)="downloadCertificate($event)"
-    (uploadFile)="uploadCertificate($event)"
-    [certificateErrors]="certificateErrors"
-  >
-  </app-new-training>
-  <app-new-training
-    *ngIf="currentFragment === fragmentsObject.allRecords || currentFragment === fragmentsObject.nonMandatoryTraining"
-    [trainingCategories]="nonMandatoryTraining"
-    [trainingType]="'Non-mandatory training'"
-    [canEditWorker]="canEditWorker"
-    [setReturnRoute]="setReturnRoute"
-    (downloadFile)="downloadCertificate($event)"
-    (uploadFile)="uploadCertificate($event)"
-    [certificateErrors]="certificateErrors"
-  >
-  </app-new-training>
-  <app-new-qualifications
-    *ngIf="currentFragment === fragmentsObject.allRecords || currentFragment === fragmentsObject.qualifications"
-    [canEditWorker]="canEditWorker"
-    [qualificationsByGroup]="qualificationsByGroup"
-    (downloadFile)="downloadCertificate($event)"
-    (uploadFile)="uploadCertificate($event)"
-    [certificateErrors]="certificateErrors"
-  >
-  </app-new-qualifications>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <app-new-training
+      *ngIf="currentFragment === fragmentsObject.allRecords || currentFragment === fragmentsObject.mandatoryTraining"
+      [trainingCategories]="mandatoryTraining"
+      [trainingType]="'Mandatory training'"
+      [isMandatoryTraining]="true"
+      [canEditWorker]="canEditWorker"
+      [setReturnRoute]="setReturnRoute"
+      [missingMandatoryTraining]="missingMandatoryTraining.length > 0"
+      (downloadFile)="downloadCertificate($event)"
+      (uploadFile)="uploadCertificate($event)"
+      [certificateErrors]="certificateErrors"
+    >
+    </app-new-training>
+    <app-new-training
+      *ngIf="currentFragment === fragmentsObject.allRecords || currentFragment === fragmentsObject.nonMandatoryTraining"
+      [trainingCategories]="nonMandatoryTraining"
+      [trainingType]="'Non-mandatory training'"
+      [canEditWorker]="canEditWorker"
+      [setReturnRoute]="setReturnRoute"
+      (downloadFile)="downloadCertificate($event)"
+      (uploadFile)="uploadCertificate($event)"
+      [certificateErrors]="certificateErrors"
+    >
+    </app-new-training>
+    <app-new-qualifications
+      *ngIf="currentFragment === fragmentsObject.allRecords || currentFragment === fragmentsObject.qualifications"
+      [canEditWorker]="canEditWorker"
+      [qualificationsByGroup]="qualificationsByGroup"
+      (downloadFile)="downloadCertificate($event)"
+      (uploadFile)="uploadCertificate($event)"
+      [certificateErrors]="certificateErrors"
+    >
+    </app-new-qualifications>
+  </div>
 </div>


### PR DESCRIPTION
#### Issue
This is a second attempt at resolving an issue highlighted by a user where they were unable to click on links in the actions list on the individual staff training and quals page.
The first attempt did not resolve the issue and a potential cause has now become clear
https://github.com/NMDSdevopsServiceAdm/SopraSteria-SFC/pull/6559

#### Work done
- Updated html to wrap column in govuk-grid-row on individual staff training and quals page to stop help button container blocking user interaction 

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [X] No, they are not required for this change
