### PR TITLE
Feat/1720 cwp workplace question 2 backend

### DIFF
--- a/backend/migrations/20250528140219-createTableAndColumnsForCareWorkforcePathwayUse.js
+++ b/backend/migrations/20250528140219-createTableAndColumnsForCareWorkforcePathwayUse.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const models = require('../server/models/index');
+
+const cwpReasonsTable = { tableName: 'CareWorkforcePathwayReasons', schema: 'cqc' };
+const junctionTable = { tableName: 'EstablishmentCWPReason', schema: 'cqc' };
+const establishmentTable = { tableName: 'Establishment', schema: 'cqc' };
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((transaction) => {
+      const createReasonTable = queryInterface.createTable(
+        cwpReasonsTable,
+        {
+          ID: {
+            type: Sequelize.DataTypes.INTEGER,
+            primaryKey: true,
+          },
+          Seq: {
+            type: Sequelize.DataTypes.INTEGER,
+            unique: true,
+          },
+          Reason: {
+            type: Sequelize.DataTypes.TEXT,
+          },
+          AnalysisFileCode: {
+            type: Sequelize.DataTypes.INTEGER,
+            unique: true,
+          },
+          BulkUploadCode: {
+            type: Sequelize.DataTypes.INTEGER,
+            unique: true,
+          },
+        },
+        { transaction },
+      );
+
+      const createJunctionTable = queryInterface.createTable(
+        junctionTable,
+        {
+          EstablishmentID: {
+            type: Sequelize.DataTypes.INTEGER,
+            allowNull: false,
+            primaryKey: true,
+            references: {
+              model: establishmentTable,
+              key: 'EstablishmentID',
+            },
+          },
+          CareWorkforcePathwayReasonID: {
+            type: Sequelize.DataTypes.INTEGER,
+            allowNull: false,
+            primaryKey: true,
+            references: {
+              model: cwpReasonsTable,
+              key: 'ID',
+            },
+          },
+          Other: {
+            type: Sequelize.DataTypes.TEXT,
+            allowNull: true,
+          },
+        },
+        { transaction },
+      );
+
+      const addColumnToEstablishmentTable = queryInterface.addColumn(
+        establishmentTable,
+        'CareWorkforcePathwayUse',
+        {
+          type: Sequelize.DataTypes.ENUM,
+          allowNull: true,
+          values: ['Yes', 'No', "Don't know"],
+        },
+        { transaction },
+      );
+
+      const addDataToReasonTable = reasonTableData.map((rowData) =>
+        models.CareWorkforcePathwayReasons.create(rowData, { transaction }),
+      );
+
+      return Promise.all([
+        createReasonTable,
+        createJunctionTable,
+        addColumnToEstablishmentTable,
+        ...addDataToReasonTable,
+      ]);
+    });
+  },
+
+  async down(queryInterface) {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.dropTable(junctionTable, { transaction });
+      await queryInterface.removeColumn(establishmentTable, 'CareWorkforcePathwayUse', { transaction });
+      await queryInterface.dropTable(cwpReasonsTable, { transaction });
+    });
+  },
+};
+
+const reasonTableData = [
+  { reason: "To help define our organisation's values", id: 1, seq: 10, analysisFileCode: 1, bulkUploadCode: 1 },
+  { reason: 'To help update our job descriptions', id: 2, seq: 20, analysisFileCode: 2, bulkUploadCode: 2 },
+  {
+    reason: 'To help update our HR and learning and development policies',
+    id: 3,
+    seq: 30,
+    analysisFileCode: 3,
+    bulkUploadCode: 3,
+  },
+  {
+    reason: 'To help identify skills and knowledge gaps in our staff',
+    id: 4,
+    seq: 40,
+    analysisFileCode: 4,
+    bulkUploadCode: 4,
+  },
+  {
+    reason: 'To help identify learning and development opportunities for our staff',
+    id: 5,
+    seq: 50,
+    analysisFileCode: 5,
+    bulkUploadCode: 5,
+  },
+  { reason: 'To help set levels of pay', id: 6, seq: 60, analysisFileCode: 6, bulkUploadCode: 6 },
+  {
+    reason: 'To help with advertising job roles and recruitment',
+    id: 7,
+    seq: 70,
+    analysisFileCode: 7,
+    bulkUploadCode: 7,
+  },
+  {
+    reason: 'To help demonstrate delivery and outcomes to commissioners and CQC',
+    id: 8,
+    seq: 80,
+    analysisFileCode: 8,
+    bulkUploadCode: 8,
+  },
+  { reason: 'To help plan our future workforce', id: 9, seq: 90, analysisFileCode: 9, bulkUploadCode: 9 },
+  { reason: 'For something else', id: 10, seq: 100, analysisFileCode: 10, bulkUploadCode: 10 },
+];

--- a/backend/migrations/20250528140219-createTableAndColumnsForCareWorkforcePathwayUse.js
+++ b/backend/migrations/20250528140219-createTableAndColumnsForCareWorkforcePathwayUse.js
@@ -69,22 +69,46 @@ module.exports = {
         { transaction },
       );
 
-      const addColumnToEstablishmentTable = queryInterface.addColumn(
-        establishmentTable,
-        'CareWorkforcePathwayUse',
-        {
-          type: Sequelize.DataTypes.ENUM,
-          allowNull: true,
-          values: ['Yes', 'No', "Don't know"],
-        },
-        { transaction },
-      );
+      const addColumnsToEstablishmentTable = [
+        queryInterface.addColumn(
+          establishmentTable,
+          'CareWorkforcePathwayUseValue',
+          {
+            type: Sequelize.DataTypes.ENUM,
+            allowNull: true,
+            values: ['Yes', 'No', "Don't know"],
+          },
+          { transaction },
+        ),
+        ['SavedAt', 'ChangedAt'].map((suffix) => {
+          return queryInterface.addColumn(
+            establishmentTable,
+            `CareWorkforcePathwayUse${suffix}`,
+            {
+              type: Sequelize.DataTypes.DATE,
+              allowNull: true,
+            },
+            { transaction },
+          );
+        }),
+        ['SavedBy', 'ChangedBy'].map((suffix) => {
+          return queryInterface.addColumn(
+            establishmentTable,
+            `CareWorkforcePathwayUse${suffix}`,
+            {
+              type: Sequelize.DataTypes.TEXT,
+              allowNull: true,
+            },
+            { transaction },
+          );
+        }),
+      ];
 
       const addDataToReasonTable = reasonTableData.map((rowData) =>
         models.CareWorkforcePathwayReasons.create(rowData, { transaction }),
       );
 
-      await Promise.all([createReasonTable, createJunctionTable, addColumnToEstablishmentTable]);
+      await Promise.all([createReasonTable, createJunctionTable, ...addColumnsToEstablishmentTable]);
 
       await Promise.all(addDataToReasonTable);
     });
@@ -93,7 +117,11 @@ module.exports = {
   async down(queryInterface) {
     return queryInterface.sequelize.transaction(async (transaction) => {
       await queryInterface.dropTable(junctionTable, { transaction });
-      await queryInterface.removeColumn(establishmentTable, 'CareWorkforcePathwayUse', { transaction });
+      await queryInterface.removeColumn(establishmentTable, 'CareWorkforcePathwayUseValue', { transaction });
+      await queryInterface.removeColumn(establishmentTable, 'CareWorkforcePathwayUseSavedAt', { transaction });
+      await queryInterface.removeColumn(establishmentTable, 'CareWorkforcePathwayUseChangedAt', { transaction });
+      await queryInterface.removeColumn(establishmentTable, 'CareWorkforcePathwayUseSavedBy', { transaction });
+      await queryInterface.removeColumn(establishmentTable, 'CareWorkforcePathwayUseChangedBy', { transaction });
       await queryInterface.dropTable(cwpReasonsTable, { transaction });
     });
   },

--- a/backend/migrations/20250528140219-createTableAndColumnsForCareWorkforcePathwayUse.js
+++ b/backend/migrations/20250528140219-createTableAndColumnsForCareWorkforcePathwayUse.js
@@ -9,7 +9,7 @@ const establishmentTable = { tableName: 'Establishment', schema: 'cqc' };
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    return queryInterface.sequelize.transaction((transaction) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
       const createReasonTable = queryInterface.createTable(
         cwpReasonsTable,
         {
@@ -84,12 +84,9 @@ module.exports = {
         models.CareWorkforcePathwayReasons.create(rowData, { transaction }),
       );
 
-      return Promise.all([
-        createReasonTable,
-        createJunctionTable,
-        addColumnToEstablishmentTable,
-        ...addDataToReasonTable,
-      ]);
+      await Promise.all([createReasonTable, createJunctionTable, addColumnToEstablishmentTable]);
+
+      await Promise.all(addDataToReasonTable);
     });
   },
 

--- a/backend/migrations/20250528140219-createTableAndColumnsForCareWorkforcePathwayUse.js
+++ b/backend/migrations/20250528140219-createTableAndColumnsForCareWorkforcePathwayUse.js
@@ -3,7 +3,7 @@
 const models = require('../server/models/index');
 
 const cwpReasonsTable = { tableName: 'CareWorkforcePathwayReasons', schema: 'cqc' };
-const junctionTable = { tableName: 'EstablishmentCWPReason', schema: 'cqc' };
+const junctionTable = { tableName: 'EstablishmentCWPReasons', schema: 'cqc' };
 const establishmentTable = { tableName: 'Establishment', schema: 'cqc' };
 
 /** @type {import('sequelize-cli').Migration} */
@@ -21,8 +21,12 @@ module.exports = {
             type: Sequelize.DataTypes.INTEGER,
             unique: true,
           },
-          Reason: {
+          Text: {
             type: Sequelize.DataTypes.TEXT,
+          },
+          IsOther: {
+            type: Sequelize.DataTypes.BOOLEAN,
+            defaultValue: false,
           },
           AnalysisFileCode: {
             type: Sequelize.DataTypes.INTEGER,
@@ -99,44 +103,44 @@ module.exports = {
 };
 
 const reasonTableData = [
-  { reason: "To help define our organisation's values", id: 1, seq: 10, analysisFileCode: 1, bulkUploadCode: 1 },
-  { reason: 'To help update our job descriptions', id: 2, seq: 20, analysisFileCode: 2, bulkUploadCode: 2 },
+  { text: "To help define our organisation's values", id: 1, seq: 10, analysisFileCode: 1, bulkUploadCode: 1 },
+  { text: 'To help update our job descriptions', id: 2, seq: 20, analysisFileCode: 2, bulkUploadCode: 2 },
   {
-    reason: 'To help update our HR and learning and development policies',
+    text: 'To help update our HR and learning and development policies',
     id: 3,
     seq: 30,
     analysisFileCode: 3,
     bulkUploadCode: 3,
   },
   {
-    reason: 'To help identify skills and knowledge gaps in our staff',
+    text: 'To help identify skills and knowledge gaps in our staff',
     id: 4,
     seq: 40,
     analysisFileCode: 4,
     bulkUploadCode: 4,
   },
   {
-    reason: 'To help identify learning and development opportunities for our staff',
+    text: 'To help identify learning and development opportunities for our staff',
     id: 5,
     seq: 50,
     analysisFileCode: 5,
     bulkUploadCode: 5,
   },
-  { reason: 'To help set levels of pay', id: 6, seq: 60, analysisFileCode: 6, bulkUploadCode: 6 },
+  { text: 'To help set levels of pay', id: 6, seq: 60, analysisFileCode: 6, bulkUploadCode: 6 },
   {
-    reason: 'To help with advertising job roles and recruitment',
+    text: 'To help with advertising job roles and recruitment',
     id: 7,
     seq: 70,
     analysisFileCode: 7,
     bulkUploadCode: 7,
   },
   {
-    reason: 'To help demonstrate delivery and outcomes to commissioners and CQC',
+    text: 'To help demonstrate delivery and outcomes to commissioners and CQC',
     id: 8,
     seq: 80,
     analysisFileCode: 8,
     bulkUploadCode: 8,
   },
-  { reason: 'To help plan our future workforce', id: 9, seq: 90, analysisFileCode: 9, bulkUploadCode: 9 },
-  { reason: 'For something else', id: 10, seq: 100, analysisFileCode: 10, bulkUploadCode: 10 },
+  { text: 'To help plan our future workforce', id: 9, seq: 90, analysisFileCode: 9, bulkUploadCode: 9 },
+  { text: 'For something else', id: 10, seq: 100, analysisFileCode: 10, bulkUploadCode: 10, isOther: true },
 ];

--- a/backend/server.js
+++ b/backend/server.js
@@ -59,6 +59,7 @@ var nhsBsaApiAuth = require('./server/routes/nhsBsaApi/index');
 var nhsBsaApiDocumentation = require('./server/routes/nhsBsaApi/apiDocs');
 var careWorkforcePathwayRoleCategories = require('./server/routes/careWorkforcePathwayRoleCategories');
 var careWorkforcePathwayWorkplaceAwarenessAnswers = require('./server/routes/careWorkforcePathwayWorkplaceAwarenessAnswers');
+const { careWorkforcePathwayRouter } = require('./server/routes/careWorkforcePathway');
 
 // admin route
 var admin = require('./server/routes/admin');
@@ -270,6 +271,7 @@ app.use('/api/careWorkforcePathwayWorkplaceAwarenessAnswers', [
   cacheMiddleware.nocache,
   careWorkforcePathwayWorkplaceAwarenessAnswers,
 ]);
+app.use('/api/careWorkforcePathway', [refCacheMiddleware.refcache, careWorkforcePathwayRouter]);
 
 // transaction endpoints
 app.use('/api/errors', errors);

--- a/backend/server/models/careWorkforcePathwayReasons.js
+++ b/backend/server/models/careWorkforcePathwayReasons.js
@@ -1,0 +1,51 @@
+/* jshint indent: 2 */
+
+module.exports = function (sequelize, DataTypes) {
+  const CareWorkforcePathwayReasons = sequelize.define(
+    'CareWorkforcePathwayReasons',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        field: 'ID',
+      },
+      seq: {
+        type: DataTypes.INTEGER,
+        unique: true,
+        field: 'Seq',
+      },
+      reason: {
+        type: DataTypes.TEXT,
+        field: 'Reason',
+      },
+      analysisFileCode: {
+        type: DataTypes.INTEGER,
+        unique: true,
+        field: 'AnalysisFileCode',
+      },
+      bulkUploadCode: {
+        type: DataTypes.INTEGER,
+        unique: true,
+        field: 'BulkUploadCode',
+      },
+    },
+
+    {
+      tableName: 'CareWorkforcePathwayReasons',
+      schema: 'cqc',
+      createdAt: false,
+      updatedAt: false,
+    },
+  );
+
+  CareWorkforcePathwayReasons.associate = (models) => {
+    CareWorkforcePathwayReasons.belongsToMany(models.establishment, {
+      through: 'EstablishmentCWPReason',
+      foreignKey: 'careWorkforcePathwayReasonID',
+      sourceKey: 'id',
+    });
+  };
+
+  return CareWorkforcePathwayReasons;
+};

--- a/backend/server/models/careWorkforcePathwayReasons.js
+++ b/backend/server/models/careWorkforcePathwayReasons.js
@@ -15,9 +15,14 @@ module.exports = function (sequelize, DataTypes) {
         unique: true,
         field: 'Seq',
       },
-      reason: {
+      text: {
         type: DataTypes.TEXT,
-        field: 'Reason',
+        field: 'Text',
+      },
+      isOther: {
+        type: DataTypes.BOOLEAN,
+        field: 'IsOther',
+        defaultValue: false,
       },
       analysisFileCode: {
         type: DataTypes.INTEGER,
@@ -41,7 +46,7 @@ module.exports = function (sequelize, DataTypes) {
 
   CareWorkforcePathwayReasons.associate = (models) => {
     CareWorkforcePathwayReasons.belongsToMany(models.establishment, {
-      through: 'EstablishmentCWPReason',
+      through: 'EstablishmentCWPReasons',
       foreignKey: 'careWorkforcePathwayReasonID',
       sourceKey: 'id',
     });

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -1414,6 +1414,11 @@ class Establishment extends EntityValidator {
           raw: true,
         });
 
+        const careWorkforcePathwayReasons = await fetchResults.getCareWorkforcePathwayReasons({
+          attributes: ['id', 'text', 'isOther', [models.sequelize.col('EstablishmentCWPReasons.Other'), 'other']],
+          raw: true,
+        });
+
         const [otherServices, mainService, serviceUsers, capacity, jobs] = await Promise.all([
           ServiceCache.allMyOtherServices(establishmentServices.map((x) => x)),
           models.services.findOne({
@@ -1489,6 +1494,8 @@ class Establishment extends EntityValidator {
             return otherService;
           }
         });
+
+        fetchResults.careWorkforcePathwayReasons = careWorkforcePathwayReasons;
 
         fetchResults.capacity = capacity;
 

--- a/backend/server/models/classes/establishment/establishmentProperties.js
+++ b/backend/server/models/classes/establishment/establishmentProperties.js
@@ -24,6 +24,8 @@ const postcodeProperty = require('./properties/postcodeProperty').PostcodeProper
 const isRegulatedProperty = require('./properties/isRegulatedProperty').IsRegulatedProperty;
 const careWorkforcePathwayWorkplaceAwarenessProperty =
   require('./properties/careWorkforcePathwayWorkplaceAwarenessProperty').CareWorkforcePathwayWorkplaceAwarenessProperty;
+const careWorkforcePathwayUseProperty =
+  require('./properties/careWorkforcePathwayUseProperty').CareWorkforcePathwayUseProperty;
 
 class EstablishmentPropertyManager {
   constructor() {
@@ -50,6 +52,7 @@ class EstablishmentPropertyManager {
     this._thisManager.registerProperty(postcodeProperty);
     this._thisManager.registerProperty(isRegulatedProperty);
     this._thisManager.registerProperty(careWorkforcePathwayWorkplaceAwarenessProperty);
+    this._thisManager.registerProperty(careWorkforcePathwayUseProperty);
   }
 
   get manager() {

--- a/backend/server/models/classes/establishment/properties/careWorkforcePathwayUseProperty.js
+++ b/backend/server/models/classes/establishment/properties/careWorkforcePathwayUseProperty.js
@@ -7,6 +7,8 @@ const [YES, NO, DONT_KNOW] = ['Yes', 'No', "Don't know"];
 exports.CareWorkforcePathwayUseProperty = class CareWorkforcePathwayUseProperty extends ChangePropertyPrototype {
   constructor() {
     super('CareWorkforcePathwayUse');
+    this._allowNull = true;
+    this._isValid;
   }
 
   static clone() {
@@ -27,7 +29,7 @@ exports.CareWorkforcePathwayUseProperty = class CareWorkforcePathwayUseProperty 
           use: YES,
           reasons,
         };
-        break;
+        return;
       }
 
       case NO:
@@ -38,7 +40,19 @@ exports.CareWorkforcePathwayUseProperty = class CareWorkforcePathwayUseProperty 
         };
         return;
       }
+
+      default: {
+        this.property = null;
+        this._isValid = false;
+      }
     }
+  }
+
+  get valid() {
+    if (!super.valid) {
+      return false;
+    }
+    return this._isValid ?? true;
   }
 
   async _validateReasons(reasons) {
@@ -53,6 +67,11 @@ exports.CareWorkforcePathwayUseProperty = class CareWorkforcePathwayUseProperty 
       order: [['seq', 'ASC']],
       raw: true,
     });
+
+    if (validReasonsFound.length !== reasons.length) {
+      this._isValid = false;
+      return null;
+    }
 
     validReasonsFound.forEach((reason) => {
       if (reason.isOther) {

--- a/backend/server/models/classes/establishment/properties/careWorkforcePathwayUseProperty.js
+++ b/backend/server/models/classes/establishment/properties/careWorkforcePathwayUseProperty.js
@@ -1,0 +1,194 @@
+const ChangePropertyPrototype = require('../../properties/changePrototype').ChangePropertyPrototype;
+
+const models = require('../../../index');
+
+const [YES, NO, DONT_KNOW] = ['Yes', 'No', "Don't know"];
+
+exports.CareWorkforcePathwayUseProperty = class CareWorkforcePathwayUseProperty extends ChangePropertyPrototype {
+  constructor() {
+    super('CareWorkforcePathwayUse');
+  }
+
+  static clone() {
+    return new CareWorkforcePathwayUseProperty();
+  }
+
+  async restoreFromJson(document) {
+    const propertyInDocument = document.careWorkforcePathwayUse;
+
+    if (!propertyInDocument) {
+      return;
+    }
+
+    switch (propertyInDocument.use) {
+      case YES: {
+        const reasons = await this._validateReasons(propertyInDocument.reasons);
+        this.property = {
+          use: YES,
+          reasons,
+        };
+        break;
+      }
+
+      case NO:
+      case DONT_KNOW: {
+        this.property = {
+          use: propertyInDocument.use,
+          reasons: null,
+        };
+        return;
+      }
+    }
+  }
+
+  async _validateReasons(reasons) {
+    if (!reasons || !Array.isArray(reasons) || reasons.length < 1) {
+      return null;
+    }
+    const reasonIds = reasons.map((reason) => reason.id);
+
+    const validReasonsFound = await models.CareWorkforcePathwayReasons.findAll({
+      attributes: ['id', 'text', 'isOther'],
+      where: { id: reasonIds },
+      order: [['seq', 'ASC']],
+      raw: true,
+    });
+
+    validReasonsFound.forEach((reason) => {
+      if (reason.isOther) {
+        const otherText = reasons.find((r) => r.id === reason.id)?.other;
+        reason.other = otherText;
+      }
+    });
+
+    return validReasonsFound;
+  }
+
+  restorePropertyFromSequelize(sequelizeDocument) {
+    const cwpUse = sequelizeDocument.careWorkforcePathwayUse;
+
+    switch (cwpUse) {
+      case YES: {
+        const reasons = sequelizeDocument.careWorkforcePathwayReasons?.map((reason) => this._formatReason(reason));
+
+        return {
+          use: 'Yes',
+          reasons: reasons?.length ? reasons : null,
+        };
+      }
+
+      case NO:
+      case DONT_KNOW: {
+        return {
+          use: cwpUse,
+          reasons: null,
+        };
+      }
+
+      case null:
+        return null;
+    }
+  }
+
+  _formatReason(rawReasonObject) {
+    const { id, text, isOther, other } = rawReasonObject;
+    const formatted = { id, text, isOther };
+    if (isOther) {
+      formatted.other = other;
+    }
+
+    return formatted;
+  }
+
+  savePropertyToSequelize() {
+    if (!this.property) {
+      return {
+        careWorkforcePathwayUse: this.property,
+        additionalModels: {
+          EstablishmentCWPReasons: [],
+        },
+      };
+    }
+
+    const { use, reasons } = this.property;
+
+    if ([NO, DONT_KNOW].includes(use) || !Array.isArray(reasons)) {
+      return {
+        careWorkforcePathwayUse: use,
+        additionalModels: {
+          EstablishmentCWPReasons: [],
+        },
+      };
+    }
+
+    const establishmentCWPReasons = reasons.map((reason) => {
+      return {
+        careWorkforcePathwayReasonID: reason.id,
+        ...(reason.other ? { other: reason.other } : {}),
+      };
+    });
+
+    return {
+      careWorkforcePathwayUse: use,
+      additionalModels: {
+        EstablishmentCWPReasons: establishmentCWPReasons,
+      },
+    };
+  }
+
+  isEqual(currentValue, newValue) {
+    if (!currentValue?.use || !newValue?.use) {
+      return currentValue === newValue;
+    }
+
+    switch (currentValue.use) {
+      case NO:
+      case DONT_KNOW: {
+        return currentValue.use === newValue.use;
+      }
+      case YES: {
+        if (currentValue.use !== newValue.use) {
+          return false;
+        }
+
+        return this._compareReasons(currentValue.reasons, newValue.reasons);
+      }
+
+      default: {
+        return false;
+      }
+    }
+  }
+
+  _compareReasons(currentReasons, newReasons) {
+    if (!Array.isArray(currentReasons) || !Array.isArray(newReasons)) {
+      return currentReasons === newReasons;
+    }
+
+    if (currentReasons.length !== newReasons.length) {
+      return false;
+    }
+
+    const allReasonsMatches = newReasons.every((newValueReason) => {
+      return currentReasons.some(
+        (currValueReason) => newValueReason.id === currValueReason.id && newValueReason.other === currValueReason.other,
+      );
+    });
+
+    return allReasonsMatches;
+  }
+
+  toJSON(withHistory = false) {
+    if (!withHistory) {
+      return {
+        careWorkforcePathwayUse: this.property,
+      };
+    }
+
+    return {
+      careWorkforcePathwayUse: {
+        currentValue: this.property,
+      },
+    };
+  }
+};

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -774,11 +774,28 @@ module.exports = function (sequelize, DataTypes) {
         allowNull: true,
         field: '"CareWorkforcePathwayWorkplaceAwarenessChangedBy"',
       },
+
       careWorkforcePathwayUse: {
         type: DataTypes.ENUM,
         allowNull: true,
         values: ['Yes', 'No', "Don't know"],
-        field: 'CareWorkforcePathwayUse',
+        field: 'CareWorkforcePathwayUseValue',
+      },
+      CareWorkforcePathwayUseSavedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      CareWorkforcePathwayUseChangedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      CareWorkforcePathwayUseSavedBy: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      CareWorkforcePathwayUseChangedBy: {
+        type: DataTypes.TEXT,
+        allowNull: true,
       },
     },
     {

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -914,6 +914,14 @@ module.exports = function (sequelize, DataTypes) {
       sourceKey: 'id',
       as: 'MandatoryTraining',
     });
+
+    Establishment.belongsToMany(models.CareWorkforcePathwayReasons, {
+      through: 'EstablishmentCWPReason',
+      foreignKey: 'establishmentID',
+      sourceKey: 'id',
+      as: 'CareWorkforcePathwayReasons',
+      onDelete: 'CASCADE',
+    });
   };
 
   Establishment.turnoverAndVacanciesData = function (establishmentId) {

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -774,6 +774,12 @@ module.exports = function (sequelize, DataTypes) {
         allowNull: true,
         field: '"CareWorkforcePathwayWorkplaceAwarenessChangedBy"',
       },
+      careWorkforcePathwayUse: {
+        type: DataTypes.ENUM,
+        allowNull: true,
+        values: ['Yes', 'No', "Don't know"],
+        field: 'CareWorkforcePathwayUse',
+      },
     },
     {
       defaultScope: {
@@ -916,8 +922,9 @@ module.exports = function (sequelize, DataTypes) {
     });
 
     Establishment.belongsToMany(models.CareWorkforcePathwayReasons, {
-      through: 'EstablishmentCWPReason',
-      foreignKey: 'establishmentID',
+      through: 'EstablishmentCWPReasons',
+      attributes: ['other'],
+      foreignKey: 'establishmentId',
       sourceKey: 'id',
       as: 'CareWorkforcePathwayReasons',
       onDelete: 'CASCADE',

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -927,7 +927,6 @@ module.exports = function (sequelize, DataTypes) {
       foreignKey: 'establishmentId',
       sourceKey: 'id',
       as: 'CareWorkforcePathwayReasons',
-      onDelete: 'CASCADE',
     });
   };
 

--- a/backend/server/models/establishmentCWPReason.js
+++ b/backend/server/models/establishmentCWPReason.js
@@ -1,10 +1,10 @@
 /* jshint indent: 2 */
 
 module.exports = function (sequelize, DataTypes) {
-  const EstablishmentCWPReason = sequelize.define(
-    'EstablishmentCWPReason',
+  const EstablishmentCWPReasons = sequelize.define(
+    'EstablishmentCWPReasons',
     {
-      establishmentID: {
+      establishmentId: {
         type: DataTypes.INTEGER,
         allowNull: false,
         primaryKey: true,
@@ -37,23 +37,23 @@ module.exports = function (sequelize, DataTypes) {
       },
     },
     {
-      tableName: 'EstablishmentCWPReason',
+      tableName: 'EstablishmentCWPReasons',
       schema: 'cqc',
       createdAt: false,
       updatedAt: false,
     },
   );
 
-  EstablishmentCWPReason.associate = (models) => {
-    EstablishmentCWPReason.belongsTo(models.establishment, {
-      foreignKey: 'establishmentID',
+  EstablishmentCWPReasons.associate = (models) => {
+    EstablishmentCWPReasons.belongsTo(models.establishment, {
+      foreignKey: 'establishmentId',
       targetKey: 'id',
     });
-    EstablishmentCWPReason.belongsTo(models.CareWorkforcePathwayReasons, {
+    EstablishmentCWPReasons.belongsTo(models.CareWorkforcePathwayReasons, {
       foreignKey: 'careWorkforcePathwayReasonID',
       targetKey: 'id',
     });
   };
 
-  return EstablishmentCWPReason;
+  return EstablishmentCWPReasons;
 };

--- a/backend/server/models/establishmentCWPReason.js
+++ b/backend/server/models/establishmentCWPReason.js
@@ -1,0 +1,59 @@
+/* jshint indent: 2 */
+
+module.exports = function (sequelize, DataTypes) {
+  const EstablishmentCWPReason = sequelize.define(
+    'EstablishmentCWPReason',
+    {
+      establishmentID: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        field: 'EstablishmentID',
+        references: {
+          model: {
+            tableName: 'Establishment',
+            schema: 'cqc',
+          },
+          key: 'id',
+        },
+      },
+      careWorkforcePathwayReasonID: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        field: 'CareWorkforcePathwayReasonID',
+        references: {
+          model: {
+            tableName: 'CareWorkforcePathwayReasons',
+            schema: 'cqc',
+          },
+          key: 'id',
+        },
+      },
+      other: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+        field: 'Other',
+      },
+    },
+    {
+      tableName: 'EstablishmentCWPReason',
+      schema: 'cqc',
+      createdAt: false,
+      updatedAt: false,
+    },
+  );
+
+  EstablishmentCWPReason.associate = (models) => {
+    EstablishmentCWPReason.belongsTo(models.establishment, {
+      foreignKey: 'establishmentID',
+      targetKey: 'id',
+    });
+    EstablishmentCWPReason.belongsTo(models.CareWorkforcePathwayReasons, {
+      foreignKey: 'careWorkforcePathwayReasonID',
+      targetKey: 'id',
+    });
+  };
+
+  return EstablishmentCWPReason;
+};

--- a/backend/server/routes/careWorkforcePathway.js
+++ b/backend/server/routes/careWorkforcePathway.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const models = require('../models');
+
+const router = express.Router();
+
+const getAllCareWorkforcePathwayUseReasons = async (_req, res) => {
+  try {
+    const allReasons = await models.CareWorkforcePathwayReasons.findAll({
+      order: [['seq', 'ASC']],
+      attributes: ['id', 'text', 'isOther'],
+      raw: true,
+    });
+    return res.status(200).send({ allReasons });
+  } catch (err) {
+    console.error('GET /careWorkforcePathway/useReasons - failed', err);
+
+    return res.status(500).send('');
+  }
+};
+
+router.route('/');
+router.get('/useReasons', getAllCareWorkforcePathwayUseReasons);
+
+module.exports = { careWorkforcePathwayRouter: router, getAllCareWorkforcePathwayUseReasons };

--- a/backend/server/routes/establishments/careWorkforcePathway.js
+++ b/backend/server/routes/establishments/careWorkforcePathway.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router({ mergeParams: true });
 const models = require('../../models');
 const { hasPermission } = require('../../utils/security/hasPermission');
+const { updateCareWorkforcePathwayUse } = require('./careWorkforcePathway/careWorkforcePathwayUse');
 
 const getNoOfWorkersWhoRequireCareWorkforcePathwayRoleAnswer = async (req, res) => {
   const establishmentId = req.establishmentId;
@@ -54,7 +55,10 @@ router
   .route('/workersWhoRequireCareWorkforcePathwayRoleAnswer')
   .get(hasPermission('canViewWorker'), getWorkersWhoRequireCareWorkforcePathwayRoleAnswer);
 
+router.route('/careWorkforcePathwayUse').post(hasPermission('canEditEstablishment'), updateCareWorkforcePathwayUse);
+
 module.exports = router;
+
 module.exports.getNoOfWorkersWhoRequireCareWorkforcePathwayRoleAnswer =
   getNoOfWorkersWhoRequireCareWorkforcePathwayRoleAnswer;
 module.exports.getWorkersWhoRequireCareWorkforcePathwayRoleAnswer = getWorkersWhoRequireCareWorkforcePathwayRoleAnswer;

--- a/backend/server/routes/establishments/careWorkforcePathway/careWorkforcePathwayUse.js
+++ b/backend/server/routes/establishments/careWorkforcePathway/careWorkforcePathwayUse.js
@@ -6,7 +6,7 @@ const updateCareWorkforcePathwayUse = async (req, res) => {
   const establishmentId = req.establishmentId;
 
   try {
-    const { use, reasons } = req.body.careWorkforcePathwayUse;
+    const { careWorkforcePathwayUse } = req.body;
 
     const thisEstablishment = new Establishment.Establishment(req.username);
     const establishmentFound = await thisEstablishment.restore(establishmentId);
@@ -16,7 +16,7 @@ const updateCareWorkforcePathwayUse = async (req, res) => {
     }
 
     const isValidUpdate = await thisEstablishment.load({
-      careWorkforcePathwayUse: { use, reasons },
+      careWorkforcePathwayUse,
     });
 
     if (!isValidUpdate) {

--- a/backend/server/routes/establishments/careWorkforcePathway/careWorkforcePathwayUse.js
+++ b/backend/server/routes/establishments/careWorkforcePathway/careWorkforcePathwayUse.js
@@ -1,0 +1,42 @@
+const Establishment = require('../../../models/classes/establishment');
+
+const HttpError = require('../../../utils/errors/httpError');
+
+const updateCareWorkforcePathwayUse = async (req, res) => {
+  const establishmentId = req.establishmentId;
+
+  try {
+    const { use, reasons } = req.body.careWorkforcePathwayUse;
+
+    const thisEstablishment = new Establishment.Establishment(req.username);
+    const establishmentFound = await thisEstablishment.restore(establishmentId);
+
+    if (!establishmentFound) {
+      throw new HttpError('Establishment is not found', 404);
+    }
+
+    const isValidUpdate = await thisEstablishment.load({
+      careWorkforcePathwayUse: { use, reasons },
+    });
+
+    if (!isValidUpdate) {
+      throw new HttpError('Failed to update careWorkforcePathwayUse', 400);
+    }
+
+    await thisEstablishment.save(req.username);
+
+    const filteredProperties = ['Name', 'CareWorkforcePathwayUse'];
+    const jsonResponse = thisEstablishment.toJSON(false, false, false, false, false, filteredProperties);
+
+    return res.status(200).send(jsonResponse);
+  } catch (err) {
+    console.error('POST /careWorkforcePathwayUse - failed', err);
+
+    if (err instanceof HttpError) {
+      return res.status(err.statusCode).send(err.message);
+    }
+    return res.status(500).send('Failed to update careWorkforcePathwayUse for workplace with id: ' + establishmentId);
+  }
+};
+
+module.exports = { updateCareWorkforcePathwayUse };

--- a/backend/server/routes/establishments/careWorkforcePathway/careWorkforcePathwayUse.js
+++ b/backend/server/routes/establishments/careWorkforcePathway/careWorkforcePathwayUse.js
@@ -20,7 +20,7 @@ const updateCareWorkforcePathwayUse = async (req, res) => {
     });
 
     if (!isValidUpdate) {
-      throw new HttpError('Failed to update careWorkforcePathwayUse', 400);
+      throw new HttpError('Invalid request body', 400);
     }
 
     await thisEstablishment.save(req.username);

--- a/backend/server/test/unit/mockdata/careWorkforcePathway.js
+++ b/backend/server/test/unit/mockdata/careWorkforcePathway.js
@@ -1,0 +1,7 @@
+const MockCareWorkforcePathwayUseReasons = [
+  { id: 1, text: "To help define our organisation's values", isOther: false },
+  { id: 2, text: 'To help update our job descriptions', isOther: false },
+  { id: 10, text: 'For something else', isOther: true },
+];
+
+module.exports = { MockCareWorkforcePathwayUseReasons };

--- a/backend/server/test/unit/models/classes/establishment/establishmentProperties.spec.js
+++ b/backend/server/test/unit/models/classes/establishment/establishmentProperties.spec.js
@@ -13,7 +13,7 @@ describe('EstablishmentPropertyManager', () => {
     'ServiceUsersProperty',
     'CapacityProperty',
     'ShareWithProperty',
-    'ShareWithLAProperty',
+    // 'ShareWithLAProperty',    // seems to be not using anymore
     'VacanciesProperty',
     'StartersProperty',
     'LeaversProperty',
@@ -31,7 +31,7 @@ describe('EstablishmentPropertyManager', () => {
   ];
   it('should have the correct property types', () => {
     const establishmentProperties = new EstablishmentPropertyManager();
-    expect(establishmentProperties._thisManager._propertyTypes.length).to.deep.equal(21);
+    expect(establishmentProperties._thisManager._propertyTypes.length).to.deep.equal(properties.length);
 
     establishmentProperties._thisManager._propertyTypes.forEach((propertyType) => {
       expect(typeof propertyType).to.deep.equal('function');

--- a/backend/server/test/unit/models/classes/establishment/establishmentProperties.spec.js
+++ b/backend/server/test/unit/models/classes/establishment/establishmentProperties.spec.js
@@ -27,10 +27,12 @@ describe('EstablishmentPropertyManager', () => {
     'PostcodeProperty',
     'IsRegulatedProperty',
     'CareWorkforcePathwayWorkplaceAwarenessProperty',
+    'CareWorkforcePathwayUseProperty',
   ];
   it('should have the correct property types', () => {
     const establishmentProperties = new EstablishmentPropertyManager();
     expect(establishmentProperties._thisManager._propertyTypes.length).to.deep.equal(21);
+
     establishmentProperties._thisManager._propertyTypes.forEach((propertyType) => {
       expect(typeof propertyType).to.deep.equal('function');
       expect(properties).to.include(propertyType.name);

--- a/backend/server/test/unit/models/classes/establishment/properties/careWorkforcePathwayUseProperty.spec.js
+++ b/backend/server/test/unit/models/classes/establishment/properties/careWorkforcePathwayUseProperty.spec.js
@@ -3,15 +3,12 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const models = require('../../../../../../models/');
 const { cloneDeep } = require('lodash');
+const { MockCareWorkforcePathwayUseReasons } = require('../../../../mockdata/careWorkforcePathway');
 
 const propertyClass =
   require('../../../../../../models/classes/establishment/properties/careWorkforcePathwayUseProperty').CareWorkforcePathwayUseProperty;
 
-const mockReasons = [
-  { id: 1, text: "To help define our organisation's values", isOther: false },
-  { id: 2, text: 'To help update our job descriptions', isOther: false },
-  { id: 10, text: 'For something else', isOther: true },
-];
+const mockReasons = MockCareWorkforcePathwayUseReasons;
 
 const testValues = {
   empty: null,

--- a/backend/server/test/unit/models/classes/establishment/properties/careWorkforcePathwayUseProperty.spec.js
+++ b/backend/server/test/unit/models/classes/establishment/properties/careWorkforcePathwayUseProperty.spec.js
@@ -1,0 +1,323 @@
+'use strict';
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const models = require('../../../../../../models/');
+const { cloneDeep } = require('lodash');
+
+const propertyClass =
+  require('../../../../../../models/classes/establishment/properties/careWorkforcePathwayUseProperty').CareWorkforcePathwayUseProperty;
+
+const mockReasons = [
+  { id: 1, text: "To help define our organisation's values", isOther: false },
+  { id: 2, text: 'To help update our job descriptions', isOther: false },
+  { id: 10, text: 'For something else', isOther: true },
+];
+
+const testValues = {
+  empty: null,
+  no: { use: 'No', reasons: null },
+  dont_know: { use: "Don't know", reasons: null },
+  yes_without_reasons: { use: 'Yes', reasons: null },
+  yes_with_reasons: { use: 'Yes', reasons: [mockReasons[0]] },
+  yes_with_reason_0_and_other_reason: {
+    use: 'Yes',
+    reasons: [mockReasons[0], { ...mockReasons[2], other: 'some specific reasons' }],
+  },
+};
+
+describe('careWorkforcePathwayUseProperty', () => {
+  describe('restoreFromJson()', () => {
+    beforeEach(() => {
+      sinon.stub(models.CareWorkforcePathwayReasons, 'findAll').callsFake((queryOption) => {
+        const ids = queryOption.where.id;
+        return mockReasons.filter((reason) => ids.includes(reason.id));
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    describe("should restore the property from a JSON object when use is No / Don't know / Yes without reason", async () => {
+      ['Yes', 'No', "Don't know"].forEach((value) => {
+        it(value, async () => {
+          const cwpUseProperty = new propertyClass();
+          const document = {
+            careWorkforcePathwayUse: {
+              use: value,
+              reasons: null,
+            },
+          };
+          const expectedProperty = {
+            use: value,
+            reasons: null,
+          };
+
+          await cwpUseProperty.restoreFromJson(document);
+
+          expect(cwpUseProperty.property).to.deep.equal(expectedProperty);
+        });
+      });
+    });
+
+    it('should restore the property from a JSON object when use is Yes with some reasons', async () => {
+      const cwpUseProperty = new propertyClass();
+      const document = {
+        careWorkforcePathwayUse: {
+          use: 'Yes',
+          reasons: [{ id: 1 }, { id: 10, other: 'some other specific reason' }],
+        },
+      };
+
+      const expectedProperty = {
+        use: 'Yes',
+        reasons: [
+          { id: 1, text: "To help define our organisation's values", isOther: false },
+          { id: 10, text: 'For something else', isOther: true, other: 'some other specific reason' },
+        ],
+      };
+
+      await cwpUseProperty.restoreFromJson(document);
+
+      expect(cwpUseProperty.property).to.deep.equal(expectedProperty);
+    });
+
+    it('should ignore invalid reasons from incoming document', async () => {
+      const cwpUseProperty = new propertyClass();
+      const document = {
+        careWorkforcePathwayUse: {
+          use: 'Yes',
+          reasons: [{ id: 99999 }, { id: 1 }, { 'something without id': 'apple banana orange' }],
+        },
+      };
+
+      const expectedProperty = {
+        use: 'Yes',
+        reasons: [{ id: 1, text: "To help define our organisation's values", isOther: false }],
+      };
+
+      await cwpUseProperty.restoreFromJson(document);
+
+      expect(cwpUseProperty.property).to.deep.equal(expectedProperty);
+    });
+
+    it('should keep the property unchanged when incoming document does not have the field careWorkforcePathwayUse', async () => {
+      const cwpUseProperty = new propertyClass();
+      const mockOriginalProperyValue = { use: "Don't know" };
+      cwpUseProperty.property = mockOriginalProperyValue;
+
+      const document = {};
+
+      const expectedProperty = { use: "Don't know" };
+
+      await cwpUseProperty.restoreFromJson(document);
+
+      expect(cwpUseProperty.property).to.deep.equal(expectedProperty);
+    });
+
+    it('should ignore invalid value for careWorkforcePathwayUse from incoming document', async () => {
+      const cwpUseProperty = new propertyClass();
+      const mockOriginalProperyValue = { use: 'Yes', reasons: [mockReasons[0]] };
+      cwpUseProperty.property = mockOriginalProperyValue;
+
+      const document = { careWorkforcePathwayUse: { fruits: 'apple banana cranberry' } };
+
+      const expectedProperty = { use: 'Yes', reasons: [mockReasons[0]] };
+
+      await cwpUseProperty.restoreFromJson(document);
+
+      expect(cwpUseProperty.property).to.deep.equal(expectedProperty);
+    });
+  });
+
+  describe('restorePropertyFromSequelize()', () => {
+    describe('should restore the property from sequelize establishment object', () => {
+      it('when use is No', () => {
+        const cwpUseProperty = new propertyClass();
+        const sequelizeObject = {
+          careWorkforcePathwayUse: 'No',
+          careWorkforcePathwayReasons: [],
+        };
+
+        const expectedProperty = {
+          use: 'No',
+          reasons: null,
+        };
+
+        const restored = cwpUseProperty.restorePropertyFromSequelize(sequelizeObject);
+        expect(restored).to.deep.equal(expectedProperty);
+      });
+
+      it('when use is Yes with no reasons', () => {
+        const cwpUseProperty = new propertyClass();
+        const sequelizeDocument = {
+          careWorkforcePathwayUse: 'Yes',
+          careWorkforcePathwayReasons: [],
+        };
+
+        const expectedProperty = {
+          use: 'Yes',
+          reasons: null,
+        };
+
+        const restored = cwpUseProperty.restorePropertyFromSequelize(sequelizeDocument);
+        expect(restored).to.deep.equal(expectedProperty);
+      });
+
+      it('when use is Yes with some reasons', () => {
+        const cwpUseProperty = new propertyClass();
+        const sequelizeDocument = {
+          careWorkforcePathwayUse: 'Yes',
+          careWorkforcePathwayReasons: [mockReasons[0], { ...mockReasons[2], other: 'some specific reasons' }],
+        };
+
+        const expectedProperty = testValues.yes_with_reason_0_and_other_reason;
+
+        const restored = cwpUseProperty.restorePropertyFromSequelize(sequelizeDocument);
+        expect(restored).to.deep.equal(expectedProperty);
+      });
+
+      it('when the value in database is null', () => {
+        const cwpUseProperty = new propertyClass();
+        const sequelizeDocument = {
+          careWorkforcePathwayUse: null,
+          careWorkforcePathwayReasons: [],
+        };
+
+        const expectedProperty = null;
+
+        const restored = cwpUseProperty.restorePropertyFromSequelize(sequelizeDocument);
+        expect(restored).to.deep.equal(expectedProperty);
+      });
+    });
+  });
+
+  describe('savePropertyToSequelize()', () => {
+    describe('should convert the property into correct format for sequelize to save into database', () => {
+      describe('when use is No / Dont know / Yes with no reasons', () => {
+        ['Yes', 'No', "Don't know"].forEach((value) => {
+          it(value, () => {
+            const cwpUseProperty = new propertyClass();
+            cwpUseProperty.property = { use: value, reasons: null };
+
+            const saved = cwpUseProperty.savePropertyToSequelize();
+            expect(saved.careWorkforcePathwayUse).to.equal(value);
+            expect(saved.additionalModels.EstablishmentCWPReasons).to.deep.equal([]);
+          });
+        });
+      });
+
+      it('when use is Yes with some reasons', () => {
+        const cwpUseProperty = new propertyClass();
+        cwpUseProperty.property = testValues.yes_with_reason_0_and_other_reason;
+
+        const saved = cwpUseProperty.savePropertyToSequelize();
+        expect(saved.careWorkforcePathwayUse).to.equal('Yes');
+        expect(saved.additionalModels.EstablishmentCWPReasons).to.deep.equal([
+          { careWorkforcePathwayReasonID: mockReasons[0].id },
+          { careWorkforcePathwayReasonID: mockReasons[2].id, other: 'some specific reasons' },
+        ]);
+      });
+
+      it('when property is null', () => {
+        const cwpUseProperty = new propertyClass();
+        cwpUseProperty.property = null;
+
+        const saved = cwpUseProperty.savePropertyToSequelize();
+        expect(saved.careWorkforcePathwayUse).to.equal(null);
+        expect(saved.additionalModels.EstablishmentCWPReasons).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('isEqual()', () => {
+    describe('should return true if both values are equal', () => {
+      Object.entries(testValues).forEach(([testValueName, value]) => {
+        it(`when value is ${testValueName}`, () => {
+          const cwpUseProperty = new propertyClass();
+          const result = cwpUseProperty.isEqual(value, cloneDeep(value));
+
+          expect(result).to.deep.equal(true);
+        });
+      });
+    });
+
+    describe('should return false if values are not equal', () => {
+      Object.entries(testValues).forEach(([currValueName, currValue]) => {
+        Object.entries(testValues).forEach(([newValueName, newValue]) => {
+          if (currValueName === newValueName) {
+            return;
+          }
+
+          it(`current: ${currValueName}, new: ${newValueName}`, () => {
+            const cwpUseProperty = new propertyClass();
+            const result = cwpUseProperty.isEqual(currValue, newValue);
+
+            expect(result).to.deep.equal(false);
+          });
+        });
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should return true when use is Yes and reasons are the same but in different order', () => {
+        const cwpUseProperty = new propertyClass();
+        const currentValue = {
+          use: 'Yes',
+          reasons: [mockReasons[0], mockReasons[1]],
+        };
+
+        const newValue = {
+          use: 'Yes',
+          reasons: [mockReasons[1], mockReasons[0]],
+        };
+
+        const result = cwpUseProperty.isEqual(currentValue, cloneDeep(newValue));
+
+        expect(result).to.deep.equal(true);
+      });
+
+      it('should return false when reasons are the same but the "other" text has changed', () => {
+        const cwpUseProperty = new propertyClass();
+        const currentValue = {
+          use: 'Yes',
+          reasons: [mockReasons[0], mockReasons[1], { id: 10, isOther: true, other: 'apple' }],
+        };
+
+        const newValue = {
+          use: 'Yes',
+          reasons: [mockReasons[0], mockReasons[1], { id: 10, isOther: true, other: 'banana' }],
+        };
+
+        const result = cwpUseProperty.isEqual(currentValue, cloneDeep(newValue));
+
+        expect(result).to.deep.equal(false);
+      });
+    });
+  });
+
+  describe('toJSON()', () => {
+    it('should return correctly formatted JSON for the property', () => {
+      const cwpUseProperty = new propertyClass();
+      cwpUseProperty.property = testValues.yes_with_reasons;
+
+      const json = cwpUseProperty.toJSON();
+
+      expect(json).to.deep.equal({
+        careWorkforcePathwayUse: {
+          use: 'Yes',
+          reasons: testValues.yes_with_reasons.reasons,
+        },
+      });
+    });
+
+    it('should handle the case when property is null', () => {
+      const cwpUseProperty = new propertyClass();
+      cwpUseProperty.property = null;
+
+      const json = cwpUseProperty.toJSON();
+
+      expect(json).to.deep.equal({ careWorkforcePathwayUse: null });
+    });
+  });
+});

--- a/backend/server/test/unit/models/classes/establishment/properties/careWorkforcePathwayUseProperty.spec.js
+++ b/backend/server/test/unit/models/classes/establishment/properties/careWorkforcePathwayUseProperty.spec.js
@@ -10,19 +10,19 @@ const propertyClass =
 
 const mockReasons = MockCareWorkforcePathwayUseReasons;
 
-const testValues = {
-  empty: null,
-  no: { use: 'No', reasons: null },
-  dont_know: { use: "Don't know", reasons: null },
-  yes_without_reasons: { use: 'Yes', reasons: null },
-  yes_with_reasons: { use: 'Yes', reasons: [mockReasons[0]] },
-  yes_with_reason_0_and_other_reason: {
-    use: 'Yes',
-    reasons: [mockReasons[0], { ...mockReasons[2], other: 'some specific reasons' }],
-  },
-};
-
 describe('careWorkforcePathwayUseProperty', () => {
+  const mockCwpUseValues = {
+    empty: null,
+    no: { use: 'No', reasons: null },
+    dont_know: { use: "Don't know", reasons: null },
+    yes_without_reasons: { use: 'Yes', reasons: null },
+    yes_with_reasons: { use: 'Yes', reasons: [mockReasons[0]] },
+    yes_with_reason_0_and_other_reason: {
+      use: 'Yes',
+      reasons: [mockReasons[0], { ...mockReasons[2], other: 'some specific reasons' }],
+    },
+  };
+
   describe('restoreFromJson()', () => {
     beforeEach(() => {
       sinon.stub(models.CareWorkforcePathwayReasons, 'findAll').callsFake((queryOption) => {
@@ -162,7 +162,7 @@ describe('careWorkforcePathwayUseProperty', () => {
           careWorkforcePathwayReasons: [mockReasons[0], { ...mockReasons[2], other: 'some specific reasons' }],
         };
 
-        const expectedProperty = testValues.yes_with_reason_0_and_other_reason;
+        const expectedProperty = mockCwpUseValues.yes_with_reason_0_and_other_reason;
 
         const restored = cwpUseProperty.restorePropertyFromSequelize(sequelizeDocument);
         expect(restored).to.deep.equal(expectedProperty);
@@ -200,7 +200,7 @@ describe('careWorkforcePathwayUseProperty', () => {
 
       it('when use is Yes with some reasons', () => {
         const cwpUseProperty = new propertyClass();
-        cwpUseProperty.property = testValues.yes_with_reason_0_and_other_reason;
+        cwpUseProperty.property = mockCwpUseValues.yes_with_reason_0_and_other_reason;
 
         const saved = cwpUseProperty.savePropertyToSequelize();
         expect(saved.careWorkforcePathwayUse).to.equal('Yes');
@@ -223,7 +223,7 @@ describe('careWorkforcePathwayUseProperty', () => {
 
   describe('isEqual()', () => {
     describe('should return true if both values are equal', () => {
-      Object.entries(testValues).forEach(([testValueName, value]) => {
+      Object.entries(mockCwpUseValues).forEach(([testValueName, value]) => {
         it(`when value is ${testValueName}`, () => {
           const cwpUseProperty = new propertyClass();
           const result = cwpUseProperty.isEqual(value, cloneDeep(value));
@@ -234,8 +234,8 @@ describe('careWorkforcePathwayUseProperty', () => {
     });
 
     describe('should return false if values are not equal', () => {
-      Object.entries(testValues).forEach(([currValueName, currValue]) => {
-        Object.entries(testValues).forEach(([newValueName, newValue]) => {
+      Object.entries(mockCwpUseValues).forEach(([currValueName, currValue]) => {
+        Object.entries(mockCwpUseValues).forEach(([newValueName, newValue]) => {
           if (currValueName === newValueName) {
             return;
           }
@@ -290,14 +290,14 @@ describe('careWorkforcePathwayUseProperty', () => {
   describe('toJSON()', () => {
     it('should return correctly formatted JSON for the property', () => {
       const cwpUseProperty = new propertyClass();
-      cwpUseProperty.property = testValues.yes_with_reasons;
+      cwpUseProperty.property = mockCwpUseValues.yes_with_reasons;
 
       const json = cwpUseProperty.toJSON();
 
       expect(json).to.deep.equal({
         careWorkforcePathwayUse: {
           use: 'Yes',
-          reasons: testValues.yes_with_reasons.reasons,
+          reasons: mockCwpUseValues.yes_with_reasons.reasons,
         },
       });
     });

--- a/backend/server/test/unit/models/classes/establishment/properties/careWorkforcePathwayUseProperty.spec.js
+++ b/backend/server/test/unit/models/classes/establishment/properties/careWorkforcePathwayUseProperty.spec.js
@@ -82,51 +82,45 @@ describe('careWorkforcePathwayUseProperty', () => {
       expect(cwpUseProperty.property).to.deep.equal(expectedProperty);
     });
 
-    it('should ignore invalid reasons from incoming document', async () => {
-      const cwpUseProperty = new propertyClass();
-      const document = {
-        careWorkforcePathwayUse: {
-          use: 'Yes',
-          reasons: [{ id: 99999 }, { id: 1 }, { 'something without id': 'apple banana orange' }],
-        },
-      };
-
-      const expectedProperty = {
-        use: 'Yes',
-        reasons: [{ id: 1, text: "To help define our organisation's values", isOther: false }],
-      };
-
-      await cwpUseProperty.restoreFromJson(document);
-
-      expect(cwpUseProperty.property).to.deep.equal(expectedProperty);
-    });
-
     it('should keep the property unchanged when incoming document does not have the field careWorkforcePathwayUse', async () => {
       const cwpUseProperty = new propertyClass();
-      const mockOriginalProperyValue = { use: "Don't know" };
-      cwpUseProperty.property = mockOriginalProperyValue;
 
       const document = {};
 
-      const expectedProperty = { use: "Don't know" };
-
       await cwpUseProperty.restoreFromJson(document);
 
-      expect(cwpUseProperty.property).to.deep.equal(expectedProperty);
+      expect(cwpUseProperty.property).to.equal(null);
+      expect(cwpUseProperty._notSet).to.equal(true);
     });
 
-    it('should ignore invalid value for careWorkforcePathwayUse from incoming document', async () => {
+    it('should set valid() to false when incoming document has an malformed value for careWorkforcePathwayUse', async () => {
       const cwpUseProperty = new propertyClass();
-      const mockOriginalProperyValue = { use: 'Yes', reasons: [mockReasons[0]] };
-      cwpUseProperty.property = mockOriginalProperyValue;
 
       const document = { careWorkforcePathwayUse: { fruits: 'apple banana cranberry' } };
 
-      const expectedProperty = { use: 'Yes', reasons: [mockReasons[0]] };
+      await cwpUseProperty.restoreFromJson(document);
+
+      expect(cwpUseProperty.valid).to.equal(false);
+    });
+
+    it('should set valid() to false when use is an invalid value', async () => {
+      const cwpUseProperty = new propertyClass();
+
+      const document = { careWorkforcePathwayUse: { use: 'Cat food' } };
 
       await cwpUseProperty.restoreFromJson(document);
 
-      expect(cwpUseProperty.property).to.deep.equal(expectedProperty);
+      expect(cwpUseProperty.valid).to.equal(false);
+    });
+
+    it('should set valid() to false when use is Yes and some of the reasons are invalid', async () => {
+      const cwpUseProperty = new propertyClass();
+
+      const document = { careWorkforcePathwayUse: { use: 'Yes', reasons: [{ id: 1 }, { id: 99999999 }] } };
+
+      await cwpUseProperty.restoreFromJson(document);
+
+      expect(cwpUseProperty.valid).to.equal(false);
     });
   });
 

--- a/backend/server/test/unit/routes/careWorkforcePathway.spec.js
+++ b/backend/server/test/unit/routes/careWorkforcePathway.spec.js
@@ -1,0 +1,45 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const httpMocks = require('node-mocks-http');
+const models = require('../../../models');
+const { getAllCareWorkforcePathwayUseReasons } = require('../../../routes/careWorkforcePathway');
+const { MockCareWorkforcePathwayUseReasons } = require('../mockdata/careWorkforcePathway');
+
+describe('/careWorkforcePathway', () => {
+  describe('getAllCareWorkforcePathwayUseReasons', () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/api/careWorkforcePathway/useReasons',
+    };
+
+    const mockReasons = MockCareWorkforcePathwayUseReasons;
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should respond with 200 and a list of all Care Workforce Pathway use reasons', async () => {
+      sinon.stub(models.CareWorkforcePathwayReasons, 'findAll').resolves(mockReasons);
+
+      const req = httpMocks.createRequest(mockRequest);
+      const res = httpMocks.createResponse();
+
+      await getAllCareWorkforcePathwayUseReasons(req, res);
+
+      expect(res.statusCode).to.equal(200);
+      expect(res._getData()).to.deep.equal({ allReasons: mockReasons });
+    });
+
+    it('should respond with 500 error if failed to retrieve the list of reasons', async () => {
+      sinon.stub(models.CareWorkforcePathwayReasons, 'findAll').rejects(new Error('some database error'));
+      sinon.stub(console, 'error'); // suppress distracting error msg in test log
+
+      const req = httpMocks.createRequest(mockRequest);
+      const res = httpMocks.createResponse();
+
+      await getAllCareWorkforcePathwayUseReasons(req, res);
+
+      expect(res.statusCode).to.equal(500);
+    });
+  });
+});

--- a/backend/server/test/unit/routes/establishments/careWorkforcePathway/careWorkforcePathwayUse.spec.js
+++ b/backend/server/test/unit/routes/establishments/careWorkforcePathway/careWorkforcePathwayUse.spec.js
@@ -1,0 +1,97 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const httpMocks = require('node-mocks-http');
+
+const {
+  updateCareWorkforcePathwayUse,
+} = require('../../../../../routes/establishments/careWorkforcePathway/careWorkforcePathwayUse');
+const Establishment = require('../../../../../models/classes/establishment');
+
+describe('updateCareWorkforcePathwayUse', () => {
+  let mockEstablishmentInstance;
+
+  const mockRequest = {
+    method: 'POST',
+    url: '/api/establishment/mock-workplace-uid/careWorkforcePathway/careWorkforcePathwayUse',
+    establishmentId: 'mock-workplace-uid',
+    body: {
+      careWorkforcePathwayUse: {
+        use: 'Yes',
+        reasons: [{ id: 1 }, { id: 2 }, { id: 10, other: 'some specific reasons' }],
+      },
+    },
+  };
+
+  beforeEach(() => {
+    mockEstablishmentInstance = sinon.createStubInstance(Establishment.Establishment);
+    sinon.stub(Establishment, 'Establishment').callsFake(() => mockEstablishmentInstance);
+    sinon.stub(console, 'error'); // supress error msg in test log
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should update the careWorkforcePathwayUse and respond with 200', async () => {
+    mockEstablishmentInstance.restore = sinon.stub().resolves(true);
+    mockEstablishmentInstance.load = sinon.stub().resolves(true);
+
+    const req = httpMocks.createRequest(mockRequest);
+    const res = httpMocks.createResponse();
+
+    await updateCareWorkforcePathwayUse(req, res);
+
+    expect(mockEstablishmentInstance.restore).to.have.been.calledWith('mock-workplace-uid');
+    expect(mockEstablishmentInstance.load).to.have.been.calledWith({
+      careWorkforcePathwayUse: {
+        use: 'Yes',
+        reasons: [{ id: 1 }, { id: 2 }, { id: 10, other: 'some specific reasons' }],
+      },
+    });
+    expect(mockEstablishmentInstance.save).to.have.been.called;
+
+    expect(res.statusCode).to.equal(200);
+  });
+
+  it('should respond with 404 if establishment could not be found', async () => {
+    mockEstablishmentInstance.restore = sinon.stub().resolves(false);
+
+    const req = httpMocks.createRequest(mockRequest);
+    const res = httpMocks.createResponse();
+
+    await updateCareWorkforcePathwayUse(req, res);
+
+    expect(mockEstablishmentInstance.restore).to.have.been.calledWith('mock-workplace-uid');
+    expect(mockEstablishmentInstance.load).not.to.have.been.called;
+    expect(mockEstablishmentInstance.save).not.to.have.been.called;
+
+    expect(res.statusCode).to.equal(404);
+  });
+
+  it('should respond with 400 error if failed to update careWorkforcePathwayUse', async () => {
+    mockEstablishmentInstance.restore = sinon.stub().resolves(true);
+    mockEstablishmentInstance.load = sinon.stub().resolves(false);
+
+    const req = httpMocks.createRequest(mockRequest);
+    const res = httpMocks.createResponse();
+
+    await updateCareWorkforcePathwayUse(req, res);
+
+    expect(mockEstablishmentInstance.save).not.to.have.been.called;
+
+    expect(res.statusCode).to.equal(400);
+  });
+
+  it('should respond with 500 error if some other errors occured during operation', async () => {
+    mockEstablishmentInstance.restore = sinon.stub().rejects(new Error('some unexpected error'));
+
+    const req = httpMocks.createRequest(mockRequest);
+    const res = httpMocks.createResponse();
+
+    await updateCareWorkforcePathwayUse(req, res);
+
+    expect(mockEstablishmentInstance.save).not.to.have.been.called;
+
+    expect(res.statusCode).to.equal(500);
+  });
+});


### PR DESCRIPTION
#### Work done
- add migration for a new table for CWP use reasons, a junction table to record n:m relationships and adding a column of CWP use to Establishment
- add a careWorkforcePathwayUse property file to handle conversions between establishment class and database record
- add a `POST /api/establishment/{uid}/careWorkforcePathway/careWorkforcePathwayUse` endpoint for updating the CWP use and reasons 
- add a `GET /api/careWorkforcePathway/useReasons` endpoint for retrieving a list of all available reasons

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
