### PR TITLE
Feat/1721 workplace summary flag for CWP awareness

### DIFF
--- a/backend/migrations/20250530144042-addCWPQuestionViewedColumn.js
+++ b/backend/migrations/20250530144042-addCWPQuestionViewedColumn.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const establishmentTable = {
+  tableName: 'Establishment',
+  schema: 'cqc',
+};
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.addColumn(establishmentTable, 'CWPAwarenessQuestionViewed', {
+      type: Sequelize.DataTypes.BOOLEAN,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    return queryInterface.removeColumn(establishmentTable, 'CWPAwarenessQuestionViewed');
+  },
+};

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -100,6 +100,7 @@ class Establishment extends EntityValidator {
     this._primaryAuthorityCssr = null;
     this._careWorkforcePathwayWorkplaceAwareness = null;
     this._careWorkforcePathwayUse = null;
+    this._CWPAwarenessQuestionViewed = null;
 
     // interim reasons for leaving - https://trello.com/c/vNHbfdms
     this._reasonsForLeaving = null;
@@ -404,6 +405,10 @@ class Establishment extends EntityValidator {
       : null;
   }
 
+  get CWPAwarenessQuestionViewed() {
+    return this._CWPAwarenessQuestionViewed;
+  }
+
   // used by save to initialise a new Establishment; returns true if having initialised this Establishment
   _initialise() {
     if (this._uid === null) {
@@ -613,11 +618,17 @@ class Establishment extends EntityValidator {
         if ('isParentApprovedBannerViewed' in document) {
           this._isParentApprovedBannerViewed = document.isParentApprovedBannerViewed;
         }
+
         if ('primaryAuthorityCssr' in document) {
           this._primaryAuthorityCssr = document.primaryAuthorityCssr;
         }
+
         if ('careWorkforcePathwayWorkplaceAwareness' in document) {
           this._careWorkforcePathwayWorkplaceAwareness = document.careWorkforcePathwayWorkplaceAwareness;
+        }
+
+        if ('CWPAwarenessQuestionViewed' in document) {
+          this._CWPAwarenessQuestionViewed = document.CWPAwarenessQuestionViewed;
         }
       }
 
@@ -844,6 +855,7 @@ class Establishment extends EntityValidator {
           isParentApprovedBannerViewed: this._isParentApprovedBannerViewed,
           primaryAuthorityCssr: this._primaryAuthorityCssr,
           careWorkforcePathwayWorkplaceAwarenessFK: this._careWorkforcePathwayWorkplaceAwareness?.id,
+          CWPAwarenessQuestionViewed: this._CWPAwarenessQuestionViewed,
         };
 
         // need to create the Establishment record and the Establishment Audit event
@@ -1075,6 +1087,7 @@ class Establishment extends EntityValidator {
             isParentApprovedBannerViewed: this._isParentApprovedBannerViewed,
             primaryAuthorityCssr: this._primaryAuthorityCssr,
             careWorkforcePathwayWorkplaceAwarenessFK: this._careWorkforcePathwayWorkplaceAwareness?.id,
+            CWPAwarenessQuestionViewed: this._CWPAwarenessQuestionViewed,
           };
 
           // Every time the establishment is saved, need to calculate
@@ -1389,8 +1402,9 @@ class Establishment extends EntityValidator {
         this._careWorkersLeaveDaysPerYear = fetchResults.careWorkersLeaveDaysPerYear;
         this._careWorkersCashLoyaltyForFirstTwoYears = fetchResults.careWorkersCashLoyaltyForFirstTwoYears;
         this._isParentApprovedBannerViewed = fetchResults.isParentApprovedBannerViewed;
-
         this._primaryAuthorityCssr = this.primaryAuthorityCssr;
+        this._CWPAwarenessQuestionViewed = fetchResults.CWPAwarenessQuestionViewed;
+
         // if history of the User is also required; attach the association
         //  and order in reverse chronological - note, order on id (not when)
         //  because ID is primay key and hence indexed
@@ -1847,6 +1861,7 @@ class Establishment extends EntityValidator {
         myDefaultJSON.careWorkersLeaveDaysPerYear = this.careWorkersLeaveDaysPerYear;
         myDefaultJSON.careWorkersCashLoyaltyForFirstTwoYears = this.careWorkersCashLoyaltyForFirstTwoYears;
         myDefaultJSON.isParentApprovedBannerViewed = this.isParentApprovedBannerViewed;
+        myDefaultJSON.CWPAwarenessQuestionViewed = this.CWPAwarenessQuestionViewed;
       }
 
       if (this.showSharingPermissionsBanner !== null) {

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -774,7 +774,11 @@ module.exports = function (sequelize, DataTypes) {
         allowNull: true,
         field: '"CareWorkforcePathwayWorkplaceAwarenessChangedBy"',
       },
-
+      CWPAwarenessQuestionViewed: {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+        field: 'CWPAwarenessQuestionViewed',
+      },
       careWorkforcePathwayUse: {
         type: DataTypes.ENUM,
         allowNull: true,

--- a/frontend/src/app/core/model/establishment.model.ts
+++ b/frontend/src/app/core/model/establishment.model.ts
@@ -173,6 +173,7 @@ export interface Establishment {
   provId?: string;
   careWorkforcePathwayWorkplaceAwareness: CareWorkforcePathwayWorkplaceAwareness;
   careWorkforcePathwayUse: CareWorkforcePathwayUse;
+  CWPAwarenessQuestionViewed?: boolean;
 }
 
 export interface UpdateJobsRequest {

--- a/frontend/src/app/core/services/tabs.service.ts
+++ b/frontend/src/app/core/services/tabs.service.ts
@@ -27,7 +27,7 @@ export const SubsidiaryViewTabs = {
 };
 
 export const UrlPartsRelatedToTabs = [
-  { urlPart: 'awareness-of-care-workforce-pathway', tabSlug: MainDashboardTabs.workplaceTab.slug },
+  { urlPart: 'care-workforce-pathway-awareness', tabSlug: MainDashboardTabs.workplaceTab.slug },
   { urlPart: 'staff-record', tabSlug: MainDashboardTabs.staffRecordsTab.slug },
   { urlPart: 'staff-records', tabSlug: MainDashboardTabs.staffRecordsTab.slug },
   { urlPart: 'training-and-qualifications-record', tabSlug: MainDashboardTabs.tAndQTab.slug },

--- a/frontend/src/app/core/services/tabs.service.ts
+++ b/frontend/src/app/core/services/tabs.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
+
 import { PreviousRouteService } from './previous-route.service';
 
 export interface Tab {
@@ -26,6 +27,7 @@ export const SubsidiaryViewTabs = {
 };
 
 export const UrlPartsRelatedToTabs = [
+  { urlPart: 'awareness-of-care-workforce-pathway', tabSlug: MainDashboardTabs.workplaceTab.slug },
   { urlPart: 'staff-record', tabSlug: MainDashboardTabs.staffRecordsTab.slug },
   { urlPart: 'staff-records', tabSlug: MainDashboardTabs.staffRecordsTab.slug },
   { urlPart: 'training-and-qualifications-record', tabSlug: MainDashboardTabs.tAndQTab.slug },

--- a/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.html
@@ -10,6 +10,7 @@
     [workersNotCompleted]="workersNotCompleted"
     [(navigateToTab)]="navigateToTab"
     [canViewEstablishment]="canViewEstablishment"
+    [canEditEstablishment]="canEditEstablishment"
     [canEditWorker]="canEditWorker"
     [noOfWorkersWhoRequireInternationalRecruitment]="noOfWorkersWhoRequireInternationalRecruitment"
     [noOfWorkersWithCareWorkforcePathwayCategoryRoleUnanswered]="

--- a/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
+++ b/frontend/src/app/features/new-dashboard/parent-home-tab/parent-home-tab.component.html
@@ -21,6 +21,7 @@
   [(navigateToTab)]="navigateToTab"
   [canViewListOfWorkers]="canViewListOfWorkers"
   [canViewEstablishment]="canViewEstablishment"
+  [canEditEstablishment]="canEditEstablishment"
   [canEditWorker]="canEditWorker"
   [showMissingCqcMessage]="showMissingCqcMessage"
   [workplacesCount]="workplacesCount"

--- a/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
+++ b/frontend/src/app/features/subsidiary/home/view-subsidiary-home.component.html
@@ -15,6 +15,7 @@
     [workersNotCompleted]="workersNotCompleted"
     [(navigateToTab)]="navigateToTab"
     [canViewEstablishment]="canViewEstablishment"
+    [canEditEstablishment]="canEditEstablishment"
     [canEditWorker]="canEditWorker"
     [isParentSubsidiaryView]="true"
     [noOfWorkersWhoRequireInternationalRecruitment]="noOfWorkersWhoRequireInternationalRecruitment"

--- a/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
@@ -7,9 +7,13 @@ import { CheckPermissionsGuard } from '@core/guards/permissions/check-permission
 import { HasPermissionsGuard } from '@core/guards/permissions/has-permissions/has-permissions.guard';
 import { ArticleListResolver } from '@core/resolvers/article-list.resolver';
 import { BenchmarksResolver } from '@core/resolvers/benchmarks.resolver';
+import { CareWorkforcePathwayUseReasonsResolver } from '@core/resolvers/care-workforce-pathway-use-reasons.resolver';
+import { CareWorkforcePathwayWorkplaceAwarenessAnswersResolver } from '@core/resolvers/careWorkforcePathway/care-workforce-pathway-workplace-awareness';
+import { GetNoOfWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver } from '@core/resolvers/careWorkforcePathway/no-of-workers-with-care-workforce-pathway-category-role-unanswered.resolver';
 import { AllUsersForEstablishmentResolver } from '@core/resolvers/dashboard/all-users-for-establishment.resolver';
 import { TotalStaffRecordsResolver } from '@core/resolvers/dashboard/total-staff-records.resolver';
 import { ExpiresSoonAlertDatesResolver } from '@core/resolvers/expiresSoonAlertDates.resolver';
+import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
 import { GetNoOfWorkersWhoRequireInternationalRecruitmentAnswersResolver } from '@core/resolvers/international-recruitment/no-of-workers-who-require-international-recruitment-answers.resolver';
 import { JobsResolver } from '@core/resolvers/jobs.resolver';
 import { RankingsResolver } from '@core/resolvers/rankings.resolver';
@@ -24,6 +28,8 @@ import { DeleteWorkplaceComponent } from '@features/new-dashboard/delete-workpla
 import { StaffBasicRecord } from '@features/new-dashboard/staff-tab/staff-basic-record/staff-basic-record.component';
 import { AcceptPreviousCareCertificateComponent } from '@features/workplace/accept-previous-care-certificate/accept-previous-care-certificate.component';
 import { BenefitsStatutorySickPayComponent } from '@features/workplace/benefits-statutory-sick-pay/benefits-statutory-sick-pay.component';
+import { CareWorkforcePathwayAwarenessComponent } from '@features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component';
+import { CareWorkforcePathwayUseComponent } from '@features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component';
 import { ChangeExpiresSoonAlertsComponent } from '@features/workplace/change-expires-soon-alerts/change-expires-soon-alerts.component';
 import { CheckAnswersComponent } from '@features/workplace/check-answers/check-answers.component';
 import { CreateUserAccountComponent } from '@features/workplace/create-user-account/create-user-account.component';
@@ -78,11 +84,6 @@ import { ViewSubsidiaryStaffRecordsComponent } from './staff-records/view-subsid
 import { ViewSubsidiaryTrainingAndQualificationsComponent } from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
 import { ViewSubsidiaryWorkplaceUsersComponent } from './workplace-users/view-subsidiary-workplace-users.component';
 import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
-import { GetNoOfWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver } from '@core/resolvers/careWorkforcePathway/no-of-workers-with-care-workforce-pathway-category-role-unanswered.resolver';
-import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
-import { CareWorkforcePathwayAwarenessComponent } from '@features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component';
-import { CareWorkforcePathwayUseComponent } from '@features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component';
-import { CareWorkforcePathwayUseReasonsResolver } from '@core/resolvers/care-workforce-pathway-use-reasons.resolver';
 
 // eslint-disable-next-line max-len
 const routes: Routes = [
@@ -555,6 +556,9 @@ const routes: Routes = [
         data: {
           permissions: ['canEditEstablishment'],
           title: 'Care Workforce Pathway Awareness',
+        },
+        resolve: {
+          careWorkforcePathwayWorkplaceAwarenessAnswers: CareWorkforcePathwayWorkplaceAwarenessAnswersResolver,
         },
       },
       {

--- a/frontend/src/app/features/subsidiary/subsidiary.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary.module.ts
@@ -3,7 +3,11 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BenchmarksResolver } from '@core/resolvers/benchmarks.resolver';
+import { CareWorkforcePathwayUseReasonsResolver } from '@core/resolvers/care-workforce-pathway-use-reasons.resolver';
+import { CareWorkforcePathwayWorkplaceAwarenessAnswersResolver } from '@core/resolvers/careWorkforcePathway/care-workforce-pathway-workplace-awareness';
+import { GetNoOfWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver } from '@core/resolvers/careWorkforcePathway/no-of-workers-with-care-workforce-pathway-category-role-unanswered.resolver';
 import { ExpiresSoonAlertDatesResolver } from '@core/resolvers/expiresSoonAlertDates.resolver';
+import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
 import { GetMissingCqcLocationsResolver } from '@core/resolvers/getMissingCqcLocations/getMissingCqcLocations.resolver';
 import { GetNoOfWorkersWhoRequireInternationalRecruitmentAnswersResolver } from '@core/resolvers/international-recruitment/no-of-workers-who-require-international-recruitment-answers.resolver';
 import { JobsResolver } from '@core/resolvers/jobs.resolver';
@@ -24,9 +28,6 @@ import { SubsidiaryRoutingModule } from './subsidiary-routing.module';
 import { ViewSubsidiaryTrainingAndQualificationsComponent } from './training-and-qualifications/view-subsidiary-training-and-qualifications.component';
 import { ViewSubsidiaryWorkplaceUsersComponent } from './workplace-users/view-subsidiary-workplace-users.component';
 import { ViewSubsidiaryWorkplaceComponent } from './workplace/view-subsidiary-workplace.component';
-import { GetNoOfWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver } from '@core/resolvers/careWorkforcePathway/no-of-workers-with-care-workforce-pathway-category-role-unanswered.resolver';
-import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
-import { CareWorkforcePathwayUseReasonsResolver } from '@core/resolvers/care-workforce-pathway-use-reasons.resolver';
 
 @NgModule({
   imports: [
@@ -62,6 +63,7 @@ import { CareWorkforcePathwayUseReasonsResolver } from '@core/resolvers/care-wor
     GetNoOfWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver,
     FeatureFlagsResolver,
     CareWorkforcePathwayUseReasonsResolver,
+    CareWorkforcePathwayWorkplaceAwarenessAnswersResolver,
   ],
 })
 export class SubsidiaryModule {}

--- a/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.spec.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.spec.ts
@@ -1,12 +1,10 @@
-import { repeat } from 'lodash';
-import { of, throwError } from 'rxjs';
-
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { CareWorkforcePathwayUseReason } from '@core/model/care-workforce-pathway.model';
+import { BackLinkService } from '@core/services/backLink.service';
 import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { MockCareWorkforcePathwayService } from '@core/test-utils/MockCareWorkforcePathwayService';
@@ -15,6 +13,8 @@ import { MockRouter } from '@core/test-utils/MockRouter';
 import { SharedModule } from '@shared/shared.module';
 import { render, screen, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+import { repeat } from 'lodash';
+import { of, throwError } from 'rxjs';
 
 import { CareWorkforcePathwayUseComponent } from './care-workforce-pathway-use.component';
 
@@ -38,6 +38,7 @@ describe('CareWorkforcePathwayUseComponent', () => {
 
   const setup = async (overrides: any = {}) => {
     const routerSpy = jasmine.createSpy().and.resolveTo(true);
+    const backLinkServiceSpy = jasmine.createSpyObj('BacklinkService', ['showBackLink']);
 
     const setupTools = await render(CareWorkforcePathwayUseComponent, {
       imports: [SharedModule, RouterModule, ReactiveFormsModule, HttpClientTestingModule],
@@ -63,6 +64,10 @@ describe('CareWorkforcePathwayUseComponent', () => {
             isAwareOfCareWorkforcePathway: () => overrides.workplaceIsAwareOfCareWorkforcePathway ?? true,
           }),
         },
+        {
+          provide: BackLinkService,
+          useValue: backLinkServiceSpy,
+        },
       ],
     });
 
@@ -73,7 +78,7 @@ describe('CareWorkforcePathwayUseComponent', () => {
     );
 
     const component = setupTools.fixture.componentInstance;
-    return { ...setupTools, component, establishmentService, establishmentServiceSpy, routerSpy };
+    return { ...setupTools, component, establishmentService, establishmentServiceSpy, routerSpy, backLinkServiceSpy };
   };
 
   it('should create', async () => {
@@ -369,5 +374,11 @@ describe('CareWorkforcePathwayUseComponent', () => {
       expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid', 'cash-loyalty']);
       expect(establishmentServiceSpy).not.toHaveBeenCalled();
     });
+  });
+
+  it('should set the back link', async () => {
+    const { backLinkServiceSpy } = await setup();
+
+    expect(backLinkServiceSpy.showBackLink).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.ts
@@ -6,6 +6,7 @@ import {
   UpdateCareWorkforcePathwayUsePayload,
 } from '@core/model/care-workforce-pathway.model';
 import { BackService } from '@core/services/back.service';
+import { BackLinkService } from '@core/services/backLink.service';
 import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -35,6 +36,7 @@ export class CareWorkforcePathwayUseComponent extends Question implements OnInit
     protected establishmentService: EstablishmentService,
     protected careWorkforcePathwayService: CareWorkforcePathwayService,
     protected route: ActivatedRoute,
+    private backLinkService: BackLinkService,
   ) {
     super(formBuilder, router, backService, errorSummaryService, establishmentService);
   }
@@ -63,6 +65,11 @@ export class CareWorkforcePathwayUseComponent extends Question implements OnInit
 
   private setPreviousRoute(): void {
     this.previousRoute = ['/workplace', this.establishment.uid, 'care-workforce-pathway-awareness'];
+  }
+
+  protected setBackLink(): void {
+    this.back = this.return ? this.return : { url: this.previousRoute };
+    this.backLinkService.showBackLink();
   }
 
   private setupForm(): void {

--- a/frontend/src/app/features/workplace/question/question.component.ts
+++ b/frontend/src/app/features/workplace/question/question.component.ts
@@ -68,7 +68,7 @@ export class Question implements OnInit, OnDestroy, AfterViewInit {
     this.errorSummaryService.formEl$.next(this.formEl);
   }
 
-  setBackLink() {
+  protected setBackLink(): void {
     this.back = this.return ? this.return : { url: this.previousRoute };
     this.backService.setBackLink(this.back);
   }

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
@@ -1,4 +1,3 @@
-import { BehaviorSubject } from 'rxjs';
 import { Location } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
@@ -12,6 +11,7 @@ import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+import { BehaviorSubject } from 'rxjs';
 
 import { NewTabsComponent } from './new-tabs.component';
 
@@ -192,6 +192,10 @@ describe('NewTabsComponent', () => {
           mockUrl: `/workplace/${mockUid1}/training-and-qualifications/missing-mandatory-training`,
           expectedActiveTab: 'training-and-qualifications',
         },
+        {
+          mockUrl: `/workplace/${mockUid1}/awareness-of-care-workforce-pathway`,
+          expectedActiveTab: 'workplace',
+        },
       ];
 
       testCases.forEach(({ mockUrl, expectedActiveTab }) => {
@@ -227,6 +231,10 @@ describe('NewTabsComponent', () => {
         {
           mockUrl: `/subsidiary/workplace/${mockUid1}/training-and-qualifications/missing-mandatory-training`,
           expectedActiveTab: 'training-and-qualifications',
+        },
+        {
+          mockUrl: `/subsidiary/workplace/${mockUid1}/awareness-of-care-workforce-pathway`,
+          expectedActiveTab: 'workplace',
         },
       ];
 

--- a/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
+++ b/frontend/src/app/shared/components/new-tabs/new-tabs.component.spec.ts
@@ -193,7 +193,7 @@ describe('NewTabsComponent', () => {
           expectedActiveTab: 'training-and-qualifications',
         },
         {
-          mockUrl: `/workplace/${mockUid1}/awareness-of-care-workforce-pathway`,
+          mockUrl: `/workplace/${mockUid1}/care-workforce-pathway-awareness`,
           expectedActiveTab: 'workplace',
         },
       ];
@@ -233,7 +233,7 @@ describe('NewTabsComponent', () => {
           expectedActiveTab: 'training-and-qualifications',
         },
         {
-          mockUrl: `/subsidiary/workplace/${mockUid1}/awareness-of-care-workforce-pathway`,
+          mockUrl: `/subsidiary/workplace/${mockUid1}/care-workforce-pathway-awareness`,
           expectedActiveTab: 'workplace',
         },
       ];

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -168,17 +168,71 @@ describe('Summary section', () => {
       expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
     });
 
-    it('should show the CWP awareness message if workplace details added and CWPAwarenessQuestionViewed null', async () => {
-      const establishment = {
-        ...Establishment,
-        showAddWorkplaceDetailsBanner: false,
-        CWPAwarenessQuestionViewed: null,
-      };
-      const { getByTestId } = await setup(true, establishment);
+    describe('CWP awareness question', () => {
+      it('should show the CWP awareness message if workplace details added, CWPAwarenessQuestionViewed null and awareness question not answered', async () => {
+        const establishment = {
+          ...Establishment,
+          showAddWorkplaceDetailsBanner: false,
+          CWPAwarenessQuestionViewed: null,
+          careWorkforcePathwayWorkplaceAwareness: null,
+        };
 
-      const workplaceRow = getByTestId('workplace-row');
-      expect(within(workplaceRow).getByText('How aware of the CWP is your workplace?')).toBeTruthy();
-      expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+        const { getByTestId } = await setup(true, establishment);
+
+        const workplaceRow = getByTestId('workplace-row');
+        expect(within(workplaceRow).getByText('How aware of the CWP is your workplace?')).toBeTruthy();
+        expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+      });
+
+      it('should not show the CWP awareness message if workplace details added and CWPAwarenessQuestionViewed null, but awareness question answered', async () => {
+        // user has answered question in workplace flow or from workplace tab so should not show
+        const establishment = {
+          ...Establishment,
+          showAddWorkplaceDetailsBanner: false,
+          CWPAwarenessQuestionViewed: null,
+          careWorkforcePathwayWorkplaceAwareness: {
+            id: 1,
+            title: 'Aware of how the care workforce pathway works in practice',
+          },
+        };
+
+        const { getByTestId } = await setup(true, establishment);
+
+        const workplaceRow = getByTestId('workplace-row');
+        expect(within(workplaceRow).queryByText('How aware of the CWP is your workplace?')).toBeFalsy();
+      });
+
+      it('should not show the CWP awareness message if CWPAwarenessQuestionViewed true and awareness question not answered', async () => {
+        // user has clicked link and still not answered, should no longer see it
+        const establishment = {
+          ...Establishment,
+          showAddWorkplaceDetailsBanner: false,
+          CWPAwarenessQuestionViewed: true,
+          careWorkforcePathwayWorkplaceAwareness: null,
+        };
+
+        const { getByTestId } = await setup(true, establishment);
+
+        const workplaceRow = getByTestId('workplace-row');
+        expect(within(workplaceRow).queryByText('How aware of the CWP is your workplace?')).toBeFalsy();
+      });
+
+      it('should not show the CWP awareness message if CWPAwarenessQuestionViewed true and awareness question answered', async () => {
+        const establishment = {
+          ...Establishment,
+          showAddWorkplaceDetailsBanner: false,
+          CWPAwarenessQuestionViewed: null,
+          careWorkforcePathwayWorkplaceAwareness: {
+            id: 1,
+            title: 'Aware of how the care workforce pathway works in practice',
+          },
+        };
+
+        const { getByTestId } = await setup(true, establishment);
+
+        const workplaceRow = getByTestId('workplace-row');
+        expect(within(workplaceRow).queryByText('How aware of the CWP is your workplace?')).toBeFalsy();
+      });
     });
 
     it('should navigate to sub workplace page when clicking the add workplace details message in sub view', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { provideRouter, Router, RouterModule } from '@angular/router';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -12,13 +12,14 @@ import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
 import dayjs from 'dayjs';
+import { of } from 'rxjs';
 
 import { Establishment } from '../../../../mockdata/establishment';
 import { SummarySectionComponent } from './summary-section.component';
 
 describe('Summary section', () => {
   const setup = async (overrides: any = {}) => {
-    const { fixture, getByText, queryByText, getByTestId, queryByTestId } = await render(SummarySectionComponent, {
+    const setupTools = await render(SummarySectionComponent, {
       imports: [SharedModule, HttpClientTestingModule, RouterModule],
       providers: [
         {
@@ -30,14 +31,7 @@ describe('Summary section', () => {
           useFactory: MockEstablishmentServiceCheckCQCDetails.factory(overrides.checkCqcDetails ?? false),
           deps: [HttpClient],
         },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            snapshot: {
-              data: {},
-            },
-          },
-        },
+        provideRouter([]),
       ],
       componentProperties: {
         workplace: overrides.establishment ?? Establishment,
@@ -62,22 +56,24 @@ describe('Summary section', () => {
       },
     });
 
-    const component = fixture.componentInstance;
+    const component = setupTools.fixture.componentInstance;
     const injector = getTestBed();
 
     const router = injector.inject(Router) as Router;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
     const tabsService = injector.inject(TabsService) as TabsService;
 
+    const establishmentService = injector.inject(EstablishmentService) as EstablishmentService;
+    const updateSingleFieldSpy = spyOn(establishmentService, 'updateSingleEstablishmentField').and.returnValue(
+      of(null),
+    );
+
     return {
+      ...setupTools,
       component,
-      fixture,
-      getByText,
-      queryByText,
-      getByTestId,
-      queryByTestId,
       routerSpy,
       tabsService,
+      updateSingleFieldSpy,
     };
   };
 
@@ -177,7 +173,7 @@ describe('Summary section', () => {
           careWorkforcePathwayWorkplaceAwareness: null,
         };
 
-        const { getByTestId } = await setup(true, establishment);
+        const { getByTestId } = await setup({ establishment });
 
         const workplaceRow = getByTestId('workplace-row');
         expect(within(workplaceRow).getByText('How aware of the CWP is your workplace?')).toBeTruthy();
@@ -192,7 +188,7 @@ describe('Summary section', () => {
           careWorkforcePathwayWorkplaceAwareness: null,
         };
 
-        const { getByTestId, routerSpy } = await setup(true, establishment);
+        const { getByTestId, routerSpy } = await setup({ establishment });
 
         const workplaceRow = getByTestId('workplace-row');
         const link = within(workplaceRow).getByText('How aware of the CWP is your workplace?');
@@ -203,6 +199,43 @@ describe('Summary section', () => {
           Establishment.uid,
           'awareness-of-care-workforce-pathway',
         ]);
+      });
+
+      it("should update CWPAwarenessQuestionViewed when question link clicked so user doesn't see question again", async () => {
+        const establishment = {
+          ...Establishment,
+          showAddWorkplaceDetailsBanner: false,
+          CWPAwarenessQuestionViewed: null,
+          careWorkforcePathwayWorkplaceAwareness: null,
+        };
+
+        const { getByTestId, updateSingleFieldSpy } = await setup({ establishment });
+
+        const workplaceRow = getByTestId('workplace-row');
+        const link = within(workplaceRow).getByText('How aware of the CWP is your workplace?');
+
+        fireEvent.click(link);
+        expect(updateSingleFieldSpy).toHaveBeenCalledWith(Establishment.uid, {
+          property: 'CWPAwarenessQuestionViewed',
+          value: true,
+        });
+      });
+
+      it('should not update CWPAwarenessQuestionViewed when Workplace link clicked', async () => {
+        const establishment = {
+          ...Establishment,
+          showAddWorkplaceDetailsBanner: false,
+          CWPAwarenessQuestionViewed: null,
+          careWorkforcePathwayWorkplaceAwareness: null,
+        };
+
+        const { getByTestId, updateSingleFieldSpy } = await setup({ establishment });
+
+        const workplaceRow = getByTestId('workplace-row');
+        const link = within(workplaceRow).getByText('Workplace');
+
+        fireEvent.click(link);
+        expect(updateSingleFieldSpy).not.toHaveBeenCalled();
       });
 
       it('should not show the CWP awareness message if workplace details added and CWPAwarenessQuestionViewed null, but awareness question answered', async () => {
@@ -217,7 +250,7 @@ describe('Summary section', () => {
           },
         };
 
-        const { getByTestId } = await setup(true, establishment);
+        const { getByTestId } = await setup({ establishment });
 
         const workplaceRow = getByTestId('workplace-row');
         expect(within(workplaceRow).queryByText('How aware of the CWP is your workplace?')).toBeFalsy();
@@ -232,7 +265,7 @@ describe('Summary section', () => {
           careWorkforcePathwayWorkplaceAwareness: null,
         };
 
-        const { getByTestId } = await setup(true, establishment);
+        const { getByTestId } = await setup({ establishment });
 
         const workplaceRow = getByTestId('workplace-row');
         expect(within(workplaceRow).queryByText('How aware of the CWP is your workplace?')).toBeFalsy();
@@ -249,7 +282,7 @@ describe('Summary section', () => {
           },
         };
 
-        const { getByTestId } = await setup(true, establishment);
+        const { getByTestId } = await setup({ establishment });
 
         const workplaceRow = getByTestId('workplace-row');
         expect(within(workplaceRow).queryByText('How aware of the CWP is your workplace?')).toBeFalsy();

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -36,7 +36,7 @@ describe('Summary section', () => {
       componentProperties: {
         workplace: overrides.establishment ?? Establishment,
         trainingCounts: (overrides.trainingCounts as TrainingCounts) ?? ({} as TrainingCounts),
-        navigateToTab: (event, _selectedTab) => {
+        navigateToTab: (event) => {
           event.preventDefault();
         },
         workerCount: overrides?.workerCount ?? Establishment.numberOfStaff,
@@ -167,15 +167,16 @@ describe('Summary section', () => {
     });
 
     describe('CWP awareness question', () => {
-      it('should show the CWP awareness message if workplace details added, CWPAwarenessQuestionViewed null and awareness question not answered', async () => {
-        const establishment = {
+      const establishmentWhichShouldSeeMessage = () => {
+        return {
           ...Establishment,
           showAddWorkplaceDetailsBanner: false,
           CWPAwarenessQuestionViewed: null,
           careWorkforcePathwayWorkplaceAwareness: null,
         };
-
-        const { getByTestId } = await setup({ establishment });
+      };
+      it('should show the CWP awareness message if workplace details added, CWPAwarenessQuestionViewed null and awareness question not answered', async () => {
+        const { getByTestId } = await setup({ establishment: establishmentWhichShouldSeeMessage() });
 
         const workplaceRow = getByTestId('workplace-row');
         expect(within(workplaceRow).getByText('How aware of the CWP is your workplace?')).toBeTruthy();
@@ -183,14 +184,7 @@ describe('Summary section', () => {
       });
 
       it('should navigate to care-workforce-pathway-awareness when question link clicked', async () => {
-        const establishment = {
-          ...Establishment,
-          showAddWorkplaceDetailsBanner: false,
-          CWPAwarenessQuestionViewed: null,
-          careWorkforcePathwayWorkplaceAwareness: null,
-        };
-
-        const { getByTestId, routerSpy } = await setup({ establishment });
+        const { getByTestId, routerSpy } = await setup({ establishment: establishmentWhichShouldSeeMessage() });
 
         const workplaceRow = getByTestId('workplace-row');
         const link = within(workplaceRow).getByText('How aware of the CWP is your workplace?');
@@ -200,14 +194,9 @@ describe('Summary section', () => {
       });
 
       it("should update CWPAwarenessQuestionViewed when question link clicked so user doesn't see question again", async () => {
-        const establishment = {
-          ...Establishment,
-          showAddWorkplaceDetailsBanner: false,
-          CWPAwarenessQuestionViewed: null,
-          careWorkforcePathwayWorkplaceAwareness: null,
-        };
-
-        const { getByTestId, updateSingleFieldSpy } = await setup({ establishment });
+        const { getByTestId, updateSingleFieldSpy } = await setup({
+          establishment: establishmentWhichShouldSeeMessage(),
+        });
 
         const workplaceRow = getByTestId('workplace-row');
         const link = within(workplaceRow).getByText('How aware of the CWP is your workplace?');
@@ -220,14 +209,7 @@ describe('Summary section', () => {
       });
 
       it('should set return in establishment service when question link clicked', async () => {
-        const establishment = {
-          ...Establishment,
-          showAddWorkplaceDetailsBanner: false,
-          CWPAwarenessQuestionViewed: null,
-          careWorkforcePathwayWorkplaceAwareness: null,
-        };
-
-        const { getByTestId, setReturnToSpy } = await setup({ establishment });
+        const { getByTestId, setReturnToSpy } = await setup({ establishment: establishmentWhichShouldSeeMessage() });
 
         const workplaceRow = getByTestId('workplace-row');
         const link = within(workplaceRow).getByText('How aware of the CWP is your workplace?');
@@ -237,14 +219,9 @@ describe('Summary section', () => {
       });
 
       it('should not update CWPAwarenessQuestionViewed when Workplace link clicked', async () => {
-        const establishment = {
-          ...Establishment,
-          showAddWorkplaceDetailsBanner: false,
-          CWPAwarenessQuestionViewed: null,
-          careWorkforcePathwayWorkplaceAwareness: null,
-        };
-
-        const { getByTestId, updateSingleFieldSpy } = await setup({ establishment });
+        const { getByTestId, updateSingleFieldSpy } = await setup({
+          establishment: establishmentWhichShouldSeeMessage(),
+        });
 
         const workplaceRow = getByTestId('workplace-row');
         const link = within(workplaceRow).getByText('Workplace');

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -168,6 +168,19 @@ describe('Summary section', () => {
       expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
     });
 
+    it('should show the CWP awareness message if workplace details added and CWPAwarenessQuestionViewed null', async () => {
+      const establishment = {
+        ...Establishment,
+        showAddWorkplaceDetailsBanner: false,
+        CWPAwarenessQuestionViewed: null,
+      };
+      const { getByTestId } = await setup(true, establishment);
+
+      const workplaceRow = getByTestId('workplace-row');
+      expect(within(workplaceRow).getByText('How aware of the CWP is your workplace?')).toBeTruthy();
+      expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+    });
+
     it('should navigate to sub workplace page when clicking the add workplace details message in sub view', async () => {
       const establishment = { ...Establishment, showAddWorkplaceDetailsBanner: true };
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -67,6 +67,7 @@ describe('Summary section', () => {
     const updateSingleFieldSpy = spyOn(establishmentService, 'updateSingleEstablishmentField').and.returnValue(
       of(null),
     );
+    const setReturnToSpy = spyOn(establishmentService, 'setReturnTo');
 
     return {
       ...setupTools,
@@ -74,6 +75,7 @@ describe('Summary section', () => {
       routerSpy,
       tabsService,
       updateSingleFieldSpy,
+      setReturnToSpy,
     };
   };
 
@@ -215,6 +217,23 @@ describe('Summary section', () => {
           property: 'CWPAwarenessQuestionViewed',
           value: true,
         });
+      });
+
+      it('should set return in establishment service when question link clicked', async () => {
+        const establishment = {
+          ...Establishment,
+          showAddWorkplaceDetailsBanner: false,
+          CWPAwarenessQuestionViewed: null,
+          careWorkforcePathwayWorkplaceAwareness: null,
+        };
+
+        const { getByTestId, setReturnToSpy } = await setup({ establishment });
+
+        const workplaceRow = getByTestId('workplace-row');
+        const link = within(workplaceRow).getByText('How aware of the CWP is your workplace?');
+
+        fireEvent.click(link);
+        expect(setReturnToSpy).toHaveBeenCalled();
       });
 
       it('should not update CWPAwarenessQuestionViewed when Workplace link clicked', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -180,7 +180,7 @@ describe('Summary section', () => {
         expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
       });
 
-      it('should navigate to awareness-of-care-workforce-pathway when question link clicked', async () => {
+      it('should navigate to care-workforce-pathway-awareness when question link clicked', async () => {
         const establishment = {
           ...Establishment,
           showAddWorkplaceDetailsBanner: false,
@@ -194,11 +194,7 @@ describe('Summary section', () => {
         const link = within(workplaceRow).getByText('How aware of the CWP is your workplace?');
 
         fireEvent.click(link);
-        expect(routerSpy).toHaveBeenCalledWith([
-          '/workplace',
-          Establishment.uid,
-          'awareness-of-care-workforce-pathway',
-        ]);
+        expect(routerSpy).toHaveBeenCalledWith(['/workplace', Establishment.uid, 'care-workforce-pathway-awareness']);
       });
 
       it("should update CWPAwarenessQuestionViewed when question link clicked so user doesn't see question again", async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -184,6 +184,27 @@ describe('Summary section', () => {
         expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
       });
 
+      it('should navigate to awareness-of-care-workforce-pathway when question link clicked', async () => {
+        const establishment = {
+          ...Establishment,
+          showAddWorkplaceDetailsBanner: false,
+          CWPAwarenessQuestionViewed: null,
+          careWorkforcePathwayWorkplaceAwareness: null,
+        };
+
+        const { getByTestId, routerSpy } = await setup(true, establishment);
+
+        const workplaceRow = getByTestId('workplace-row');
+        const link = within(workplaceRow).getByText('How aware of the CWP is your workplace?');
+
+        fireEvent.click(link);
+        expect(routerSpy).toHaveBeenCalledWith([
+          '/workplace',
+          Establishment.uid,
+          'awareness-of-care-workforce-pathway',
+        ]);
+      });
+
       it('should not show the CWP awareness message if workplace details added and CWPAwarenessQuestionViewed null, but awareness question answered', async () => {
         // user has answered question in workplace flow or from workplace tab so should not show
         const establishment = {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -45,6 +45,7 @@ describe('Summary section', () => {
         isParent: overrides.isParent ?? false,
         canViewListOfWorkers: overrides.canViewListOfWorkers ?? true,
         canEditWorker: overrides.canEditWorker ?? true,
+        canEditEstablishment: overrides.canEditEstablishment ?? true,
         canViewEstablishment: overrides.canViewEstablishment ?? true,
         showMissingCqcMessage: overrides.showMissingCqcMessage ?? false,
         workplacesCount: overrides.workplacesCount ?? 0,
@@ -175,6 +176,7 @@ describe('Summary section', () => {
           careWorkforcePathwayWorkplaceAwareness: null,
         };
       };
+
       it('should show the CWP awareness message if workplace details added, CWPAwarenessQuestionViewed null and awareness question not answered', async () => {
         const { getByTestId } = await setup({ establishment: establishmentWhichShouldSeeMessage() });
 
@@ -278,6 +280,20 @@ describe('Summary section', () => {
 
         const workplaceRow = getByTestId('workplace-row');
         expect(within(workplaceRow).queryByText('How aware of the CWP is your workplace?')).toBeFalsy();
+      });
+
+      it('should show with no link if there CWP awareness not viewed or answered but no edit permission for establishment', async () => {
+        const { getByTestId, getByText } = await setup({
+          canEditEstablishment: false,
+          establishment: establishmentWhichShouldSeeMessage(),
+        });
+
+        const workplaceRow = getByTestId('workplace-row');
+        const cwpMessage = within(workplaceRow).queryByText('How aware of the CWP is your workplace?');
+        expect(cwpMessage.tagName).not.toBe('A');
+
+        const workplaceLink = getByText('Workplace');
+        expect(workplaceLink.tagName).toBe('A');
       });
     });
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -97,6 +97,7 @@ export class SummarySectionComponent implements OnInit, OnChanges {
       this.sections[0].message = 'Add more details to your workplace';
     } else if (!this.workplace.CWPAwarenessQuestionViewed && !this.workplace.careWorkforcePathwayWorkplaceAwareness) {
       this.sections[0].message = 'How aware of the CWP is your workplace?';
+      this.sections[0].route = ['/workplace', this.workplace.uid, 'awareness-of-care-workforce-pathway'];
     } else if (this.establishmentService.checkCQCDetailsBanner) {
       this.sections[0].message = 'You need to check your CQC details';
     } else if (numberOfStaff === undefined || numberOfStaff === null) {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -95,6 +95,8 @@ export class SummarySectionComponent implements OnInit, OnChanges {
     this.sections[0].redFlag = false;
     if (showAddWorkplaceDetailsBanner) {
       this.sections[0].message = 'Add more details to your workplace';
+    } else if (!this.workplace.CWPAwarenessQuestionViewed) {
+      this.sections[0].message = 'How aware of the CWP is your workplace?';
     } else if (this.establishmentService.checkCQCDetailsBanner) {
       this.sections[0].message = 'You need to check your CQC details';
     } else if (numberOfStaff === undefined || numberOfStaff === null) {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -75,6 +75,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     event.preventDefault();
     if (this.careWorkforcePathwayLinkDisplaying && fragment == 'workplace') {
       this.setCwpAwarenessQuestionViewed();
+      this.establishmentService.setReturnTo({ url: ['/dashboard'], fragment: 'home' });
     }
 
     if (this.isParentSubsidiaryView) {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -71,8 +71,6 @@ export class SummarySectionComponent implements OnInit, OnChanges, OnDestroy {
     this.getOtherWorkplacesSummaryMessage();
   }
 
-  ngOnChanges(): void {}
-
   public async onClick(event: Event, fragment: string, route: string[], skipTabSwitch: boolean = false): Promise<void> {
     event.preventDefault();
     if (this.careWorkforcePathwayLinkDisplaying && fragment == 'workplace') {
@@ -104,7 +102,7 @@ export class SummarySectionComponent implements OnInit, OnChanges, OnDestroy {
       this.sections[0].message = 'Add more details to your workplace';
     } else if (!this.workplace.CWPAwarenessQuestionViewed && !this.workplace.careWorkforcePathwayWorkplaceAwareness) {
       this.sections[0].message = 'How aware of the CWP is your workplace?';
-      this.sections[0].route = ['/workplace', this.workplace.uid, 'awareness-of-care-workforce-pathway'];
+      this.sections[0].route = ['/workplace', this.workplace.uid, 'care-workforce-pathway-awareness'];
       this.careWorkforcePathwayLinkDisplaying = true;
     } else if (this.establishmentService.checkCQCDetailsBanner) {
       this.sections[0].message = 'You need to check your CQC details';

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -23,6 +23,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   @Input() canViewListOfWorkers: boolean;
   @Input() canViewEstablishment: boolean;
   @Input() canEditWorker: boolean;
+  @Input() canEditEstablishment: boolean;
   @Input() showMissingCqcMessage: boolean;
   @Input() workplacesCount: number;
   @Input() isParentSubsidiaryView: boolean;
@@ -105,6 +106,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
       this.sections[0].message = 'How aware of the CWP is your workplace?';
       this.sections[0].route = ['/workplace', this.workplace.uid, 'care-workforce-pathway-awareness'];
       this.careWorkforcePathwayLinkDisplaying = true;
+      this.sections[0].showMessageAsText = !this.canEditEstablishment;
     } else if (this.establishmentService.checkCQCDetailsBanner) {
       this.sections[0].message = 'You need to check your CQC details';
     } else if (numberOfStaff === undefined || numberOfStaff === null) {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -95,7 +95,7 @@ export class SummarySectionComponent implements OnInit, OnChanges {
     this.sections[0].redFlag = false;
     if (showAddWorkplaceDetailsBanner) {
       this.sections[0].message = 'Add more details to your workplace';
-    } else if (!this.workplace.CWPAwarenessQuestionViewed) {
+    } else if (!this.workplace.CWPAwarenessQuestionViewed && !this.workplace.careWorkforcePathwayWorkplaceAwareness) {
       this.sections[0].message = 'How aware of the CWP is your workplace?';
     } else if (this.establishmentService.checkCQCDetailsBanner) {
       this.sections[0].message = 'You need to check your CQC details';

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
@@ -13,7 +13,7 @@ import { Subscription } from 'rxjs';
   templateUrl: './summary-section.component.html',
   styleUrls: ['./summary-section.component.scss'],
 })
-export class SummarySectionComponent implements OnInit, OnChanges, OnDestroy {
+export class SummarySectionComponent implements OnInit, OnDestroy {
   @Input() workplace: Establishment;
   @Input() workerCount: number;
   @Input() workersCreatedDate;

--- a/frontend/src/mockdata/establishment.js
+++ b/frontend/src/mockdata/establishment.js
@@ -140,4 +140,5 @@ module.exports.Establishment = {
   dataOwnershipRequested: '',
   ownershipChangeRequestId: '',
   showAddWorkplaceDetailsBanner: false,
+  CWPAwarenessQuestionViewed: true,
 };


### PR DESCRIPTION
#### Work done
- Added question to workplace section of home summary panel when user has not answered awareness question
- Don't show link again on summary panel after user has clicked it, even if they don't answer the question
- Updated the back link on CWP use question to use smart back link service so back correctly navigates to previous page (awareness question or workplace summary)

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
