### PR TITLE
Feat/1750 parent sort option

### DIFF
--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2281,6 +2281,7 @@ module.exports = function (sequelize, DataTypes) {
     searchTerm = '',
     getPendingWorkplaces = false,
     getAttentionFlags = false,
+    sortBy = 'workplaceNameAsc',
   ) {
     const offset = pageIndex * limit;
     let ustatus;
@@ -2297,6 +2298,30 @@ module.exports = function (sequelize, DataTypes) {
         [Op.is]: null,
       };
     }
+
+    const order = {
+      workplaceNameAsc: [
+        [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
+        ['NameValue', 'ASC'],
+      ],
+      workplaceNameDesc: [
+        [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
+        ['NameValue', 'DESC'],
+      ],
+      workplaceToCheckAsc: [
+        [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
+        ['showFlag', 'DESC'],
+        ['NameValue', 'ASC'],
+      ],
+      workplaceToCheckDesc: [
+        [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
+        ['showFlag', 'DESC'],
+        ['NameValue', 'DESC'],
+      ],
+    }[sortBy] || [
+      [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
+      ['NameValue', 'ASC'],
+    ];
 
     const data = await this.findAndCountAll({
       attributes: [
@@ -2323,10 +2348,7 @@ module.exports = function (sequelize, DataTypes) {
         ustatus,
         ...(searchTerm ? { NameValue: { [Op.iLike]: `%${searchTerm}%` } } : {}),
       },
-      order: [
-        [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
-        ['NameValue', 'ASC'],
-      ],
+      order,
       ...(limit ? { limit } : {}),
       offset,
     });

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2299,28 +2299,22 @@ module.exports = function (sequelize, DataTypes) {
       };
     }
 
-    const order = {
-      workplaceNameAsc: [
-        [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
-        ['NameValue', 'ASC'],
-      ],
-      workplaceNameDesc: [
-        [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
-        ['NameValue', 'DESC'],
-      ],
+    const sortOptions = {
+      workplaceNameAsc: [['NameValue', 'ASC']],
+      workplaceNameDesc: [['NameValue', 'DESC']],
       workplaceToCheckAsc: [
-        [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
         ['showFlag', 'DESC'],
         ['NameValue', 'ASC'],
       ],
       workplaceToCheckDesc: [
-        [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
         ['showFlag', 'DESC'],
         ['NameValue', 'DESC'],
       ],
-    }[sortBy] || [
+    };
+
+    const order = [
       [sequelize.literal("\"Status\" IN ('PENDING', 'IN PROGRESS')"), 'ASC'],
-      ['NameValue', 'ASC'],
+      ...(sortOptions[sortBy] ?? [['NameValue', 'ASC']]),
     ];
 
     const data = await this.findAndCountAll({
@@ -2596,4 +2590,4 @@ module.exports = function (sequelize, DataTypes) {
   };
 
   return Establishment;
-};
+};;

--- a/backend/server/routes/establishments/childWorkplaces.js
+++ b/backend/server/routes/establishments/childWorkplaces.js
@@ -5,7 +5,7 @@ const Authorization = require('../../utils/security/isAuthenticated');
 
 const getChildWorkplaces = async (req, res) => {
   try {
-    const { itemsPerPage, pageIndex, searchTerm, getPendingWorkplaces } = req.query;
+    const { itemsPerPage, pageIndex, searchTerm, getPendingWorkplaces, sortBy } = req.query;
 
     const childWorkplaces = await models.establishment.getChildWorkplaces(
       req.params.id,
@@ -14,6 +14,7 @@ const getChildWorkplaces = async (req, res) => {
       searchTerm,
       convertToBoolean(getPendingWorkplaces),
       true,
+      sortBy,
     );
 
     const activeWorkplaceCount = childWorkplaces.count - childWorkplaces.pendingCount;

--- a/backend/server/test/unit/routes/establishments/childWorkplaces.spec.js
+++ b/backend/server/test/unit/routes/establishments/childWorkplaces.spec.js
@@ -165,6 +165,16 @@ describe('server/routes/establishments/childWorkplaces', () => {
 
       expect(modelStub.args[0][5]).to.equal(true);
     });
+
+    it('should call getChildWorkplaces on establishment model with sortBy when sortBy in req', async () => {
+      const modelStub = sinon.stub(models.establishment, 'getChildWorkplaces').returns(modelData);
+
+      req.query.sortBy = 'workplaceNameDesc';
+
+      await getChildWorkplaces(req, res);
+
+      expect(modelStub.args[0][6]).to.equal(req.query.sortBy);
+    });
   });
 
   describe('formatChildWorkplaces', () => {

--- a/frontend/src/app/core/model/establishment.model.ts
+++ b/frontend/src/app/core/model/establishment.model.ts
@@ -306,8 +306,16 @@ export enum SortTrainingAndQualsOptionsCat {
   '3_category' = 'Category',
 }
 
+export enum SortYourOtherWorkplaces {
+  '0_asc' = 'Workplace name (A to Z)',
+  '0_dsc' = 'Workplace name (Z to A)',
+  '1_asc' = 'Workplaces to check (A to Z)',
+  '1_dsc' = 'Workplaces to check (Z to A)',
+}
+
 export enum FilterTrainingAndQualsOptions {
   '0_showall' = 'Show all',
   '1_expired' = 'Expired',
   '2_expires_soon' = 'Expires soon',
 }
+

--- a/frontend/src/app/core/resolvers/child-workplaces.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/child-workplaces.resolver.spec.ts
@@ -4,8 +4,6 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 
 import { ChildWorkplacesResolver } from './child-workplaces.resolver';
-import { WorkplaceService } from '@core/services/workplace.service';
-import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
 
 describe('ChildWorkplacesResolver', () => {
   function setup() {
@@ -17,23 +15,17 @@ describe('ChildWorkplacesResolver', () => {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
         },
-        {
-          provide: WorkplaceService,
-          useClass: MockWorkplaceService,
-        },
       ],
     });
 
     const resolver = TestBed.inject(ChildWorkplacesResolver);
 
-    const workplaceService = TestBed.inject(WorkplaceService) as WorkplaceService;
     const establishmentService = TestBed.inject(EstablishmentService);
     spyOn(establishmentService, 'getChildWorkplaces').and.callThrough();
 
     return {
       resolver,
       establishmentService,
-      workplaceService,
     };
   }
 
@@ -55,16 +47,18 @@ describe('ChildWorkplacesResolver', () => {
   });
 
   it('should call getChildWorkplaces with id from establishmentService, initial pagination params and sort value', () => {
-    const { resolver, establishmentService, workplaceService } = setup();
+    const { resolver, establishmentService } = setup();
 
     const sortKey = 'workplaceToCheckAsc';
 
-    workplaceService.setAllWorkplacesSortValue(sortKey);
+    const localStorageSpy = spyOn(localStorage, 'getItem').and.returnValue(sortKey);
+
     const primaryWorkplaceUid = '98a83eef-e1e1-49f3-89c5-b1287a3cc8de';
     const queryParams = { pageIndex: 0, itemsPerPage: 12, getPendingWorkplaces: true, sortBy: sortKey };
 
     resolver.resolve();
 
+    expect(localStorageSpy).toHaveBeenCalled();
     expect(establishmentService.getChildWorkplaces).toHaveBeenCalledWith(primaryWorkplaceUid, queryParams);
   });
 });

--- a/frontend/src/app/core/resolvers/child-workplaces.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/child-workplaces.resolver.spec.ts
@@ -1,32 +1,39 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 
 import { ChildWorkplacesResolver } from './child-workplaces.resolver';
+import { WorkplaceService } from '@core/services/workplace.service';
+import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
 
 describe('ChildWorkplacesResolver', () => {
   function setup() {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      imports: [HttpClientTestingModule],
       providers: [
         ChildWorkplacesResolver,
         {
           provide: EstablishmentService,
           useClass: MockEstablishmentService,
         },
+        {
+          provide: WorkplaceService,
+          useClass: MockWorkplaceService,
+        },
       ],
     });
 
     const resolver = TestBed.inject(ChildWorkplacesResolver);
 
+    const workplaceService = TestBed.inject(WorkplaceService) as WorkplaceService;
     const establishmentService = TestBed.inject(EstablishmentService);
     spyOn(establishmentService, 'getChildWorkplaces').and.callThrough();
 
     return {
       resolver,
       establishmentService,
+      workplaceService,
     };
   }
 
@@ -40,7 +47,21 @@ describe('ChildWorkplacesResolver', () => {
     const { resolver, establishmentService } = setup();
 
     const primaryWorkplaceUid = '98a83eef-e1e1-49f3-89c5-b1287a3cc8de';
-    const queryParams = { pageIndex: 0, itemsPerPage: 12, getPendingWorkplaces: true };
+    const queryParams = { pageIndex: 0, itemsPerPage: 12, getPendingWorkplaces: true, sortBy: null };
+
+    resolver.resolve();
+
+    expect(establishmentService.getChildWorkplaces).toHaveBeenCalledWith(primaryWorkplaceUid, queryParams);
+  });
+
+  it('should call getChildWorkplaces with id from establishmentService, initial pagination params and sort value', () => {
+    const { resolver, establishmentService, workplaceService } = setup();
+
+    const sortKey = 'workplaceToCheckAsc';
+
+    workplaceService.setAllWorkplacesSortValue(sortKey);
+    const primaryWorkplaceUid = '98a83eef-e1e1-49f3-89c5-b1287a3cc8de';
+    const queryParams = { pageIndex: 0, itemsPerPage: 12, getPendingWorkplaces: true, sortBy: sortKey };
 
     resolver.resolve();
 

--- a/frontend/src/app/core/resolvers/child-workplaces.resolver.ts
+++ b/frontend/src/app/core/resolvers/child-workplaces.resolver.ts
@@ -2,21 +2,16 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { GetChildWorkplacesResponse } from '@core/model/my-workplaces.model';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { WorkplaceService } from '@core/services/workplace.service';
 import { Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class ChildWorkplacesResolver {
-  constructor(
-    private router: Router,
-    private establishmentService: EstablishmentService,
-    private workplaceService: WorkplaceService,
-  ) {}
+  constructor(private router: Router, private establishmentService: EstablishmentService) {}
 
   resolve(): Observable<GetChildWorkplacesResponse | null> {
     const primaryWorkplaceUid = this.establishmentService.primaryWorkplace.uid;
-    const sortByValueFromHomePage = this.workplaceService.getAllWorkplacesSortValue() ?? null;
+    const sortByValueFromHomePage = localStorage.getItem('yourOtherWorkplacesSortValue') ?? null;
 
     return this.establishmentService
       .getChildWorkplaces(primaryWorkplaceUid, {

--- a/frontend/src/app/core/resolvers/child-workplaces.resolver.ts
+++ b/frontend/src/app/core/resolvers/child-workplaces.resolver.ts
@@ -2,18 +2,29 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { GetChildWorkplacesResponse } from '@core/model/my-workplaces.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { WorkplaceService } from '@core/services/workplace.service';
 import { Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
-export class ChildWorkplacesResolver  {
-  constructor(private router: Router, private establishmentService: EstablishmentService) {}
+export class ChildWorkplacesResolver {
+  constructor(
+    private router: Router,
+    private establishmentService: EstablishmentService,
+    private workplaceService: WorkplaceService,
+  ) {}
 
   resolve(): Observable<GetChildWorkplacesResponse | null> {
     const primaryWorkplaceUid = this.establishmentService.primaryWorkplace.uid;
+    const sortByValueFromHomePage = this.workplaceService.getAllWorkplacesSortValue() ?? null;
 
     return this.establishmentService
-      .getChildWorkplaces(primaryWorkplaceUid, { pageIndex: 0, itemsPerPage: 12, getPendingWorkplaces: true })
+      .getChildWorkplaces(primaryWorkplaceUid, {
+        pageIndex: 0,
+        itemsPerPage: 12,
+        getPendingWorkplaces: true,
+        sortBy: sortByValueFromHomePage,
+      })
       .pipe(
         catchError(() => {
           this.router.navigate(['/problem-with-the-service']);

--- a/frontend/src/app/core/services/workplace.service.spec.ts
+++ b/frontend/src/app/core/services/workplace.service.spec.ts
@@ -25,10 +25,10 @@ describe('WorkplaceService', () => {
   });
 
   it('should set the international recruitment worker answers', () => {
-    const allWorkplaceSortValue = 'workplaceToCheckAsc';
+    const allWorkplacesSortValue = 'workplaceToCheckAsc';
 
-    service.setAllWorkplaceSortValue(allWorkplaceSortValue);
+    service.setAllWorkplacesSortValue(allWorkplacesSortValue);
 
-    expect(service.getAllWorkplaceSortValue()).toBe(allWorkplaceSortValue);
+    expect(service.getAllWorkplacesSortValue()).toBe(allWorkplacesSortValue);
   });
 });

--- a/frontend/src/app/core/services/workplace.service.spec.ts
+++ b/frontend/src/app/core/services/workplace.service.spec.ts
@@ -23,12 +23,4 @@ describe('WorkplaceService', () => {
   it('should create the service', () => {
     expect(service).toBeTruthy();
   });
-
-  it('should set the all workplaces sort value answers', () => {
-    const allWorkplacesSortValue = 'workplaceToCheckAsc';
-
-    service.setAllWorkplacesSortValue(allWorkplacesSortValue);
-
-    expect(service.getAllWorkplacesSortValue()).toBe(allWorkplacesSortValue);
-  });
 });

--- a/frontend/src/app/core/services/workplace.service.spec.ts
+++ b/frontend/src/app/core/services/workplace.service.spec.ts
@@ -24,7 +24,7 @@ describe('WorkplaceService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should set the international recruitment worker answers', () => {
+  it('should set the all workplaces sort value answers', () => {
     const allWorkplacesSortValue = 'workplaceToCheckAsc';
 
     service.setAllWorkplacesSortValue(allWorkplacesSortValue);

--- a/frontend/src/app/core/services/workplace.service.spec.ts
+++ b/frontend/src/app/core/services/workplace.service.spec.ts
@@ -1,0 +1,34 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { WorkplaceService } from './workplace.service';
+import { TestBed } from '@angular/core/testing';
+
+describe('WorkplaceService', () => {
+  let service: WorkplaceService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [WorkplaceService],
+    });
+    service = TestBed.inject(WorkplaceService);
+
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    TestBed.inject(HttpTestingController).verify();
+  });
+
+  it('should create the service', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should set the international recruitment worker answers', () => {
+    const allWorkplaceSortValue = 'workplaceToCheckAsc';
+
+    service.setAllWorkplaceSortValue(allWorkplaceSortValue);
+
+    expect(service.getAllWorkplaceSortValue()).toBe(allWorkplaceSortValue);
+  });
+});

--- a/frontend/src/app/core/services/workplace.service.ts
+++ b/frontend/src/app/core/services/workplace.service.ts
@@ -17,6 +17,7 @@ export class WorkplaceService extends WorkplaceInterfaceService {
     super(http);
   }
 
+  private _allWorkplaceSortValue: string;
   public addWorkplaceFlow$: BehaviorSubject<string> = new BehaviorSubject(null);
   public addWorkplaceInProgress$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public serverErrorsMap: ErrorDefinition[] = [
@@ -27,7 +28,9 @@ export class WorkplaceService extends WorkplaceInterfaceService {
   ];
 
   public getServicesByCategory(isRegulated: boolean): Observable<Array<ServiceGroup>> {
-    return this.http.get<Array<ServiceGroup>>(`${environment.appRunnerEndpoint}/api/services/byCategory?cqc=${isRegulated}`);
+    return this.http.get<Array<ServiceGroup>>(
+      `${environment.appRunnerEndpoint}/api/services/byCategory?cqc=${isRegulated}`,
+    );
   }
 
   public getAllMandatoryTrainings(establishmentId: number): Observable<any> {
@@ -35,7 +38,10 @@ export class WorkplaceService extends WorkplaceInterfaceService {
   }
 
   public addWorkplace(establishmentuid: string, request: AddWorkplaceRequest): Observable<AddWorkplaceResponse> {
-    return this.http.post<AddWorkplaceResponse>(`${environment.appRunnerEndpoint}/api/establishment/${establishmentuid}`, request);
+    return this.http.post<AddWorkplaceResponse>(
+      `${environment.appRunnerEndpoint}/api/establishment/${establishmentuid}`,
+      request,
+    );
   }
 
   public resetService(): void {
@@ -65,5 +71,13 @@ export class WorkplaceService extends WorkplaceInterfaceService {
       totalStaff: WorkplaceTotalStaff,
       typeOfEmployer: employerTypeObject,
     };
+  }
+
+  public setAllWorkplaceSortValue(value: string) {
+    this._allWorkplaceSortValue = value;
+  }
+
+  public getAllWorkplaceSortValue() {
+    return this._allWorkplaceSortValue;
   }
 }

--- a/frontend/src/app/core/services/workplace.service.ts
+++ b/frontend/src/app/core/services/workplace.service.ts
@@ -17,7 +17,6 @@ export class WorkplaceService extends WorkplaceInterfaceService {
     super(http);
   }
 
-  private _allWorkplacesSortValue: string;
   public addWorkplaceFlow$: BehaviorSubject<string> = new BehaviorSubject(null);
   public addWorkplaceInProgress$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public serverErrorsMap: ErrorDefinition[] = [
@@ -71,13 +70,5 @@ export class WorkplaceService extends WorkplaceInterfaceService {
       totalStaff: WorkplaceTotalStaff,
       typeOfEmployer: employerTypeObject,
     };
-  }
-
-  public setAllWorkplacesSortValue(value: string) {
-    this._allWorkplacesSortValue = value;
-  }
-
-  public getAllWorkplacesSortValue(): string {
-    return this._allWorkplacesSortValue;
   }
 }

--- a/frontend/src/app/core/services/workplace.service.ts
+++ b/frontend/src/app/core/services/workplace.service.ts
@@ -17,7 +17,7 @@ export class WorkplaceService extends WorkplaceInterfaceService {
     super(http);
   }
 
-  private _allWorkplaceSortValue: string;
+  private _allWorkplacesSortValue: string;
   public addWorkplaceFlow$: BehaviorSubject<string> = new BehaviorSubject(null);
   public addWorkplaceInProgress$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public serverErrorsMap: ErrorDefinition[] = [
@@ -73,11 +73,11 @@ export class WorkplaceService extends WorkplaceInterfaceService {
     };
   }
 
-  public setAllWorkplaceSortValue(value: string) {
-    this._allWorkplaceSortValue = value;
+  public setAllWorkplacesSortValue(value: string) {
+    this._allWorkplacesSortValue = value;
   }
 
-  public getAllWorkplaceSortValue() {
-    return this._allWorkplaceSortValue;
+  public getAllWorkplacesSortValue(): string {
+    return this._allWorkplacesSortValue;
   }
 }

--- a/frontend/src/app/core/test-utils/MockWorkplaceService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkplaceService.ts
@@ -94,7 +94,6 @@ export class MockWorkplaceService extends WorkplaceService {
   public postcodeOrLocationId$: BehaviorSubject<string> = new BehaviorSubject(null);
   public totalStaff$: BehaviorSubject<any> = new BehaviorSubject(null);
   public typeOfEmployer$: BehaviorSubject<EmployerType> = new BehaviorSubject(null);
-  public allWorkplacesSortValue: string;
 
   public static factory(typeOfEmployer: EmployerType = { value: 'Private Sector' }, manyLocationAddresses = false) {
     return (http: HttpClient) => {
@@ -136,14 +135,6 @@ export class MockWorkplaceService extends WorkplaceService {
 
   public checkIfEstablishmentExists(locationId: string): Observable<EstablishmentExistsResponse> {
     return of({ exists: false });
-  }
-
-  public setAllWorkplacesSortValue(value: string) {
-    this.allWorkplacesSortValue = value;
-  }
-
-  public getAllWorkplacesSortValue(): string {
-    return this.allWorkplacesSortValue;
   }
 }
 

--- a/frontend/src/app/core/test-utils/MockWorkplaceService.ts
+++ b/frontend/src/app/core/test-utils/MockWorkplaceService.ts
@@ -94,6 +94,7 @@ export class MockWorkplaceService extends WorkplaceService {
   public postcodeOrLocationId$: BehaviorSubject<string> = new BehaviorSubject(null);
   public totalStaff$: BehaviorSubject<any> = new BehaviorSubject(null);
   public typeOfEmployer$: BehaviorSubject<EmployerType> = new BehaviorSubject(null);
+  public allWorkplacesSortValue: string;
 
   public static factory(typeOfEmployer: EmployerType = { value: 'Private Sector' }, manyLocationAddresses = false) {
     return (http: HttpClient) => {
@@ -135,6 +136,14 @@ export class MockWorkplaceService extends WorkplaceService {
 
   public checkIfEstablishmentExists(locationId: string): Observable<EstablishmentExistsResponse> {
     return of({ exists: false });
+  }
+
+  public setAllWorkplacesSortValue(value: string) {
+    this.allWorkplacesSortValue = value;
+  }
+
+  public getAllWorkplacesSortValue(): string {
+    return this.allWorkplacesSortValue;
   }
 }
 

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.html
@@ -48,13 +48,41 @@
 </div>
 
 <div *ngIf="totalWorkplaceCount; else noWorkplaces">
-  <div *ngIf="totalWorkplaceCount > itemsPerPage" class="govuk-grid-row govuk-!-margin-bottom-5">
-    <div class="govuk-grid-column-three-quarters">
+  <div class="govuk-grid-row govuk-!-margin-bottom-5">
+    <div
+      *ngIf="totalWorkplaceCount > itemsPerPage"
+      class="govuk-grid-column-three-quarters govuk-!-padding-right-0 search-column"
+    >
       <app-search-input
         accessibleLabel="child workplace records"
         [prevSearch]="searchTerm"
         (emitInput)="handleSearch($event)"
       ></app-search-input>
+    </div>
+
+    <div
+      class="govuk-grid-column-one-quarter govuk-!-padding-top-2 govuk-!-margin-right-0 "
+      data-testid="sortBy"
+      *ngIf="totalWorkplaceCount > 1"
+      style="width: fit-content !important"
+      [ngClass]="{ 'sort-column' : totalWorkplaceCount > itemsPerPage, 'govuk-util__float-right' : totalWorkplaceCount <= itemsPerPage}"
+    >
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="sortBy"> Sort by </label>
+        <select
+          class="govuk-select"
+
+          id="sortBy"
+          name="sortBy"
+          (change)="sortBy($event.target.value)"
+        >
+          <option
+            *ngFor="let option of sortOptions | keyvalue"
+            value="{{ option.key }}"
+            [selected]="option.key === sortBySelectedKey"
+          >{{ option.value }}</option>
+        </select>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.scss
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.scss
@@ -1,0 +1,12 @@
+@media (min-width: 40.0625em) {
+  .search-column {
+    width: 70.5% !important;
+  }
+}
+
+@media (min-width: 1024px) {
+  .sort-column {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+}

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
@@ -345,7 +345,7 @@ describe('ViewMyWorkplacesComponent', () => {
       expect(component.sortBySelectedValue).toEqual(component.sortByParamMap[sortKey]);
     });
 
-    it('should call the sortBy function when selecting a different parameter for sorting and emit properties for getting workers', async () => {
+    it('should call the sortBy function when selecting a different parameter for sorting', async () => {
       const { component, getByLabelText, getChildWorkplacesSpy } = await setup();
 
       const handleSortSpy = spyOn(component, 'sortBy').and.callThrough();

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
@@ -25,8 +25,6 @@ import sinon from 'sinon';
 
 import { WorkplaceInfoPanelComponent } from '../workplace-info-panel/workplace-info-panel.component';
 import { ViewMyWorkplacesComponent } from './view-my-workplaces.component';
-import { WorkplaceService } from '@core/services/workplace.service';
-import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
 
 describe('ViewMyWorkplacesComponent', () => {
   async function setup(overrides: any = {}) {
@@ -61,10 +59,6 @@ describe('ViewMyWorkplacesComponent', () => {
         {
           provide: FeatureFlagsService,
           useClass: MockFeatureFlagsService,
-        },
-        {
-          provide: WorkplaceService,
-          useClass: MockWorkplaceService,
         },
         {
           provide: ActivatedRoute,
@@ -103,7 +97,6 @@ describe('ViewMyWorkplacesComponent', () => {
 
     const permissionsService = injector.inject(PermissionsService) as PermissionsService;
     const establishmentService = TestBed.inject(EstablishmentService) as EstablishmentService;
-    const workplaceService = TestBed.inject(WorkplaceService) as WorkplaceService;
 
     const getChildWorkplacesSpy = spyOn(establishmentService, 'getChildWorkplaces').and.callThrough();
 
@@ -112,7 +105,6 @@ describe('ViewMyWorkplacesComponent', () => {
       component,
       getChildWorkplacesSpy,
       establishmentService,
-      workplaceService,
     };
   }
 
@@ -308,15 +300,16 @@ describe('ViewMyWorkplacesComponent', () => {
       expect(sortByDiv.getAttribute('class')).toContain('govuk-util__float-right');
     });
 
-    it('should call set the sort to value set in getAllWorkplacesSortValue', async () => {
-      const { component, workplaceService } = await setup({ hasChildWorkplaces: true });
+    it('should call localStorage to get the sort to value set', async () => {
+      const { component } = await setup({ hasChildWorkplaces: true });
 
       const sortKey = '1_asc';
 
-      workplaceService.setAllWorkplacesSortValue(component.sortByParamMap[sortKey]);
+      const localStorageSpy = spyOn(localStorage, 'getItem').and.returnValue(component.sortByParamMap[sortKey]);
 
       component.ngOnInit();
 
+      expect(localStorageSpy).toHaveBeenCalled();
       expect(component.sortBySelectedValue).toEqual(component.sortByParamMap[sortKey]);
     });
 
@@ -324,6 +317,7 @@ describe('ViewMyWorkplacesComponent', () => {
       const { component, getByLabelText, getChildWorkplacesSpy } = await setup();
 
       const handleSortSpy = spyOn(component, 'sortBy').and.callThrough();
+      const localStorageSpy = spyOn(localStorage, 'setItem');
 
       const sortByObjectKeys = Object.keys(component.sortOptions);
       userEvent.selectOptions(getByLabelText('Sort by'), sortByObjectKeys[1]);
@@ -336,6 +330,7 @@ describe('ViewMyWorkplacesComponent', () => {
         getPendingWorkplaces: true,
         sortBy: sortBySelectedValue,
       });
+      expect(localStorageSpy.calls.all()[0].args).toEqual(['yourOtherWorkplacesSortValue', sortBySelectedValue]);
     });
   });
 });

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
@@ -75,7 +75,7 @@ describe('ViewMyWorkplacesComponent', () => {
                   overrides.hasChildWorkplaces ?? true
                     ? {
                         childWorkplaces: [subsid1, subsid2, subsid3],
-                        count: 3,
+                        count: overrides.totalWorkplaceCount ?? 3,
                         activeWorkplaceCount: 2,
                       }
                     : {
@@ -157,11 +157,7 @@ describe('ViewMyWorkplacesComponent', () => {
     });
 
     it('should call getChildWorkplaces with correct search term if passed', async () => {
-      const { component, fixture, getByLabelText, getChildWorkplacesSpy } = await setup();
-
-      // show search
-      component.totalWorkplaceCount = 13;
-      fixture.detectChanges();
+      const { getByLabelText, getChildWorkplacesSpy } = await setup({ totalWorkplaceCount: 13 });
 
       const searchInput = getByLabelText('Search child workplace records');
       expect(searchInput).toBeTruthy();
@@ -180,10 +176,7 @@ describe('ViewMyWorkplacesComponent', () => {
     });
 
     it('should reset the pageIndex before calling getChildWorkplaces when handling search', async () => {
-      const { fixture, component, getByLabelText, getChildWorkplacesSpy } = await setup();
-
-      component.totalWorkplaceCount = 13;
-      fixture.detectChanges();
+      const { fixture, getByLabelText, getChildWorkplacesSpy } = await setup({ totalWorkplaceCount: 13 });
 
       fixture.componentInstance.currentPageIndex = 1;
       fixture.detectChanges();
@@ -193,10 +186,7 @@ describe('ViewMyWorkplacesComponent', () => {
     });
 
     it('should render the no results returned message when 0 workplaces returned from getChildWorkplaces after search', async () => {
-      const { fixture, component, getByLabelText, establishmentService, getByText } = await setup();
-
-      component.totalWorkplaceCount = 13;
-      fixture.detectChanges();
+      const { fixture, getByLabelText, establishmentService, getByText } = await setup({ totalWorkplaceCount: 13 });
 
       sinon.stub(establishmentService, 'getChildWorkplaces').returns(
         of({
@@ -218,10 +208,9 @@ describe('ViewMyWorkplacesComponent', () => {
     });
 
     it('should not update All workplaces count when search results returned but should set workplaceCount used for pagination', async () => {
-      const { component, fixture, getByLabelText, establishmentService, getByText } = await setup();
-
-      component.totalWorkplaceCount = 13;
-      fixture.detectChanges();
+      const { component, fixture, getByLabelText, establishmentService, getByText } = await setup({
+        totalWorkplaceCount: 13,
+      });
 
       sinon.stub(establishmentService, 'getChildWorkplaces').returns(
         of({
@@ -290,29 +279,19 @@ describe('ViewMyWorkplacesComponent', () => {
     });
 
     it('should not show if there is 1 workplace', async () => {
-      const { component, queryByTestId, fixture } = await setup({ hasChildWorkplaces: true });
-
-      component.totalWorkplaceCount = 1;
-      fixture.detectChanges();
+      const { queryByTestId } = await setup({ hasChildWorkplaces: true, totalWorkplaceCount: 1 });
 
       expect(queryByTestId('sortBy')).toBeFalsy();
     });
 
     it('should show if there is more than 1 workplace', async () => {
-      const { component, fixture, getByTestId } = await setup({ hasChildWorkplaces: true });
-
-      component.totalWorkplaceCount = 5;
-      fixture.detectChanges();
+      const { getByTestId } = await setup({ hasChildWorkplaces: true, totalWorkplaceCount: 5 });
 
       expect(getByTestId('sortBy')).toBeTruthy();
     });
 
     it('should add the sort-column class when there is search and pagination', async () => {
-      const { component, fixture } = await setup({ hasChildWorkplaces: true });
-
-      component.totalWorkplaceCount = 15;
-
-      fixture.detectChanges();
+      const { fixture } = await setup({ hasChildWorkplaces: true, totalWorkplaceCount: 13 });
 
       const sortByDiv = fixture.nativeElement.querySelector('div[data-testid="sortBy"]');
 
@@ -321,11 +300,7 @@ describe('ViewMyWorkplacesComponent', () => {
     });
 
     it('should add the govuk-util__float-right class when there is no search and pagination', async () => {
-      const { component, fixture } = await setup({ hasChildWorkplaces: true });
-
-      component.totalWorkplaceCount = 4;
-
-      fixture.detectChanges();
+      const { fixture } = await setup({ hasChildWorkplaces: true, totalWorkplaceCount: 4 });
 
       const sortByDiv = fixture.nativeElement.querySelector('div[data-testid="sortBy"]');
 

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.spec.ts
@@ -25,48 +25,54 @@ import sinon from 'sinon';
 
 import { WorkplaceInfoPanelComponent } from '../workplace-info-panel/workplace-info-panel.component';
 import { ViewMyWorkplacesComponent } from './view-my-workplaces.component';
+import { WorkplaceService } from '@core/services/workplace.service';
+import { MockWorkplaceService } from '@core/test-utils/MockWorkplaceService';
 
 describe('ViewMyWorkplacesComponent', () => {
-  async function setup(hasChildWorkplaces = true) {
-    const { fixture, getByText, getByTestId, queryByText, getByLabelText, queryByLabelText, queryByTestId } =
-      await render(ViewMyWorkplacesComponent, {
-        imports: [SharedModule, RouterModule, HttpClientTestingModule],
-        declarations: [WorkplaceInfoPanelComponent],
-        providers: [
-          AlertService,
-          WindowRef,
-          {
-            provide: PermissionsService,
-            useFactory: MockPermissionsService.factory(['canAddEstablishment']),
-            deps: [HttpClient, Router, UserService],
-          },
-          {
-            provide: AuthService,
-            useClass: MockAuthService,
-          },
-          {
-            provide: UserService,
-            useClass: MockUserService,
-            deps: [HttpClient],
-          },
-          {
-            provide: EstablishmentService,
-            useClass: MockEstablishmentService,
-          },
-          {
-            provide: BreadcrumbService,
-            useClass: MockBreadcrumbService,
-          },
-          {
-            provide: FeatureFlagsService,
-            useClass: MockFeatureFlagsService,
-          },
-          {
-            provide: ActivatedRoute,
-            useValue: {
-              snapshot: {
-                data: {
-                  childWorkplaces: hasChildWorkplaces
+  async function setup(overrides: any = {}) {
+    const setupTools = await render(ViewMyWorkplacesComponent, {
+      imports: [SharedModule, RouterModule, HttpClientTestingModule],
+      declarations: [WorkplaceInfoPanelComponent],
+      providers: [
+        AlertService,
+        WindowRef,
+        {
+          provide: PermissionsService,
+          useFactory: MockPermissionsService.factory(['canAddEstablishment']),
+          deps: [HttpClient, Router, UserService],
+        },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
+        },
+        {
+          provide: UserService,
+          useClass: MockUserService,
+          deps: [HttpClient],
+        },
+        {
+          provide: EstablishmentService,
+          useClass: MockEstablishmentService,
+        },
+        {
+          provide: BreadcrumbService,
+          useClass: MockBreadcrumbService,
+        },
+        {
+          provide: FeatureFlagsService,
+          useClass: MockFeatureFlagsService,
+        },
+        {
+          provide: WorkplaceService,
+          useClass: MockWorkplaceService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                childWorkplaces:
+                  overrides.hasChildWorkplaces ?? true
                     ? {
                         childWorkplaces: [subsid1, subsid2, subsid3],
                         count: 3,
@@ -77,40 +83,36 @@ describe('ViewMyWorkplacesComponent', () => {
                         count: 0,
                         activeWorkplaceCount: 0,
                       },
-                  cqcLocations: hasChildWorkplaces
+                cqcLocations:
+                  overrides.hasChildWorkplaces ?? true
                     ? {
                         showMissingCqcMessage: true,
                       }
                     : {
                         showMissingCqcMessage: false,
                       },
-                },
               },
             },
           },
-        ],
-      });
+        },
+      ],
+    });
 
-    const component = fixture.componentInstance;
+    const component = setupTools.fixture.componentInstance;
     const injector = getTestBed();
 
     const permissionsService = injector.inject(PermissionsService) as PermissionsService;
     const establishmentService = TestBed.inject(EstablishmentService) as EstablishmentService;
+    const workplaceService = TestBed.inject(WorkplaceService) as WorkplaceService;
 
     const getChildWorkplacesSpy = spyOn(establishmentService, 'getChildWorkplaces').and.callThrough();
 
     return {
+      ...setupTools,
       component,
-      fixture,
-      permissionsService,
-      getByText,
-      getByTestId,
-      queryByText,
-      getByLabelText,
-      queryByLabelText,
-      queryByTestId,
       getChildWorkplacesSpy,
       establishmentService,
+      workplaceService,
     };
   }
 
@@ -142,7 +144,7 @@ describe('ViewMyWorkplacesComponent', () => {
   });
 
   it('should display no workplaces message when workplace has no child workplaces', async () => {
-    const { getByTestId } = await setup(false);
+    const { getByTestId } = await setup({ hasChildWorkplaces: false });
     expect(getByTestId('noWorkplacesMessage')).toBeTruthy();
   });
 
@@ -171,6 +173,7 @@ describe('ViewMyWorkplacesComponent', () => {
         itemsPerPage: 12,
         searchTerm: 'search term here',
         getPendingWorkplaces: true,
+        sortBy: 'workplaceNameAsc',
       };
 
       expect(getChildWorkplacesSpy.calls.mostRecent().args[1]).toEqual(expectedEmit);
@@ -242,19 +245,19 @@ describe('ViewMyWorkplacesComponent', () => {
 
   describe('missing cqc workplaces message', () => {
     it('should not show if missingCqcWorkplaces is false ', async () => {
-      const { queryByTestId } = await setup(false);
+      const { queryByTestId } = await setup({ hasChildWorkplaces: false });
 
       expect(queryByTestId('missingCqcWorkplaces')).toBeFalsy();
     });
 
     it('should not show if missingCqcWorkplaces is true', async () => {
-      const { queryByTestId } = await setup(true);
+      const { queryByTestId } = await setup({ hasChildWorkplaces: true });
 
       expect(queryByTestId('missingCqcWorkplaces')).toBeTruthy();
     });
 
     it('should show the primary workplace name, if missingCqcWorkplaces is true', async () => {
-      const { component, getByTestId } = await setup(true);
+      const { component, getByTestId } = await setup({ hasChildWorkplaces: true });
 
       const missingCqcWorkplacesMessage = getByTestId('missingCqcWorkplaces');
 
@@ -262,7 +265,7 @@ describe('ViewMyWorkplacesComponent', () => {
     });
 
     it('should show link to CQC provider page with provider ID in url', async () => {
-      const { component, getByText } = await setup(true);
+      const { component, getByText } = await setup({ hasChildWorkplaces: true });
 
       const cqcLink = getByText('Please check your CQC workplaces');
 
@@ -277,5 +280,87 @@ describe('ViewMyWorkplacesComponent', () => {
 
     expect(linkText).toBeTruthy();
     expect(linkText.getAttribute('href')).toEqual('/workplace/about-parents');
+  });
+
+  describe('sort by', () => {
+    it('should not show if there are no workplaces', async () => {
+      const { queryByTestId } = await setup({ hasChildWorkplaces: false });
+
+      expect(queryByTestId('sortBy')).toBeFalsy();
+    });
+
+    it('should not show if there is 1 workplace', async () => {
+      const { component, queryByTestId, fixture } = await setup({ hasChildWorkplaces: true });
+
+      component.totalWorkplaceCount = 1;
+      fixture.detectChanges();
+
+      expect(queryByTestId('sortBy')).toBeFalsy();
+    });
+
+    it('should show if there is more than 1 workplace', async () => {
+      const { component, fixture, getByTestId } = await setup({ hasChildWorkplaces: true });
+
+      component.totalWorkplaceCount = 5;
+      fixture.detectChanges();
+
+      expect(getByTestId('sortBy')).toBeTruthy();
+    });
+
+    it('should add the sort-column class when there is search and pagination', async () => {
+      const { component, fixture } = await setup({ hasChildWorkplaces: true });
+
+      component.totalWorkplaceCount = 15;
+
+      fixture.detectChanges();
+
+      const sortByDiv = fixture.nativeElement.querySelector('div[data-testid="sortBy"]');
+
+      expect(sortByDiv.getAttribute('class')).toContain('sort-column');
+      expect(sortByDiv.getAttribute('class')).not.toContain('govuk-util__float-right');
+    });
+
+    it('should add the govuk-util__float-right class when there is no search and pagination', async () => {
+      const { component, fixture } = await setup({ hasChildWorkplaces: true });
+
+      component.totalWorkplaceCount = 4;
+
+      fixture.detectChanges();
+
+      const sortByDiv = fixture.nativeElement.querySelector('div[data-testid="sortBy"]');
+
+      expect(sortByDiv.getAttribute('class')).not.toContain('sort-column');
+      expect(sortByDiv.getAttribute('class')).toContain('govuk-util__float-right');
+    });
+
+    it('should call set the sort to value set in getAllWorkplacesSortValue', async () => {
+      const { component, workplaceService } = await setup({ hasChildWorkplaces: true });
+
+      const sortKey = '1_asc';
+
+      workplaceService.setAllWorkplacesSortValue(component.sortByParamMap[sortKey]);
+
+      component.ngOnInit();
+
+      expect(component.sortBySelectedValue).toEqual(component.sortByParamMap[sortKey]);
+    });
+
+    it('should call the sortBy function when selecting a different parameter for sorting and emit properties for getting workers', async () => {
+      const { component, getByLabelText, getChildWorkplacesSpy } = await setup();
+
+      const handleSortSpy = spyOn(component, 'sortBy').and.callThrough();
+
+      const sortByObjectKeys = Object.keys(component.sortOptions);
+      userEvent.selectOptions(getByLabelText('Sort by'), sortByObjectKeys[1]);
+
+      expect(handleSortSpy).toHaveBeenCalledWith(sortByObjectKeys[1]);
+      const { primaryWorkplace, currentPageIndex, itemsPerPage, sortBySelectedValue } = component;
+      expect(getChildWorkplacesSpy).toHaveBeenCalledWith(primaryWorkplace.uid, {
+        pageIndex: currentPageIndex,
+        itemsPerPage,
+        getPendingWorkplaces: true,
+        sortBy: sortBySelectedValue,
+      });
+    });
   });
 });

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
@@ -10,7 +10,6 @@ import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
-import { WorkplaceService } from '@core/services/workplace.service';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -35,7 +34,7 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
   public providerId: string;
   public showMissingCqcMessage: boolean;
   public missingCqcLocations: any;
-  public sortByValueFromHomePage: string;
+  public sortByValueFromLocalStorage: string;
   public sortBySelectedKey: string;
   public sortBySelectedValue = 'workplaceNameAsc';
   public sortOptions: any;
@@ -53,7 +52,6 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
     private permissionsService: PermissionsService,
     private route: ActivatedRoute,
     private alertService: AlertService,
-    private workplaceService: WorkplaceService,
   ) {}
 
   ngOnInit(): void {
@@ -75,11 +73,11 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
 
     this.sortOptions = SortYourOtherWorkplaces;
 
-    this.sortByValueFromHomePage = this.workplaceService.getAllWorkplacesSortValue();
+    this.sortByValueFromLocalStorage = localStorage.getItem('yourOtherWorkplacesSortValue');
 
-    this.sortBySelectedValue = this.sortByValueFromHomePage ?? this.sortBySelectedValue;
+    this.sortBySelectedValue = this.sortByValueFromLocalStorage ?? this.sortBySelectedValue;
     this.sortBySelectedKey =
-      this.getSortKeyByValue(this.sortByParamMap, this.sortByValueFromHomePage) ?? this.sortBySelectedKey;
+      this.getSortKeyByValue(this.sortByParamMap, this.sortByValueFromLocalStorage) ?? this.sortBySelectedKey;
   }
 
   public getSortKeyByValue(object: any, value: string) {
@@ -139,6 +137,7 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
 
   public sortBy(sortType: string): void {
     this.sortBySelectedValue = this.sortByParamMap[sortType];
+    localStorage.setItem('yourOtherWorkplacesSortValue', this.sortBySelectedValue);
     this.currentPageIndex = 0;
 
     this.getChildWorkplaces();

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.html
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.html
@@ -49,7 +49,7 @@
     <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-left-4 govuk-!-margin-right-4" />
     <div class="summary-section" data-testid="workplaces-row">
       <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-3 govuk-body-l summary-section__links">
-        <a class="govuk-link--no-visited-state" [routerLink]="['/workplace/view-all-workplaces']">
+        <a class="govuk-link--no-visited-state" (click)="navigateToYourOtherWorkplaces($event, 'workplaceNameAsc')" href="#" id="otherWorkplacesSectionLinkText">
           {{ otherWorkplacesSection.linkText }}
         </a>
       </div>
@@ -69,7 +69,7 @@
             data-testid="red-flag"
             *ngIf="otherWorkplacesSection.redFlag"
           />
-          <a [routerLink]="['/workplace', 'view-all-workplaces']" href="#"> {{ otherWorkplacesSection.message }}</a>
+          <a (click)="navigateToYourOtherWorkplaces($event, 'workplaceToCheckAsc')" href="#" id="otherWorkplacesSectionMessage"> {{ otherWorkplacesSection.message }}</a>
         </ng-container>
         <ng-template #noWorkplacesLink>
           {{ otherWorkplacesSection.message }}

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -71,7 +71,7 @@ describe('Summary section', () => {
     );
     const setReturnToSpy = spyOn(establishmentService, 'setReturnTo');
     const workplaceService = injector.inject(WorkplaceService) as WorkplaceService;
-    const workplaceServiceSpy = spyOn(workplaceService, 'setAllWorkplaceSortValue').and.callThrough();
+    const workplaceServiceSpy = spyOn(workplaceService, 'setAllWorkplacesSortValue').and.callThrough();
 
     return {
       ...setupTools,

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -16,7 +16,6 @@ import { of } from 'rxjs';
 
 import { Establishment } from '../../../../mockdata/establishment';
 import { SummarySectionComponent } from './summary-section.component';
-import { WorkplaceService } from '@core/services/workplace.service';
 
 describe('Summary section', () => {
   const setup = async (overrides: any = {}) => {
@@ -70,8 +69,8 @@ describe('Summary section', () => {
       of(null),
     );
     const setReturnToSpy = spyOn(establishmentService, 'setReturnTo');
-    const workplaceService = injector.inject(WorkplaceService) as WorkplaceService;
-    const workplaceServiceSpy = spyOn(workplaceService, 'setAllWorkplacesSortValue').and.callThrough();
+
+    const localStorageSpy = spyOn(localStorage, 'setItem');
 
     return {
       ...setupTools,
@@ -80,7 +79,7 @@ describe('Summary section', () => {
       tabsService,
       updateSingleFieldSpy,
       setReturnToSpy,
-      workplaceServiceSpy,
+      localStorageSpy,
     };
   };
 
@@ -1215,36 +1214,36 @@ describe('Summary section', () => {
     });
 
     describe('navigating to "Your other workplaces"', () => {
-      it('should call setAllWorkplaceSortValue with', async () => {
+      it('should call localstorage with the "workplaceNameAsc" sort value', async () => {
         const establishment = {
           ...Establishment,
           isParent: true,
         };
         const overrides = { establishment };
-        const { getByText, routerSpy, workplaceServiceSpy } = await setup(overrides);
+        const { getByText, routerSpy, localStorageSpy } = await setup(overrides);
 
         const yourOtherWorkplacesText = getByText('Your other workplaces');
 
         fireEvent.click(yourOtherWorkplacesText);
 
+        expect(localStorageSpy.calls.all()[0].args).toEqual(['yourOtherWorkplacesSortValue', 'workplaceNameAsc']);
         expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'view-all-workplaces']);
-        expect(workplaceServiceSpy).toHaveBeenCalledWith('workplaceNameAsc');
       });
 
-      it('should call setAllWorkplaceSortValue with', async () => {
+      it('should call localstorage with the "workplaceToCheckAsc" sort value', async () => {
         const establishment = {
           ...Establishment,
           isParent: true,
         };
         const overrides = { establishment, workplacesCount: 1, workplacesNeedAttention: true };
-        const { getByText, routerSpy, workplaceServiceSpy } = await setup(overrides);
+        const { getByText, routerSpy, localStorageSpy } = await setup(overrides);
 
         const checkWorkplacesText = getByText('You need to check your other workplaces');
 
         fireEvent.click(checkWorkplacesText);
 
+        expect(localStorageSpy.calls.all()[0].args).toEqual(['yourOtherWorkplacesSortValue', 'workplaceToCheckAsc']);
         expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'view-all-workplaces']);
-        expect(workplaceServiceSpy).toHaveBeenCalledWith('workplaceToCheckAsc');
       });
     });
   });

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -270,7 +270,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
 
   public navigateToYourOtherWorkplaces(event: Event, value: string) {
     event.preventDefault();
-    this.workplaceService.setAllWorkplaceSortValue(value);
+    this.workplaceService.setAllWorkplacesSortValue(value);
     this.router.navigate(['/workplace', 'view-all-workplaces']);
   }
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -5,6 +5,7 @@ import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { TabsService } from '@core/services/tabs.service';
+import { WorkplaceService } from '@core/services/workplace.service';
 import dayjs from 'dayjs';
 import { Subscription } from 'rxjs';
 
@@ -60,6 +61,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     private tabsService: TabsService,
     private establishmentService: EstablishmentService,
     private router: Router,
+    private workplaceService: WorkplaceService,
   ) {}
 
   ngOnInit(): void {
@@ -264,6 +266,12 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.establishmentService.updateSingleEstablishmentField(this.workplace.uid, cwpData).subscribe(),
     );
+  }
+
+  public navigateToYourOtherWorkplaces(event: Event, value: string) {
+    event.preventDefault();
+    this.workplaceService.setAllWorkplaceSortValue(value);
+    this.router.navigate(['/workplace', 'view-all-workplaces']);
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -5,7 +5,6 @@ import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { TabsService } from '@core/services/tabs.service';
-import { WorkplaceService } from '@core/services/workplace.service';
 import dayjs from 'dayjs';
 import { Subscription } from 'rxjs';
 
@@ -61,7 +60,6 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     private tabsService: TabsService,
     private establishmentService: EstablishmentService,
     private router: Router,
-    private workplaceService: WorkplaceService,
   ) {}
 
   ngOnInit(): void {
@@ -268,9 +266,9 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     );
   }
 
-  public navigateToYourOtherWorkplaces(event: Event, value: string) {
+  public navigateToYourOtherWorkplaces(event: Event, yourOtherWorkplacesSortValue: string) {
     event.preventDefault();
-    this.workplaceService.setAllWorkplacesSortValue(value);
+    localStorage.setItem('yourOtherWorkplacesSortValue', yourOtherWorkplacesSortValue);
     this.router.navigate(['/workplace', 'view-all-workplaces']);
   }
 


### PR DESCRIPTION
#### Work done
- Add sort option to Your other workplaces page
- Update backend to return child workplaces in the order of requested sort
- Add function in WorkplaceService to hold sort value when coming from home page

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
