### PR TITLE
Bug fix: 1776 Users unable to download training files in bulk upload

### DIFF
--- a/backend/server/routes/establishments/bulkUpload/download/trainingCSV.js
+++ b/backend/server/routes/establishments/bulkUpload/download/trainingCSV.js
@@ -12,7 +12,7 @@ const toCSV = (establishmentId, workerId, entity) => {
     convertDateFormatToDayMonthYearWithSlashes(entity.completed),
     convertDateFormatToDayMonthYearWithSlashes(entity.expires),
     convertAccredited(entity.accredited),
-    entity.notes ? csvQuote(decodeURI(entity.notes)) : '',
+    entity.notes ? csvQuote(unescape(entity.notes)) : '',
   ];
 
   return columns.join(',');

--- a/backend/server/test/unit/routes/establishments/bulkUpload/download/trainingCSV.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/download/trainingCSV.spec.js
@@ -97,12 +97,14 @@ describe('trainingCSV', () => {
             expect(csvAsArray[6]).to.equal(accredited);
           });
         });
+
         it('should return training notes', async () => {
           const csv = toCSV(establishment.LocalIdentifierValue, worker.LocalIdentifierValue, trainingRecord);
           const csvAsArray = csv.split(',');
 
           expect(csvAsArray[7]).to.equal(trainingRecord.notes);
         });
+
         it('should not return training notes', async () => {
           trainingRecord.notes = null;
           const csv = toCSV(establishment.LocalIdentifierValue, worker.LocalIdentifierValue, trainingRecord);
@@ -110,6 +112,39 @@ describe('trainingCSV', () => {
 
           expect(csvAsArray[7]).to.equal('');
         });
+      });
+    });
+
+    describe('Notes edge cases', () => {
+      it('should leave notes as is when unusual characters in original string which are not hexadecimal conversions', () => {
+        const trainingRecord = apiTrainingBuilder();
+        trainingRecord.notes = 'A%b%%c!£$%^&*(';
+
+        const csv = toCSV(establishment.LocalIdentifierValue, worker.LocalIdentifierValue, trainingRecord);
+        const csvAsArray = csv.split(',');
+
+        expect(csvAsArray[7]).to.equal(trainingRecord.notes);
+      });
+
+      it('should convert %20s into spaces', () => {
+        const trainingRecord = apiTrainingBuilder();
+        trainingRecord.notes = 'Fire%20safety%20training';
+
+        const csv = toCSV(establishment.LocalIdentifierValue, worker.LocalIdentifierValue, trainingRecord);
+        const csvAsArray = csv.split(',');
+
+        expect(csvAsArray[7]).to.equal('Fire safety training');
+      });
+
+      it('should convert hexadecimal codes of unusual characters into original characters', () => {
+        const trainingRecord = apiTrainingBuilder();
+        trainingRecord.notes =
+          'A%20very%20important%20note%27s%20hard%20to%20find%20-%20this%20saying%20is%20such%20a%20clich%E9';
+
+        const csv = toCSV(establishment.LocalIdentifierValue, worker.LocalIdentifierValue, trainingRecord);
+        const csvAsArray = csv.split(',');
+
+        expect(csvAsArray[7]).to.equal("A very important note's hard to find - this saying is such a cliché");
       });
     });
   });


### PR DESCRIPTION
#### Issue
Some users had reported that they were unable to download their training files in bulk upload. Investigation showed that it was linked to unusual characters in their training notes. 

#### Work done
- Updated `toCSV` function to use the same conversion as other areas of codebase for training notes

#### Note
This matches the way notes are converted in the codebase, as notes are escaped before saving to the database, and are unescaped using the `unescape` function in the training class. However, it's not ideal using escape before saving to the database. The function itself was deprecated due to inconsistencies in how it parses strings, but also there's not much of a use case for escaping it as it is just a text field.

All notes are saved in this format so it would be a big job to change this set up and this is the easiest solution for now.

#### Tests
Does this PR include tests for the changes introduced?
- [X] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
