### PR TITLE
Feat/1703 cwp staff record summary

### DIFF
--- a/frontend/src/app/core/model/feature-flag.model.ts
+++ b/frontend/src/app/core/model/feature-flag.model.ts
@@ -1,0 +1,1 @@
+export type FeatureFlags = Record<string, boolean>;

--- a/frontend/src/app/core/resolvers/feature-flags.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/feature-flags.resolver.spec.ts
@@ -7,7 +7,7 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 import { FeatureFlagsResolver } from './feature-flags.resolver';
 
-fdescribe('FeatureFlagsResolver', () => {
+describe('FeatureFlagsResolver', () => {
   async function setup(overrides: any = {}) {
     const cwpQuestionsFlag: boolean = overrides.cwpQuestionsFlag ?? false;
     const mockFeatureFlag: boolean = overrides.mockFeatureFlag ?? false;

--- a/frontend/src/app/core/resolvers/feature-flags.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/feature-flags.resolver.spec.ts
@@ -1,0 +1,74 @@
+import { SettingKeyValue } from 'configcat-common/lib/ConfigCatClient';
+
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+
+import { FeatureFlagsResolver } from './feature-flags.resolver';
+
+fdescribe('FeatureFlagsResolver', () => {
+  async function setup(overrides: any = {}) {
+    const cwpQuestionsFlag: boolean = overrides.cwpQuestionsFlag ?? false;
+    const mockFeatureFlag: boolean = overrides.mockFeatureFlag ?? false;
+    const mockResponseFromConfigCat: SettingKeyValue[] = [
+      {
+        settingKey: 'mockFeatureFlag',
+        settingValue: mockFeatureFlag,
+      },
+      {
+        settingKey: 'cwpQuestions',
+        settingValue: cwpQuestionsFlag,
+      },
+    ];
+
+    TestBed.configureTestingModule({
+      providers: [
+        FeatureFlagsResolver,
+        {
+          provide: FeatureFlagsService,
+          useClass: MockFeatureFlagsService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {},
+          },
+        },
+      ],
+    });
+
+    const resolver = TestBed.inject(FeatureFlagsResolver);
+    const route = TestBed.inject(ActivatedRoute);
+
+    const featureFlagsService = TestBed.inject(FeatureFlagsService);
+    const featureFlagsSpy = spyOn(featureFlagsService.configCatClient, 'getAllValuesAsync').and.resolveTo(
+      mockResponseFromConfigCat,
+    );
+
+    return {
+      resolver,
+      route,
+      featureFlagsService,
+      featureFlagsSpy,
+    };
+  }
+
+  it('should create', async () => {
+    const { resolver } = await setup();
+
+    expect(resolver).toBeTruthy();
+  });
+
+  it('should retrieve the feature flags by FeatureFlagsService', async () => {
+    const { resolver, route, featureFlagsSpy } = await setup({ cwpQuestionsFlag: true, mockFeatureFlag: false });
+
+    const featureFlags = await resolver.resolve(route.snapshot).toPromise();
+
+    expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
+    expect(featureFlags).toEqual({
+      cwpQuestions: true,
+      mockFeatureFlag: false,
+    });
+  });
+});

--- a/frontend/src/app/core/resolvers/feature-flags.resolver.ts
+++ b/frontend/src/app/core/resolvers/feature-flags.resolver.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { FeatureFlags } from '@core/model/feature-flag.model';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+import { IConfigCatClient } from 'configcat-common/lib/ConfigCatClient';
+import { from, Observable } from 'rxjs';
+
+@Injectable()
+export class FeatureFlagsResolver {
+  private client: IConfigCatClient;
+
+  constructor(private featureFlagService: FeatureFlagsService) {
+    this.client = this.featureFlagService.configCatClient;
+  }
+
+  resolve(_route: ActivatedRouteSnapshot): Observable<FeatureFlags> {
+    const promise = this.client.getAllValuesAsync().then((allFeatureFlagsAndValues) => {
+      const featureFlags = {};
+
+      allFeatureFlagsAndValues.forEach((keyValuePair) => {
+        const flagName = keyValuePair.settingKey;
+        const value = keyValuePair.settingValue;
+        featureFlags[flagName] = value;
+      });
+
+      return featureFlags;
+    });
+
+    return from(promise);
+  }
+}

--- a/frontend/src/app/core/test-utils/MockCareWorkforcePathwayService.ts
+++ b/frontend/src/app/core/test-utils/MockCareWorkforcePathwayService.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { CareWorkforcePathwayRoleCategory } from '@core/model/careWorkforcePathwayCategory.model';
 import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
 import { Observable, of } from 'rxjs';
+import lodash from 'lodash';
 
 export const careWorkforcePathwayRoleCategories = [
   {
@@ -19,7 +20,22 @@ export const careWorkforcePathwayRoleCategories = [
     title: 'I do not know',
     description: null,
   },
+  {
+    id: 102,
+    title: 'None of the above',
+    description: 'Select this for admin, ancillary and other roles not yet included in the care workforce pathway',
+  },
 ];
+
+export const MockCWPRoleCategories = lodash.mapValues(
+  {
+    NewToCare: careWorkforcePathwayRoleCategories[0],
+    CareOrSupportWorker: careWorkforcePathwayRoleCategories[1],
+    IDoNotKnow: careWorkforcePathwayRoleCategories[2],
+    NoneOfTheAbove: careWorkforcePathwayRoleCategories[3],
+  },
+  (obj) => ({ ...obj, roleCategoryId: obj.id }),
+);
 
 @Injectable()
 export class MockCareWorkforcePathwayService extends CareWorkforcePathwayService {

--- a/frontend/src/app/core/test-utils/MockConfigCatClient.ts
+++ b/frontend/src/app/core/test-utils/MockConfigCatClient.ts
@@ -1,6 +1,14 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { IConfigCatClient, SettingKeyValue } from 'configcat-common/lib/ConfigCatClient';
 
+export const DefaultFeatureFlagsForLocalTest = {
+  wdfUser: true,
+  wdfNewDesign: true,
+  homePageNewDesign: true,
+  homePageNewDesignParent: true,
+  cwpQuestions: false,
+};
+
 export const mockConfigCatClient = {
   dispose: () => {},
   getValue: () => {},
@@ -35,47 +43,20 @@ export const mockConfigCatClient = {
     });
   },
   getAllValues: () => {},
-  getAllValuesAsync: () => {
-    return new Promise((resolve) => {
-      return new SettingKeyValue();
-    });
+  getAllValuesAsync: async () => {
+    const mockConfigCatResponse: SettingKeyValue[] = Object.entries(DefaultFeatureFlagsForLocalTest).map(
+      ([key, value]) => {
+        return {
+          settingKey: key,
+          settingValue: value,
+        };
+      },
+    );
+    return mockConfigCatResponse;
   },
 
-  getValueAsync: (flagName, defaultSetting) => {
-    if (flagName === 'wdfUser') {
-      return new Promise((resolve) => {
-        return resolve(false);
-      });
-    }
-    if (flagName === 'wdfNewDesign') {
-      return new Promise((resolve) => {
-        return resolve(false);
-      });
-    }
-    if (flagName === 'homePageNewDesign') {
-      return new Promise((resolve) => {
-        return resolve(true);
-      });
-    }
-    if (flagName === 'homePageNewDesignParent') {
-      return new Promise((resolve) => {
-        return resolve(true);
-      });
-    }
-
-    if (flagName === 'newBenchmarksDataArea') {
-      return new Promise((resolve) => {
-        return resolve(true);
-      });
-    }
-    if (flagName === 'cwpQuestionsFlag') {
-      return new Promise((resolve) => {
-        return resolve(true);
-      });
-    }
-
-    return new Promise((resolve) => {
-      return resolve(defaultSetting);
-    });
+  getValueAsync: (flagName: string, defaultSetting: boolean) => {
+    const flagValue = DefaultFeatureFlagsForLocalTest[flagName] ?? defaultSetting;
+    return Promise.resolve(flagValue);
   },
 } as IConfigCatClient;

--- a/frontend/src/app/core/test-utils/MockFeatureFlagService.ts
+++ b/frontend/src/app/core/test-utils/MockFeatureFlagService.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { mockConfigCatClient } from './MockConfigCatClient';
 
 @Injectable()
@@ -9,39 +9,6 @@ export class MockFeatureFlagsService extends FeatureFlagsService {
 
   constructor() {
     super();
-    this.configCatClient.getValueAsync = (flagName, defaultSetting) => {
-      if (flagName === 'wdfUser') {
-        return new Promise((resolve) => {
-          return resolve(true);
-        });
-      }
-
-      if (flagName === 'wdfNewDesign') {
-        return new Promise((resolve) => {
-          return resolve(true);
-        });
-      }
-      if (flagName === 'homePageNewDesign') {
-        return new Promise((resolve) => {
-          return resolve(true);
-        });
-      }
-      if (flagName === 'homePageNewDesignParent') {
-        return new Promise((resolve) => {
-          return resolve(true);
-        });
-      }
-
-      if (flagName === 'cwpQuestionsFlag') {
-        return new Promise((resolve) => {
-          return resolve(true);
-        });
-      }
-
-      return new Promise((resolve) => {
-        return resolve(defaultSetting);
-      });
-    };
   }
   public static factory(override: Record<string, boolean>) {
     return () => {

--- a/frontend/src/app/features/funding/funding-routing.module.ts
+++ b/frontend/src/app/features/funding/funding-routing.module.ts
@@ -8,56 +8,36 @@ import { PageResolver } from '@core/resolvers/page.resolver';
 import { WorkerResolver } from '@core/resolvers/worker.resolver';
 import { WorkersResolver } from '@core/resolvers/workers.resolver';
 import { WorkplaceResolver } from '@core/resolvers/workplace.resolver';
-import {
-  AdultSocialCareStartedComponent,
-} from '@features/workers/adult-social-care-started/adult-social-care-started.component';
-import {
-  ApprenticeshipTrainingComponent,
-} from '@features/workers/apprenticeship-training/apprenticeship-training.component';
+import { AdultSocialCareStartedComponent } from '@features/workers/adult-social-care-started/adult-social-care-started.component';
+import { ApprenticeshipTrainingComponent } from '@features/workers/apprenticeship-training/apprenticeship-training.component';
 import { AverageWeeklyHoursComponent } from '@features/workers/average-weekly-hours/average-weekly-hours.component';
 import { BritishCitizenshipComponent } from '@features/workers/british-citizenship/british-citizenship.component';
 import { CareCertificateComponent } from '@features/workers/care-certificate/care-certificate.component';
-import {
-  ContractWithZeroHoursComponent,
-} from '@features/workers/contract-with-zero-hours/contract-with-zero-hours.component';
+import { ContractWithZeroHoursComponent } from '@features/workers/contract-with-zero-hours/contract-with-zero-hours.component';
 import { CountryOfBirthComponent } from '@features/workers/country-of-birth/country-of-birth.component';
 import { DateOfBirthComponent } from '@features/workers/date-of-birth/date-of-birth.component';
 import { DaysOfSicknessComponent } from '@features/workers/days-of-sickness/days-of-sickness.component';
 import { DisabilityComponent } from '@features/workers/disability/disability.component';
-import {
-  EmployedFromOutsideUkComponent,
-} from '@features/workers/employed-from-outside-uk/employed-from-outside-uk.component';
+import { EmployedFromOutsideUkComponent } from '@features/workers/employed-from-outside-uk/employed-from-outside-uk.component';
 import { EthnicityComponent } from '@features/workers/ethnicity/ethnicity.component';
 import { GenderComponent } from '@features/workers/gender/gender.component';
 import { HealthAndCareVisaComponent } from '@features/workers/health-and-care-visa/health-and-care-visa.component';
 import { HomePostcodeComponent } from '@features/workers/home-postcode/home-postcode.component';
-import {
-  Level2AdultSocialCareCertificateComponent,
-} from '@features/workers/level-2-adult-social-care-certificate/level-2-adult-social-care-certificate.component';
+import { Level2AdultSocialCareCertificateComponent } from '@features/workers/level-2-adult-social-care-certificate/level-2-adult-social-care-certificate.component';
 import { MainJobRoleComponent } from '@features/workers/main-job-role/main-job-role.component';
 import { MainJobStartDateComponent } from '@features/workers/main-job-start-date/main-job-start-date.component';
-import {
-  MentalHealthProfessionalComponent,
-} from '@features/workers/mental-health-professional/mental-health-professional.component';
-import {
-  NationalInsuranceNumberComponent,
-} from '@features/workers/national-insurance-number/national-insurance-number.component';
+import { MentalHealthProfessionalComponent } from '@features/workers/mental-health-professional/mental-health-professional.component';
+import { NationalInsuranceNumberComponent } from '@features/workers/national-insurance-number/national-insurance-number.component';
 import { NationalityComponent } from '@features/workers/nationality/nationality.component';
 import { NursingCategoryComponent } from '@features/workers/nursing-category/nursing-category.component';
 import { NursingSpecialismComponent } from '@features/workers/nursing-specialism/nursing-specialism.component';
-import {
-  OtherQualificationsLevelComponent,
-} from '@features/workers/other-qualifications-level/other-qualifications-level.component';
+import { OtherQualificationsLevelComponent } from '@features/workers/other-qualifications-level/other-qualifications-level.component';
 import { OtherQualificationsComponent } from '@features/workers/other-qualifications/other-qualifications.component';
 import { RecruitedFromComponent } from '@features/workers/recruited-from/recruited-from.component';
 import { SalaryComponent } from '@features/workers/salary/salary.component';
 import { SelectRecordTypeComponent } from '@features/workers/select-record-type/select-record-type.component';
-import {
-  SocialCareQualificationLevelComponent,
-} from '@features/workers/social-care-qualification-level/social-care-qualification-level.component';
-import {
-  SocialCareQualificationComponent,
-} from '@features/workers/social-care-qualification/social-care-qualification.component';
+import { SocialCareQualificationLevelComponent } from '@features/workers/social-care-qualification-level/social-care-qualification-level.component';
+import { SocialCareQualificationComponent } from '@features/workers/social-care-qualification/social-care-qualification.component';
 import { StaffDetailsComponent } from '@features/workers/staff-details/staff-details.component';
 import { WeeklyContractedHoursComponent } from '@features/workers/weekly-contracted-hours/weekly-contracted-hours.component';
 import { YearArrivedUkComponent } from '@features/workers/year-arrived-uk/year-arrived-uk.component';
@@ -68,6 +48,7 @@ import { WdfDataComponent } from './wdf-data/wdf-data.component';
 import { WdfOverviewComponent } from './wdf-overview/wdf-overview.component';
 import { WdfStaffRecordComponent } from './wdf-staff-record/wdf-staff-record.component';
 import { CareWorkforcePathwayRoleComponent } from '@features/workers/care-workforce-pathway/care-workforce-pathway.component';
+import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
 
 const routes: Routes = [
   {
@@ -105,13 +86,16 @@ const routes: Routes = [
             path: 'staff-record/:id',
             resolve: { worker: WorkerResolver, establishment: WorkplaceResolver },
             canActivate: [HasPermissionsGuard],
-            data: { permissions: ['canViewWdfReport'], title: 'Staff Record Summary' },
+            data: {
+              permissions: ['canViewWdfReport'],
+              title: 'Staff Record Summary',
+            },
             children: [
               {
                 path: '',
                 component: WdfStaffRecordComponent,
                 data: { title: 'Funding Staff Record' },
-                resolve: { report: FundingReportResolver },
+                resolve: { featureFlags: FeatureFlagsResolver },
               },
               {
                 path: 'staff-details',
@@ -319,7 +303,7 @@ const routes: Routes = [
         path: '',
         component: WdfStaffRecordComponent,
         data: { title: 'Funding Staff Record' },
-        resolve: { report: FundingReportResolver },
+        resolve: { report: FundingReportResolver, featureFlags: FeatureFlagsResolver },
       },
       {
         path: 'staff-details',

--- a/frontend/src/app/features/funding/funding-routing.module.ts
+++ b/frontend/src/app/features/funding/funding-routing.module.ts
@@ -95,7 +95,7 @@ const routes: Routes = [
                 path: '',
                 component: WdfStaffRecordComponent,
                 data: { title: 'Funding Staff Record' },
-                resolve: { featureFlags: FeatureFlagsResolver },
+                resolve: { report: FundingReportResolver, featureFlags: FeatureFlagsResolver },
               },
               {
                 path: 'staff-details',

--- a/frontend/src/app/features/workers/workers-routing.module.ts
+++ b/frontend/src/app/features/workers/workers-routing.module.ts
@@ -15,39 +15,21 @@ import { TrainingRecordsForCategoryResolver } from '@core/resolvers/training-rec
 import { WorkerReasonsForLeavingResolver } from '@core/resolvers/worker-reasons-for-leaving.resolver';
 import { WorkerResolver } from '@core/resolvers/worker.resolver';
 import { WorkplaceUpdateFlowType } from '@core/services/vacancies-and-turnover.service';
-import {
-  SelectQualificationTypeComponent,
-} from '@features/training-and-qualifications/add-edit-qualification/select-qualification-type/select-qualification-type.component';
-import {
-  SelectTrainingCategoryComponent,
-} from '@features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component';
-import {
-  ViewTrainingComponent,
-} from '@shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component';
-import {
-  UpdateLeaversComponent,
-} from '@shared/components/update-starters-leavers-vacancies/update-leavers/update-leavers.component';
-import {
-  UpdateStartersComponent,
-} from '@shared/components/update-starters-leavers-vacancies/update-starters/update-starters.component';
-import {
-  UpdateVacanciesComponent,
-} from '@shared/components/update-starters-leavers-vacancies/update-vacancies/update-vacancies.component';
+import { SelectQualificationTypeComponent } from '@features/training-and-qualifications/add-edit-qualification/select-qualification-type/select-qualification-type.component';
+import { SelectTrainingCategoryComponent } from '@features/training-and-qualifications/add-edit-training/select-training-category/select-training-category.component';
+import { ViewTrainingComponent } from '@shared/components/training-and-qualifications-categories/view-trainings/view-trainings.component';
+import { UpdateLeaversComponent } from '@shared/components/update-starters-leavers-vacancies/update-leavers/update-leavers.component';
+import { UpdateStartersComponent } from '@shared/components/update-starters-leavers-vacancies/update-starters/update-starters.component';
+import { UpdateVacanciesComponent } from '@shared/components/update-starters-leavers-vacancies/update-vacancies/update-vacancies.component';
 
 import {
   JobRoleType,
   SelectJobRolesToAddComponent,
 } from '../../shared/components/update-starters-leavers-vacancies/select-job-roles-to-add/select-job-roles-to-add.component';
-import {
-  AddEditQualificationComponent,
-} from '../training-and-qualifications/add-edit-qualification/add-edit-qualification.component';
+import { AddEditQualificationComponent } from '../training-and-qualifications/add-edit-qualification/add-edit-qualification.component';
 import { AddEditTrainingComponent } from '../training-and-qualifications/add-edit-training/add-edit-training.component';
-import {
-  DeleteRecordComponent,
-} from '../training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component';
-import {
-  NewTrainingAndQualificationsRecordComponent,
-} from '../training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component';
+import { DeleteRecordComponent } from '../training-and-qualifications/new-training-qualifications-record/delete-record/delete-record.component';
+import { NewTrainingAndQualificationsRecordComponent } from '../training-and-qualifications/new-training-qualifications-record/new-training-and-qualifications-record.component';
 import { AddAnotherStaffRecordComponent } from './add-another-staff-record/add-another-staff-record.component';
 import { AdultSocialCareStartedComponent } from './adult-social-care-started/adult-social-care-started.component';
 import { ApprenticeshipTrainingComponent } from './apprenticeship-training/apprenticeship-training.component';
@@ -68,9 +50,7 @@ import { EthnicityComponent } from './ethnicity/ethnicity.component';
 import { GenderComponent } from './gender/gender.component';
 import { HealthAndCareVisaComponent } from './health-and-care-visa/health-and-care-visa.component';
 import { HomePostcodeComponent } from './home-postcode/home-postcode.component';
-import {
-  Level2AdultSocialCareCertificateComponent,
-} from './level-2-adult-social-care-certificate/level-2-adult-social-care-certificate.component';
+import { Level2AdultSocialCareCertificateComponent } from './level-2-adult-social-care-certificate/level-2-adult-social-care-certificate.component';
 import { LongTermAbsenceComponent } from './long-term-absence/long-term-absence.component';
 import { MainJobRoleComponent } from './main-job-role/main-job-role.component';
 import { MainJobStartDateComponent } from './main-job-start-date/main-job-start-date.component';
@@ -85,22 +65,17 @@ import { OtherQualificationsComponent } from './other-qualifications/other-quali
 import { RecruitedFromComponent } from './recruited-from/recruited-from.component';
 import { SalaryComponent } from './salary/salary.component';
 import { SelectRecordTypeComponent } from './select-record-type/select-record-type.component';
-import {
-  SocialCareQualificationLevelComponent,
-} from './social-care-qualification-level/social-care-qualification-level.component';
+import { SocialCareQualificationLevelComponent } from './social-care-qualification-level/social-care-qualification-level.component';
 import { SocialCareQualificationComponent } from './social-care-qualification/social-care-qualification.component';
 import { StaffDetailsComponent } from './staff-details/staff-details.component';
 import { StaffRecordComponent } from './staff-record/staff-record.component';
 import { TotalStaffChangeComponent } from './total-staff-change/total-staff-change.component';
-import {
-  UpdateTotalNumberOfStaffComponent,
-} from './update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component';
-import {
-  UpdateWorkplaceDetailsAfterStaffChangesComponent,
-} from './update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component';
+import { UpdateTotalNumberOfStaffComponent } from './update-workplace-details-after-staff-changes/update-total-number-of-staff/update-total-number-of-staff.component';
+import { UpdateWorkplaceDetailsAfterStaffChangesComponent } from './update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component';
 import { WeeklyContractedHoursComponent } from './weekly-contracted-hours/weekly-contracted-hours.component';
 import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.component';
 import { CareWorkforcePathwayRoleComponent } from './care-workforce-pathway/care-workforce-pathway.component';
+import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
 
 const routes: Routes = [
   {
@@ -279,7 +254,7 @@ const routes: Routes = [
     path: ':id',
     canActivate: [CheckPermissionsGuard],
     component: EditWorkerComponent,
-    resolve: { worker: WorkerResolver, jobs: JobsResolver },
+    resolve: { worker: WorkerResolver, jobs: JobsResolver, featureFlags: FeatureFlagsResolver },
     data: {
       permissions: ['canViewWorker'],
     },

--- a/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
@@ -218,7 +218,7 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Care workforce pathway role category</dt>
     <dd class="govuk-summary-list__value">
-      {{ worker.careWorkforcePathwayRoleCategory?.title || '-' | closedEndedAnswer }}
+      {{ worker.careWorkforcePathwayRoleCategory | CWPRoleCategoryTitle }}
     </dd>
     <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
       <app-summary-record-change

--- a/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
@@ -214,4 +214,19 @@
       [staffRecordView]="true"
     ></app-wdf-field-confirmation>
   </ng-container>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Care workforce pathway role category</dt>
+    <dd class="govuk-summary-list__value">
+      {{ worker.careWorkforcePathwayRoleCategory?.title || '-' | closedEndedAnswer }}
+    </dd>
+    <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
+      <app-summary-record-change
+        [explanationText]="' care workforce pathway role category'"
+        [link]="getRoutePath('care-workforce-pathway', wdfView)"
+        [hasData]="!!worker.careWorkforcePathwayRoleCategory"
+        (setReturnClicked)="this.setReturn()"
+      ></app-summary-record-change>
+    </dd>
+  </div>
 </dl>

--- a/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
+++ b/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.html
@@ -215,18 +215,20 @@
     ></app-wdf-field-confirmation>
   </ng-container>
 
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Care workforce pathway role category</dt>
-    <dd class="govuk-summary-list__value">
-      {{ worker.careWorkforcePathwayRoleCategory | CWPRoleCategoryTitle }}
-    </dd>
-    <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
-      <app-summary-record-change
-        [explanationText]="' care workforce pathway role category'"
-        [link]="getRoutePath('care-workforce-pathway', wdfView)"
-        [hasData]="!!worker.careWorkforcePathwayRoleCategory"
-        (setReturnClicked)="this.setReturn()"
-      ></app-summary-record-change>
-    </dd>
-  </div>
+  <ng-container *ngIf="!cwpQuestionsFlag">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Care workforce pathway role category</dt>
+      <dd class="govuk-summary-list__value">
+        {{ worker.careWorkforcePathwayRoleCategory | CWPRoleCategoryTitle }}
+      </dd>
+      <dd *ngIf="canEditWorker" class="govuk-summary-list__actions">
+        <app-summary-record-change
+          [explanationText]="' care workforce pathway role category'"
+          [link]="getRoutePath('care-workforce-pathway', wdfView)"
+          [hasData]="!!worker.careWorkforcePathwayRoleCategory"
+          (setReturnClicked)="this.setReturn()"
+        ></app-summary-record-change>
+      </dd>
+    </div>
+  </ng-container>
 </dl>

--- a/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { provideRouter, RouterModule } from '@angular/router';
-// import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -20,10 +19,10 @@ describe('QualificationsAndTrainingComponent', () => {
   async function setup(overrides: any = {}) {
     const configs = { isWdf: false, canEditWorker: true, ...overrides };
 
-    const { isWdf, canEditWorker } = configs;
+    const { isWdf, canEditWorker, cwpQuestionsFlag } = configs;
     const mockWorker = { ...workerWithWdf(), ...(overrides.workerOverrides ?? {}) };
 
-    const { fixture, getByText } = await render(QualificationsAndTrainingComponent, {
+    const setupTools = await render(QualificationsAndTrainingComponent, {
       imports: [SharedModule, RouterModule, HttpClientTestingModule],
       declarations: [SummaryRecordChangeComponent],
       providers: [
@@ -33,7 +32,12 @@ describe('QualificationsAndTrainingComponent', () => {
           useFactory: MockPermissionsService.factory(canEditWorker ? ['canEditWorker'] : []),
           deps: [HttpClient],
         },
-        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { data: { featureFlags: { cwpQuestions: cwpQuestionsFlag } } },
+          },
+        },
       ],
       componentProperties: {
         canEditWorker: canEditWorker,
@@ -43,12 +47,13 @@ describe('QualificationsAndTrainingComponent', () => {
       },
     });
 
+    const fixture = setupTools.fixture;
     const component = fixture.componentInstance;
 
     return {
+      ...setupTools,
       component,
       fixture,
-      getByText,
     };
   }
 
@@ -166,60 +171,75 @@ describe('QualificationsAndTrainingComponent', () => {
   });
 
   describe('Care workforce pathway role category', () => {
-    it('should render Add link and a dash when the question is not answered', async () => {
-      const workerOverrides = { careWorkforcePathwayRoleCategory: null };
-      const { component, getByText } = await setup({ workerOverrides });
+    describe('when cwpQuestionsFlag is true (feature is turned off)', () => {
+      const cwpQuestionsFlag = true;
 
-      const section = getByText('Care workforce pathway role category').parentElement;
-      const addLink = within(section).getByText('Add');
+      it('should not show a row of Care workforce pathway role category', async () => {
+        const workerOverrides = { careWorkforcePathwayRoleCategory: null };
+        const { queryByText } = await setup({ workerOverrides, cwpQuestionsFlag });
 
-      expect(within(section).getByText('-')).toBeTruthy();
-
-      expect(addLink.getAttribute('href')).toBe(
-        `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
-      );
+        expect(queryByText('Care workforce pathway role category')).toBeFalsy();
+      });
     });
 
-    it('should render Change link when the question is answered', async () => {
-      const workerOverrides = { careWorkforcePathwayRoleCategory: MockCWPRoleCategories.NewToCare };
-      const { component, getByText } = await setup({ workerOverrides });
+    describe('when cwpQuestionsFlag is false (feature is turned on)', () => {
+      const cwpQuestionsFlag = false;
 
-      const section = getByText('Care workforce pathway role category').parentElement;
-      const changeLink = within(section).getByText('Change');
+      it('should render Add link and a dash when the question is not answered', async () => {
+        const workerOverrides = { careWorkforcePathwayRoleCategory: null };
+        const { component, getByText } = await setup({ workerOverrides, cwpQuestionsFlag });
 
-      expect(within(section).getByText('New to care')).toBeTruthy();
+        const section = getByText('Care workforce pathway role category').parentElement;
+        const addLink = within(section).getByText('Add');
 
-      expect(changeLink.getAttribute('href')).toBe(
-        `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
-      );
-    });
+        expect(within(section).getByText('-')).toBeTruthy();
 
-    it('should render Change link and "Not known" when the answer is "I do not know"', async () => {
-      const workerOverrides = { careWorkforcePathwayRoleCategory: MockCWPRoleCategories.IDoNotKnow };
-      const { component, getByText } = await setup({ workerOverrides });
+        expect(addLink.getAttribute('href')).toBe(
+          `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
+        );
+      });
 
-      const section = getByText('Care workforce pathway role category').parentElement;
-      const changeLink = within(section).getByText('Change');
+      it('should render Change link when the question is answered', async () => {
+        const workerOverrides = { careWorkforcePathwayRoleCategory: MockCWPRoleCategories.NewToCare };
+        const { component, getByText } = await setup({ workerOverrides, cwpQuestionsFlag });
 
-      expect(within(section).getByText('Not known')).toBeTruthy();
+        const section = getByText('Care workforce pathway role category').parentElement;
+        const changeLink = within(section).getByText('Change');
 
-      expect(changeLink.getAttribute('href')).toBe(
-        `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
-      );
-    });
+        expect(within(section).getByText('New to care')).toBeTruthy();
 
-    it('should render Change link and "Role not included" when the answer is "None of the above"', async () => {
-      const workerOverrides = { careWorkforcePathwayRoleCategory: MockCWPRoleCategories.NoneOfTheAbove };
-      const { component, getByText } = await setup({ workerOverrides });
+        expect(changeLink.getAttribute('href')).toBe(
+          `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
+        );
+      });
 
-      const section = getByText('Care workforce pathway role category').parentElement;
-      const changeLink = within(section).getByText('Change');
+      it('should render Change link and "Not known" when the answer is "I do not know"', async () => {
+        const workerOverrides = { careWorkforcePathwayRoleCategory: MockCWPRoleCategories.IDoNotKnow };
+        const { component, getByText } = await setup({ workerOverrides, cwpQuestionsFlag });
 
-      expect(within(section).getByText('Role not included')).toBeTruthy();
+        const section = getByText('Care workforce pathway role category').parentElement;
+        const changeLink = within(section).getByText('Change');
 
-      expect(changeLink.getAttribute('href')).toBe(
-        `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
-      );
+        expect(within(section).getByText('Not known')).toBeTruthy();
+
+        expect(changeLink.getAttribute('href')).toBe(
+          `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
+        );
+      });
+
+      it('should render Change link and "Role not included" when the answer is "None of the above"', async () => {
+        const workerOverrides = { careWorkforcePathwayRoleCategory: MockCWPRoleCategories.NoneOfTheAbove };
+        const { component, getByText } = await setup({ workerOverrides, cwpQuestionsFlag });
+
+        const section = getByText('Care workforce pathway role category').parentElement;
+        const changeLink = within(section).getByText('Change');
+
+        expect(within(section).getByText('Role not included')).toBeTruthy();
+
+        expect(changeLink.getAttribute('href')).toBe(
+          `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
+        );
+      });
     });
   });
 });

--- a/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.spec.ts
@@ -15,7 +15,7 @@ import { render, within } from '@testing-library/angular';
 import { QualificationsAndTrainingComponent } from './qualifications-and-training.component';
 import { InternationalRecruitmentService } from '@core/services/international-recruitment.service';
 
-describe('QualificationsAndTrainingComponent', () => {
+fdescribe('QualificationsAndTrainingComponent', () => {
   async function setup(isWdf = false, canEditWorker = true) {
     const { fixture, getByText } = await render(QualificationsAndTrainingComponent, {
       imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
@@ -155,6 +155,42 @@ describe('QualificationsAndTrainingComponent', () => {
           `/funding/staff-record/${component.worker.uid}/level-2-care-certificate`,
         );
       });
+    });
+  });
+
+  describe('Care workforce pathway role category', () => {
+    it('should render Add link when the question is not answered', async () => {
+      const { fixture, component, getByText } = await setup();
+
+      component.worker.careWorkforcePathwayRoleCategory = null;
+      fixture.detectChanges();
+
+      const section = getByText('Care workforce pathway role category').parentElement;
+      const addLink = within(section).getByText('Add');
+
+      expect(addLink.getAttribute('href')).toBe(
+        `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
+      );
+    });
+
+    it('should render Change link when the question is answered', async () => {
+      const { fixture, component, getByText } = await setup();
+
+      component.worker.careWorkforcePathwayRoleCategory = {
+        roleCategoryId: 1,
+        title: 'New to care',
+        description: "Is in a care-providing role that's a start point for a career in social care",
+      };
+      fixture.detectChanges();
+
+      const section = getByText('Care workforce pathway role category').parentElement;
+      const changeLink = within(section).getByText('Change');
+
+      expect(within(section).getByText('New to care')).toBeTruthy();
+
+      expect(changeLink.getAttribute('href')).toBe(
+        `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,
+      );
     });
   });
 });

--- a/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.spec.ts
@@ -208,14 +208,14 @@ describe('QualificationsAndTrainingComponent', () => {
       );
     });
 
-    it('should render Change link and "Role not included yet" when the answer is "None of the above"', async () => {
+    it('should render Change link and "Role not included" when the answer is "None of the above"', async () => {
       const workerOverrides = { careWorkforcePathwayRoleCategory: MockCWPRoleCategories.NoneOfTheAbove };
       const { component, getByText } = await setup({ workerOverrides });
 
       const section = getByText('Care workforce pathway role category').parentElement;
       const changeLink = within(section).getByText('Change');
 
-      expect(within(section).getByText('Role not included yet')).toBeTruthy();
+      expect(within(section).getByText('Role not included')).toBeTruthy();
 
       expect(changeLink.getAttribute('href')).toBe(
         `/workplace/${component.workplace.uid}/staff-record/${component.worker.uid}/staff-record-summary/care-workforce-pathway`,

--- a/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.spec.ts
@@ -35,7 +35,7 @@ describe('QualificationsAndTrainingComponent', () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            snapshot: { data: { featureFlags: { cwpQuestions: cwpQuestionsFlag } } },
+            snapshot: { data: { featureFlags: { cwpQuestions: cwpQuestionsFlag } }, params: {} },
           },
         },
       ],

--- a/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.ts
@@ -7,9 +7,16 @@ import { StaffRecordSummaryComponent } from '../staff-record-summary.component';
   templateUrl: './qualifications-and-training.component.html',
 })
 export class QualificationsAndTrainingComponent extends StaffRecordSummaryComponent {
+  public cwpQuestionsFlag: boolean;
+
   @Input() wdfView = false;
   @Input() overallWdfEligibility: boolean;
   @Input() public canEditWorker: boolean;
+
+  protected init(): void {
+    const snapshotData = this.route.snapshot.data;
+    this.cwpQuestionsFlag = snapshotData?.featureFlags?.cwpQuestions ?? false;
+  }
 
   get displaySocialCareQualifications() {
     return this.worker.qualificationInSocialCare === 'Yes';

--- a/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/qualifications-and-training/qualifications-and-training.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, OnChanges } from '@angular/core';
 
 import { StaffRecordSummaryComponent } from '../staff-record-summary.component';
 
@@ -6,7 +6,10 @@ import { StaffRecordSummaryComponent } from '../staff-record-summary.component';
   selector: 'app-qualifications-and-training',
   templateUrl: './qualifications-and-training.component.html',
 })
-export class QualificationsAndTrainingComponent extends StaffRecordSummaryComponent {
+export class QualificationsAndTrainingComponent
+  extends StaffRecordSummaryComponent
+  implements OnInit, OnDestroy, OnChanges
+{
   public cwpQuestionsFlag: boolean;
 
   @Input() wdfView = false;
@@ -15,7 +18,7 @@ export class QualificationsAndTrainingComponent extends StaffRecordSummaryCompon
 
   protected init(): void {
     const snapshotData = this.route.snapshot.data;
-    this.cwpQuestionsFlag = snapshotData?.featureFlags?.cwpQuestions ?? false;
+    this.cwpQuestionsFlag = snapshotData?.featureFlags?.cwpQuestions ?? true;
   }
 
   get displaySocialCareQualifications() {
@@ -26,7 +29,7 @@ export class QualificationsAndTrainingComponent extends StaffRecordSummaryCompon
     return this.worker.otherQualification === 'Yes';
   }
 
-  public showWdfConfirmations: any = {
+  public showWdfConfirmations: Record<string, boolean> = {
     careCertificate: null,
     qualificationInSocialCare: null,
     socialCareQualification: null,

--- a/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
@@ -70,7 +70,11 @@ export class StaffRecordSummaryComponent implements OnInit, OnDestroy {
       const returnTo = { url: staffRecordPath };
       this.workerService.setReturnTo(returnTo);
     }
+
+    this.init();
   }
+
+  protected init(): void {}
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();

--- a/frontend/src/app/shared/pipes/care-workforce-pathway-role-category.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/care-workforce-pathway-role-category.pipe.spec.ts
@@ -1,0 +1,52 @@
+import { CareWorkforcePathwayRoleCategoryPipe } from './care-workforce-pathway-role-category.pipe';
+
+describe('CareWorkforcePathwayRoleCategoryPipe', () => {
+  it('create an instance', () => {
+    const pipe = new CareWorkforcePathwayRoleCategoryPipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should convert null to "-"', () => {
+    const pipe = new CareWorkforcePathwayRoleCategoryPipe();
+    const roleCategory = null;
+    const expectedValue = '-';
+
+    expect(pipe.transform(roleCategory)).toEqual(expectedValue);
+  });
+
+  it('should convert "None of the above" to "Role not included yet"', () => {
+    const pipe = new CareWorkforcePathwayRoleCategoryPipe();
+    const roleCategory = {
+      id: 102,
+      title: 'None of the above',
+      description: '',
+    };
+    const expectedValue = 'Role not included yet';
+
+    expect(pipe.transform(roleCategory)).toEqual(expectedValue);
+  });
+
+  it('should convert "I do not know" to "Not known"', () => {
+    const pipe = new CareWorkforcePathwayRoleCategoryPipe();
+    const roleCategory = {
+      id: 101,
+      title: 'I do not know',
+      description: '',
+    };
+    const expectedValue = 'Not known';
+
+    expect(pipe.transform(roleCategory)).toEqual(expectedValue);
+  });
+
+  it('should return the title unchanged if for other role categories', () => {
+    const pipe = new CareWorkforcePathwayRoleCategoryPipe();
+    const roleCategory = {
+      id: 1,
+      title: 'New to care',
+      description: '',
+    };
+    const expectedValue = 'New to care';
+
+    expect(pipe.transform(roleCategory)).toEqual(expectedValue);
+  });
+});

--- a/frontend/src/app/shared/pipes/care-workforce-pathway-role-category.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/care-workforce-pathway-role-category.pipe.spec.ts
@@ -14,14 +14,14 @@ describe('CareWorkforcePathwayRoleCategoryPipe', () => {
     expect(pipe.transform(roleCategory)).toEqual(expectedValue);
   });
 
-  it('should convert "None of the above" to "Role not included yet"', () => {
+  it('should convert "None of the above" to "Role not included"', () => {
     const pipe = new CareWorkforcePathwayRoleCategoryPipe();
     const roleCategory = {
       id: 102,
       title: 'None of the above',
       description: '',
     };
-    const expectedValue = 'Role not included yet';
+    const expectedValue = 'Role not included';
 
     expect(pipe.transform(roleCategory)).toEqual(expectedValue);
   });

--- a/frontend/src/app/shared/pipes/care-workforce-pathway-role-category.pipe.ts
+++ b/frontend/src/app/shared/pipes/care-workforce-pathway-role-category.pipe.ts
@@ -15,7 +15,7 @@ export class CareWorkforcePathwayRoleCategoryPipe implements PipeTransform {
         return 'Not known';
 
       case 'None of the above':
-        return 'Role not included yet';
+        return 'Role not included';
 
       default:
         return value.title;

--- a/frontend/src/app/shared/pipes/care-workforce-pathway-role-category.pipe.ts
+++ b/frontend/src/app/shared/pipes/care-workforce-pathway-role-category.pipe.ts
@@ -1,0 +1,24 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { CareWorkforcePathwayRoleCategory } from '@core/model/careWorkforcePathwayCategory.model';
+
+@Pipe({
+  name: 'CWPRoleCategoryTitle',
+})
+export class CareWorkforcePathwayRoleCategoryPipe implements PipeTransform {
+  transform(value: CareWorkforcePathwayRoleCategory): string {
+    if (!value) {
+      return '-';
+    }
+
+    switch (value.title) {
+      case 'I do not know':
+        return 'Not known';
+
+      case 'None of the above':
+        return 'Role not included yet';
+
+      default:
+        return value.title;
+    }
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -142,6 +142,7 @@ import { WorkerDaysPipe } from './pipes/worker-days.pipe';
 import { WorkerPayPipe } from './pipes/worker-pay.pipe';
 import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-bearer.pipe';
 import { JobRoleNumbersTableComponent } from './components/job-role-numbers-table/job-role-numbers-table.component';
+import { CareWorkforcePathwayRoleCategoryPipe } from './pipes/care-workforce-pathway-role-category.pipe';
 
 @NgModule({
   imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, OverlayModule],
@@ -285,6 +286,7 @@ import { JobRoleNumbersTableComponent } from './components/job-role-numbers-tabl
     SelectJobRolesToAddComponent,
     NumberInputWithButtonsComponent,
     JobRoleNumbersTableComponent,
+    CareWorkforcePathwayRoleCategoryPipe,
   ],
   exports: [
     AbsoluteNumberPipe,
@@ -420,6 +422,7 @@ import { JobRoleNumbersTableComponent } from './components/job-role-numbers-tabl
     NumberInputWithButtonsComponent,
     NumberInputWithButtonsComponent,
     JobRoleNumbersTableComponent,
+    CareWorkforcePathwayRoleCategoryPipe,
   ],
   providers: [DialogService, TotalStaffComponent, ArticleListResolver, PageResolver, QuestionsAndAnswersResolver],
 })

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -143,6 +143,7 @@ import { WorkerPayPipe } from './pipes/worker-pay.pipe';
 import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-bearer.pipe';
 import { JobRoleNumbersTableComponent } from './components/job-role-numbers-table/job-role-numbers-table.component';
 import { CareWorkforcePathwayRoleCategoryPipe } from './pipes/care-workforce-pathway-role-category.pipe';
+import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
 
 @NgModule({
   imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, OverlayModule],
@@ -424,6 +425,13 @@ import { CareWorkforcePathwayRoleCategoryPipe } from './pipes/care-workforce-pat
     JobRoleNumbersTableComponent,
     CareWorkforcePathwayRoleCategoryPipe,
   ],
-  providers: [DialogService, TotalStaffComponent, ArticleListResolver, PageResolver, QuestionsAndAnswersResolver],
+  providers: [
+    DialogService,
+    TotalStaffComponent,
+    ArticleListResolver,
+    PageResolver,
+    QuestionsAndAnswersResolver,
+    FeatureFlagsResolver,
+  ],
 })
 export class SharedModule {}


### PR DESCRIPTION
#### Work done
- Add a row for Care workforce pathway role category to Staff record summary `qualifications-and-training` component
- Add a pipe to convert the role category titles for summary (e.g. I do not know --> Not known)
- Add a FeatureFlagsResolver so that component no need to call FeatureFlags service
- Refactor MockFeatureFlagsService to remove repetitive code

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
