### PR TITLE
Fix/1687 total number of staff

### DIFF
--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -224,6 +224,24 @@ describe('NewWorkplaceSummaryComponent', () => {
         );
       });
 
+      it('should not render the error message and conditional classes if the number of staff is 0', async () => {
+        const { component, fixture, getByTestId } = await setup();
+
+        component.canEditEstablishment = true;
+        component.workplace.numberOfStaff = 0;
+        component.checkNumberOfStaffErrorsAndWarnings();
+
+        fixture.detectChanges();
+
+        const numberOfStaffRow = getByTestId('numberOfStaff');
+
+        expect(within(numberOfStaffRow).queryByText('You need to add your total number of staff')).toBeFalsy();
+        expect(numberOfStaffRow.getAttribute('class')).not.toContain('govuk-summary-list__error');
+        expect(within(numberOfStaffRow).queryByTestId('number-of-staff-top-row').getAttribute('class')).not.toContain(
+          'govuk-summary-list__row--no-bottom-border govuk-summary-list__row--no-bottom-padding',
+        );
+      });
+
       it('should render correct warning message, with View staff records link and conditional classes if no of staff is more than no of staff records and more than 8 weeks since first login', async () => {
         const { component, fixture, getByTestId } = await setup(null, ['canEditEstablishment', 'canViewListOfWorkers']);
 

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
@@ -10,6 +10,7 @@ import { VacanciesAndTurnoverService } from '@core/services/vacancies-and-turnov
 import { WorkplaceUtil } from '@core/utils/workplace-util';
 import { sortBy } from 'lodash';
 import { Subscription } from 'rxjs';
+import { TabsService } from '../../../core/services/tabs.service';
 
 @Component({
   selector: 'app-new-workplace-summary',
@@ -88,7 +89,7 @@ export class NewWorkplaceSummaryComponent implements OnInit, OnDestroy {
   }
 
   public checkNumberOfStaffErrorsAndWarnings(): void {
-    this.numberOfStaffError = !this.workplace.numberOfStaff;
+    this.numberOfStaffError = this.workplace.numberOfStaff === null || this.workplace.numberOfStaff === undefined;
     const afterEightWeeksFromFirstLogin = new Date(this.workplace.eightWeeksFromFirstLogin) < new Date();
     this.numberOfStaffWarning = this.workplace.numberOfStaff !== this.workerCount && afterEightWeeksFromFirstLogin;
   }

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.ts
@@ -11,6 +11,7 @@ import { WorkplaceUtil } from '@core/utils/workplace-util';
 import { sortBy } from 'lodash';
 import { Subscription } from 'rxjs';
 import { TabsService } from '../../../core/services/tabs.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-new-workplace-summary',
@@ -46,6 +47,9 @@ export class NewWorkplaceSummaryComponent implements OnInit, OnDestroy {
     private establishmentService: EstablishmentService,
     private cqcStatusChangeService: CqcStatusChangeService,
     private vacanciesAndTurnoverService: VacanciesAndTurnoverService,
+    // TabsService and Router are needed here for navigateToTab() to work properly
+    private tabsService: TabsService,
+    private router: Router,
   ) {
     this.pluralMap['How many beds do you have?'] = {
       '=1': '# bed available',

--- a/frontend/src/app/shared/components/total-staff-panel/total-staff-panel.component.html
+++ b/frontend/src/app/shared/components/total-staff-panel/total-staff-panel.component.html
@@ -1,20 +1,21 @@
 <dl class="govuk-list--tab">
   <div class="govuk-list--tab__column">
-    <dt data-testid="totalStaffNumber" *ngIf="totalStaff">
+    <dt data-testid="totalStaffNumber" *ngIf="totalStaff | hasValue">
       {{ totalStaff }}
     </dt>
     <dd data-testid="totalStaffText">
-      <span>{{ !totalStaff ? 'Total' : 'total' }} number of staff {{ !totalStaff ? 'is missing' : '' }}</span>
+      <span>{{ (totalStaff | hasValue) ? ' total number of staff' : 'Total number of staff is missing' }}</span>
     </dd>
     <dd data-testid="totalStaffLink">
       <a
         *ngIf="canEditEstablishment"
         [routerLink]="['/workplace', workplace.uid, 'staff-record', 'total-staff']"
         class="govuk-!-font-size-19 govuk-!-font-weight-regular govuk-!-padding-right-9 govuk-!-margin-right-9"
-        [ngClass]="{ 'govuk-!-padding-right-9 govuk-!-margin-right-9': !totalStaff }"
+        [ngClass]="{ 'govuk-!-padding-right-9 govuk-!-margin-right-9': !(totalStaff | hasValue) }"
         (click)="setReturn()"
       >
-        {{ totalStaff ? 'Change' : 'Add' }} <span class="govuk-visually-hidden"> total number of staff</span>
+        {{ (totalStaff | hasValue) ? 'Change' : 'Add' }}
+        <span class="govuk-visually-hidden"> total number of staff</span>
       </a>
     </dd>
   </div>
@@ -32,7 +33,7 @@
     </dd>
   </div>
 
-  <ng-container *ngIf="totalStaff && totalStaff !== totalWorkers">
+  <ng-container *ngIf="(totalStaff | hasValue) && totalStaff !== totalWorkers">
     <div class="govuk-list--tab__column">
       <dt data-testid="changeNumber">
         <img

--- a/frontend/src/app/shared/components/total-staff-panel/total-staff-panel.component.spec.ts
+++ b/frontend/src/app/shared/components/total-staff-panel/total-staff-panel.component.spec.ts
@@ -7,6 +7,7 @@ import { within } from '@testing-library/angular';
 import { Establishment } from '../../../../mockdata/establishment';
 import { Permissions } from '../../../../mockdata/permissions';
 import { TotalStaffPanelComponent } from './total-staff-panel.component';
+import { SharedModule } from '@shared/shared.module';
 
 describe('TotalStaffPanelComponent', () => {
   let component: TotalStaffPanelComponent;
@@ -16,7 +17,7 @@ describe('TotalStaffPanelComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [RouterTestingModule, HttpClientTestingModule],
+        imports: [RouterTestingModule, HttpClientTestingModule, SharedModule],
         declarations: [TotalStaffPanelComponent],
       }).compileComponents();
     }),
@@ -101,6 +102,28 @@ describe('TotalStaffPanelComponent', () => {
     expect(staffAddedText.textContent).toContain('staff records added');
     expect(changeNumber.length).toEqual(0);
     expect(changeText.length).toEqual(0);
+  });
+
+  it('should show total staff, change link, "x staff records added" and "x staff records to delete" if total staff is 0', () => {
+    component.totalStaff = 0;
+    component.totalWorkers = 3;
+    fixture.detectChanges();
+
+    const totalStaffNumber = within(document.body).queryByTestId('totalStaffNumber');
+    const totalStaffLink = within(document.body).queryByTestId('totalStaffLink');
+    const totalStaffText = within(document.body).queryByTestId('totalStaffText');
+    const staffAddedNumber = within(document.body).queryByTestId('staffAddedNumber');
+    const staffAddedText = within(document.body).queryByTestId('staffAddedText');
+    const changeNumber = within(document.body).queryByTestId('changeNumber');
+    const changeText = within(document.body).queryByTestId('changeText');
+
+    expect(totalStaffNumber.innerHTML).toContain('0');
+    expect(totalStaffLink.innerHTML).toContain('Change');
+    expect(totalStaffText.innerHTML).toContain('total number of staff');
+    expect(staffAddedNumber.innerHTML).toContain('3');
+    expect(staffAddedText.textContent).toContain('staff records added');
+    expect(changeNumber.innerHTML).toContain('3');
+    expect(changeText.textContent).toContain('staff records to delete');
   });
 
   it('should show total staff and staff added but not changes if total staff is undefined', () => {


### PR DESCRIPTION
#### Work done
- When total number of staff is 0, change workplace summary page to show warning "You've more staff records than staff" instead of error "You need to add your total number of staff"
- When total number of staff is 0, change staff record summary to show the number difference instead of "Total number of staff is missing"
- Fix the problem of "View staff records" link not working in workplace summary page

below are screenshots after fixing
1. Workplace summary
![Screenshot 2025-05-09 at 16 22 52](https://github.com/user-attachments/assets/72f9dc60-b149-4362-b1ec-5ff96be96219)

2. Staff records summary
![Screenshot 2025-05-09 at 16 23 08](https://github.com/user-attachments/assets/bc54327d-d907-4780-8cec-0ec34f121cd6)


#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
