### PR TITLE
Feat/1697 staff record green banner change

### DIFF
--- a/frontend/cypress/e2e/standAloneEstablishment/EditUser/staffRecordsPage.spec.cy.js
+++ b/frontend/cypress/e2e/standAloneEstablishment/EditUser/staffRecordsPage.spec.cy.js
@@ -112,6 +112,88 @@ describe('Standalone staff records page as edit user', () => {
     });
   });
 
+  describe('Add new staff record workflow', () => {
+    const skipAllQuestions = () => {
+      cy.get('a').contains('Skip this question').click();
+      cy.location('pathname').then((pathname) => {
+        if (pathname.includes('staff-record-summary')) {
+          return;
+        }
+        skipAllQuestions();
+      });
+    };
+
+    const skipAllQuestionsBySaveButton = () => {
+      cy.get('button').contains('Save and continue').click();
+      cy.location('pathname').then((pathname) => {
+        if (pathname.includes('staff-record-summary')) {
+          return;
+        }
+        skipAllQuestionsBySaveButton();
+      });
+    };
+
+    it('should show a "Staff record details saved" alert when user completed the workflow and answered some questions', () => {
+      const name = 'Mr Cool';
+      const contractType = 'Permanent';
+      const mainJobRole = 'Care worker';
+
+      createStaffRecordWithMandatoryDetails(name, contractType, mainJobRole);
+
+      expectContentToBeDisplayedOnMandatoryDetailsPage(name, contractType, mainJobRole);
+
+      cy.get('button').contains('Add details to this record').click();
+
+      // answer the date of birth question
+      cy.getByLabel('Day').type('1');
+      cy.getByLabel('Month').type('1');
+      cy.getByLabel('Year').type('2000');
+      cy.get('button').contains('Save and continue').click();
+
+      // wait until saved and navigated to next question
+      cy.get('h1').should('contain', "What's their National Insurance number?");
+
+      skipAllQuestions();
+
+      cy.get('h1').should('contain.text', 'Staff record');
+      cy.contains('Staff record details saved').should('be.visible');
+    });
+
+    it('should not show a "Staff record details saved" alert when user completed the workflow and skipped all questions', () => {
+      const name = 'Mr Smith';
+      const contractType = 'Permanent';
+      const mainJobRole = 'Care worker';
+
+      createStaffRecordWithMandatoryDetails(name, contractType, mainJobRole);
+
+      expectContentToBeDisplayedOnMandatoryDetailsPage(name, contractType, mainJobRole);
+
+      cy.get('button').contains('Add details to this record').click();
+
+      skipAllQuestions();
+
+      cy.get('h1').should('contain.text', 'Staff record');
+      cy.contains('Staff record details saved').should('not.exist');
+    });
+
+    it('should not show a "Staff record details saved" alert when user completed the workflow and click Save for all question without answering', () => {
+      const name = 'Bob';
+      const contractType = 'Permanent';
+      const mainJobRole = 'Care worker';
+
+      createStaffRecordWithMandatoryDetails(name, contractType, mainJobRole);
+
+      expectContentToBeDisplayedOnMandatoryDetailsPage(name, contractType, mainJobRole);
+
+      cy.get('button').contains('Add details to this record').click();
+
+      skipAllQuestionsBySaveButton();
+
+      cy.get('h1').should('contain.text', 'Staff record');
+      cy.contains('Staff record details saved').should('not.exist');
+    });
+  });
+
   describe('Delete a staff record', () => {
     it('should delete a staff record successfully', () => {
       const workerName = 'Mr Warm';

--- a/frontend/src/app/core/model/worker.model.ts
+++ b/frontend/src/app/core/model/worker.model.ts
@@ -109,6 +109,27 @@ export interface Worker {
   employedFromOutsideUk?: string;
 }
 
+const MandatoryInfoFields = ['nameOrId', 'mainJob', 'contract'];
+const MetadataFields = [
+  'uid',
+  'ustatus',
+  'created',
+  'updated',
+  'updatedBy',
+  'completed',
+  'localIdentifier',
+  'wdf',
+  'wdfEligible',
+  'trainingCount',
+  'trainingLastUpdated',
+  'expiredTrainingCount',
+  'qualificationsLastUpdated',
+  'missingMandatoryTrainingCount',
+  'qualificationCount',
+];
+
+export const MandatoryInfoAndMetadataFields = MandatoryInfoFields.concat(MetadataFields);
+
 export interface WorkerPay {
   value: string;
   rate: number;

--- a/frontend/src/app/core/services/worker.service.spec.ts
+++ b/frontend/src/app/core/services/worker.service.spec.ts
@@ -4,7 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import { WorkerService } from './worker.service';
 import { build, fake, oneOf } from '@jackfranklin/test-data-bot';
 
-fdescribe('WorkerService', () => {
+describe('WorkerService', () => {
   let service: WorkerService;
 
   const workerBuilder = build('Worker', {

--- a/frontend/src/app/core/services/worker.service.spec.ts
+++ b/frontend/src/app/core/services/worker.service.spec.ts
@@ -1,0 +1,73 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { WorkerService } from './worker.service';
+import { build, fake, oneOf } from '@jackfranklin/test-data-bot';
+
+fdescribe('WorkerService', () => {
+  let service: WorkerService;
+
+  const workerBuilder = build('Worker', {
+    fields: {
+      uid: fake((f) => f.datatype.uuid()),
+      contract: 'Permanent',
+      mainJob: {
+        id: 20,
+        jobId: 20,
+      },
+      created: fake((f) => f.datatype.datetime()),
+      updated: fake((f) => f.datatype.datetime()),
+      updatedBy: 'admin3',
+      completed: oneOf(true, false),
+    },
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [WorkerService],
+    });
+    service = TestBed.inject(WorkerService);
+  });
+
+  it('should create the service', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('hasNonMandatoryQuestionAnswered', () => {
+    it('should return false if the current worker only has mandatory info', async () => {
+      const mockWorker = workerBuilder();
+      service.setState(mockWorker);
+
+      expect(service.hasAnsweredNonMandatoryQuestion()).toBe(false);
+    });
+
+    it('should return true if the current worker has non-mandatory question answered', async () => {
+      const mockWorker = { ...workerBuilder(), dateOfBirth: '2000-01-01' };
+      service.setState(mockWorker);
+
+      expect(service.hasAnsweredNonMandatoryQuestion()).toBe(true);
+    });
+
+    it('should return true even if the current worker has several non-mandatory questions answered', async () => {
+      const mockWorker = {
+        ...workerBuilder(),
+        dateOfBirth: '2000-01-01',
+        recruitedFrom: {
+          value: 'Yes',
+          from: {
+            recruitedFromId: 1,
+            from: 'Adult care sector: local authority',
+          },
+        },
+        daysSick: {
+          value: 'Yes',
+          days: 5,
+        },
+      };
+      service.setState(mockWorker);
+
+      expect(service.hasAnsweredNonMandatoryQuestion()).toBe(true);
+    });
+  });
+});

--- a/frontend/src/app/core/services/worker.service.ts
+++ b/frontend/src/app/core/services/worker.service.ts
@@ -19,7 +19,7 @@ import {
 } from '@core/model/training.model';
 import { TrainingAndQualificationRecords } from '@core/model/trainingAndQualifications.model';
 import { URLStructure } from '@core/model/url.model';
-import { Worker, WorkerEditResponse, WorkersResponse } from '@core/model/worker.model';
+import { MandatoryInfoAndMetadataFields, Worker, WorkerEditResponse, WorkersResponse } from '@core/model/worker.model';
 import { BehaviorSubject, forkJoin, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -331,5 +331,17 @@ export class WorkerService {
 
   public clearNewWorkerMandatoryInfo(): void {
     this._newWorkerMandatoryInfo = null;
+  }
+
+  public hasAnsweredNonMandatoryQuestion(): boolean {
+    if (!this.worker) {
+      return false;
+    }
+
+    const nonMandatoryQuestions = Object.entries(this.worker).filter(
+      ([fieldName, _answer]) => !MandatoryInfoAndMetadataFields.includes(fieldName),
+    );
+
+    return nonMandatoryQuestions.some(([_fieldName, answer]) => answer !== null);
   }
 }

--- a/frontend/src/app/features/workers/final-question/final-question.component.ts
+++ b/frontend/src/app/features/workers/final-question/final-question.component.ts
@@ -10,6 +10,8 @@ import { QuestionComponent } from '../question/question.component';
 
 @Directive()
 export class FinalQuestionComponent extends QuestionComponent {
+  protected continueToNextQuestion: boolean = false;
+
   constructor(
     protected formBuilder: UntypedFormBuilder,
     protected router: Router,
@@ -25,35 +27,27 @@ export class FinalQuestionComponent extends QuestionComponent {
 
   onSubmit(): void {
     super.onSubmit();
-    this.addAlertIfStaffRecordChanged();
+    this.handleAddAlertWhenSkippedQuestion();
   }
 
-  protected addAlert(): void {
-    if (this.insideFlow) {
+  public addAlert(): void {
+    if (this.insideFlow && !this.continueToNextQuestion) {
       this.addCompletedStaffFlowAlert();
     }
   }
 
-  protected formValueIsEmpty(): boolean {
-    throw new Error('Should be implemented at child component');
-  }
-
-  private addAlertIfStaffRecordChanged() {
-    if (!this.insideFlow) {
+  private handleAddAlertWhenSkippedQuestion(): void {
+    if (!this.insideFlow || this.continueToNextQuestion) {
       return;
     }
 
-    const skippedThisQuestion = !this.submitted;
+    const skippedThisQuestion = !this.submitted || this.formValueIsEmpty();
 
-    const thisQuestionNotAnswered = skippedThisQuestion || this.formValueIsEmpty();
-    const allOtherQuestionsNotAnswered = !this.workerService.hasAnsweredNonMandatoryQuestion();
+    const hasSavedStaffRecordDetailsBefore = this.workerService.hasAnsweredNonMandatoryQuestion();
 
-    if (thisQuestionNotAnswered && allOtherQuestionsNotAnswered) {
-      return;
+    if (skippedThisQuestion && hasSavedStaffRecordDetailsBefore) {
+      this.addCompletedStaffFlowAlert();
     }
-
-    // at least one question was anwsered before
-    this.addCompletedStaffFlowAlert();
   }
 
   private addCompletedStaffFlowAlert(): void {
@@ -61,5 +55,9 @@ export class FinalQuestionComponent extends QuestionComponent {
       type: 'success',
       message: 'Staff record details saved',
     });
+  }
+
+  protected formValueIsEmpty(): boolean {
+    throw new Error('Should be implemented at child component');
   }
 }

--- a/frontend/src/app/features/workers/final-question/final-question.component.ts
+++ b/frontend/src/app/features/workers/final-question/final-question.component.ts
@@ -1,0 +1,65 @@
+import { Directive } from '@angular/core';
+import { UntypedFormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BackLinkService } from '@core/services/backLink.service';
+import { ErrorSummaryService } from '@core/services/error-summary.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkerService } from '@core/services/worker.service';
+import { AlertService } from '../../../core/services/alert.service';
+import { QuestionComponent } from '../question/question.component';
+
+@Directive()
+export class FinalQuestionComponent extends QuestionComponent {
+  constructor(
+    protected formBuilder: UntypedFormBuilder,
+    protected router: Router,
+    protected route: ActivatedRoute,
+    protected backLinkService: BackLinkService,
+    protected errorSummaryService: ErrorSummaryService,
+    protected workerService: WorkerService,
+    protected establishmentService: EstablishmentService,
+    protected alertService: AlertService,
+  ) {
+    super(formBuilder, router, route, backLinkService, errorSummaryService, workerService, establishmentService);
+  }
+
+  onSubmit(): void {
+    super.onSubmit();
+    this.addAlertIfStaffRecordChanged();
+  }
+
+  protected addAlert(): void {
+    if (this.insideFlow) {
+      this.addCompletedStaffFlowAlert();
+    }
+  }
+
+  protected formValueIsEmpty(): boolean {
+    throw new Error('Should be implemented at child component');
+  }
+
+  private addAlertIfStaffRecordChanged() {
+    if (!this.insideFlow) {
+      return;
+    }
+
+    const skippedThisQuestion = !this.submitted;
+
+    const thisQuestionNotAnswered = skippedThisQuestion || this.formValueIsEmpty();
+    const allOtherQuestionsNotAnswered = !this.workerService.hasAnsweredNonMandatoryQuestion();
+
+    if (thisQuestionNotAnswered && allOtherQuestionsNotAnswered) {
+      return;
+    }
+
+    // at least one question was anwsered before
+    this.addCompletedStaffFlowAlert();
+  }
+
+  private addCompletedStaffFlowAlert(): void {
+    this.alertService.addAlert({
+      type: 'success',
+      message: 'Staff record details saved',
+    });
+  }
+}

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -244,7 +244,7 @@ describe('OtherQualificationsLevelComponent', () => {
 
       expect(alertSpy).toHaveBeenCalledWith({
         type: 'success',
-        message: 'Staff record saved',
+        message: 'Staff record details saved',
       });
     });
 
@@ -256,7 +256,7 @@ describe('OtherQualificationsLevelComponent', () => {
 
         expect(alertSpy).toHaveBeenCalledWith({
           type: 'success',
-          message: 'Staff record saved',
+          message: 'Staff record details saved',
         });
       });
     });

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -60,6 +60,11 @@ describe('OtherQualificationsLevelComponent', () => {
     const alertService = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alertService, 'addAlert').and.stub();
 
+    // hasAnsweredNonMandatoryQuestion should always be true,
+    // as this question only visited when OtherQualifications was answered with yes
+    const workerService = injector.inject(WorkerService) as WorkerService;
+    spyOn(workerService, 'hasAnsweredNonMandatoryQuestion').and.returnValue(true);
+
     return {
       ...setupTools,
       component: setupTools.fixture.componentInstance,

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -88,7 +88,7 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
   addCompletedStaffFlowAlert(): void {
     this.alertService.addAlert({
       type: 'success',
-      message: 'Staff record saved',
+      message: 'Staff record details saved',
     });
   }
 }

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -9,13 +9,13 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { QualificationService } from '@core/services/qualification.service';
 import { WorkerService } from '@core/services/worker.service';
 
-import { QuestionComponent } from '../question/question.component';
+import { FinalQuestionComponent } from '../final-question/final-question.component';
 
 @Component({
   selector: 'app-other-qualifications-level',
   templateUrl: './other-qualifications-level.component.html',
 })
-export class OtherQualificationsLevelComponent extends QuestionComponent {
+export class OtherQualificationsLevelComponent extends FinalQuestionComponent {
   public qualifications: QualificationLevel[];
   public section = 'Training and qualifications';
 
@@ -28,9 +28,18 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
     protected workerService: WorkerService,
     protected establishmentService: EstablishmentService,
     private qualificationService: QualificationService,
-    private alertService: AlertService,
+    protected alertService: AlertService,
   ) {
-    super(formBuilder, router, route, backLinkService, errorSummaryService, workerService, establishmentService);
+    super(
+      formBuilder,
+      router,
+      route,
+      backLinkService,
+      errorSummaryService,
+      workerService,
+      establishmentService,
+      alertService,
+    );
 
     this.form = this.formBuilder.group({
       qualification: null,
@@ -71,24 +80,8 @@ export class OtherQualificationsLevelComponent extends QuestionComponent {
     return props;
   }
 
-  onSubmit(): void {
-    super.onSubmit();
-
-    if (!this.submitted && this.insideFlow) {
-      this.addCompletedStaffFlowAlert();
-    }
-  }
-
-  addAlert(): void {
-    if (this.insideFlow) {
-      this.addCompletedStaffFlowAlert();
-    }
-  }
-
-  addCompletedStaffFlowAlert(): void {
-    this.alertService.addAlert({
-      type: 'success',
-      message: 'Staff record details saved',
-    });
+  protected formValueIsEmpty(): boolean {
+    const { qualification } = this.form.value;
+    return qualification === null;
   }
 }

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -12,7 +12,7 @@ import { fireEvent, render } from '@testing-library/angular';
 import { WorkersModule } from '../workers.module';
 import { OtherQualificationsComponent } from './other-qualifications.component';
 
-fdescribe('OtherQualificationsComponent', () => {
+describe('OtherQualificationsComponent', () => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   async function setup(overrides: any = {}) {
     const insideFlow = overrides.insideFlow ?? false;

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -12,7 +12,7 @@ import { fireEvent, render } from '@testing-library/angular';
 import { WorkersModule } from '../workers.module';
 import { OtherQualificationsComponent } from './other-qualifications.component';
 
-describe('OtherQualificationsComponent', () => {
+fdescribe('OtherQualificationsComponent', () => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   async function setup(overrides: any = {}) {
     const insideFlow = overrides.insideFlow ?? false;
@@ -55,12 +55,15 @@ describe('OtherQualificationsComponent', () => {
     const alertService = injector.inject(AlertService) as AlertService;
     const alertSpy = spyOn(alertService, 'addAlert').and.stub();
 
+    const workerService = injector.inject(WorkerService) as WorkerService;
+
     return {
       ...setupTools,
       component: setupTools.fixture.componentInstance,
       routerSpy,
       router,
       alertSpy,
+      workerService,
     };
   }
 
@@ -120,14 +123,24 @@ describe('OtherQualificationsComponent', () => {
           ]);
         });
 
-        it(`should add Staff record added alert when '${link}' is clicked`, async () => {
-          const { getByText, alertSpy } = await setup({ insideFlow: true });
+        it(`should not add Staff record added alert when '${link}' is clicked and all non-mandatory questions were not answered`, async () => {
+          const { getByText, alertSpy, workerService } = await setup({ insideFlow: true });
+          spyOn(workerService, 'hasAnsweredNonMandatoryQuestion').and.returnValue(false);
+
+          fireEvent.click(getByText(link));
+
+          expect(alertSpy).not.toHaveBeenCalled();
+        });
+
+        it(`should add Staff record added alert when '${link}' is clicked and some non-mandatory questions were answered`, async () => {
+          const { getByText, alertSpy, workerService } = await setup({ insideFlow: true });
+          spyOn(workerService, 'hasAnsweredNonMandatoryQuestion').and.returnValue(true);
 
           fireEvent.click(getByText(link));
 
           expect(alertSpy).toHaveBeenCalledWith({
             type: 'success',
-            message: 'Staff record saved',
+            message: 'Staff record details saved',
           });
         });
       });
@@ -166,7 +179,7 @@ describe('OtherQualificationsComponent', () => {
 
           expect(alertSpy).toHaveBeenCalledWith({
             type: 'success',
-            message: 'Staff record saved',
+            message: 'Staff record details saved',
           });
         });
       });
@@ -229,7 +242,7 @@ describe('OtherQualificationsComponent', () => {
 
         expect(alertSpy).not.toHaveBeenCalledWith({
           type: 'success',
-          message: 'Staff record saved',
+          message: 'Staff record details saved',
         });
       });
     });

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -88,5 +88,9 @@ export class OtherQualificationsComponent extends FinalQuestionComponent {
 
   onSuccess(): void {
     this.next = this.determineConditionalRouting();
+
+    if (!this.next.includes('staff-record-summary')) {
+      this.continueToNextQuestion = true;
+    }
   }
 }

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -7,13 +7,13 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkerService } from '@core/services/worker.service';
 
-import { QuestionComponent } from '../question/question.component';
+import { FinalQuestionComponent } from '../final-question/final-question.component';
 
 @Component({
   selector: 'app-other-qualifications',
   templateUrl: './other-qualifications.component.html',
 })
-export class OtherQualificationsComponent extends QuestionComponent {
+export class OtherQualificationsComponent extends FinalQuestionComponent {
   public answersAvailable = [
     { value: 'Yes', tag: 'Yes' },
     { value: 'No', tag: 'No' },
@@ -30,7 +30,16 @@ export class OtherQualificationsComponent extends QuestionComponent {
     protected establishmentService: EstablishmentService,
     protected alertService: AlertService,
   ) {
-    super(formBuilder, router, route, backLinkService, errorSummaryService, workerService, establishmentService);
+    super(
+      formBuilder,
+      router,
+      route,
+      backLinkService,
+      errorSummaryService,
+      workerService,
+      establishmentService,
+      alertService,
+    );
 
     this.form = this.formBuilder.group({
       otherQualification: null,
@@ -72,33 +81,9 @@ export class OtherQualificationsComponent extends QuestionComponent {
     return nextRoute;
   }
 
-  onSubmit(): void {
-    super.onSubmit();
+  protected formValueIsEmpty(): boolean {
     const { otherQualification } = this.form.value;
-
-    const answerNotSelected = !otherQualification;
-    const skippedThisQuestion = !this.submitted;
-
-    if ((skippedThisQuestion || answerNotSelected) && this.insideFlow) {
-      if (this.workerService.hasAnsweredNonMandatoryQuestion()) {
-        this.addCompletedStaffFlowAlert();
-      }
-    }
-  }
-
-  addAlert(): void {
-    const { otherQualification } = this.form.value;
-
-    if (otherQualification !== 'Yes' && this.insideFlow) {
-      this.addCompletedStaffFlowAlert();
-    }
-  }
-
-  addCompletedStaffFlowAlert(): void {
-    this.alertService.addAlert({
-      type: 'success',
-      message: 'Staff record details saved',
-    });
+    return otherQualification === null;
   }
 
   onSuccess(): void {

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -76,8 +76,13 @@ export class OtherQualificationsComponent extends QuestionComponent {
     super.onSubmit();
     const { otherQualification } = this.form.value;
 
-    if ((!this.submitted || !otherQualification) && this.insideFlow) {
-      this.addCompletedStaffFlowAlert();
+    const answerNotSelected = !otherQualification;
+    const skippedThisQuestion = !this.submitted;
+
+    if ((skippedThisQuestion || answerNotSelected) && this.insideFlow) {
+      if (this.workerService.hasAnsweredNonMandatoryQuestion()) {
+        this.addCompletedStaffFlowAlert();
+      }
     }
   }
 
@@ -92,7 +97,7 @@ export class OtherQualificationsComponent extends QuestionComponent {
   addCompletedStaffFlowAlert(): void {
     this.alertService.addAlert({
       type: 'success',
-      message: 'Staff record saved',
+      message: 'Staff record details saved',
     });
   }
 


### PR DESCRIPTION
#### Work done
- Change the alert text at the end of add new worker flow "Staff record saved" --> "Staff record details saved"
- Change conditions so that the alert only appear when at least one non-mandatory question was answered
- Extract the logic for this alert to a new FinalQuestion parent class, so that it'll be easier to add a new question at the end
- Add cypress tests to cover the scenario for this alert

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
