### PR TITLE
Fix/E2E test on pipeline pull limit error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13
+FROM public.ecr.aws/docker/library/postgres:13
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
#### Work done
- In Dockerfile, use postgres image from AWS ECR public gallery instead of docker hub, so that we can avoid the pull limit of dockerhub.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
