### PR TITLE
fix/1745 CWP use savedAt / changedAt date unexpected update when awareness question is answered.

### DIFF
--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -1404,6 +1404,7 @@ class Establishment extends EntityValidator {
         this._isParentApprovedBannerViewed = fetchResults.isParentApprovedBannerViewed;
         this._primaryAuthorityCssr = this.primaryAuthorityCssr;
         this._CWPAwarenessQuestionViewed = fetchResults.CWPAwarenessQuestionViewed;
+        this._careWorkforcePathwayUse = fetchResults.careWorkforcePathwayUse;
 
         // if history of the User is also required; attach the association
         //  and order in reverse chronological - note, order on id (not when)

--- a/backend/server/routes/establishments/careWorkforcePathway/careWorkforcePathwayAwareness.js
+++ b/backend/server/routes/establishments/careWorkforcePathway/careWorkforcePathwayAwareness.js
@@ -16,9 +16,12 @@ const updateCareWorkforcePathwayAwareness = async (req, res) => {
     let filteredProperties = ['Name', 'careWorkforcePathwayWorkplaceAwareness'];
 
     const notAwareAnswers = [4, 5];
+    const workplaceIsNotAwareOfCWP = notAwareAnswers.includes(careWorkforcePathwayWorkplaceAwareness?.id);
+    const cwpUseHasValue = thisEstablishment._careWorkforcePathwayUse !== null;
+
     let isValidEstablishment;
 
-    if (notAwareAnswers.includes(careWorkforcePathwayWorkplaceAwareness?.id)) {
+    if (workplaceIsNotAwareOfCWP && cwpUseHasValue) {
       isValidEstablishment = await thisEstablishment.load({
         careWorkforcePathwayWorkplaceAwareness,
         careWorkforcePathwayUse: { use: null, reasons: [] },

--- a/backend/server/test/unit/routes/establishments/careWorkforcePathway/careWorkforcePathwayAwareness.spec.js
+++ b/backend/server/test/unit/routes/establishments/careWorkforcePathway/careWorkforcePathwayAwareness.spec.js
@@ -27,6 +27,10 @@ describe('server/routes/establishments/careWorkforcePathway/CareWorkforcePathway
   const awareAnswers = [1, 2, 3];
   const notAwareAnswers = [4, 5];
 
+  const mockCWPUseValue = (useValue) => {
+    establishmentRecord._careWorkforcePathwayUse = useValue ?? null;
+  };
+
   beforeEach(() => {
     establishmentRecord = sinon.createStubInstance(Establishment.Establishment);
     sinon.stub(Establishment, 'Establishment').callsFake(() => establishmentRecord);
@@ -52,40 +56,73 @@ describe('server/routes/establishments/careWorkforcePathway/CareWorkforcePathway
     expect(res.statusCode).to.equal(200);
   });
 
-  awareAnswers.forEach((awareAnswer) => {
-    it(`should not call the load function with careWorkforcePathwayUse when the value is ${awareAnswer}`, async () => {
-      setupMockRequest(awareAnswer);
+  describe('When careWorkforcePathwayUse is null, it should not change careWorkforcePathwayUse', () => {
+    beforeEach(() => {
+      mockCWPUseValue(null);
+    });
 
-      establishmentRecord.restore = sinon.stub().resolves(true);
-      establishmentRecord.load = sinon.stub().resolves(true);
-      establishmentRecord.save = sinon.stub().resolves(true);
+    [...awareAnswers, ...notAwareAnswers].forEach((awarenessAnswer) => {
+      it(`awareness answer: ${awarenessAnswer}`, async () => {
+        setupMockRequest(awarenessAnswer);
 
-      const req = httpMocks.createRequest(mockRequest);
-      const res = httpMocks.createResponse();
-      await updateCareWorkforcePathwayAwareness(req, res);
+        establishmentRecord.restore = sinon.stub().resolves(true);
+        establishmentRecord.load = sinon.stub().resolves(true);
+        establishmentRecord.save = sinon.stub().resolves(true);
 
-      expect(establishmentRecord.load).to.have.been.calledWith(mockRequest.body);
-      expect(res.statusCode).to.equal(200);
+        const req = httpMocks.createRequest(mockRequest);
+        const res = httpMocks.createResponse();
+        await updateCareWorkforcePathwayAwareness(req, res);
+
+        expect(establishmentRecord.load).to.have.been.calledWith({
+          careWorkforcePathwayWorkplaceAwareness: { id: awarenessAnswer },
+        });
+        expect(res.statusCode).to.equal(200);
+      });
     });
   });
 
-  notAwareAnswers.forEach((awareAnswer) => {
-    it(`should call the load function with careWorkforcePathwayUse when the value is ${awareAnswer}`, async () => {
-      setupMockRequest(awareAnswer);
+  describe('When careWorkforcePathwayUse is not null, it should set careWorkforcePathwayUse to null only when awareness is falsy', () => {
+    beforeEach(() => {
+      mockCWPUseValue('Yes');
+    });
 
-      establishmentRecord.restore = sinon.stub().resolves(true);
-      establishmentRecord.load = sinon.stub().resolves(true);
-      establishmentRecord.save = sinon.stub().resolves(true);
+    awareAnswers.forEach((awarenessAnswer) => {
+      it(`awareness answer: ${awarenessAnswer}, should not change careWorkforcePathwayUse`, async () => {
+        setupMockRequest(awarenessAnswer);
 
-      const req = httpMocks.createRequest(mockRequest);
-      const res = httpMocks.createResponse();
-      await updateCareWorkforcePathwayAwareness(req, res);
+        establishmentRecord.restore = sinon.stub().resolves(true);
+        establishmentRecord.load = sinon.stub().resolves(true);
+        establishmentRecord.save = sinon.stub().resolves(true);
 
-      expect(establishmentRecord.load).to.have.been.calledWith({
-        careWorkforcePathwayWorkplaceAwareness: { id: awareAnswer },
-        careWorkforcePathwayUse: { use: null, reasons: [] },
+        const req = httpMocks.createRequest(mockRequest);
+        const res = httpMocks.createResponse();
+        await updateCareWorkforcePathwayAwareness(req, res);
+
+        expect(establishmentRecord.load).to.have.been.calledWith({
+          careWorkforcePathwayWorkplaceAwareness: { id: awarenessAnswer },
+        });
+        expect(res.statusCode).to.equal(200);
       });
-      expect(res.statusCode).to.equal(200);
+    });
+
+    notAwareAnswers.forEach((awarenessAnswer) => {
+      it(`awareness answer: ${awarenessAnswer}, should change careWorkforcePathwayUse to null`, async () => {
+        setupMockRequest(awarenessAnswer);
+
+        establishmentRecord.restore = sinon.stub().resolves(true);
+        establishmentRecord.load = sinon.stub().resolves(true);
+        establishmentRecord.save = sinon.stub().resolves(true);
+
+        const req = httpMocks.createRequest(mockRequest);
+        const res = httpMocks.createResponse();
+        await updateCareWorkforcePathwayAwareness(req, res);
+
+        expect(establishmentRecord.load).to.have.been.calledWith({
+          careWorkforcePathwayWorkplaceAwareness: { id: awarenessAnswer },
+          careWorkforcePathwayUse: { use: null, reasons: [] },
+        });
+        expect(res.statusCode).to.equal(200);
+      });
     });
   });
 


### PR DESCRIPTION
#### Work done
- Change CWP awareness endpoint to set CWP use to null only when both of the following conditions are met:
  1. CWP awareness is answered as "Not aware" or "Do not know"
  2. CWP use already got an answer before

When CareWorkforcePathway use is null (not answered) and CareWorkforcePathway Awareness is answered as “Not aware“ or “I don’t know“, currently the backend will try to set CareWorkforcePathway use to null again and add a date to the columns of CareWorkforcePathwayUseSavedAt and CareWorkforcePathwayUseChangedAt.  
This change is to prevent the said unwanted behaviour.
 
#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
