### PR TITLE
Fix/care workforce pathway worker question alert

### DIFF
--- a/frontend/cypress/e2e/standAloneEstablishment/EditUser/staffRecordsPage.spec.cy.js
+++ b/frontend/cypress/e2e/standAloneEstablishment/EditUser/staffRecordsPage.spec.cy.js
@@ -163,8 +163,7 @@ describe('Standalone staff records page as edit user', () => {
       cy.contains('Staff record details saved').should('be.visible');
     });
 
-    // skipped this test, as the expected behaviour is broken by a bug introduced when we added CWP role category question
-    it.skip('should not show a "Staff record details saved" alert when user completed the workflow and skipped all questions', () => {
+    it('should not show a "Staff record details saved" alert when user completed the workflow and skipped all questions', () => {
       const name = 'Mr Smith';
       const contractType = 'Permanent';
       const mainJobRole = 'Care worker';

--- a/frontend/src/app/features/workers/care-workforce-pathway/care-workforce-pathway.component.spec.ts
+++ b/frontend/src/app/features/workers/care-workforce-pathway/care-workforce-pathway.component.spec.ts
@@ -257,9 +257,11 @@ describe('CareWorkforcePathwayRoleComponent', () => {
     });
 
     ['Skip this question', 'View this staff record'].forEach((link) => {
-      it(`should add Staff record added alert when '${link}' is clicked`, async () => {
+      it(`should add Staff record added alert when '${link}' is clicked, if user has answered other question before`, async () => {
         const overrides = { insideFlow: true };
-        const { getByText, alertSpy } = await setup(overrides);
+        const { getByText, alertSpy, workerService } = await setup(overrides);
+
+        spyOn(workerService, 'hasAnsweredNonMandatoryQuestion').and.returnValue(true);
 
         fireEvent.click(getByText(link));
 
@@ -267,6 +269,17 @@ describe('CareWorkforcePathwayRoleComponent', () => {
           type: 'success',
           message: 'Staff record details saved',
         });
+      });
+
+      it(`should not add Staff record added alert when '${link}' is clicked, if user have not answered other question before`, async () => {
+        const overrides = { insideFlow: true };
+        const { getByText, alertSpy, workerService } = await setup(overrides);
+
+        spyOn(workerService, 'hasAnsweredNonMandatoryQuestion').and.returnValue(false);
+
+        fireEvent.click(getByText(link));
+
+        expect(alertSpy).not.toHaveBeenCalled();
       });
     });
 

--- a/frontend/src/app/features/workers/care-workforce-pathway/care-workforce-pathway.component.ts
+++ b/frontend/src/app/features/workers/care-workforce-pathway/care-workforce-pathway.component.ts
@@ -110,20 +110,12 @@ export class CareWorkforcePathwayRoleComponent extends FinalQuestionComponent {
     };
   }
 
-  onSubmit(): void {
-    super.onSubmit();
-
-    if (!this.submitted && this.insideFlow) {
-      this.addCompletedStaffFlowAlert();
-    }
-  }
-
   addAlert(): void {
-    if (this.insideFlow) {
-      this.addCompletedStaffFlowAlert();
-    } else if (this.cameFromCWPSummaryPage) {
+    if (!this.insideFlow && this.cameFromCWPSummaryPage) {
       this.addRoleCategorySavedAlert();
     }
+
+    super.addAlert();
   }
 
   private addRoleCategorySavedAlert(): void {


### PR DESCRIPTION
#### Work done
- fix an issue of 'Staff record details saved' alert appear after CWP worker question, when all questions were skipped
(this also fix a broken test in our e2e test suite)

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
