### PR TITLE
Fix: Hide CWP question in add staff record flow when feature flag on

### DIFF
--- a/frontend/src/app/features/workers/care-workforce-pathway/care-workforce-pathway.component.spec.ts
+++ b/frontend/src/app/features/workers/care-workforce-pathway/care-workforce-pathway.component.spec.ts
@@ -1,32 +1,33 @@
-import { fireEvent, render, within } from '@testing-library/angular';
-import { CareWorkforcePathwayRoleComponent } from './care-workforce-pathway.component';
-import { UntypedFormBuilder } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { SharedModule } from '@shared/shared.module';
-import { WorkersModule } from '../workers.module';
-import { WindowRef } from '@core/services/window.ref';
 import { AlertService } from '@core/services/alert.service';
+import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
+import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
+import {
+  careWorkforcePathwayRoleCategories,
+  MockCareWorkforcePathwayService,
+} from '@core/test-utils/MockCareWorkforcePathwayService';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockWorkerServiceWithOverrides, workerBuilder } from '@core/test-utils/MockWorkerService';
 import { DetailsComponent } from '@shared/components/details/details.component';
-import { getTestBed } from '@angular/core/testing';
-import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
-import {
-  MockCareWorkforcePathwayService,
-  careWorkforcePathwayRoleCategories,
-} from '@core/test-utils/MockCareWorkforcePathwayService';
-import { HttpClient } from '@angular/common/http';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
-import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { SharedModule } from '@shared/shared.module';
+import { fireEvent, render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+
+import { WorkersModule } from '../workers.module';
+import { CareWorkforcePathwayRoleComponent } from './care-workforce-pathway.component';
 
 describe('CareWorkforcePathwayRoleComponent', () => {
   const categorySelected = careWorkforcePathwayRoleCategories[0].title;
 
   async function setup(overrides: any = {}) {
     const insideFlow = overrides.insideFlow ?? false;
-    const cwpQuestionsFlag = overrides.cwpQuestionsFlag ?? false;
+    const cwpQuestions = overrides.cwpQuestionsFlag ?? false;
     const setupTools = await render(CareWorkforcePathwayRoleComponent, {
       imports: [SharedModule, RouterModule, HttpClientTestingModule, WorkersModule],
       declarations: [DetailsComponent],
@@ -58,7 +59,7 @@ describe('CareWorkforcePathwayRoleComponent', () => {
           provide: CareWorkforcePathwayService,
           useClass: MockCareWorkforcePathwayService,
         },
-        { provide: FeatureFlagsService, useFactory: MockFeatureFlagsService.factory({ cwpQuestionsFlag }) },
+        { provide: FeatureFlagsService, useFactory: MockFeatureFlagsService.factory({ cwpQuestions }) },
         AlertService,
         WindowRef,
       ],

--- a/frontend/src/app/features/workers/care-workforce-pathway/care-workforce-pathway.component.ts
+++ b/frontend/src/app/features/workers/care-workforce-pathway/care-workforce-pathway.component.ts
@@ -1,14 +1,15 @@
+import { Component } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Component } from '@angular/core';
+import { CareWorkforcePathwayRoleCategory } from '@core/model/careWorkforcePathwayCategory.model';
+import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
+import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkerService } from '@core/services/worker.service';
-import { CareWorkforcePathwayRoleCategory } from '@core/model/careWorkforcePathwayCategory.model';
-import { AlertService } from '@core/services/alert.service';
-import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+
 import { FinalQuestionComponent } from '../final-question/final-question.component';
 
 @Component({
@@ -60,7 +61,7 @@ export class CareWorkforcePathwayRoleComponent extends FinalQuestionComponent {
 
     this.setupPageWhenCameFromCWPSummaryPage();
 
-    this.cwpQuestionsFlag = await this.featureFlagService.configCatClient.getValueAsync('cwpQuestionsFlag', false);
+    this.cwpQuestionsFlag = await this.featureFlagService.configCatClient.getValueAsync('cwpQuestions', false);
     this.featureFlagService.cwpQuestionsFlag = this.cwpQuestionsFlag;
     this.next = this.getRoutePath('staff-record-summary');
   }

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.spec.ts
@@ -1,25 +1,25 @@
+import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { AlertService } from '@core/services/alert.service';
 import { QualificationService } from '@core/services/qualification.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
-import { MockQualificationService } from '@core/test-utils/MockQualificationsService';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
+import { MockQualificationService } from '@core/test-utils/MockQualificationsService';
 import { MockWorkerServiceWithOverrides } from '@core/test-utils/MockWorkerService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 
 import { WorkersModule } from '../workers.module';
 import { OtherQualificationsLevelComponent } from './other-qualifications-level.component';
-import { AlertService } from '@core/services/alert.service';
-import { HttpClient } from '@angular/common/http';
 
 describe('OtherQualificationsLevelComponent', () => {
   async function setup(overrides: any = {}) {
-    const cwpQuestionsFlag = overrides.cwpQuestionsFlag ?? false;
+    const cwpQuestions = overrides.cwpQuestionsFlag ?? false;
     const setupTools = await render(OtherQualificationsLevelComponent, {
       imports: [SharedModule, RouterModule, HttpClientTestingModule, WorkersModule],
       providers: [
@@ -60,13 +60,10 @@ describe('OtherQualificationsLevelComponent', () => {
           provide: QualificationService,
           useClass: MockQualificationService,
         },
-        { provide: FeatureFlagsService, useFactory: MockFeatureFlagsService.factory({ cwpQuestionsFlag }) },
+        { provide: FeatureFlagsService, useFactory: MockFeatureFlagsService.factory({ cwpQuestions }) },
         AlertService,
         WindowRef,
       ],
-      componentProperties: {
-        cwpQuestionsFlag: overrides.cwpQuestionsFlag,
-      },
     });
     const injector = getTestBed();
 

--- a/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications-level/other-qualifications-level.component.ts
@@ -2,15 +2,15 @@ import { Component } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { QualificationLevel } from '@core/model/qualification.model';
+import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { QualificationService } from '@core/services/qualification.service';
 import { WorkerService } from '@core/services/worker.service';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 import { FinalQuestionComponent } from '../final-question/final-question.component';
-import { AlertService } from '@core/services/alert.service';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 
 @Component({
   selector: 'app-other-qualifications-level',
@@ -55,7 +55,7 @@ export class OtherQualificationsLevelComponent extends FinalQuestionComponent {
       this.prefill();
     }
 
-    this.cwpQuestionsFlag = await this.featureFlagService.configCatClient.getValueAsync('cwpQuestionsFlag', false);
+    this.cwpQuestionsFlag = await this.featureFlagService.configCatClient.getValueAsync('cwpQuestions', false);
     this.featureFlagService.cwpQuestionsFlag = this.cwpQuestionsFlag;
 
     this.cwpQuestionsFlag

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.spec.ts
@@ -1,6 +1,3 @@
-import { of } from 'rxjs';
-import { delay } from 'rxjs/operators';
-
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
@@ -9,21 +6,23 @@ import { WorkerEditResponse } from '@core/model/worker.model';
 import { AlertService } from '@core/services/alert.service';
 import { WindowRef } from '@core/services/window.ref';
 import { WorkerService } from '@core/services/worker.service';
+import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockWorkerServiceWithOverrides } from '@core/test-utils/MockWorkerService';
+import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
+import { of } from 'rxjs';
+import { delay } from 'rxjs/operators';
 
 import { WorkersModule } from '../workers.module';
 import { OtherQualificationsComponent } from './other-qualifications.component';
-import { FeatureFlagsService } from '@shared/services/feature-flags.service';
-import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 
 describe('OtherQualificationsComponent', () => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   async function setup(overrides: any = {}) {
     const insideFlow = overrides.insideFlow ?? false;
     const workerOverrides = overrides.worker ?? { otherQualification: null };
-    const cwpQuestionsFlag = overrides.cwpQuestionsFlag ?? false;
+    const cwpQuestions = overrides.cwpQuestionsFlag ?? false;
 
     const setupTools = await render(OtherQualificationsComponent, {
       imports: [SharedModule, RouterModule, HttpClientTestingModule, WorkersModule],
@@ -50,7 +49,7 @@ describe('OtherQualificationsComponent', () => {
           useFactory: MockWorkerServiceWithOverrides.factory({ worker: workerOverrides }),
           deps: [HttpClient],
         },
-        { provide: FeatureFlagsService, useFactory: MockFeatureFlagsService.factory({ cwpQuestionsFlag }) },
+        { provide: FeatureFlagsService, useFactory: MockFeatureFlagsService.factory({ cwpQuestions }) },
         WindowRef,
         AlertService,
       ],

--- a/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
+++ b/frontend/src/app/features/workers/other-qualifications/other-qualifications.component.ts
@@ -1,13 +1,13 @@
 import { Component } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { AlertService } from '@core/services/alert.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkerService } from '@core/services/worker.service';
-
-import { AlertService } from '@core/services/alert.service';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
+
 import { FinalQuestionComponent } from '../final-question/final-question.component';
 
 @Component({
@@ -49,7 +49,7 @@ export class OtherQualificationsComponent extends FinalQuestionComponent {
   }
 
   async init() {
-    this.cwpQuestionsFlag = await this.featureFlagService.configCatClient.getValueAsync('cwpQuestionsFlag', false);
+    this.cwpQuestionsFlag = await this.featureFlagService.configCatClient.getValueAsync('cwpQuestions', false);
     this.featureFlagService.cwpQuestionsFlag = this.cwpQuestionsFlag;
 
     if (this.worker.otherQualification) {

--- a/frontend/src/app/shared/services/feature-flags.service.ts
+++ b/frontend/src/app/shared/services/feature-flags.service.ts
@@ -44,11 +44,11 @@ export class FeatureFlagsService {
     this._newDataAreaFlag = value;
   }
 
-    public get cwpQuestionsFlag(): boolean {
+  public get cwpQuestionsFlag(): boolean {
     return this._cwpQuestionsFlag;
   }
 
   public set cwpQuestionsFlag(value: boolean) {
-    this._cwpQuestionsFlag= value;
+    this._cwpQuestionsFlag = value;
   }
 }


### PR DESCRIPTION
#### Work done
- Corrected feature flag name in staff record other quals question pages to prevent user from being taken to CWP page when adding a staff record and cwpQuestions flag is on

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
