### PR TITLE
Bugfix/1730 updating other qual and social care qual in funding

### DIFF
--- a/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
@@ -239,6 +239,78 @@ describe('StaffRecordSummaryComponent', () => {
 
       expect(component.allRequiredFieldsUpdatedAndEligible()).toBeTrue();
     });
+
+    it('should return true if otherQualification needs updating but is set to Yes and all other required fields are eligible', async () => {
+      const { component, fixture } = await setup();
+
+      component.worker.wdf.otherQualification = eligibleButNotUpdatedObject;
+      component.worker.otherQualification = 'Yes';
+
+      fixture.detectChanges();
+
+      expect(component.allRequiredFieldsUpdatedAndEligible()).toBeTrue();
+    });
+
+    it('should return false if otherQualification is set to Yes but highestQualification needs updating', async () => {
+      const { component, fixture } = await setup();
+
+      component.worker.wdf.otherQualification = eligibleButNotUpdatedObject;
+      component.worker.otherQualification = 'Yes';
+
+      component.worker.wdf.highestQualification = eligibleButNotUpdatedObject;
+
+      fixture.detectChanges();
+
+      expect(component.allRequiredFieldsUpdatedAndEligible()).toBeFalse();
+    });
+
+    it('should return true if qualificationInSocialCare needs updating but is set to Yes and all other required fields are eligible', async () => {
+      const { component, fixture } = await setup();
+
+      component.worker.wdf.qualificationInSocialCare = eligibleButNotUpdatedObject;
+      component.worker.qualificationInSocialCare = 'Yes';
+
+      fixture.detectChanges();
+
+      expect(component.allRequiredFieldsUpdatedAndEligible()).toBeTrue();
+    });
+
+    it('should return false if qualificationInSocialCare is set to Yes but socialCareQualification needs updating', async () => {
+      const { component, fixture } = await setup();
+
+      component.worker.wdf.qualificationInSocialCare = eligibleButNotUpdatedObject;
+      component.worker.qualificationInSocialCare = 'Yes';
+
+      component.worker.wdf.socialCareQualification = eligibleButNotUpdatedObject;
+
+      fixture.detectChanges();
+
+      expect(component.allRequiredFieldsUpdatedAndEligible()).toBeFalse();
+    });
+
+    ['No', "Don't know"].forEach((answer) => {
+      it(`should return false if otherQualification needs updating and is set to something other than Yes (${answer})`, async () => {
+        const { component, fixture } = await setup();
+
+        component.worker.wdf.otherQualification = eligibleButNotUpdatedObject;
+        component.worker.otherQualification = answer;
+
+        fixture.detectChanges();
+
+        expect(component.allRequiredFieldsUpdatedAndEligible()).toBeFalse();
+      });
+
+      it(`should return false if qualificationInSocialCare needs updating and is set to something other than Yes (${answer})`, async () => {
+        const { component, fixture } = await setup();
+
+        component.worker.wdf.qualificationInSocialCare = eligibleButNotUpdatedObject;
+        component.worker.qualificationInSocialCare = answer;
+
+        fixture.detectChanges();
+
+        expect(component.allRequiredFieldsUpdatedAndEligible()).toBeFalse();
+      });
+    });
   });
 
   describe('WdfFieldConfirmation', () => {

--- a/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.spec.ts
@@ -2,8 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter, Router } from '@angular/router';
 import { Contracts } from '@core/model/contracts.enum';
 import { Establishment } from '@core/model/establishment.model';
 import { Eligibility } from '@core/model/wdf.model';
@@ -26,7 +25,7 @@ import { StaffRecordSummaryComponent } from './staff-record-summary.component';
 describe('StaffRecordSummaryComponent', () => {
   const setup = async (overrides: any = {}) => {
     const setupTools = await render(StaffRecordSummaryComponent, {
-      imports: [SharedModule, RouterTestingModule, HttpClientTestingModule, BrowserModule, FundingModule],
+      imports: [SharedModule, HttpClientTestingModule, BrowserModule, FundingModule],
       providers: [
         InternationalRecruitmentService,
         {
@@ -39,6 +38,7 @@ describe('StaffRecordSummaryComponent', () => {
           useClass: MockWorkerService,
         },
         WdfConfirmFieldsService,
+        provideRouter([]),
       ],
       componentProperties: {
         wdfView: overrides.wdfView ?? true,

--- a/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
+++ b/frontend/src/app/shared/components/staff-record-summary/staff-record-summary.component.ts
@@ -173,11 +173,11 @@ export class StaffRecordSummaryComponent implements OnInit, OnDestroy {
       'highestQualification',
       'mainJob',
       'mainJobStartDate',
-      'otherQualification',
-      'socialCareQualification',
       'weeklyHoursAverage',
       'weeklyHoursContracted',
       'zeroHoursContract',
+      this.worker.otherQualification === 'Yes' ? 'highestQualification' : 'otherQualification',
+      this.worker.qualificationInSocialCare === 'Yes' ? 'socialCareQualification' : 'qualificationInSocialCare',
     ];
 
     return requiredFields.every((field) => {


### PR DESCRIPTION
#### Issue
An issue was raised where staff records are showing as ineligible in the funding section, but there are no flags asking them to update/confirm fields. After investigation, this was found to be linked to how confirmations work for the ‘Other qualifications’ and ‘Highest level of other qualifications’ fields, and the same issue exists with ‘Qualification in social care’ and ‘Highest level in social care’.

If you’ve answered yes to the other qualifications question, you only see the confirmation button on the highest level question, and when you click confirm, it confirms for both questions. However, if the user goes in and changes the answer to the highest level question instead of confirming, then it only updates ‘Other qualifications’. In this case, the user will not see a confirmation button, but ‘Other qualifications’ still needs updating.

#### Work done
- Updated checks for whether all required fields have been updated to check first or second questions depending on answers to the two part qualification questions
- Refactored spec file to simplify how worker fields are set and to avoid having to update fields after the component has rendered in the tests

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
