### PR TITLE
fix/1765-employer-type-free-text-box-does-not-appear-when-other-is-selected

### DIFF
--- a/frontend/src/app/features/workplace/type-of-employer/type-of-employer.component.html
+++ b/frontend/src/app/features/workplace/type-of-employer/type-of-employer.component.html
@@ -26,6 +26,7 @@
                   name="employerType"
                   type="radio"
                   [value]="option.value"
+                  (click)="onOtherSelect(option.value)"
                 />
                 <label class="govuk-label govuk-radios__label" for="employerType-{{ idx }}">
                   {{ option.text }}
@@ -35,8 +36,9 @@
               <div
                 *ngIf="option.value === 'Other'"
                 class="govuk-radios__conditional"
-                [class.govuk-radios__conditional--hidden]="form.get('employerType').value !== 'Other'"
+                [class.govuk-radios__conditional--hidden]="!showOtherInputField"
                 id="conditional-employerType-conditional-1"
+                data-testid="conditionalTextBox"
               >
                 <div class="govuk-form-group">
                   <label class="govuk-label" for="other"> Other employer type (optional)</label>

--- a/frontend/src/app/features/workplace/type-of-employer/type-of-employer.component.spec.ts
+++ b/frontend/src/app/features/workplace/type-of-employer/type-of-employer.component.spec.ts
@@ -28,7 +28,7 @@ describe('TypeOfEmployerComponent', () => {
         provideRouter([]),
         {
           provide: EstablishmentService,
-          useFactory: overrides.mockEstablishment
+          useFactory: overrides.establishment
             ? MockEstablishmentServiceWithOverrides.factory(overrides.establishment)
             : MockEstablishmentServiceWithNoEmployerType.factory(
                 overrides.employerTypeHasValue ?? true,
@@ -219,7 +219,7 @@ describe('TypeOfEmployerComponent', () => {
     });
 
     it('should show when "Other" was the previously saved answer', async () => {
-      const overrides = { mockEstablishment: true, establishment: { value: 'Other', other: 'some employer type' } };
+      const overrides = { establishment: { employerType: { value: 'Other', other: 'some employer type' } } };
       const { getByTestId, establishmentService } = await setup(overrides);
       spyOn(establishmentService, 'getEstablishment').and.callThrough();
 

--- a/frontend/src/app/features/workplace/type-of-employer/type-of-employer.component.spec.ts
+++ b/frontend/src/app/features/workplace/type-of-employer/type-of-employer.component.spec.ts
@@ -1,9 +1,12 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { getTestBed } from '@angular/core/testing';
 import { UntypedFormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { provideRouter, Router, RouterModule } from '@angular/router';
 import { EstablishmentService } from '@core/services/establishment.service';
-import { MockEstablishmentServiceWithNoEmployerType } from '@core/test-utils/MockEstablishmentService';
+import {
+  MockEstablishmentServiceWithNoEmployerType,
+  MockEstablishmentServiceWithOverrides,
+} from '@core/test-utils/MockEstablishmentService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
@@ -25,10 +28,12 @@ describe('TypeOfEmployerComponent', () => {
         provideRouter([]),
         {
           provide: EstablishmentService,
-          useFactory: MockEstablishmentServiceWithNoEmployerType.factory(
-            overrides.employerTypeHasValue ?? true,
-            overrides.owner ?? 'Workplace',
-          ),
+          useFactory: overrides.mockEstablishment
+            ? MockEstablishmentServiceWithOverrides.factory(overrides.establishment)
+            : MockEstablishmentServiceWithNoEmployerType.factory(
+                overrides.employerTypeHasValue ?? true,
+                overrides.owner ?? 'Workplace',
+              ),
         },
       ],
     });
@@ -184,5 +189,43 @@ describe('TypeOfEmployerComponent', () => {
     fixture.detectChanges();
 
     expect(routerSpy).toHaveBeenCalledWith(['/workplace', 'mocked-uid']);
+  });
+
+  describe('Other textbox', () => {
+    optionsWithoutOther.forEach((answer) => {
+      it(`should not show when ${answer.text} is selected`, async () => {
+        const { fixture, getByLabelText, getByTestId, establishmentService } = await setup();
+        spyOn(establishmentService, 'getEstablishment').and.callThrough();
+
+        const radioButton = getByLabelText(answer.text);
+        fireEvent.click(radioButton);
+        fixture.detectChanges();
+
+        expect(getByTestId('conditionalTextBox').getAttribute('class')).toContain('govuk-radios__conditional--hidden');
+      });
+    });
+
+    it('should show when "Other" is selected', async () => {
+      const { fixture, getByTestId, getByLabelText, establishmentService } = await setup();
+      spyOn(establishmentService, 'getEstablishment').and.callThrough();
+
+      const radioButton = getByLabelText('Other');
+      fireEvent.click(radioButton);
+      fixture.detectChanges();
+
+      expect(getByTestId('conditionalTextBox').getAttribute('class')).not.toContain(
+        'govuk-radios__conditional--hidden',
+      );
+    });
+
+    it('should show when "Other" was the previously saved answer', async () => {
+      const overrides = { mockEstablishment: true, establishment: { value: 'Other', other: 'some employer type' } };
+      const { getByTestId, establishmentService } = await setup(overrides);
+      spyOn(establishmentService, 'getEstablishment').and.callThrough();
+
+      expect(getByTestId('conditionalTextBox').getAttribute('class')).not.toContain(
+        'govuk-radios__conditional--hidden',
+      );
+    });
   });
 });

--- a/frontend/src/app/features/workplace/type-of-employer/type-of-employer.component.ts
+++ b/frontend/src/app/features/workplace/type-of-employer/type-of-employer.component.ts
@@ -23,6 +23,7 @@ export class TypeOfEmployerComponent extends Question {
   public showSkipButton = true;
   public callToAction = 'Save and continue';
   public dataOwner: any;
+  public showOtherInputField = false;
 
   constructor(
     protected formBuilder: UntypedFormBuilder,
@@ -64,6 +65,10 @@ export class TypeOfEmployerComponent extends Question {
         employerType: this.establishment.employerType.value,
         other: this.establishment.employerType.other,
       });
+    }
+
+    if (this.establishment.employerType?.value === 'Other') {
+      this.showOtherInputField = true;
     }
   }
 
@@ -113,5 +118,9 @@ export class TypeOfEmployerComponent extends Question {
         (error) => this.onError(error),
       ),
     );
+  }
+
+  protected onOtherSelect(radioValue: string): void {
+    this.showOtherInputField = radioValue === 'Other';
   }
 }


### PR DESCRIPTION
### Issue
The employer type free text box does not appear when other is initially selected. It does flash up when you save and return and is there when you go back in to update/change but does not appear as it should

#### Work done
- The text box wasn't appearing due to the update on submit functionality on the form. Added a function to show the text box when other is selected and also when previously answered

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
