### PR TITLE
Feat/1698 staff record continue button changes

### DIFF
--- a/frontend/src/app/core/services/worker.service.ts
+++ b/frontend/src/app/core/services/worker.service.ts
@@ -56,7 +56,6 @@ export class WorkerService {
   public getRoute$: BehaviorSubject<any> = new BehaviorSubject<any>(null);
   public createStaffResponse = null;
   private _newWorkerMandatoryInfo: NewWorkerMandatoryInfo = null;
-  private _hasCompletedStaffRecordFlow: boolean = null;
 
   private _workers$: BehaviorSubject<Worker[]> = new BehaviorSubject<Worker[]>(null);
   public workers$: Observable<Worker[]> = this._workers$.asObservable();
@@ -332,17 +331,5 @@ export class WorkerService {
 
   public clearNewWorkerMandatoryInfo(): void {
     this._newWorkerMandatoryInfo = null;
-  }
-
-  public set hasCompletedStaffRecordFlow(hasCompleted: boolean) {
-    this._hasCompletedStaffRecordFlow = hasCompleted;
-  }
-
-  public get hasCompletedStaffRecordFlow(): boolean {
-    return this._hasCompletedStaffRecordFlow;
-  }
-
-  public clearHasCompletedStaffRecordFlow(): void {
-    this._hasCompletedStaffRecordFlow = null;
   }
 }

--- a/frontend/src/app/core/test-utils/MockWorkerService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkerService.ts
@@ -411,6 +411,7 @@ export const qualificationRecord = {
 export class MockWorkerService extends WorkerService {
   public _worker;
   public _alert;
+  public _addStaffRecordInProgress: boolean;
 
   public static factory(worker: Worker) {
     return (httpClient: HttpClient) => {
@@ -433,6 +434,14 @@ export class MockWorkerService extends WorkerService {
 
   public set worker(val) {
     this._worker = val;
+  }
+
+  public set addStaffRecordInProgress(value: boolean) {
+    this._addStaffRecordInProgress = value;
+  }
+
+  public get addStaffRecordInProgress(): boolean {
+    return this._addStaffRecordInProgress;
   }
 
   public get returnTo(): URLStructure {

--- a/frontend/src/app/features/workers/main-job-role/main-job-role.component.spec.ts
+++ b/frontend/src/app/features/workers/main-job-role/main-job-role.component.spec.ts
@@ -111,7 +111,6 @@ describe('MainJobRoleComponent', () => {
     const alertSpy = spyOn(alertService, 'addAlert').and.callThrough();
 
     const setAddStaffRecordInProgressSpy = spyOn(workerService, 'setAddStaffRecordInProgress');
-    const clearHasCompletedStaffRecordFlowSpy = spyOn(workerService, 'clearHasCompletedStaffRecordFlow');
 
     if (addNewWorker) {
       spyOn(workerService, 'setState').and.callFake(() => {
@@ -136,7 +135,6 @@ describe('MainJobRoleComponent', () => {
       workerService,
       alertSpy,
       setAddStaffRecordInProgressSpy,
-      clearHasCompletedStaffRecordFlowSpy,
     };
   }
 
@@ -279,16 +277,6 @@ describe('MainJobRoleComponent', () => {
         userEvent.click(getByText('Save this staff record'));
 
         expect(setAddStaffRecordInProgressSpy).toHaveBeenCalledWith(true);
-      });
-
-      it('should call clearHasCompletedStaffRecordFlow when clicking save this staff record', async () => {
-        const { getByText, clearHasCompletedStaffRecordFlowSpy } = await setup(true, false, true);
-
-        userEvent.click(getByText('Care providing roles'));
-        userEvent.click(getByText('Care worker'));
-        userEvent.click(getByText('Save this staff record'));
-
-        expect(clearHasCompletedStaffRecordFlowSpy).toHaveBeenCalled();
       });
 
       it('should return the user to the staff records tab when clicking cancel', async () => {

--- a/frontend/src/app/features/workers/main-job-role/main-job-role.component.ts
+++ b/frontend/src/app/features/workers/main-job-role/main-job-role.component.ts
@@ -125,7 +125,6 @@ export class MainJobRoleComponent extends QuestionComponent implements OnInit, O
     } else {
       this.next = this.getRoutePath('mandatory-details');
       this.workerService.setAddStaffRecordInProgress(true);
-      this.workerService.clearHasCompletedStaffRecordFlow();
     }
   }
 

--- a/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.ts
+++ b/frontend/src/app/features/workers/mandatory-details/mandatory-details.component.ts
@@ -49,7 +49,6 @@ export class MandatoryDetailsComponent implements OnInit, OnDestroy {
 
   onSubmit(event: Event): void {
     event.preventDefault();
-    this.workerService.clearHasCompletedStaffRecordFlow();
 
     const urlArr = this.router.url.split('/');
     const url = urlArr.slice(0, urlArr.length - 1).join('/');

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.spec.ts
@@ -295,7 +295,6 @@ describe('StaffRecordComponent', () => {
 
         await setup({
           workerService: {
-            hasCompletedStaffRecordFlow: true,
             updateWorker: updateWorkerSpy,
             worker: { completed: true },
           },

--- a/frontend/src/app/features/workers/staff-record/staff-record.component.ts
+++ b/frontend/src/app/features/workers/staff-record/staff-record.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
 import { URLStructure } from '@core/model/url.model';
@@ -38,7 +38,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
     private establishmentService: EstablishmentService,
     private permissionsService: PermissionsService,
     private route: ActivatedRoute,
-    private router: Router,
     private workerService: WorkerService,
     protected backLinkService: BackLinkService,
     public breadcrumbService: BreadcrumbService,
@@ -46,7 +45,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.hasCompletedStaffRecordFlow = this.workerService.hasCompletedStaffRecordFlow;
+    this.hasCompletedStaffRecordFlow = this.workerService.addStaffRecordInProgress;
     this.workplace = this.route.parent.snapshot.data.establishment;
     this.isParent = this.establishmentService.primaryWorkplace.isParent;
 
@@ -58,10 +57,7 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
       this.workerService.worker$.pipe(take(1)).subscribe((worker) => {
         this.worker = worker;
         if (!this.worker?.completed) {
-          this.workerService.hasCompletedStaffRecordFlow = true;
-          this.hasCompletedStaffRecordFlow = true;
           this.updateCompleted();
-          this.showContinueButtons();
         }
       }),
     );
@@ -83,7 +79,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
   private showContinueButtons(): void {
     this.continueRoute = ['/workplace', this.workplace.uid, 'staff-record', 'add-another-staff-record'];
     this.vacanciesAndTurnoverService.clearDoYouWantToAddOrDeleteAnswer();
-    this.trackNavigationToClearHasCompletedStaffRecordFlow();
   }
 
   public backLinkNavigation(): URLStructure {
@@ -117,18 +112,6 @@ export class StaffRecordComponent implements OnInit, OnDestroy {
           console.log(error);
         },
       ),
-    );
-  }
-
-  private trackNavigationToClearHasCompletedStaffRecordFlow(): void {
-    this.subscriptions.add(
-      this.router.events.subscribe((event) => {
-        if (event instanceof NavigationStart) {
-          if (!event.url?.includes('staff-record-summary') && !event.url?.includes('add-another-staff-record')) {
-            this.workerService.clearHasCompletedStaffRecordFlow();
-          }
-        }
-      }),
     );
   }
 

--- a/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
+++ b/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
@@ -46,7 +46,6 @@ export class StaffSummaryDirective implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.workerService.clearHasCompletedStaffRecordFlow();
     this.totalWorkerCount = this.workerCount;
     this.paginatedWorkers = this.workers;
     this.canViewWorker = this.permissionsService.can(this.workplace.uid, 'canViewWorker');


### PR DESCRIPTION
#### Work done
- Updated display of Continue buttons on staff summary to be based on existing addStaffRecordInProgress logic, so that Continue buttons are not displayed when user comes to the page from adding more details to an existing staff record or by clicking into the staff record directly

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
