### PR TITLE
Feat/1706 rename labels workplace summary

### DIFF
--- a/frontend/src/app/features/login/vacancies-and-turnover-login-message/vacancies-and-turnover-login-message.component.html
+++ b/frontend/src/app/features/login/vacancies-and-turnover-login-message/vacancies-and-turnover-login-message.component.html
@@ -8,10 +8,10 @@
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Current staff vacancies</h2>
     <p>We'll show DHSC and others how shortfalls in staffing affect the sector.</p>
 
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">New starters in the last 12 months</h2>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Starters in the last 12 months</h2>
     <p>We'll learn whether the sector is attracting new staff and whether recruitment plans are working.</p>
 
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Staff leavers in the last 12 months</h2>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Leavers in the last 12 months</h2>
     <p>We'll reveal staff retention issues and help DHSC and the government make policy and funding decisions.</p>
 
     <a [routerLink]="['/dashboard']" class="govuk-button govuk-!-margin-top-6">Continue</a>

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
@@ -328,7 +328,9 @@
               <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy | formatSLV }}</li>
             </ul>
           </ng-container>
-          <ng-container *ngIf="!isArray(workplace.vacancies)">{{ workplace.vacancies }} </ng-container>
+          <ng-container *ngIf="!isArray(workplace.vacancies)"
+            >{{ workplace.vacancies | closedEndedAnswer }}
+          </ng-container>
         </ng-template>
       </dd>
       <dd *ngIf="canEditEstablishment" class="govuk-summary-list__actions">
@@ -362,7 +364,7 @@
       }"
       data-testid="starters"
     >
-      <dt class="govuk-summary-list__key">New starters in the last 12 months</dt>
+      <dt class="govuk-summary-list__key">Starters in the last 12 months</dt>
       <dd class="govuk-summary-list__value">
         <ng-container *ngIf="!workplace.starters?.length; else starters"> - </ng-container>
         <ng-template #starters>
@@ -372,7 +374,7 @@
             </ul>
           </ng-container>
           <ng-container *ngIf="!isArray(workplace.starters)">
-            {{ workplace.starters }}
+            {{ workplace.starters | closedEndedAnswer }}
           </ng-container>
         </ng-template>
       </dd>
@@ -407,7 +409,7 @@
           showWdfConfirmations.leavers || workplace.wdf?.leavers?.isEligible === Eligibility.NO
       }"
     >
-      <dt class="govuk-summary-list__key">Staff leavers in the last 12 months</dt>
+      <dt class="govuk-summary-list__key">Leavers in the last 12 months</dt>
       <dd class="govuk-summary-list__value">
         <ng-container *ngIf="!workplace.leavers?.length; else leavers"> - </ng-container>
         <ng-template #leavers>
@@ -417,7 +419,7 @@
             </ul>
           </ng-container>
           <ng-container *ngIf="!isArray(workplace.leavers)">
-            {{ workplace.leavers }}
+            {{ workplace.leavers | closedEndedAnswer }}
           </ng-container>
         </ng-template>
       </dd>

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
@@ -573,10 +573,10 @@ describe('WDFWorkplaceSummaryComponent', () => {
         expect(within(vacanciesRow).queryByText('-')).toBeTruthy();
       });
 
-      it(`should show Don't know and a Change link when vacancies is set to Don't know`, async () => {
+      it(`should show Not known and a Change link when vacancies is set to Don't know`, async () => {
         const { component, fixture } = await setup();
 
-        component.workplace.vacancies = `Don't know`;
+        component.workplace.vacancies = 'Not known';
 
         fixture.detectChanges();
 
@@ -585,7 +585,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
 
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/update-vacancies`);
-        expect(within(vacanciesRow).queryByText(`Don't know`)).toBeTruthy();
+        expect(within(vacanciesRow).queryByText('Not known')).toBeTruthy();
       });
 
       it(`should show None and a Change link when vacancies is set to None`, async () => {
@@ -654,7 +654,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
 
         const startersRow = getByTestId('starters');
 
-        expect(within(startersRow).getByText('New starters in the last 12 months')).toBeTruthy();
+        expect(within(startersRow).getByText('Starters in the last 12 months')).toBeTruthy();
       });
 
       it('should show dash and have Add information button on when starters is null', async () => {
@@ -672,10 +672,10 @@ describe('WDFWorkplaceSummaryComponent', () => {
         expect(within(startersRow).queryByText('-')).toBeTruthy();
       });
 
-      it(`should show Don't know and a Change link when starters is set to Don't know`, async () => {
+      it(`should show Not known and a Change link when starters is set to Don't know`, async () => {
         const { component, fixture } = await setup();
 
-        component.workplace.starters = `Don't know`;
+        component.workplace.starters = 'Not known';
 
         fixture.detectChanges();
 
@@ -684,7 +684,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
 
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/update-starters`);
-        expect(within(startersRow).queryByText(`Don't know`)).toBeTruthy();
+        expect(within(startersRow).queryByText('Not known')).toBeTruthy();
       });
 
       it(`should show None and a Change link when starters is set to None`, async () => {
@@ -753,7 +753,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
 
         const leaversRow = getByTestId('leavers');
 
-        expect(within(leaversRow).getByText('Staff leavers in the last 12 months')).toBeTruthy();
+        expect(within(leaversRow).getByText('Leavers in the last 12 months')).toBeTruthy();
       });
 
       it('should show dash and have Add information button on when leavers is null', async () => {
@@ -771,10 +771,10 @@ describe('WDFWorkplaceSummaryComponent', () => {
         expect(within(leaversRow).queryByText('-')).toBeTruthy();
       });
 
-      it(`should show Don't know and a Change link when leavers is set to Don't know`, async () => {
+      it(`should show Not known and a Change link when leavers is set to Don't know`, async () => {
         const { component, fixture } = await setup();
 
-        component.workplace.leavers = `Don't know`;
+        component.workplace.leavers = 'Not known';
 
         fixture.detectChanges();
 
@@ -783,7 +783,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
 
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/update-leavers`);
-        expect(within(leaversRow).queryByText(`Don't know`)).toBeTruthy();
+        expect(within(leaversRow).queryByText('Not known')).toBeTruthy();
       });
 
       it(`should show None and a Change link when leavers is set to None`, async () => {

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -32,7 +32,9 @@
                       <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy | formatSLV }}</li>
                     </ul>
                   </ng-container>
-                  <ng-container *ngIf="!isArray(workplace.vacancies)">{{ workplace.vacancies }} </ng-container>
+                  <ng-container *ngIf="!isArray(workplace.vacancies)"
+                    >{{ workplace.vacancies | closedEndedAnswer }}
+                  </ng-container>
                 </ng-template>
               </app-summary-record-value>
             </dd>
@@ -56,7 +58,7 @@
       </div>
       <dl class="govuk-summary-list govuk-summary-list--medium">
         <div class="govuk-summary-list__row" data-testid="starters">
-          <dt class="govuk-summary-list__key">New starters in the last 12 months</dt>
+          <dt class="govuk-summary-list__key">Starters in the last 12 months</dt>
           <dd class="govuk-summary-list__value">
             <app-summary-record-value>
               <ng-container *ngIf="!workplace.starters?.length; else starters"> - </ng-container>
@@ -67,7 +69,7 @@
                   </ul>
                 </ng-container>
                 <ng-container *ngIf="!isArray(workplace.starters)">
-                  {{ workplace.starters }}
+                  {{ workplace.starters | closedEndedAnswer }}
                 </ng-container>
               </ng-template>
             </app-summary-record-value>
@@ -83,7 +85,7 @@
         </div>
 
         <div class="govuk-summary-list__row" data-testid="leavers">
-          <dt class="govuk-summary-list__key">Staff leavers in the last 12 months</dt>
+          <dt class="govuk-summary-list__key">Leavers in the last 12 months</dt>
           <dd class="govuk-summary-list__value">
             <app-summary-record-value>
               <ng-container *ngIf="!workplace.leavers?.length; else leavers"> - </ng-container>
@@ -94,7 +96,7 @@
                   </ul>
                 </ng-container>
                 <ng-container *ngIf="!isArray(workplace.leavers)">
-                  {{ workplace.leavers }}
+                  {{ workplace.leavers | closedEndedAnswer }}
                 </ng-container>
               </ng-template>
             </app-summary-record-value>

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -839,10 +839,10 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(within(vacanciesRow).queryByText('-')).toBeTruthy();
       });
 
-      it(`should show Don't know and a Change link when vacancies is set to Don't know`, async () => {
+      it(`should show Not known and a Change link when vacancies is set to Don't know`, async () => {
         const { component, fixture, getByTestId } = await setup();
 
-        component.workplace.vacancies = `Don't know`;
+        component.workplace.vacancies = 'Not known';
         component.canEditEstablishment = true;
         fixture.detectChanges();
 
@@ -851,7 +851,7 @@ describe('NewWorkplaceSummaryComponent', () => {
 
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/update-vacancies`);
-        expect(within(vacanciesRow).queryByText(`Don't know`)).toBeTruthy();
+        expect(within(vacanciesRow).queryByText('Not known')).toBeTruthy();
       });
 
       it(`should show None and a Change link when vacancies is set to None`, async () => {
@@ -958,7 +958,7 @@ describe('NewWorkplaceSummaryComponent', () => {
 
         const startersRow = getByTestId('starters');
 
-        expect(within(startersRow).getByText('New starters in the last 12 months')).toBeTruthy();
+        expect(within(startersRow).getByText('Starters in the last 12 months')).toBeTruthy();
       });
 
       it('should show dash and have Add information button on when starters is null', async () => {
@@ -976,10 +976,10 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(within(startersRow).queryByText('-')).toBeTruthy();
       });
 
-      it(`should show Don't know and a Change link when starters is set to Don't know`, async () => {
+      it(`should show Not known and a Change link when starters is set to Don't know`, async () => {
         const { component, fixture, getByTestId } = await setup();
 
-        component.workplace.starters = `Don't know`;
+        component.workplace.starters = 'Not known';
         component.canEditEstablishment = true;
         fixture.detectChanges();
 
@@ -988,7 +988,7 @@ describe('NewWorkplaceSummaryComponent', () => {
 
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/update-starters`);
-        expect(within(startersRow).queryByText(`Don't know`)).toBeTruthy();
+        expect(within(startersRow).queryByText('Not known')).toBeTruthy();
       });
 
       it(`should show None and a Change link when starters is set to None`, async () => {
@@ -1057,7 +1057,7 @@ describe('NewWorkplaceSummaryComponent', () => {
 
         const leaversRow = getByTestId('leavers');
 
-        expect(within(leaversRow).getByText('Staff leavers in the last 12 months')).toBeTruthy();
+        expect(within(leaversRow).getByText('Leavers in the last 12 months')).toBeTruthy();
       });
 
       it('should show dash and have Add information button on when leavers is null', async () => {
@@ -1075,10 +1075,10 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(within(leaversRow).queryByText('-')).toBeTruthy();
       });
 
-      it(`should show Don't know and a Change link when leavers is set to Don't know`, async () => {
+      it(`should show Not known and a Change link when leavers is set to Don't know`, async () => {
         const { component, fixture, getByTestId } = await setup();
 
-        component.workplace.leavers = `Don't know`;
+        component.workplace.leavers = 'Not known';
         component.canEditEstablishment = true;
         fixture.detectChanges();
 
@@ -1087,7 +1087,7 @@ describe('NewWorkplaceSummaryComponent', () => {
 
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/update-leavers`);
-        expect(within(leaversRow).queryByText(`Don't know`)).toBeTruthy();
+        expect(within(leaversRow).queryByText('Not known')).toBeTruthy();
       });
 
       it(`should show None and a Change link when leavers is set to None`, async () => {

--- a/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.html
@@ -390,7 +390,9 @@
                 <li *ngFor="let vacancy of workplace.vacancies">{{ vacancy | formatSLV }}</li>
               </ul>
             </ng-container>
-            <ng-container *ngIf="!isArray(workplace.vacancies)">{{ workplace.vacancies }} </ng-container>
+            <ng-container *ngIf="!isArray(workplace.vacancies)"
+              >{{ workplace.vacancies | closedEndedAnswer }}
+            </ng-container>
           </ng-template>
         </app-summary-record-value>
         <app-wdf-field-confirmation
@@ -424,7 +426,7 @@
     </div>
 
     <div class="govuk-summary-list__row" data-testid="starters">
-      <dt class="govuk-summary-list__key">New starters in the last 12 months</dt>
+      <dt class="govuk-summary-list__key">Starters in the last 12 months</dt>
       <dd class="govuk-summary-list__value">
         <app-summary-record-value
           [wdfView]="wdfView"
@@ -439,7 +441,7 @@
               </ul>
             </ng-container>
             <ng-container *ngIf="!isArray(workplace.starters)">
-              {{ workplace.starters }}
+              {{ workplace.starters | closedEndedAnswer }}
             </ng-container>
           </ng-template>
         </app-summary-record-value>
@@ -474,7 +476,7 @@
     </div>
 
     <div class="govuk-summary-list__row" data-testid="leavers">
-      <dt class="govuk-summary-list__key">Staff leavers in the last 12 months</dt>
+      <dt class="govuk-summary-list__key">Leavers in the last 12 months</dt>
       <dd class="govuk-summary-list__value">
         <app-summary-record-value
           [wdfView]="wdfView"
@@ -489,7 +491,7 @@
               </ul>
             </ng-container>
             <ng-container *ngIf="!isArray(workplace.leavers)">
-              {{ workplace.leavers }}
+              {{ workplace.leavers | closedEndedAnswer }}
             </ng-container>
           </ng-template>
         </app-summary-record-value>

--- a/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/workplace-summary/workplace-summary.component.spec.ts
@@ -720,10 +720,10 @@ describe('WorkplaceSummaryComponent', () => {
         expect(within(vacanciesRow).queryByText('-')).toBeTruthy();
       });
 
-      it(`should show Don't know and a Change link when vacancies is set to Don't know`, async () => {
+      it(`should show Not known and a Change link when vacancies is set to Don't know`, async () => {
         const { component, fixture } = await setup();
 
-        component.workplace.vacancies = `Don't know`;
+        component.workplace.vacancies = 'Not known';
         component.canEditEstablishment = true;
         fixture.detectChanges();
 
@@ -732,7 +732,7 @@ describe('WorkplaceSummaryComponent', () => {
 
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-vacancies`);
-        expect(within(vacanciesRow).queryByText(`Don't know`)).toBeTruthy();
+        expect(within(vacanciesRow).queryByText('Not known')).toBeTruthy();
       });
 
       it(`should show None and a Change link when vacancies is set to None`, async () => {
@@ -834,7 +834,7 @@ describe('WorkplaceSummaryComponent', () => {
 
         const startersRow = getByTestId('starters');
 
-        expect(within(startersRow).getByText('New starters in the last 12 months')).toBeTruthy();
+        expect(within(startersRow).getByText('Starters in the last 12 months')).toBeTruthy();
       });
 
       it('should show dash and have Add information button on when starters is null', async () => {
@@ -852,10 +852,10 @@ describe('WorkplaceSummaryComponent', () => {
         expect(within(startersRow).queryByText('-')).toBeTruthy();
       });
 
-      it(`should show Don't know and a Change link when starters is set to Don't know`, async () => {
+      it(`should show Not known and a Change link when starters is set to Don't know`, async () => {
         const { component, fixture } = await setup();
 
-        component.workplace.starters = `Don't know`;
+        component.workplace.starters = 'Not known';
         component.canEditEstablishment = true;
         fixture.detectChanges();
 
@@ -864,7 +864,7 @@ describe('WorkplaceSummaryComponent', () => {
 
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-starters`);
-        expect(within(startersRow).queryByText(`Don't know`)).toBeTruthy();
+        expect(within(startersRow).queryByText('Not known')).toBeTruthy();
       });
 
       it(`should show None and a Change link when starters is set to None`, async () => {
@@ -966,7 +966,7 @@ describe('WorkplaceSummaryComponent', () => {
 
         const leaversRow = getByTestId('leavers');
 
-        expect(within(leaversRow).getByText('Staff leavers in the last 12 months')).toBeTruthy();
+        expect(within(leaversRow).getByText('Leavers in the last 12 months')).toBeTruthy();
       });
 
       it('should show dash and have Add information button on when leavers is null', async () => {
@@ -984,10 +984,10 @@ describe('WorkplaceSummaryComponent', () => {
         expect(within(leaversRow).queryByText('-')).toBeTruthy();
       });
 
-      it(`should show Don't know and a Change link when leavers is set to Don't know`, async () => {
+      it(`should show Not known and a Change link when leavers is set to Don't know`, async () => {
         const { component, fixture } = await setup();
 
-        component.workplace.leavers = `Don't know`;
+        component.workplace.leavers = 'Not known';
         component.canEditEstablishment = true;
         fixture.detectChanges();
 
@@ -996,7 +996,7 @@ describe('WorkplaceSummaryComponent', () => {
 
         expect(link).toBeTruthy();
         expect(link.getAttribute('href')).toEqual(`/workplace/${component.workplace.uid}/do-you-have-leavers`);
-        expect(within(leaversRow).queryByText(`Don't know`)).toBeTruthy();
+        expect(within(leaversRow).queryByText('Not known')).toBeTruthy();
       });
 
       it(`should show None and a Change link when leavers is set to None`, async () => {


### PR DESCRIPTION
#### Work done
- Rename the SLV labels for the workplace summary and funding
- Rename the SLV labels for the SLV login
- Add the 'closedEndedAnswer' pipe to the summary page to change Dont know answer to Not known.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
