### PR TITLE
Fix: Saved banner flashing after answering CWP questions from summary panel link

### DIFF
--- a/frontend/src/app/features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component.spec.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component.spec.ts
@@ -320,7 +320,7 @@ describe('CareWorkforcePathwayAwarenessComponent', () => {
     notAwareAnswers.forEach((answer) => {
       it(`should display banner when user submits '${answer.title}' and return is to home page`, async () => {
         const workplaceName = 'Test workplace name';
-        const { getByText, getByLabelText, alertSpy } = await setup({
+        const { fixture, getByText, getByLabelText, alertSpy } = await setup({
           returnTo: { url: ['/dashboard'], fragment: 'home' },
           establishment: { name: workplaceName },
         });
@@ -330,6 +330,7 @@ describe('CareWorkforcePathwayAwarenessComponent', () => {
 
         const saveButton = getByText('Save');
         fireEvent.click(saveButton);
+        await fixture.whenStable();
 
         expect(alertSpy).toHaveBeenCalledWith({
           type: 'success',
@@ -339,7 +340,7 @@ describe('CareWorkforcePathwayAwarenessComponent', () => {
 
       it(`should not display banner when user submits '${answer.title}' but has not come from home page`, async () => {
         const workplaceName = 'Test workplace name';
-        const { getByText, getByLabelText, alertSpy } = await setup({
+        const { fixture, getByText, getByLabelText, alertSpy } = await setup({
           establishment: { name: workplaceName },
         });
 
@@ -348,6 +349,7 @@ describe('CareWorkforcePathwayAwarenessComponent', () => {
 
         const saveButton = getByText('Save');
         fireEvent.click(saveButton);
+        await fixture.whenStable();
 
         expect(alertSpy).not.toHaveBeenCalled();
       });
@@ -356,7 +358,7 @@ describe('CareWorkforcePathwayAwarenessComponent', () => {
     awareAnswers.forEach((answer) => {
       it('should not display banner when user gives aware answer which takes them to use question', async () => {
         const workplaceName = 'Test workplace name';
-        const { getByText, getByLabelText, alertSpy } = await setup({
+        const { fixture, getByText, getByLabelText, alertSpy } = await setup({
           returnTo: { url: ['/dashboard'], fragment: 'home' },
           establishment: { name: workplaceName },
         });
@@ -366,6 +368,7 @@ describe('CareWorkforcePathwayAwarenessComponent', () => {
 
         const saveButton = getByText('Save');
         fireEvent.click(saveButton);
+        await fixture.whenStable();
 
         expect(alertSpy).not.toHaveBeenCalled();
       });

--- a/frontend/src/app/features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-awareness/care-workforce-pathway-awareness.component.ts
@@ -19,6 +19,7 @@ export class CareWorkforcePathwayAwarenessComponent extends Question implements 
   public section = WorkplaceFlowSections.RECRUITMENT_AND_BENEFITS;
   public careWorkforcePathwayAwarenessAnswers: CareWorkforcePathwayWorkplaceAwarenessAnswer[];
   private hasGivenNotAwareAnswer: boolean;
+  private returnIsSetToHomePage: boolean;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -40,6 +41,7 @@ export class CareWorkforcePathwayAwarenessComponent extends Question implements 
     this.prefill();
 
     this.skipRoute = ['/workplace', this.establishment.uid, 'cash-loyalty'];
+    this.returnIsSetToHomePage = this.establishmentService.returnIsSetToHomePage();
   }
 
   private setPreviousRoute(): void {
@@ -111,7 +113,7 @@ export class CareWorkforcePathwayAwarenessComponent extends Question implements 
   }
 
   protected addAlert(): void {
-    if (this.establishmentService.returnIsSetToHomePage() && this.hasGivenNotAwareAnswer) {
+    if (this.returnIsSetToHomePage && this.hasGivenNotAwareAnswer) {
       this.alertService.addAlert({
         type: 'success',
         message: `Care workforce pathway information saved in '${this.establishment.name}'`,

--- a/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.spec.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.spec.ts
@@ -19,7 +19,7 @@ import { of, throwError } from 'rxjs';
 
 import { CareWorkforcePathwayUseComponent } from './care-workforce-pathway-use.component';
 
-fdescribe('CareWorkforcePathwayUseComponent', () => {
+describe('CareWorkforcePathwayUseComponent', () => {
   const RadioButtonLabels = {
     YES: 'Yes, we use the pathway for one or more reasons',
     NO: 'No, we do not currently use the pathway',
@@ -399,12 +399,13 @@ fdescribe('CareWorkforcePathwayUseComponent', () => {
     };
 
     it('should display banner when user submits and return is to home page', async () => {
-      const { getByText, getByLabelText, alertSpy } = await setup(comingFromSummaryPanelOverrides);
+      const { fixture, getByText, getByLabelText, alertSpy } = await setup(comingFromSummaryPanelOverrides);
 
       userEvent.click(getByLabelText(RadioButtonLabels.YES));
       userEvent.click(getByLabelText(mockReasons[0].text));
 
       userEvent.click(getByText('Save and return'));
+      await fixture.whenStable();
 
       expect(alertSpy).toHaveBeenCalledWith({
         type: 'success',
@@ -413,12 +414,13 @@ fdescribe('CareWorkforcePathwayUseComponent', () => {
     });
 
     it('should not display banner when user submits but has not come from home page', async () => {
-      const { getByText, getByLabelText, alertSpy } = await setup();
+      const { fixture, getByText, getByLabelText, alertSpy } = await setup();
 
       userEvent.click(getByLabelText(RadioButtonLabels.YES));
       userEvent.click(getByLabelText(mockReasons[0].text));
 
       userEvent.click(getByText('Save and return'));
+      await fixture.whenStable();
 
       expect(alertSpy).not.toHaveBeenCalled();
     });

--- a/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.ts
+++ b/frontend/src/app/features/workplace/care-workforce-pathway-use/care-workforce-pathway-use.component.ts
@@ -9,9 +9,9 @@ import { AlertService } from '@core/services/alert.service';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { PreviousRouteService } from '../../../core/services/previous-route.service';
 import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 
+import { PreviousRouteService } from '../../../core/services/previous-route.service';
 import { Question } from '../question/question.component';
 
 @Component({
@@ -27,6 +27,7 @@ export class CareWorkforcePathwayUseComponent extends Question implements OnInit
   ];
   public allReasons: Array<CareWorkforcePathwayUseReason> = [];
   public OtherReasonTextMaxLength = 120;
+  private returnIsSetToHomePage: boolean;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -47,6 +48,7 @@ export class CareWorkforcePathwayUseComponent extends Question implements OnInit
     this.prefill();
     this.setPreviousRoute();
     this.skipRoute = ['/workplace', this.establishment.uid, 'cash-loyalty'];
+    this.returnIsSetToHomePage = this.establishmentService.returnIsSetToHomePage();
   }
 
   private getAllReasons() {
@@ -221,7 +223,7 @@ export class CareWorkforcePathwayUseComponent extends Question implements OnInit
   }
 
   protected addAlert(): void {
-    if (this.establishmentService.returnIsSetToHomePage()) {
+    if (this.returnIsSetToHomePage) {
       this.alertService.addAlert({
         type: 'success',
         message: `Care workforce pathway information saved in '${this.establishment.name}'`,

--- a/frontend/src/app/features/workplace/question/question.component.ts
+++ b/frontend/src/app/features/workplace/question/question.component.ts
@@ -86,7 +86,7 @@ export class Question implements OnInit, OnDestroy, AfterViewInit {
     return this.errorSummaryService.getFormErrorMessage(item, errorType, this.formErrorsMap);
   }
 
-  protected navigate(): void {
+  protected navigate(): Promise<boolean> {
     const action = this.submitAction.action;
 
     if (!action) {
@@ -95,24 +95,18 @@ export class Question implements OnInit, OnDestroy, AfterViewInit {
 
     switch (action) {
       case 'continue':
-        this.router.navigate(this.nextRoute);
-        break;
-
+        return this.router.navigate(this.nextRoute);
       case 'summary':
-        this.router.navigate(['/workplace', this.establishment.uid, 'check-answers']);
-        break;
-
+        return this.router.navigate(['/workplace', this.establishment.uid, 'check-answers']);
       case 'skip':
-        this.router.navigate(this.skipRoute);
-        break;
-
+        return this.router.navigate(this.skipRoute);
       case 'exit':
-        this.router.navigate(['/dashboard'], { fragment: 'workplace' });
-        break;
-
+        return this.router.navigate(['/dashboard'], { fragment: 'workplace' });
       case 'return':
-        this.router.navigate(this.return.url, { fragment: this.return.fragment, queryParams: this.return.queryParams });
-        break;
+        return this.router.navigate(this.return.url, {
+          fragment: this.return.fragment,
+          queryParams: this.return.queryParams,
+        });
     }
   }
 
@@ -181,8 +175,10 @@ export class Question implements OnInit, OnDestroy, AfterViewInit {
   protected _onSuccess(data) {
     this.establishmentService.setState({ ...this.establishment, ...data });
     this.onSuccess();
-    this.navigate();
-    this.addAlert();
+
+    this.navigate().then(() => {
+      this.addAlert();
+    });
   }
 
   protected onError(error) {

--- a/frontend/src/app/features/workplace/vacancies-and-turnover/how-many-starters-leavers-vacancies.directive.ts
+++ b/frontend/src/app/features/workplace/vacancies-and-turnover/how-many-starters-leavers-vacancies.directive.ts
@@ -1,16 +1,16 @@
 import { Directive, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { UntypedFormArray, UntypedFormBuilder, Validators } from '@angular/forms';
-import { Leaver, Starter, StarterLeaverVacancy, UpdateJobsRequest, Vacancy } from '@core/model/establishment.model';
-import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
-
-import { Question } from '../question/question.component';
 import { Router } from '@angular/router';
+import { Leaver, Starter, StarterLeaverVacancy, UpdateJobsRequest, Vacancy } from '@core/model/establishment.model';
 import { BackService } from '@core/services/back.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { VacanciesAndTurnoverService } from '../../../core/services/vacancies-and-turnover.service';
-import { JobRoleNumbersTableComponent } from '@shared/components/job-role-numbers-table/job-role-numbers-table.component';
 import { FormatUtil } from '@core/utils/format-util';
+import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
+import { JobRoleNumbersTableComponent } from '@shared/components/job-role-numbers-table/job-role-numbers-table.component';
+
+import { VacanciesAndTurnoverService } from '../../../core/services/vacancies-and-turnover.service';
+import { Question } from '../question/question.component';
 
 @Directive()
 export class HowManyStartersLeaversVacanciesDirective extends Question implements OnInit, OnDestroy {
@@ -96,14 +96,14 @@ export class HowManyStartersLeaversVacanciesDirective extends Question implement
 
   protected onSuccess(): void {}
 
-  protected navigate(): void {
+  protected navigate(): Promise<boolean> {
     const action = this.submitAction.action;
 
     if (['continue', 'exit', 'return'].includes(action)) {
       this.clearLocalStorageData();
     }
 
-    super.navigate();
+    return super.navigate();
   }
 
   public setBackLink(): void {


### PR DESCRIPTION
#### Work done
- Use .then to ensure navigation is complete before banner is displayed for answering CWP questions, to prevent banner flashing before user is taken back to the home page

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
