### PR TITLE
Fix/add alert when user answers CWP workplace questions from summary panel link

### DIFF
--- a/frontend/src/app/core/services/establishment.service.spec.ts
+++ b/frontend/src/app/core/services/establishment.service.spec.ts
@@ -1,8 +1,7 @@
-import { environment } from 'src/environments/environment';
-
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { UpdateCareWorkforcePathwayUsePayload } from '@core/model/care-workforce-pathway.model';
+import { environment } from 'src/environments/environment';
 
 import { EstablishmentService } from './establishment.service';
 
@@ -155,6 +154,29 @@ describe('EstablishmentService', () => {
 
       expect(expectedRequest.request.method).toBe('POST');
       expect(expectedRequest.request.body).toEqual(payload);
+    });
+  });
+
+  describe('returnIsSetToHomePage', () => {
+    it('should return true when returnTo is dashboard with fragment as home', () => {
+      const returnTo = { url: ['/dashboard'], fragment: 'home' };
+      service.setReturnTo(returnTo);
+
+      expect(service.returnIsSetToHomePage()).toBe(true);
+    });
+
+    it('should return false if url is not dashboard', () => {
+      const returnTo = { url: ['/workplace/abc123'], fragment: 'home' };
+      service.setReturnTo(returnTo);
+
+      expect(service.returnIsSetToHomePage()).toBe(false);
+    });
+
+    it('should return false if fragment is not home', () => {
+      const returnTo = { url: ['/dashboard'], fragment: 'workplace' };
+      service.setReturnTo(returnTo);
+
+      expect(service.returnIsSetToHomePage()).toBe(false);
     });
   });
 });

--- a/frontend/src/app/core/services/establishment.service.ts
+++ b/frontend/src/app/core/services/establishment.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Params } from '@angular/router';
+import { CareWorkforcePathwayUse, UpdateCareWorkforcePathwayUsePayload } from '@core/model/care-workforce-pathway.model';
 import {
   adminMoveWorkplace,
   CancelOwnerShip,
@@ -22,10 +23,6 @@ import { environment } from 'src/environments/environment';
 
 import { ShareWithRequest } from '../model/data-sharing.model';
 import { PostServicesModel } from '../model/postServices.model';
-import {
-  CareWorkforcePathwayUse,
-  UpdateCareWorkforcePathwayUsePayload,
-} from '@core/model/care-workforce-pathway.model';
 
 interface EstablishmentApiResponse {
   id: number;
@@ -211,6 +208,16 @@ export class EstablishmentService {
   public setReturnTo(returnTo: URLStructure): void {
     localStorage.setItem('returnTo', JSON.stringify(returnTo));
     this.returnTo$.next(returnTo);
+  }
+
+  public returnIsSetToHomePage(): boolean {
+    return (
+      this.returnTo &&
+      Array.isArray(this.returnTo.url) &&
+      this.returnTo.url.length === 1 &&
+      this.returnTo.url[0] === '/dashboard' &&
+      this.returnTo.fragment === 'home'
+    );
   }
 
   public get checkCQCDetailsBanner$(): Observable<boolean> {

--- a/frontend/src/app/features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component.ts
@@ -1,13 +1,15 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Question } from '../question/question.component';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { CareWorkforcePathwayWorkplaceAwarenessAnswer } from '@core/model/care-workforce-pathway.model';
+import { AlertService } from '@core/services/alert.service';
 import { BackService } from '@core/services/back.service';
+import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
-import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
-import { CareWorkforcePathwayWorkplaceAwarenessAnswer } from '@core/model/care-workforce-pathway.model';
+
+import { Question } from '../question/question.component';
 
 @Component({
   selector: 'app-care-workforce-pathway-awareness',
@@ -16,6 +18,7 @@ import { CareWorkforcePathwayWorkplaceAwarenessAnswer } from '@core/model/care-w
 export class CareWorkforcePathwayAwarenessComponent extends Question implements OnInit, OnDestroy {
   public section = WorkplaceFlowSections.RECRUITMENT_AND_BENEFITS;
   public careWorkforcePathwayAwarenessAnswers: CareWorkforcePathwayWorkplaceAwarenessAnswer[];
+  private hasGivenNotAwareAnswer: boolean;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -25,6 +28,7 @@ export class CareWorkforcePathwayAwarenessComponent extends Question implements 
     protected establishmentService: EstablishmentService,
     protected careWorkforcePathwayService: CareWorkforcePathwayService,
     protected route: ActivatedRoute,
+    private alertService: AlertService,
   ) {
     super(formBuilder, router, backService, errorSummaryService, establishmentService);
   }
@@ -102,6 +106,26 @@ export class CareWorkforcePathwayAwarenessComponent extends Question implements 
       this.submitAction = { action: 'continue', save: true };
     } else {
       this.nextRoute = this.skipRoute;
+      this.hasGivenNotAwareAnswer = true;
+    }
+  }
+
+  private hasComeFromSummaryPanelLink(): boolean {
+    return (
+      this.return &&
+      Array.isArray(this.return.url) &&
+      this.return.url.length === 1 &&
+      this.return.url[0] === '/dashboard' &&
+      this.return.fragment === 'home'
+    );
+  }
+
+  protected addAlert(): void {
+    if (this.hasComeFromSummaryPanelLink() && this.hasGivenNotAwareAnswer) {
+      this.alertService.addAlert({
+        type: 'success',
+        message: `Care workforce pathway information saved in '${this.establishment.name}'`,
+      });
     }
   }
 

--- a/frontend/src/app/features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component.ts
@@ -110,18 +110,8 @@ export class CareWorkforcePathwayAwarenessComponent extends Question implements 
     }
   }
 
-  private hasComeFromSummaryPanelLink(): boolean {
-    return (
-      this.return &&
-      Array.isArray(this.return.url) &&
-      this.return.url.length === 1 &&
-      this.return.url[0] === '/dashboard' &&
-      this.return.fragment === 'home'
-    );
-  }
-
   protected addAlert(): void {
-    if (this.hasComeFromSummaryPanelLink() && this.hasGivenNotAwareAnswer) {
+    if (this.establishmentService.returnIsSetToHomePage() && this.hasGivenNotAwareAnswer) {
       this.alertService.addAlert({
         type: 'success',
         message: `Care workforce pathway information saved in '${this.establishment.name}'`,

--- a/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.ts
@@ -222,18 +222,8 @@ export class CareWorkforcePathwayUseComponent extends Question implements OnInit
     );
   }
 
-  private hasComeFromSummaryPanelLink(): boolean {
-    return (
-      this.return &&
-      Array.isArray(this.return.url) &&
-      this.return.url.length === 1 &&
-      this.return.url[0] === '/dashboard' &&
-      this.return.fragment === 'home'
-    );
-  }
-
   protected addAlert(): void {
-    if (this.hasComeFromSummaryPanelLink()) {
+    if (this.establishmentService.returnIsSetToHomePage()) {
       this.alertService.addAlert({
         type: 'success',
         message: `Care workforce pathway information saved in '${this.establishment.name}'`,

--- a/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.ts
@@ -5,6 +5,7 @@ import {
   CareWorkforcePathwayUseReason,
   UpdateCareWorkforcePathwayUsePayload,
 } from '@core/model/care-workforce-pathway.model';
+import { AlertService } from '@core/services/alert.service';
 import { BackService } from '@core/services/back.service';
 import { BackLinkService } from '@core/services/backLink.service';
 import { CareWorkforcePathwayService } from '@core/services/care-workforce-pathway.service';
@@ -37,6 +38,7 @@ export class CareWorkforcePathwayUseComponent extends Question implements OnInit
     protected careWorkforcePathwayService: CareWorkforcePathwayService,
     protected route: ActivatedRoute,
     private backLinkService: BackLinkService,
+    protected alertService: AlertService,
   ) {
     super(formBuilder, router, backService, errorSummaryService, establishmentService);
   }
@@ -218,6 +220,25 @@ export class CareWorkforcePathwayUseComponent extends Question implements OnInit
         (error) => this.onError(error),
       ),
     );
+  }
+
+  private hasComeFromSummaryPanelLink(): boolean {
+    return (
+      this.return &&
+      Array.isArray(this.return.url) &&
+      this.return.url.length === 1 &&
+      this.return.url[0] === '/dashboard' &&
+      this.return.fragment === 'home'
+    );
+  }
+
+  protected addAlert(): void {
+    if (this.hasComeFromSummaryPanelLink()) {
+      this.alertService.addAlert({
+        type: 'success',
+        message: `Care workforce pathway information saved in '${this.establishment.name}'`,
+      });
+    }
   }
 
   protected onSuccess(): void {

--- a/frontend/src/app/features/workplace/question/question.component.ts
+++ b/frontend/src/app/features/workplace/question/question.component.ts
@@ -176,11 +176,13 @@ export class Question implements OnInit, OnDestroy, AfterViewInit {
   }
   protected createDynamicErrorMessaging(): void {}
   protected addErrorLinkFunctionality(): void {}
+  protected addAlert(): void {}
 
   protected _onSuccess(data) {
     this.establishmentService.setState({ ...this.establishment, ...data });
     this.onSuccess();
     this.navigate();
+    this.addAlert();
   }
 
   protected onError(error) {


### PR DESCRIPTION
#### Work done
- Added display of banner when user has completed the workplace CWP questions and come from the summary panel link on the home page

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
