### PR TITLE
Fix/1724 cwp staff snagging list

### DIFF
--- a/frontend/src/app/core/resolvers/careWorkforcePathway/get-workers-with-care-workforce-pathway-category-role-unanswered.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/careWorkforcePathway/get-workers-with-care-workforce-pathway-category-role-unanswered.resolver.spec.ts
@@ -1,0 +1,109 @@
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { PermissionType } from '@core/model/permissions.model';
+import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { UserService } from '@core/services/user.service';
+import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
+import { of } from 'rxjs';
+
+import { GetWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver } from './get-workers-with-care-workforce-pathway-category-role-unanswered.resolver';
+
+describe('GetWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver', () => {
+  const establishmentIdInService = '129';
+
+  const setup = (overrides: any = {}) => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        GetWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver,
+        {
+          provide: EstablishmentService,
+          useValue: {
+            establishment: { uid: establishmentIdInService },
+            establishmentId: establishmentIdInService,
+          },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { paramMap: convertToParamMap({ establishmentuid: overrides?.establishmentIdInParams }) },
+          },
+        },
+        {
+          provide: PermissionsService,
+          useFactory: MockPermissionsService.factory(overrides.permissions as PermissionType[]),
+          deps: [HttpClient, Router, UserService],
+        },
+        CareWorkforcePathwayService,
+      ],
+    });
+
+    const resolver = TestBed.inject(GetWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver);
+    const careWorkforcePathwayService = TestBed.inject(CareWorkforcePathwayService);
+    const route = TestBed.inject(ActivatedRoute);
+
+    const getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy = spyOn(
+      careWorkforcePathwayService,
+      'getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswer',
+    ).and.returnValue(of(null));
+
+    return { resolver, careWorkforcePathwayService, route, getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy };
+  };
+
+  it('should create', async () => {
+    const { resolver } = await setup();
+    expect(resolver).toBeTruthy();
+  });
+
+  it('should call getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswer with the establishmentId when in params', async () => {
+    const establishmentId = '213';
+    const overrides = { establishmentIdInParams: establishmentId, permissions: ['canEditWorker'] };
+    const { resolver, route, getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy } = await setup(overrides);
+
+    resolver.resolve(route.snapshot);
+
+    expect(getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy).toHaveBeenCalledWith(
+      establishmentId,
+      jasmine.anything(),
+    );
+  });
+
+  it('should call getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswer with uid in establishment service when no uid in params', () => {
+    const { resolver, route, getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy } = setup({
+      permissions: ['canEditWorker'],
+    });
+
+    resolver.resolve(route.snapshot);
+
+    expect(getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy).toHaveBeenCalledWith(
+      establishmentIdInService,
+      jasmine.anything(),
+    );
+  });
+
+  it('should pass in default pagination params to getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswer call', async () => {
+    const establishmentId = '213';
+    const overrides = { establishmentIdInParams: establishmentId, permissions: ['canEditWorker'] };
+    const { resolver, route, getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy } = await setup(overrides);
+
+    resolver.resolve(route.snapshot);
+
+    expect(getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy).toHaveBeenCalledWith(jasmine.anything(), {
+      pageIndex: 0,
+      itemsPerPage: 15,
+    });
+  });
+
+  it('should not make backend call if user does not have canEditWorker permission', async () => {
+    const overrides = { permissions: [] };
+    const { resolver, route, getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy } = await setup(overrides);
+
+    resolver.resolve(route.snapshot);
+
+    expect(getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswerSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/core/resolvers/careWorkforcePathway/get-workers-with-care-workforce-pathway-category-role-unanswered.resolver.ts
+++ b/frontend/src/app/core/resolvers/careWorkforcePathway/get-workers-with-care-workforce-pathway-category-role-unanswered.resolver.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable()
+export class GetWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver {
+  constructor(
+    private permissionsService: PermissionsService,
+    private careWorkforcePathwayService: CareWorkforcePathwayService,
+    private establishmentService: EstablishmentService,
+  ) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    const queryParams = { pageIndex: 0, itemsPerPage: 15 };
+
+    const workplaceUid = route.paramMap.get('establishmentuid')
+      ? route.paramMap.get('establishmentuid')
+      : this.establishmentService.establishmentId;
+
+    if (!this.permissionsService.can(workplaceUid, 'canEditWorker')) return of(null);
+
+    return this.careWorkforcePathwayService
+      .getAllWorkersWhoRequireCareWorkforcePathwayRoleAnswer(workplaceUid, queryParams)
+      .pipe(
+        catchError(() => {
+          return of(null);
+        }),
+      );
+  }
+}

--- a/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
@@ -10,8 +10,11 @@
     [workersNotCompleted]="workersNotCompleted"
     [(navigateToTab)]="navigateToTab"
     [canViewEstablishment]="canViewEstablishment"
+    [canEditWorker]="canEditWorker"
     [noOfWorkersWhoRequireInternationalRecruitment]="noOfWorkersWhoRequireInternationalRecruitment"
-    [noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered]="noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered"
+    [noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered]="
+      noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered
+    "
     [cwpQuestionsFlag]="cwpQuestionsFlag"
   ></app-summary-section>
 </div>

--- a/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
@@ -21,10 +21,13 @@
   [(navigateToTab)]="navigateToTab"
   [canViewListOfWorkers]="canViewListOfWorkers"
   [canViewEstablishment]="canViewEstablishment"
+  [canEditWorker]="canEditWorker"
   [showMissingCqcMessage]="showMissingCqcMessage"
   [workplacesCount]="workplacesCount"
   [noOfWorkersWhoRequireInternationalRecruitment]="noOfWorkersWhoRequireInternationalRecruitment"
-  [noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered]="noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered"
+  [noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered]="
+    noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered
+  "
   [cwpQuestionsFlag]="cwpQuestionsFlag"
   data-cy="summary-section"
 ></app-summary-section>

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
@@ -15,9 +15,12 @@
     [workersNotCompleted]="workersNotCompleted"
     [(navigateToTab)]="navigateToTab"
     [canViewEstablishment]="canViewEstablishment"
+    [canEditWorker]="canEditWorker"
     [isParentSubsidiaryView]="true"
     [noOfWorkersWhoRequireInternationalRecruitment]="noOfWorkersWhoRequireInternationalRecruitment"
-    [noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered]="noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered"
+    [noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered]="
+      noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered
+    "
     [cwpQuestionsFlag]="cwpQuestionsFlag"
   ></app-summary-section>
 </div>

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.ts
@@ -41,6 +41,7 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
   public canRunLocalAuthorityReport: boolean;
   public canBulkUpload: boolean;
   public canEditEstablishment: boolean;
+  public canEditWorker: boolean;
   public canViewListOfWorkers: boolean;
   public trainingCounts: TrainingCounts;
   public now: Date = new Date();
@@ -118,6 +119,7 @@ export class ViewSubsidiaryHomeComponent implements OnInit {
     const workplaceUid: string = this.subsidiaryWorkplace ? this.subsidiaryWorkplace.uid : null;
     this.canEditEstablishment = this.permissionsService.can(workplaceUid, 'canEditEstablishment');
     this.canAddWorker = this.permissionsService.can(workplaceUid, 'canAddWorker');
+    this.canEditWorker = this.permissionsService.can(workplaceUid, 'canEditWorker');
     this.canViewListOfWorkers = this.permissionsService.can(workplaceUid, 'canViewListOfWorkers');
     this.canBulkUpload = this.permissionsService.can(workplaceUid, 'canBulkUpload');
     this.canViewWorkplaces = this.subsidiaryWorkplace && this.subsidiaryWorkplace.isParent;

--- a/frontend/src/app/features/workers/care-workforce-pathway-workers-summary/care-workforce-pathway-workers-summary.component.ts
+++ b/frontend/src/app/features/workers/care-workforce-pathway-workers-summary/care-workforce-pathway-workers-summary.component.ts
@@ -1,13 +1,12 @@
-import { Subscription } from 'rxjs';
-import { take } from 'rxjs/operators';
-
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { JobRole } from '@core/model/job.model';
 import { BackLinkService } from '@core/services/backLink.service';
 import { CareWorkforcePathwayService, CWPGetAllWorkersResponse } from '@core/services/care-workforce-pathway.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkerService } from '@core/services/worker.service';
+import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-care-workforce-pathway-workers-summary',
@@ -27,12 +26,14 @@ export class CareWorkforcePathwayWorkersSummaryComponent implements OnInit, OnDe
     private backLinkService: BackLinkService,
     private router: Router,
     private careWorkforcePathwayService: CareWorkforcePathwayService,
+    private route: ActivatedRoute,
   ) {}
 
   ngOnInit(): void {
     this.backLinkService.showBackLink();
     this.workplaceUid = this.establishmentService.establishment.uid;
-    this.getWorkers();
+
+    this.handleGetWorkersResponse(this.route.snapshot.data.workersWhoRequireCWPAnswer);
   }
 
   private getWorkers(): void {

--- a/frontend/src/app/features/workers/workers-routing.module.ts
+++ b/frontend/src/app/features/workers/workers-routing.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CheckPermissionsGuard } from '@core/guards/permissions/check-permissions/check-permissions.guard';
+import { RequireCWPAnswerForSomeWorkersGuard } from '@core/guards/require-cwp-answer-for-some-workers/require-cwp-answer-for-some-workers.guard';
 import { AvailableQualificationsResolver } from '@core/resolvers/available-qualification.resolver';
+import { GetWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver } from '@core/resolvers/careWorkforcePathway/get-workers-with-care-workforce-pathway-category-role-unanswered.resolver';
 import { TotalStaffRecordsResolver } from '@core/resolvers/dashboard/total-staff-records.resolver';
 import { ExpiresSoonAlertDatesResolver } from '@core/resolvers/expiresSoonAlertDates.resolver';
+import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
 import { JobsResolver } from '@core/resolvers/jobs.resolver';
 import { LongTermAbsenceResolver } from '@core/resolvers/long-term-absence.resolver';
 import { MandatoryTrainingCategoriesResolver } from '@core/resolvers/mandatory-training-categories.resolver';
@@ -37,6 +40,8 @@ import { AverageWeeklyHoursComponent } from './average-weekly-hours/average-week
 import { BasicRecordsSaveSuccessComponent } from './basic-records-save-success/basic-records-save-success.component';
 import { BritishCitizenshipComponent } from './british-citizenship/british-citizenship.component';
 import { CareCertificateComponent } from './care-certificate/care-certificate.component';
+import { CareWorkforcePathwayWorkersSummaryComponent as CareWorkforcePathwayWorkersSummaryComponent } from './care-workforce-pathway-workers-summary/care-workforce-pathway-workers-summary.component';
+import { CareWorkforcePathwayRoleComponent } from './care-workforce-pathway/care-workforce-pathway.component';
 import { ContractWithZeroHoursComponent } from './contract-with-zero-hours/contract-with-zero-hours.component';
 import { CountryOfBirthComponent } from './country-of-birth/country-of-birth.component';
 import { DateOfBirthComponent } from './date-of-birth/date-of-birth.component';
@@ -74,10 +79,6 @@ import { UpdateTotalNumberOfStaffComponent } from './update-workplace-details-af
 import { UpdateWorkplaceDetailsAfterStaffChangesComponent } from './update-workplace-details-after-staff-changes/update-workplace-details-after-staff-changes.component';
 import { WeeklyContractedHoursComponent } from './weekly-contracted-hours/weekly-contracted-hours.component';
 import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.component';
-import { CareWorkforcePathwayRoleComponent } from './care-workforce-pathway/care-workforce-pathway.component';
-import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
-import { CareWorkforcePathwayWorkersSummaryComponent as CareWorkforcePathwayWorkersSummaryComponent } from './care-workforce-pathway-workers-summary/care-workforce-pathway-workers-summary.component';
-import { RequireCWPAnswerForSomeWorkersGuard } from '@core/guards/require-cwp-answer-for-some-workers/require-cwp-answer-for-some-workers.guard';
 
 const routes: Routes = [
   {
@@ -241,6 +242,7 @@ const routes: Routes = [
     path: 'care-workforce-pathway-workers-summary',
     component: CareWorkforcePathwayWorkersSummaryComponent,
     canActivate: [RequireCWPAnswerForSomeWorkersGuard],
+    resolve: { workersWhoRequireCWPAnswer: GetWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver },
   },
   {
     path: 'basic-records-save-success',

--- a/frontend/src/app/features/workers/workers.module.ts
+++ b/frontend/src/app/features/workers/workers.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AvailableQualificationsResolver } from '@core/resolvers/available-qualification.resolver';
+import { GetWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver } from '@core/resolvers/careWorkforcePathway/get-workers-with-care-workforce-pathway-category-role-unanswered.resolver';
 import { LongTermAbsenceResolver } from '@core/resolvers/long-term-absence.resolver';
 import { MandatoryTrainingCategoriesResolver } from '@core/resolvers/mandatory-training-categories.resolver';
 import { QualificationResolver } from '@core/resolvers/qualification.resolver';
@@ -35,6 +36,8 @@ import { AverageWeeklyHoursComponent } from './average-weekly-hours/average-week
 import { BasicRecordsSaveSuccessComponent } from './basic-records-save-success/basic-records-save-success.component';
 import { BritishCitizenshipComponent } from './british-citizenship/british-citizenship.component';
 import { CareCertificateComponent } from './care-certificate/care-certificate.component';
+import { CareWorkforcePathwayWorkersSummaryComponent } from './care-workforce-pathway-workers-summary/care-workforce-pathway-workers-summary.component';
+import { CareWorkforcePathwayRoleComponent } from './care-workforce-pathway/care-workforce-pathway.component';
 import { ContractWithZeroHoursComponent } from './contract-with-zero-hours/contract-with-zero-hours.component';
 import { CountryOfBirthComponent } from './country-of-birth/country-of-birth.component';
 import { DateOfBirthComponent } from './date-of-birth/date-of-birth.component';
@@ -75,8 +78,6 @@ import { UpdateWorkplaceDetailsAfterStaffChangesComponent } from './update-workp
 import { WeeklyContractedHoursComponent } from './weekly-contracted-hours/weekly-contracted-hours.component';
 import { WorkersRoutingModule } from './workers-routing.module';
 import { YearArrivedUkComponent } from './year-arrived-uk/year-arrived-uk.component';
-import { CareWorkforcePathwayRoleComponent } from './care-workforce-pathway/care-workforce-pathway.component';
-import { CareWorkforcePathwayWorkersSummaryComponent } from './care-workforce-pathway-workers-summary/care-workforce-pathway-workers-summary.component';
 
 @NgModule({
   imports: [CommonModule, OverlayModule, FormsModule, ReactiveFormsModule, SharedModule, WorkersRoutingModule],
@@ -158,6 +159,7 @@ import { CareWorkforcePathwayWorkersSummaryComponent } from './care-workforce-pa
     VacanciesAndTurnoverService,
     WorkerReasonsForLeavingResolver,
     CareWorkforcePathwayWorkersSummaryComponent,
+    GetWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver,
   ],
 })
 export class WorkersModule {}

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.html
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.html
@@ -27,7 +27,7 @@
               data-testid="orange-flag"
             />
           </ng-template>
-          <ng-container *ngIf="section.link; else noLink">
+          <ng-container *ngIf="section.link && !section.showMessageAsText; else noLink">
             <a (click)="onClick($event, section.fragment, section.route, section.skipTabSwitch)" href="#">
               {{ section.message }}</a
             >

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -348,7 +348,7 @@ describe('Summary section', () => {
       expect(getByText('Staff records')).toBeTruthy();
     });
 
-    it('should not show clickable staff records link if no access to data', async () => {
+    it('should not show clickable staff records link if no permissions to view staff records', async () => {
       const establishment = {
         ...Establishment,
         created: dayjs().subtract(1, 'year'),
@@ -373,6 +373,22 @@ describe('Summary section', () => {
       const staffRecordsLinkText = getByText('Staff records');
 
       expect(staffRecordsLinkText.getAttribute('href')).toBeFalsy();
+    });
+
+    it('should show default message if no permission to view staff records', async () => {
+      const overrides = {
+        checkCqcDetails: false,
+        establishment: Establishment,
+        workerCount: 0,
+        canViewListOfWorkers: false,
+      };
+
+      const { fixture, getByTestId } = await setup(overrides);
+
+      fixture.detectChanges();
+
+      const staffRecordsRow = getByTestId('staff-records-row');
+      expect(within(staffRecordsRow).getByText('Remember to check and update this data often')).toBeTruthy();
     });
 
     it('should show clickable staff records link if access to workplace', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -50,6 +50,7 @@ describe('Summary section', () => {
         workersNotCompleted: (overrides.workersNotCompleted as Worker[]) ?? ([workerBuilder()] as Worker[]),
         isParent: overrides.isParent ?? false,
         canViewListOfWorkers: overrides.canViewListOfWorkers ?? true,
+        canEditWorker: overrides.canEditWorker ?? true,
         canViewEstablishment: overrides.canViewEstablishment ?? true,
         showMissingCqcMessage: overrides.showMissingCqcMessage ?? false,
         workplacesCount: overrides.workplacesCount ?? 0,
@@ -437,6 +438,7 @@ describe('Summary section', () => {
           expect(workersCareWorkforcePathwayLink).toBeFalsy();
         });
       });
+
       describe('with cwpQuestionsFlag false', () => {
         it('should show if there are staff without an answer', async () => {
           const overrides = {
@@ -458,6 +460,21 @@ describe('Summary section', () => {
             'care-workforce-pathway-workers-summary',
           ]);
           expect(selectedTabSpy).not.toHaveBeenCalled();
+        });
+
+        it('should show with no link if there are staff without an answer but no edit permission for workers', async () => {
+          const overrides = {
+            noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered: 2,
+            cwpQuestionsFlag: false,
+            canEditWorker: false,
+          };
+          const { getByText } = await setup(overrides);
+
+          const workersCareWorkforcePathwayText = getByText('Where are your staff on the care workforce pathway?');
+          expect(workersCareWorkforcePathwayText.tagName).not.toBe('A');
+
+          const staffRecordsLink = getByText('Staff records');
+          expect(staffRecordsLink.tagName).toBe('A');
         });
 
         it('should not show if there are no staff without an answer', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -116,6 +116,11 @@ export class SummarySectionComponent implements OnInit, OnChanges {
   }
 
   public getStaffSummaryMessage(): void {
+    if (!this.canViewListOfWorkers) {
+      this.showViewSummaryLinks(this.sections[1].linkText);
+      return;
+    }
+
     const afterWorkplaceCreated = dayjs(this.workplace.created).add(12, 'M');
     if (!this.workerCount) {
       this.sections[1].message = 'You can start to add your staff records now';

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -21,6 +21,7 @@ export class SummarySectionComponent implements OnInit, OnChanges {
   @Input() workersNotCompleted: Worker[];
   @Input() canViewListOfWorkers: boolean;
   @Input() canViewEstablishment: boolean;
+  @Input() canEditWorker: boolean;
   @Input() showMissingCqcMessage: boolean;
   @Input() workplacesCount: number;
   @Input() isParentSubsidiaryView: boolean;
@@ -127,6 +128,7 @@ export class SummarySectionComponent implements OnInit, OnChanges {
         'staff-record',
         'care-workforce-pathway-workers-summary',
       ];
+      this.sections[1].showMessageAsText = !this.canEditWorker;
     } else if (this.workplace.numberOfStaff !== this.workerCount && this.afterEightWeeksFromFirstLogin()) {
       this.sections[1].message = 'Staff records added does not match staff total';
     } else if (this.noOfWorkersWhoRequireInternationalRecruitment > 0) {
@@ -241,4 +243,5 @@ interface Section {
   redFlag: boolean;
   link: boolean;
   skipTabSwitch?: boolean;
+  showMessageAsText?: boolean;
 }

--- a/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
+++ b/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
@@ -17,14 +17,26 @@ import { TabsService } from '@core/services/tabs.service';
 import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { isAdminRole } from '@core/utils/check-role-util';
-import { BecomeAParentCancelDialogComponent } from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
+import {
+  BecomeAParentCancelDialogComponent,
+} from '@shared/components/become-a-parent-cancel/become-a-parent-cancel-dialog.component';
 import { BecomeAParentDialogComponent } from '@shared/components/become-a-parent/become-a-parent-dialog.component';
-import { CancelDataOwnerDialogComponent } from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
-import { ChangeDataOwnerDialogComponent } from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
-import { LinkToParentCancelDialogComponent } from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
+import {
+  CancelDataOwnerDialogComponent,
+} from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
+import {
+  ChangeDataOwnerDialogComponent,
+} from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
+import {
+  LinkToParentCancelDialogComponent,
+} from '@shared/components/link-to-parent-cancel/link-to-parent-cancel-dialog.component';
 import { LinkToParentDialogComponent } from '@shared/components/link-to-parent/link-to-parent-dialog.component';
-import { OwnershipChangeMessageDialogComponent } from '@shared/components/ownership-change-message/ownership-change-message-dialog.component';
-import { SetDataPermissionDialogComponent } from '@shared/components/set-data-permission/set-data-permission-dialog.component';
+import {
+  OwnershipChangeMessageDialogComponent,
+} from '@shared/components/ownership-change-message/ownership-change-message-dialog.component';
+import {
+  SetDataPermissionDialogComponent,
+} from '@shared/components/set-data-permission/set-data-permission-dialog.component';
 import { ServiceNamePipe } from '@shared/pipes/service-name.pipe';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import saveAs from 'file-saver';
@@ -59,6 +71,7 @@ export class NewHomeTabDirective implements OnInit, OnDestroy, OnChanges {
   public canRunLocalAuthorityReport: boolean;
   public canBulkUpload: boolean;
   public canEditEstablishment: boolean;
+  public canEditWorker: boolean;
   public canViewListOfWorkers: boolean;
   public trainingCounts: TrainingCounts;
   public now: Date = new Date();
@@ -218,6 +231,7 @@ export class NewHomeTabDirective implements OnInit, OnDestroy, OnChanges {
     const workplaceUid: string = this.workplace ? this.workplace.uid : null;
     this.canEditEstablishment = this.permissionsService.can(workplaceUid, 'canEditEstablishment');
     this.canAddWorker = this.permissionsService.can(workplaceUid, 'canAddWorker');
+    this.canEditWorker = this.permissionsService.can(workplaceUid, 'canEditWorker');
     this.canViewListOfWorkers = this.permissionsService.can(workplaceUid, 'canViewListOfWorkers');
     this.canBulkUpload = this.permissionsService.can(workplaceUid, 'canBulkUpload');
     this.canViewWorkplaces = this.workplace && this.workplace.isParent;


### PR DESCRIPTION
#### Work done
- Created a resolver for staff who need an answer for the CWP role category question to prevent flickering on the page which lists staff
- Added check for permission to edit staff records to display the CWP question on the summary panel as a link to prevent read only users from accessing the page
- Updated check for staff records section of summary panel to always show default message when user cannot view staff records to prevent messages being displayed based on incomplete staff record data

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
