### PR TITLE
fix/1729-bug-update-new-staff-record-message-for-not-meeting-staff-in-funding

### DIFF
--- a/frontend/src/app/features/funding/wdf-staff-summary/wdf-staff-summary.component.html
+++ b/frontend/src/app/features/funding/wdf-staff-summary/wdf-staff-summary.component.html
@@ -35,7 +35,7 @@
             <app-funding-requirements-state
               [overallWdfEligibility]="overallWdfEligibility"
               [currentWdfEligibility]="worker.wdfEligible"
-              orangeFlagMessage="New staff record"
+              orangeFlagMessage="Check this staff record"
             ></app-funding-requirements-state>
           </td>
         </tr>

--- a/frontend/src/app/features/funding/wdf-staff-summary/wdf-staff-summary.component.spec.ts
+++ b/frontend/src/app/features/funding/wdf-staff-summary/wdf-staff-summary.component.spec.ts
@@ -2,8 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, provideRouter, Router, RouterModule } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -31,9 +30,10 @@ describe('WdfStaffSummaryComponent', () => {
     const workers = [workerBuilder(), workerBuilder(), workerBuilder()] as Worker[];
 
     const setupTools = await render(WdfStaffSummaryComponent, {
-      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, FundingModule, RouterModule],
+      imports: [HttpClientTestingModule, BrowserModule, SharedModule, FundingModule, RouterModule],
       declarations: [PaginationComponent, TablePaginationWrapperComponent, SearchInputComponent],
       providers: [
+        provideRouter([]),
         {
           provide: PermissionsService,
           useFactory: MockPermissionsService.factory(['canViewWorker']),
@@ -228,7 +228,7 @@ describe('WdfStaffSummaryComponent', () => {
     const redFlagVisuallyHiddenMessage = 'Red flag';
     const greenTickVisuallyHiddenMessage = 'Green tick';
     const orangeFlagVisuallyHiddenMessage = 'Orange warning flag';
-    const newStaffRecordMessage = 'New staff record';
+    const newStaffRecordMessage = 'Check this staff record';
     const notMeetingMessage = 'Not meeting';
     const meetingMessage = 'Meeting';
 
@@ -250,7 +250,7 @@ describe('WdfStaffSummaryComponent', () => {
       expect(getAllByText(meetingMessage, { exact: true }).length).toBe(3);
     });
 
-    it("should display an orange flag and 'New staff record' on staff record when the user has qualified for WDF but 1 staff record is not eligible (new)", async () => {
+    it("should display an orange flag and 'Check this staff record' on staff record when the user has qualified for WDF but 1 staff record is not eligible (new)", async () => {
       const workers = [workerBuilder(), workerBuilder(), workerBuilder()] as Worker[];
       workers[0].wdfEligible = false;
       workers[1].wdfEligible = true;

--- a/frontend/src/app/features/funding/wdf-workplaces-summary/wdf-workplaces-summary.component.html
+++ b/frontend/src/app/features/funding/wdf-workplaces-summary/wdf-workplaces-summary.component.html
@@ -55,7 +55,7 @@
         <app-funding-requirements-state
           [overallWdfEligibility]="workplace.wdf.overall"
           [currentWdfEligibility]="workplace.wdf.staff"
-          orangeFlagMessage="New staff records"
+          orangeFlagMessage="Check staff records"
         ></app-funding-requirements-state>
       </td>
     </tr>

--- a/frontend/src/app/features/funding/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
+++ b/frontend/src/app/features/funding/wdf-workplaces-summary/wdf-workplaces-summary.component.spec.ts
@@ -2,8 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter, Router } from '@angular/router';
 import { DataPermissions, WorkplaceDataOwner } from '@core/model/my-workplaces.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { EstablishmentService } from '@core/services/establishment.service';
@@ -56,7 +55,7 @@ describe('WdfWorkplacesSummaryComponent', () => {
 
   const setup = async (overrides: any = {}) => {
     const setupTools = await render(WdfWorkplacesSummaryComponent, {
-      imports: [RouterTestingModule, HttpClientTestingModule, BrowserModule, SharedModule, FundingModule],
+      imports: [HttpClientTestingModule, BrowserModule, SharedModule, FundingModule],
       providers: [
         { provide: BreadcrumbService, useClass: MockBreadcrumbService },
         { provide: EstablishmentService, useClass: MockEstablishmentService },
@@ -69,6 +68,7 @@ describe('WdfWorkplacesSummaryComponent', () => {
             : MockPermissionsService.factory(['canEditEstablishment']),
           deps: [HttpClient, Router, UserService],
         },
+        provideRouter([]),
       ],
       componentProperties: {
         workplaces: mockWorkplaces(),
@@ -199,7 +199,7 @@ describe('WdfWorkplacesSummaryComponent', () => {
         expect(getByText('Check your workplace data', { exact: true })).toBeTruthy();
       });
 
-      it("should display orange flag and 'New staff records' message when the workplace has qualified for funding but staff records are ineligible", async () => {
+      it("should display orange flag and 'Check staff records' message when the workplace has qualified for funding but staff records are ineligible", async () => {
         const workplaces = [
           {
             name: 'Workplace name',
@@ -214,7 +214,7 @@ describe('WdfWorkplacesSummaryComponent', () => {
         const { getByText } = await setup({ workplaces });
 
         expect(getByText(orangeFlagVisuallyHiddenMessage, { exact: false })).toBeTruthy();
-        expect(getByText('New staff records', { exact: true })).toBeTruthy();
+        expect(getByText('Check staff records', { exact: true })).toBeTruthy();
       });
     });
 

--- a/frontend/src/app/shared/components/funding-requirements-state/funding-requirements-state.component.spec.ts
+++ b/frontend/src/app/shared/components/funding-requirements-state/funding-requirements-state.component.spec.ts
@@ -50,7 +50,7 @@ describe('FundingRequirementsStateComponent', () => {
 
   describe('orange warning flag', () => {
     it('should show the input message if orangeFlagMessage is passed in', async () => {
-      const inputMessage = 'New staff record';
+      const inputMessage = 'Check this staff record';
       const overrides = {
         currentWdfEligibility: false,
         overallWdfEligibility: true,


### PR DESCRIPTION
#### Work done
- Update funding requirements message for orange flag on the 'Staff records' and 'Your other workplaces'

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
