### PR TITLE
Feat/1696 save and continue in add staff flow

### DIFF
--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.html
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.html
@@ -47,5 +47,5 @@
     </div>
   </div>
 
-  <app-submit-button [return]="!insideFlow" (clicked)="setSubmitAction($event)" callToAction="Save"></app-submit-button>
+  <app-submit-button [return]="!insideFlow" (clicked)="setSubmitAction($event)"></app-submit-button>
 </form>

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -83,10 +83,10 @@ describe('OtherQualificationsLevelComponent', () => {
   });
 
   describe('submit buttons', () => {
-    it('should render the page with a save button when the return value is null', async () => {
+    it('should render the page with a Save and continue button when the return value is null', async () => {
       const { getByText } = await setup(false);
 
-      const button = getByText('Save');
+      const button = getByText('Save and continue');
       const viewRecordLink = getByText('View this staff record');
 
       expect(button).toBeTruthy();
@@ -128,7 +128,7 @@ describe('OtherQualificationsLevelComponent', () => {
       const select = getByLabelText('Qualification level', { exact: false });
       fireEvent.change(select, { target: { value: '1' } });
 
-      const saveButton = getByText('Save');
+      const saveButton = getByText('Save and continue');
       fireEvent.click(saveButton);
       fixture.detectChanges();
 
@@ -239,7 +239,7 @@ describe('OtherQualificationsLevelComponent', () => {
       const select = getByLabelText('Qualification level', { exact: false });
       fireEvent.change(select, { target: { value: '1' } });
 
-      const saveButton = getByText('Save');
+      const saveButton = getByText('Save and continue');
       fireEvent.click(saveButton);
 
       expect(alertSpy).toHaveBeenCalledWith({

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.html
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.html
@@ -45,6 +45,5 @@
     [summaryContinue]="true"
     [return]="!insideFlow"
     (clicked)="setSubmitAction($event)"
-    callToAction="Save"
   ></app-submit-button>
 </form>

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -70,10 +70,10 @@ describe('OtherQualificationsComponent', () => {
   });
 
   describe('submit buttons', () => {
-    it('should render the page with a save button, view this staff record and Skip this question link when in flow', async () => {
+    it('should render the page with save and continue button, view this staff record and Skip this question link when in flow', async () => {
       const { getByText } = await setup({ insideFlow: true });
 
-      expect(getByText('Save')).toBeTruthy();
+      expect(getByText('Save and continue')).toBeTruthy();
       expect(getByText('View this staff record')).toBeTruthy();
       expect(getByText('Skip this question')).toBeTruthy();
     });
@@ -91,7 +91,7 @@ describe('OtherQualificationsComponent', () => {
         worker: { otherQualification: 'Yes' },
       });
 
-      const button = getByText('Save');
+      const button = getByText('Save and continue');
 
       fireEvent.click(button);
 
@@ -143,7 +143,7 @@ describe('OtherQualificationsComponent', () => {
             fireEvent.click(button);
           }
 
-          fireEvent.click(getByText('Save'));
+          fireEvent.click(getByText('Save and continue'));
 
           expect(routerSpy).toHaveBeenCalledWith([
             '/workplace',
@@ -162,7 +162,7 @@ describe('OtherQualificationsComponent', () => {
             fireEvent.click(button);
           }
 
-          fireEvent.click(getByText('Save'));
+          fireEvent.click(getByText('Save and continue'));
 
           expect(alertSpy).toHaveBeenCalledWith({
             type: 'success',


### PR DESCRIPTION
#### Work done
- Updated Call to action buttons in add a staff record flow to have '_Save and continue_' rather than '_Save_'

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
