### PR TITLE
Fix/1693 salaryint blank when not known selected on a staff record

### DIFF
--- a/backend/server/routes/establishments/bulkUpload/download/workerCSV.js
+++ b/backend/server/routes/establishments/bulkUpload/download/workerCSV.js
@@ -317,6 +317,16 @@ const toCSV = (establishmentId, entity, MAX_QUALIFICATIONS, downloadType) => {
       // "HOURLYRATE"
       columns.push('');
       break;
+
+    case "Don't know":
+      // "SALARYINT"
+      columns.push(999);
+      // "SALARY"
+      columns.push('');
+      // "HOURLYRATE"
+      columns.push('');
+      break;
+
     default:
       // "SALARYINT"
       columns.push('');

--- a/backend/server/test/unit/routes/establishments/bulkUpload/download/workerCSV.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/download/workerCSV.spec.js
@@ -495,36 +495,50 @@ describe('workerCSV', () => {
           expect(csvAsArray[getWorkerColumnIndex('DAYSSICK')]).to.equal('');
         });
 
-        it('should return hourly value and rate', async () => {
-          worker.AnnualHourlyPayValue = 'Hourly';
+        describe('AnnualHourlyPayValue and AnnualHourlyPayRate', () => {
+          it('should return with SALARYINT = 3 and HOURLYRATE filled if AnnualHourlyPayValue is Hourly', async () => {
+            worker.AnnualHourlyPayValue = 'Hourly';
 
-          const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
-          const csvAsArray = csv.split(',');
+            const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
+            const csvAsArray = csv.split(',');
 
-          expect(csvAsArray[getWorkerColumnIndex('SALARYINT')]).to.equal('3');
-          expect(csvAsArray[getWorkerColumnIndex('SALARY')]).to.equal('');
-          expect(csvAsArray[getWorkerColumnIndex('HOURLYRATE')]).to.equal(String(worker.AnnualHourlyPayRate));
-        });
+            expect(csvAsArray[getWorkerColumnIndex('SALARYINT')]).to.equal('3');
+            expect(csvAsArray[getWorkerColumnIndex('SALARY')]).to.equal('');
+            expect(csvAsArray[getWorkerColumnIndex('HOURLYRATE')]).to.equal(String(worker.AnnualHourlyPayRate));
+          });
 
-        it('should return annual value and rate', async () => {
-          worker.AnnualHourlyPayValue = 'Annually';
+          it('should return with SALARYINT = 1 and SALARY filled if AnnualHourlyPayValue is Annually', async () => {
+            worker.AnnualHourlyPayValue = 'Annually';
 
-          const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
-          const csvAsArray = csv.split(',');
+            const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
+            const csvAsArray = csv.split(',');
 
-          expect(csvAsArray[getWorkerColumnIndex('SALARYINT')]).to.equal('1');
-          expect(csvAsArray[getWorkerColumnIndex('SALARY')]).to.equal(String(worker.AnnualHourlyPayRate));
-          expect(csvAsArray[getWorkerColumnIndex('HOURLYRATE')]).to.equal('');
-        });
-        it('should not return annual/hourly value or rate', async () => {
-          worker.AnnualHourlyPayValue = null;
+            expect(csvAsArray[getWorkerColumnIndex('SALARYINT')]).to.equal('1');
+            expect(csvAsArray[getWorkerColumnIndex('SALARY')]).to.equal(String(worker.AnnualHourlyPayRate));
+            expect(csvAsArray[getWorkerColumnIndex('HOURLYRATE')]).to.equal('');
+          });
 
-          const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
-          const csvAsArray = csv.split(',');
+          it('should return with SALARYINT = 999, SALARY and HOURLYRATE as blank if AnnualHourlyPayValue is "Don\'t know"', () => {
+            worker.AnnualHourlyPayValue = "Don't know";
 
-          expect(csvAsArray[getWorkerColumnIndex('SALARYINT')]).to.equal('');
-          expect(csvAsArray[getWorkerColumnIndex('SALARY')]).to.equal('');
-          expect(csvAsArray[getWorkerColumnIndex('HOURLYRATE')]).to.equal('');
+            const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
+            const csvAsArray = csv.split(',');
+
+            expect(csvAsArray[getWorkerColumnIndex('SALARYINT')]).to.equal('999');
+            expect(csvAsArray[getWorkerColumnIndex('SALARY')]).to.equal('');
+            expect(csvAsArray[getWorkerColumnIndex('HOURLYRATE')]).to.equal('');
+          });
+
+          it('should return SALARYINT, SALARY and HOURLYRATE as blank if AnnualHourlyPayValue is null', async () => {
+            worker.AnnualHourlyPayValue = null;
+
+            const csv = toCSV(establishment.LocalIdentifierValue, worker, 3);
+            const csvAsArray = csv.split(',');
+
+            expect(csvAsArray[getWorkerColumnIndex('SALARYINT')]).to.equal('');
+            expect(csvAsArray[getWorkerColumnIndex('SALARY')]).to.equal('');
+            expect(csvAsArray[getWorkerColumnIndex('HOURLYRATE')]).to.equal('');
+          });
         });
 
         it('should return main job id', async () => {

--- a/lambdas/bulkUpload/classes/constants.js
+++ b/lambdas/bulkUpload/classes/constants.js
@@ -1,0 +1,13 @@
+const SALARY_INT_STRINGS = {
+  Annually: 'Annually',
+  Hourly: 'Hourly',
+  DontKnow: "Don't know",
+};
+
+const SALARY_INT_OPTIONS = [
+  { bulkUploadValue: 1, databaseValue: SALARY_INT_STRINGS.Annually },
+  { bulkUploadValue: 3, databaseValue: SALARY_INT_STRINGS.Hourly },
+  { bulkUploadValue: 999, databaseValue: SALARY_INT_STRINGS.DontKnow },
+];
+
+module.exports = { SALARY_INT_STRINGS, SALARY_INT_OPTIONS };

--- a/lambdas/bulkUpload/classes/workerCSVValidator.js
+++ b/lambdas/bulkUpload/classes/workerCSVValidator.js
@@ -1687,53 +1687,49 @@ class WorkerCsvValidator {
   }
 
   _validateSalaryInt() {
-    const salaryIntValues = [1, 3];
+    const allAllowedValues = [1, 3, 999];
+    const allStringValues = ['Annually', 'Hourly', "Don't know"];
+
     const mySalaryInt = parseInt(this._currentLine.SALARYINT, 10);
 
-    // optional
-    if (this._currentLine.SALARYINT && this._currentLine.SALARYINT.length > 0) {
-      if (isNaN(mySalaryInt)) {
-        this._validationErrors.push({
-          worker: this._currentLine.UNIQUEWORKERID,
-          name: this._currentLine.LOCALESTID,
-          lineNumber: this._lineNumber,
-          errCode: WorkerCsvValidator.SALARY_ERROR,
-          errType: 'SALARYINT_ERROR',
-          error: 'Salary Int (SALARYINT) must be an integer',
-          source: this._currentLine.SALARYINT,
-          column: 'SALARYINT',
-        });
-        return false;
-      } else if (!salaryIntValues.includes(parseInt(mySalaryInt, 10))) {
-        this._validationErrors.push({
-          worker: this._currentLine.UNIQUEWORKERID,
-          name: this._currentLine.LOCALESTID,
-          lineNumber: this._lineNumber,
-          errCode: WorkerCsvValidator.SALARY_ERROR,
-          errType: 'SALARYINT_ERROR',
-          error: 'The code you have entered for SALARYINT is incorrect',
-          source: this._currentLine.SALARYINT,
-          column: 'SALARYINT',
-        });
-        return false;
-      } else {
-        switch (mySalaryInt) {
-          case 1:
-            this._salaryInt = 'Annually';
-            break;
-          case 3:
-            this._salaryInt = 'Hourly';
-            break;
-          default:
-            // not doing anything with unpaid
-            this._salaryInt = null;
-        }
+    const fieldIsEmpty = !(this._currentLine.SALARYINT && this._currentLine.SALARYINT.length > 0);
 
-        return true;
-      }
-    } else {
+    if (fieldIsEmpty) {
       return true;
     }
+
+    if (isNaN(mySalaryInt)) {
+      this._validationErrors.push({
+        worker: this._currentLine.UNIQUEWORKERID,
+        name: this._currentLine.LOCALESTID,
+        lineNumber: this._lineNumber,
+        errCode: WorkerCsvValidator.SALARY_ERROR,
+        errType: 'SALARYINT_ERROR',
+        error: 'Salary Int (SALARYINT) must be an integer',
+        source: this._currentLine.SALARYINT,
+        column: 'SALARYINT',
+      });
+      return false;
+    }
+
+    const salaryIntValueInString = allStringValues[allAllowedValues.indexOf(mySalaryInt)];
+
+    if (!salaryIntValueInString) {
+      this._validationErrors.push({
+        worker: this._currentLine.UNIQUEWORKERID,
+        name: this._currentLine.LOCALESTID,
+        lineNumber: this._lineNumber,
+        errCode: WorkerCsvValidator.SALARY_ERROR,
+        errType: 'SALARYINT_ERROR',
+        error: 'The code you have entered for SALARYINT is incorrect',
+        source: this._currentLine.SALARYINT,
+        column: 'SALARYINT',
+      });
+      return false;
+    }
+
+    this._salaryInt = salaryIntValueInString;
+    return true;
   }
 
   _validateSalary() {
@@ -3164,6 +3160,9 @@ class WorkerCsvValidator {
       }
       if (this._salaryInt === 'Hourly') {
         changeProperties.annualHourlyPay.rate = this._hourlyRate ? this._hourlyRate : undefined;
+      }
+      if (this._salaryInt === "Don't know") {
+        changeProperties.annualHourlyPay.rate = undefined;
       }
     }
 

--- a/lambdas/bulkUpload/test/unit/classes/workerCSVValidator.spec.js
+++ b/lambdas/bulkUpload/test/unit/classes/workerCSVValidator.spec.js
@@ -68,7 +68,7 @@ const buildWorkerRecord = build('WorkerRecord', {
   },
 });
 
-describe('/lambdas/bulkUpload/classes/workerCSVValidator', async () => {
+describe.only('/lambdas/bulkUpload/classes/workerCSVValidator', async () => {
   describe('validations', () => {
     describe('days sick', () => {
       it('should emit a warning when days sick not already changed today', async () => {
@@ -1377,128 +1377,6 @@ describe('/lambdas/bulkUpload/classes/workerCSVValidator', async () => {
       });
     });
 
-    describe('_validateSalary()', () => {
-      it('should not error when the worker is not a senior manager and the salary is between £500 and £200000', async () => {
-        const worker = buildWorkerCsv({
-          overrides: {
-            STATUS: 'NEW',
-            SALARY: '20000',
-          },
-        });
-
-        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
-
-        await validator.validate();
-        await validator.transform();
-
-        expect(validator._validationErrors).to.deep.equal([]);
-        expect(validator._validationErrors.length).to.equal(0);
-      });
-
-      it('should not error when the worker is a senior manager and the salary entered is over £200000 and under £250000', async () => {
-        const worker = buildWorkerCsv({
-          overrides: {
-            STATUS: 'NEW',
-            SALARY: '240000',
-            MAINJOBROLE: '1',
-          },
-        });
-
-        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
-
-        await validator.validate();
-        await validator.transform();
-
-        expect(validator._validationErrors).to.deep.equal([]);
-        expect(validator._validationErrors.length).to.equal(0);
-      });
-
-      it('should error when salary entered is below £500', async () => {
-        const worker = buildWorkerCsv({
-          overrides: {
-            STATUS: 'NEW',
-            SALARY: '300',
-          },
-        });
-
-        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
-
-        await validator.validate();
-        await validator.transform();
-
-        expect(validator._validationErrors).to.deep.equal([
-          {
-            lineNumber: 2,
-            errCode: WorkerCsvValidator.SALARY_ERROR,
-            errType: 'SALARY_ERROR',
-            error: 'SALARY must be between £500 and £200000',
-            source: worker.SALARY,
-            column: 'SALARY',
-            name: 'MARMA',
-            worker: '3',
-          },
-        ]);
-        expect(validator._validationErrors.length).to.equal(1);
-      });
-
-      it('should error when worker is not a senior manager and salary is over £200000', async () => {
-        const worker = buildWorkerCsv({
-          overrides: {
-            STATUS: 'NEW',
-            SALARY: '250000',
-          },
-        });
-
-        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
-
-        await validator.validate();
-        await validator.transform();
-
-        expect(validator._validationErrors).to.deep.equal([
-          {
-            lineNumber: 2,
-            errCode: WorkerCsvValidator.SALARY_ERROR,
-            errType: 'SALARY_ERROR',
-            error: 'SALARY must be between £500 and £200000',
-            source: worker.SALARY,
-            column: 'SALARY',
-            name: 'MARMA',
-            worker: '3',
-          },
-        ]);
-        expect(validator._validationErrors.length).to.equal(1);
-      });
-
-      it('should error when the worker is a senior manager and the salary entered is over £250000', async () => {
-        const worker = buildWorkerCsv({
-          overrides: {
-            STATUS: 'NEW',
-            SALARY: '260000',
-            MAINJOBROLE: '1',
-          },
-        });
-
-        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
-
-        await validator.validate();
-        await validator.transform();
-
-        expect(validator._validationErrors).to.deep.equal([
-          {
-            lineNumber: 2,
-            errCode: WorkerCsvValidator.SALARY_ERROR,
-            errType: 'SALARY_ERROR',
-            error: 'SALARY must be between £500 and £250000',
-            source: worker.SALARY,
-            column: 'SALARY',
-            name: 'MARMA',
-            worker: '3',
-          },
-        ]);
-        expect(validator._validationErrors.length).to.equal(1);
-      });
-    });
-
     describe('_validateSalaryInt()', () => {
       it(`should set _salaryInt as "Annually" when SalaryInt was given as "1"`, async () => {
         const worker = buildWorkerCsv({
@@ -1628,6 +1506,311 @@ describe('/lambdas/bulkUpload/classes/workerCSVValidator', async () => {
       });
     });
 
+    describe('_validateSalary()', () => {
+      it('should not error when the worker is not a senior manager and the salary is between £500 and £200000', async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARY: '20000',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        await validator.validate();
+        await validator.transform();
+
+        expect(validator._validationErrors).to.deep.equal([]);
+        expect(validator._validationErrors.length).to.equal(0);
+      });
+
+      it('should not error when the worker is a senior manager and the salary entered is over £200000 and under £250000', async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARY: '240000',
+            MAINJOBROLE: '1',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        await validator.validate();
+        await validator.transform();
+
+        expect(validator._validationErrors).to.deep.equal([]);
+        expect(validator._validationErrors.length).to.equal(0);
+      });
+
+      it('should error when salary entered is below £500', async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARY: '300',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        await validator.validate();
+        await validator.transform();
+
+        expect(validator._validationErrors).to.deep.equal([
+          {
+            lineNumber: 2,
+            errCode: WorkerCsvValidator.SALARY_ERROR,
+            errType: 'SALARY_ERROR',
+            error: 'SALARY must be between £500 and £200000',
+            source: worker.SALARY,
+            column: 'SALARY',
+            name: 'MARMA',
+            worker: '3',
+          },
+        ]);
+        expect(validator._validationErrors.length).to.equal(1);
+      });
+
+      it('should error when worker is not a senior manager and salary is over £200000', async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARY: '250000',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        await validator.validate();
+        await validator.transform();
+
+        expect(validator._validationErrors).to.deep.equal([
+          {
+            lineNumber: 2,
+            errCode: WorkerCsvValidator.SALARY_ERROR,
+            errType: 'SALARY_ERROR',
+            error: 'SALARY must be between £500 and £200000',
+            source: worker.SALARY,
+            column: 'SALARY',
+            name: 'MARMA',
+            worker: '3',
+          },
+        ]);
+        expect(validator._validationErrors.length).to.equal(1);
+      });
+
+      it('should error when the worker is a senior manager and the salary entered is over £250000', async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARY: '260000',
+            MAINJOBROLE: '1',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        await validator.validate();
+        await validator.transform();
+
+        expect(validator._validationErrors).to.deep.equal([
+          {
+            lineNumber: 2,
+            errCode: WorkerCsvValidator.SALARY_ERROR,
+            errType: 'SALARY_ERROR',
+            error: 'SALARY must be between £500 and £250000',
+            source: worker.SALARY,
+            column: 'SALARY',
+            name: 'MARMA',
+            worker: '3',
+          },
+        ]);
+        expect(validator._validationErrors.length).to.equal(1);
+      });
+
+      it(`should give a warning when SalaryInt was "Don't know" and Salary column was filled`, async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARYINT: '999',
+            SALARY: '30000',
+            HOURLYRATE: '',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        validator.validate();
+        validator.transform();
+
+        const expectedWarning = {
+          lineNumber: 2,
+          warnCode: WorkerCsvValidator.SALARY_WARNING,
+          warnType: 'SALARY_WARNING',
+          warning: `The code you have entered for SALARY will be ignored as SALARYINT is 999`,
+          source: `SALARYINT (${worker.SALARYINT}) - SALARY (${worker.SALARY})`,
+          column: 'SALARY',
+          name: 'MARMA',
+          worker: '3',
+        };
+
+        expect(validator._validationErrors).to.deep.equal([expectedWarning]);
+        expect(validator._salaryInt).to.equal("Don't know");
+        expect(validator._salary).to.equal(null);
+      });
+    });
+
+    describe('_validateHourlyRate', () => {
+      describe('should set the hourly rate when SalaryInt was "3" and Hourly rate column was filled with decimal number', () => {
+        const test_cases = ['15.53', '0.53', '3', '3.00'];
+        const expected_results = [15.53, 0.53, 3, 3];
+
+        test_cases.forEach((input_hourly_rate, index) => {
+          it(`hourly rate = ${input_hourly_rate}`, async () => {
+            const worker = buildWorkerCsv({
+              overrides: {
+                STATUS: 'NEW',
+                SALARYINT: '3',
+                SALARY: '',
+                HOURLYRATE: input_hourly_rate,
+              },
+            });
+
+            const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+            validator.validate();
+            validator.transform();
+
+            const expected_hourly_rate = expected_results[index];
+
+            expect(validator._validationErrors).to.deep.equal([]);
+            expect(validator._salaryInt).to.equal('Hourly');
+            expect(validator._hourlyRate).to.equal(expected_hourly_rate);
+          });
+        });
+      });
+
+      it('should give an error if SalaryInt was "Annual" and Hourly rate column was filled', async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARYINT: '1',
+            SALARY: '',
+            HOURLYRATE: '15',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        validator.validate();
+        validator.transform();
+
+        const expectedError = {
+          lineNumber: 2,
+          errCode: WorkerCsvValidator.HOURLY_RATE_ERROR,
+          errType: 'HOURLY_RATE_ERROR',
+          error: 'The code you have entered for SALARYINT does not match HOURLYRATE',
+          source: `SALARYINT(${worker.SALARYINT}) - HOURLYRATE (${worker.HOURLYRATE})`,
+          column: 'SALARYINT/HOURLYRATE',
+          name: 'MARMA',
+          worker: '3',
+        };
+
+        expect(validator._validationErrors).to.deep.equal([expectedError]);
+      });
+
+      it('should give an error if SalaryInt was empty and Hourly rate column was filled', async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARYINT: '',
+            SALARY: '',
+            HOURLYRATE: '15',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        validator.validate();
+        validator.transform();
+
+        const expectedError = {
+          lineNumber: 2,
+          errCode: WorkerCsvValidator.HOURLY_RATE_ERROR,
+          errType: 'HOURLY_RATE_ERROR',
+          error: 'The code you have entered for SALARYINT does not match HOURLYRATE',
+          source: `SALARYINT(${worker.SALARYINT}) - HOURLYRATE (${worker.HOURLYRATE})`,
+          column: 'SALARYINT/HOURLYRATE',
+          name: 'MARMA',
+          worker: '3',
+        };
+
+        expect(validator._validationErrors).to.deep.equal([expectedError]);
+      });
+
+      it(`should give an error if Hourly rate column was filled with invalid value`, async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARYINT: '3',
+            SALARY: '',
+            HOURLYRATE: 'a banana',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        validator.validate();
+        validator.transform();
+
+        const expectedWarning = {
+          lineNumber: 2,
+          errCode: WorkerCsvValidator.HOURLY_RATE_ERROR,
+          errType: 'HOURLY_RATE_ERROR',
+          error: 'The code you have entered for HOURLYRATE is incorrect',
+          source: worker.HOURLYRATE,
+          column: 'HOURLYRATE',
+          name: 'MARMA',
+          worker: '3',
+        };
+        console.log(validator._validationErrors, '<--- validator._validationErrors');
+
+        expect(validator._validationErrors).to.deep.equal([expectedWarning]);
+        expect(validator._salaryInt).to.equal('Hourly');
+        expect(validator._hourlyRate).to.equal(null);
+      });
+
+      it(`should give a warning if SalaryInt was "Don't know" and Hourly rate column was filled`, async () => {
+        const worker = buildWorkerCsv({
+          overrides: {
+            STATUS: 'NEW',
+            SALARYINT: '999',
+            SALARY: '',
+            HOURLYRATE: '15',
+          },
+        });
+
+        const validator = new WorkerCsvValidator(worker, 2, null, mappings);
+
+        validator.validate();
+        validator.transform();
+
+        const expectedWarning = {
+          lineNumber: 2,
+          warnCode: WorkerCsvValidator.HOURLY_RATE_WARNING,
+          warnType: 'HOURLY_RATE_WARNING',
+          warning: `The code you have entered for HOURLYRATE will be ignored as SALARYINT is 999`,
+          source: `SALARYINT (${worker.SALARYINT}) - HOURLYRATE (${worker.HOURLYRATE})`,
+          column: 'SALARYINT/HOURLYRATE',
+          name: 'MARMA',
+          worker: '3',
+        };
+
+        expect(validator._validationErrors).to.deep.equal([expectedWarning]);
+        expect(validator._salaryInt).to.equal("Don't know");
+        expect(validator._hourlyRate).to.equal(null);
+      });
+    });
+
     describe('_validateLevel2CareCert()', () => {
       let clock;
       before(() => {
@@ -1707,8 +1890,16 @@ describe('/lambdas/bulkUpload/classes/workerCSVValidator', async () => {
             warningMessage: warningMessages.yearBefore2024,
             warnType: warnTypes.yearBefore2024,
           },
-          { l2CareCertInput: '1;2099', warningMessage: warningMessages.yearInFuture, warnType: warnTypes.yearInFuture },
-          { l2CareCertInput: '1;2026', warningMessage: warningMessages.yearInFuture, warnType: warnTypes.yearInFuture },
+          {
+            l2CareCertInput: '1;2099',
+            warningMessage: warningMessages.yearInFuture,
+            warnType: warnTypes.yearInFuture,
+          },
+          {
+            l2CareCertInput: '1;2026',
+            warningMessage: warningMessages.yearInFuture,
+            warnType: warnTypes.yearInFuture,
+          },
           { l2CareCertInput: '1;abc', warningMessage: warningMessages.otherCase, warnType: warnTypes.otherCase },
         ];
         testCasesWithInvalidYears.forEach(({ l2CareCertInput, warningMessage, warnType }) => {


### PR DESCRIPTION
#### Work done
- For bulk upload staff file download, fill `SALARYINT` as 999 when salary interval is "Don't know"
- Add missing unit tests for `_validateHourlyRate` and `_validateSalaryInt`
- For bulk upload worker CSV validator, handle the case of `SALARYINT` = 999. 
  Also amend the logic of SALARY / HOURLY column to give warning instead of error when `SALARYINT` is 999 and the column is filled.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
