### PR TITLE
Feat/1759 sort on staff records

### DIFF
--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -1852,6 +1852,12 @@ module.exports = function (sequelize, DataTypes) {
         [sequelize.literal('"workers.missingMandatoryTrainingCount"'), 'DESC'],
         ['workers', 'NameOrIdValue', 'ASC'],
       ],
+      lastUpdateNewest: [[sequelize.literal('"workers.updated"'), 'DESC']],
+      lastUpdateOldest: [[sequelize.literal('"workers.updated"'), 'ASC']],
+      addMoreDetails: [
+        [sequelize.literal('"workers.CompletedValue"'), 'ASC'],
+        ['workers', 'NameOrIdValue', 'ASC'],
+      ],
     }[sortBy] || [['workers', 'NameOrIdValue', 'ASC']];
 
     return this.findAndCountAll({

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -137,6 +137,7 @@ import { SatisfactionSurveyComponent } from './features/satisfaction-survey/sati
 import { SentryErrorHandler } from './SentryErrorHandler.component';
 import { GetNoOfWorkersWhoRequireCareWorkforcePathwayRoleAnswerResolver } from '@core/resolvers/careWorkforcePathway/no-of-workers-with-care-workforce-pathway-category-role-unanswered.resolver';
 import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
+import { SortByService } from '@core/services/sortBy.service';
 
 @NgModule({
   declarations: [
@@ -227,6 +228,7 @@ import { FeatureFlagsResolver } from '@core/resolvers/feature-flags.resolver';
     WorkerService,
     InternationalRecruitmentService,
     PreviousRouteService,
+    SortByService,
     { provide: WindowToken, useFactory: windowProvider },
     {
       provide: HTTP_INTERCEPTORS,

--- a/frontend/src/app/core/model/establishment.model.ts
+++ b/frontend/src/app/core/model/establishment.model.ts
@@ -263,6 +263,9 @@ export enum SortStaffOptions {
   '0_dsc' = 'Staff name (Z to A)',
   '1_asc' = 'Job role (A to Z)',
   '1_dsc' = 'Job role (Z to A)',
+  '3_last_update_newest' = 'Last update (newest)',
+  '3_last_update_oldest' = 'Last update (oldest)',
+  '4_add_more_details' = 'Add more details',
 }
 
 export enum WdfSortStaffOptions {

--- a/frontend/src/app/core/resolvers/workers.resolver.ts
+++ b/frontend/src/app/core/resolvers/workers.resolver.ts
@@ -3,17 +3,19 @@ import { ActivatedRouteSnapshot, Router } from '@angular/router';
 import { WorkersResponse } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { SortByService } from '@core/services/sortBy.service';
 import { WorkerService } from '@core/services/worker.service';
 import { Observable, of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 
 @Injectable()
-export class WorkersResolver  {
+export class WorkersResolver {
   constructor(
     private router: Router,
     private workerService: WorkerService,
     private establishmentService: EstablishmentService,
     private permissionsService: PermissionsService,
+    private sortByService: SortByService,
   ) {}
 
   getLastUpdatedTrainingOrQualifications(training: string, qualifications: string): string {
@@ -44,7 +46,19 @@ export class WorkersResolver  {
     const workersNotCompleted = [];
     const workersCreatedDate = [];
 
-    const paginationParams = route.data.workerPagination ? { pageIndex: 0, itemsPerPage: 15 } : {};
+    const { staffSummarySortValue, staffSummarySearchTerm, staffSummaryIndex } =
+      this.sortByService.returnLocalStorageForSort();
+
+    const pageIndexInteger = Number(staffSummaryIndex);
+
+    let pageIndex = Number.isInteger(pageIndexInteger) ? pageIndexInteger : 0;
+
+    const sortByValue = staffSummarySortValue ?? null;
+    const searchTerm = staffSummarySearchTerm ?? null;
+
+    const paginationParams = route.data.workerPagination
+      ? { pageIndex, itemsPerPage: 15, sortBy: sortByValue, ...(searchTerm ? { searchTerm } : {}) }
+      : {};
 
     return this.workerService
       .getAllWorkers(workplaceUid, paginationParams)

--- a/frontend/src/app/core/services/sortBy.Service.spec.ts
+++ b/frontend/src/app/core/services/sortBy.Service.spec.ts
@@ -24,7 +24,7 @@ describe('SortByService', () => {
 
   describe('clearLocalStorage', () => {
     it('should not be called when the url includes "staff-record"', () => {
-      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorage');
+      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorageForSort');
 
       const routerEvent$ = router.events as BehaviorSubject<any>;
       routerEvent$.next(new NavigationStart(2, '/workplace/staff-uid/staff-record/url'));
@@ -33,7 +33,7 @@ describe('SortByService', () => {
     });
 
     it('should be called when the url does not include "staff-record"', () => {
-      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorage');
+      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorageForSort');
 
       const routerEvent$ = router.events as BehaviorSubject<any>;
       routerEvent$.next(new NavigationStart(2, '/workplace/uid/url'));
@@ -44,7 +44,15 @@ describe('SortByService', () => {
     it('should call localStorage', () => {
       const localStorageSpy = spyOn(localStorage, 'removeItem');
 
-      service.clearLocalStorage();
+      service.clearLocalStorageForSort();
+      expect(localStorageSpy).toHaveBeenCalledTimes(4);
+    });
+
+    it('should return the values from localStorage', () => {
+      const localStorageSpy = spyOn(localStorage, 'getItem');
+
+      service.returnLocalStorageForSort();
+
       expect(localStorageSpy).toHaveBeenCalledTimes(4);
     });
   });

--- a/frontend/src/app/core/services/sortBy.Service.spec.ts
+++ b/frontend/src/app/core/services/sortBy.Service.spec.ts
@@ -48,11 +48,4 @@ describe('SortByService', () => {
       expect(localStorageSpy).toHaveBeenCalledTimes(4);
     });
   });
-
-  it('should set _totalWorkerCount', () => {
-    const workerCount = 14;
-    service.setInitialTotalWorkerCount(workerCount);
-
-    expect(service.getInitialTotalWorkerCount()).toEqual(workerCount);
-  });
 });

--- a/frontend/src/app/core/services/sortBy.Service.spec.ts
+++ b/frontend/src/app/core/services/sortBy.Service.spec.ts
@@ -1,0 +1,95 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SortByService } from './sortBy.service';
+import { NavigationStart, Router } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { TabsService } from './tabs.service';
+import { MockTabsService } from '@core/test-utils/MockTabsService';
+
+describe('SortByService', () => {
+  let service: SortByService;
+  let router: Router;
+  let tab: string;
+
+  const setUpTab = (selectedTab: string) => {
+    tab = selectedTab;
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [
+        SortByService,
+        Router,
+        {
+          provide: TabsService,
+          useFactory: MockTabsService.factory(tab),
+        },
+      ],
+    });
+    service = TestBed.inject(SortByService);
+    router = TestBed.inject(Router);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('clearLocalStorage', () => {
+    it('should not be called when the url includes "staff-record"', () => {
+      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorage');
+
+      const routerEvent$ = router.events as BehaviorSubject<any>;
+      routerEvent$.next(new NavigationStart(2, '/workplace/staff-uid/staff-record/url'));
+
+      expect(clearLocalStorageSpy).not.toHaveBeenCalled();
+    });
+
+    it('should be called when the url does not include "staff-record"', () => {
+      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorage');
+
+      const routerEvent$ = router.events as BehaviorSubject<any>;
+      routerEvent$.next(new NavigationStart(2, '/workplace/uid/url'));
+
+      expect(clearLocalStorageSpy).toHaveBeenCalled();
+    });
+
+    it('should not be called when the tab selected is "staff-records"', () => {
+      const selectedTab = "staff-records"
+      setUpTab(selectedTab)
+
+      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorage');
+
+      const routerEvent$ = router.events as BehaviorSubject<any>;
+      routerEvent$.next(new NavigationStart(2, `dashboard#${selectedTab}`));
+
+      expect(clearLocalStorageSpy).not.toHaveBeenCalled();
+    });
+
+    it('should be called when the url is not "staff-records"', () => {
+      const selectedTab = "workplace"
+      setUpTab(selectedTab)
+
+      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorage');
+
+      const routerEvent$ = router.events as BehaviorSubject<any>;
+      routerEvent$.next(new NavigationStart(1, `dashboard#${selectedTab}`));
+
+      expect(clearLocalStorageSpy).toHaveBeenCalled();
+    });
+
+    it('should call localStorage', () => {
+      const localStorageSpy = spyOn(localStorage, 'removeItem');
+
+      service.clearLocalStorage();
+      expect(localStorageSpy).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  it('should set _totalWorkerCount', () => {
+    const workerCount = 14;
+    service.setInitialTotalWorkerCount(workerCount);
+
+    expect(service.getInitialTotalWorkerCount()).toEqual(workerCount);
+  });
+});

--- a/frontend/src/app/core/services/sortBy.Service.spec.ts
+++ b/frontend/src/app/core/services/sortBy.Service.spec.ts
@@ -4,28 +4,15 @@ import { SortByService } from './sortBy.service';
 import { NavigationStart, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { TabsService } from './tabs.service';
-import { MockTabsService } from '@core/test-utils/MockTabsService';
 
 describe('SortByService', () => {
   let service: SortByService;
   let router: Router;
-  let tab: string;
-
-  const setUpTab = (selectedTab: string) => {
-    tab = selectedTab;
-  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
-      providers: [
-        SortByService,
-        Router,
-        {
-          provide: TabsService,
-          useFactory: MockTabsService.factory(tab),
-        },
-      ],
+      providers: [SortByService, Router, TabsService],
     });
     service = TestBed.inject(SortByService);
     router = TestBed.inject(Router);
@@ -50,30 +37,6 @@ describe('SortByService', () => {
 
       const routerEvent$ = router.events as BehaviorSubject<any>;
       routerEvent$.next(new NavigationStart(2, '/workplace/uid/url'));
-
-      expect(clearLocalStorageSpy).toHaveBeenCalled();
-    });
-
-    it('should not be called when the tab selected is "staff-records"', () => {
-      const selectedTab = "staff-records"
-      setUpTab(selectedTab)
-
-      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorage');
-
-      const routerEvent$ = router.events as BehaviorSubject<any>;
-      routerEvent$.next(new NavigationStart(2, `dashboard#${selectedTab}`));
-
-      expect(clearLocalStorageSpy).not.toHaveBeenCalled();
-    });
-
-    it('should be called when the url is not "staff-records"', () => {
-      const selectedTab = "workplace"
-      setUpTab(selectedTab)
-
-      const clearLocalStorageSpy = spyOn(service, 'clearLocalStorage');
-
-      const routerEvent$ = router.events as BehaviorSubject<any>;
-      routerEvent$.next(new NavigationStart(1, `dashboard#${selectedTab}`));
 
       expect(clearLocalStorageSpy).toHaveBeenCalled();
     });

--- a/frontend/src/app/core/services/sortBy.service.ts
+++ b/frontend/src/app/core/services/sortBy.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import {  NavigationStart, Router } from '@angular/router';
+import {  filter, } from 'rxjs/operators';
+import { TabsService } from './tabs.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SortByService {
+  public navUrl: string;
+  private _totalWorkerCount: number
+
+  constructor(private router: Router, private tabsService: TabsService) {
+    this.navUrl;
+
+    this.router.events.pipe(filter((event) => event instanceof NavigationStart)).subscribe((event: NavigationStart) => {
+      console.log(event)
+
+      const destinationUrl = event.url;
+
+      if (!destinationUrl.includes('staff-record')) {
+        this.clearLocalStorage();
+      }
+    });
+
+    this.tabsService.selectedTab$.subscribe((newTab) => {
+      if (newTab && newTab !== 'staff-records') {
+        this.clearLocalStorage();
+      }
+    });
+  }
+
+  public clearLocalStorage() {
+    localStorage.removeItem('staffSummarySortValue');
+    localStorage.removeItem('staffSummarySearchTerm');
+    localStorage.removeItem('staffSummaryIndex');
+    localStorage.removeItem('isSearchMaintained');
+  }
+
+  public setInitialTotalWorkerCount(totalWorkerCount: number) {
+    this._totalWorkerCount = totalWorkerCount
+  }
+
+  public getInitialTotalWorkerCount() {
+    return this._totalWorkerCount
+  }
+}

--- a/frontend/src/app/core/services/sortBy.service.ts
+++ b/frontend/src/app/core/services/sortBy.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import {  NavigationStart, Router } from '@angular/router';
-import {  filter, } from 'rxjs/operators';
+import { NavigationStart, Router } from '@angular/router';
+import { filter } from 'rxjs/operators';
 import { TabsService } from './tabs.service';
 
 @Injectable({
@@ -8,13 +8,13 @@ import { TabsService } from './tabs.service';
 })
 export class SortByService {
   public navUrl: string;
-  private _totalWorkerCount: number
+  private _totalWorkerCount: number;
 
   constructor(private router: Router, private tabsService: TabsService) {
     this.navUrl;
 
     this.router.events.pipe(filter((event) => event instanceof NavigationStart)).subscribe((event: NavigationStart) => {
-      console.log(event)
+      console.log(event);
 
       const destinationUrl = event.url;
 
@@ -38,10 +38,10 @@ export class SortByService {
   }
 
   public setInitialTotalWorkerCount(totalWorkerCount: number) {
-    this._totalWorkerCount = totalWorkerCount
+    this._totalWorkerCount = totalWorkerCount;
   }
 
   public getInitialTotalWorkerCount() {
-    return this._totalWorkerCount
+    return this._totalWorkerCount;
   }
 }

--- a/frontend/src/app/core/services/sortBy.service.ts
+++ b/frontend/src/app/core/services/sortBy.service.ts
@@ -8,14 +8,11 @@ import { TabsService } from './tabs.service';
 })
 export class SortByService {
   public navUrl: string;
-  private _totalWorkerCount: number;
 
   constructor(private router: Router, private tabsService: TabsService) {
     this.navUrl;
 
     this.router.events.pipe(filter((event) => event instanceof NavigationStart)).subscribe((event: NavigationStart) => {
-      console.log(event);
-
       const destinationUrl = event.url;
 
       if (!destinationUrl.includes('staff-record')) {
@@ -35,13 +32,5 @@ export class SortByService {
     localStorage.removeItem('staffSummarySearchTerm');
     localStorage.removeItem('staffSummaryIndex');
     localStorage.removeItem('isSearchMaintained');
-  }
-
-  public setInitialTotalWorkerCount(totalWorkerCount: number) {
-    this._totalWorkerCount = totalWorkerCount;
-  }
-
-  public getInitialTotalWorkerCount() {
-    return this._totalWorkerCount;
   }
 }

--- a/frontend/src/app/core/services/sortBy.service.ts
+++ b/frontend/src/app/core/services/sortBy.service.ts
@@ -16,21 +16,30 @@ export class SortByService {
       const destinationUrl = event.url;
 
       if (!destinationUrl.includes('staff-record')) {
-        this.clearLocalStorage();
+        this.clearLocalStorageForSort();
       }
     });
 
     this.tabsService.selectedTab$.subscribe((newTab) => {
       if (newTab && newTab !== 'staff-records') {
-        this.clearLocalStorage();
+        this.clearLocalStorageForSort();
       }
     });
   }
 
-  public clearLocalStorage() {
+  public clearLocalStorageForSort() {
     localStorage.removeItem('staffSummarySortValue');
     localStorage.removeItem('staffSummarySearchTerm');
     localStorage.removeItem('staffSummaryIndex');
     localStorage.removeItem('isSearchMaintained');
+  }
+
+  public returnLocalStorageForSort(): any {
+    return {
+      staffSummarySortValue: localStorage.getItem('staffSummarySortValue') ?? null,
+      staffSummarySearchTerm: localStorage.getItem('staffSummarySearchTerm') ?? null,
+      staffSummaryIndex: localStorage.getItem('staffSummaryIndex') ?? null,
+      isSearchMaintained: localStorage.getItem('isSearchMaintained') ?? null,
+    };
   }
 }

--- a/frontend/src/app/features/funding/wdf-staff-summary/wdf-staff-summary.component.ts
+++ b/frontend/src/app/features/funding/wdf-staff-summary/wdf-staff-summary.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { SortByService } from '@core/services/sortBy.service';
 import { TabsService } from '@core/services/tabs.service';
 import { WorkerService } from '@core/services/worker.service';
 import { StaffSummaryDirective } from '@shared/directives/staff-summary/staff-summary.directive';
@@ -24,8 +25,9 @@ export class WdfStaffSummaryComponent extends StaffSummaryDirective {
     protected route: ActivatedRoute,
     protected establishmentService: EstablishmentService,
     protected tabsService: TabsService,
+    protected sortByService: SortByService,
   ) {
-    super(permissionsService, workerService, router, route, establishmentService, tabsService);
+    super(permissionsService, workerService, router, route, establishmentService, tabsService, sortByService);
   }
 
   public getWorkerRecordPath(worker) {

--- a/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
+++ b/frontend/src/app/features/subsidiary/subsidiary-routing.module.ts
@@ -156,7 +156,7 @@ const routes: Routes = [
       {
         path: 'staff-records',
         component: ViewSubsidiaryStaffRecordsComponent,
-        data: { title: 'Staff Records' },
+        data: { title: 'Staff Records', workerPagination: true },
       },
       {
         path: 'training-and-qualifications',

--- a/frontend/src/app/shared/components/staff-summary/staff-summary.component.html
+++ b/frontend/src/app/shared/components/staff-summary/staff-summary.component.html
@@ -21,7 +21,7 @@
         <th *ngIf="wdfView" class="govuk-table__header" scope="col">WDF requirements</th>
       </tr>
     </thead>
-    <tbody class="govuk-table__body">
+    <tbody class="govuk-table__body" data-testid="staff-table">
       <tr class="govuk-table__row" *ngFor="let worker of paginatedWorkers">
         <td class="govuk-table__cell govuk-!-font-weight-regular">
           <ng-container *ngIf="canViewWorker; else nameOrId">

--- a/frontend/src/app/shared/components/staff-summary/staff-summary.component.html
+++ b/frontend/src/app/shared/components/staff-summary/staff-summary.component.html
@@ -8,6 +8,8 @@
   accessibleLabel="for staff records"
   (fetchData)="getPageOfWorkers($event)"
   [label]="searchLabel"
+  [isSearchMaintained]="isSearchMaintained"
+  [maintainedPageIndex]="maintainedPageIndex"
 >
   <table *ngIf="workerCount; else noWorkersFound" class="govuk-table">
     <thead class="govuk-table__head">

--- a/frontend/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
@@ -1,8 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
-import { Router, RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter, Router, RouterModule } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { Worker } from '@core/model/worker.model';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
@@ -12,35 +11,35 @@ import { establishmentBuilder } from '@core/test-utils/MockEstablishmentService'
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
-import { fireEvent, render } from '@testing-library/angular';
+import { fireEvent, render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { of } from 'rxjs';
-
 import { PaginationComponent } from '../pagination/pagination.component';
 import { TablePaginationWrapperComponent } from '../table-pagination-wrapper/table-pagination-wrapper.component';
 import { StaffSummaryComponent } from './staff-summary.component';
+import { PermissionType } from '@core/model/permissions.model';
 
 describe('StaffSummaryComponent', () => {
-  async function setup(isWdf = false) {
+  async function setup(overrides: any = {}) {
     const establishment = establishmentBuilder() as Establishment;
     const workers = [workerBuilder(), workerBuilder(), workerBuilder()] as Worker[];
-
-    const component = await render(StaffSummaryComponent, {
-      imports: [SharedModule, RouterModule, RouterTestingModule, HttpClientTestingModule],
+    const setupTools = await render(StaffSummaryComponent, {
+      imports: [SharedModule, RouterModule, HttpClientTestingModule],
       declarations: [PaginationComponent, TablePaginationWrapperComponent],
       providers: [
         {
           provide: PermissionsService,
-          useFactory: MockPermissionsService.factory(),
+          useFactory: MockPermissionsService.factory(overrides.permissions as PermissionType[]),
           deps: [HttpClient, Router, UserService],
         },
         WorkerService,
+        provideRouter([]),
       ],
       componentProperties: {
         workplace: establishment,
         workers: workers,
-        wdfView: isWdf,
-        workerCount: workers.length,
+        wdfView: overrides.isWdf ?? false,
+        workerCount: overrides.workerCount ?? workers.length,
       },
     });
 
@@ -52,7 +51,10 @@ describe('StaffSummaryComponent', () => {
       of({ workers: [...workers, ...workers, ...workers, ...workers, ...workers, ...workers], workerCount: 18 }),
     );
 
+    const component = setupTools.fixture.componentInstance;
+
     return {
+      ...setupTools,
       router,
       component,
       workers,
@@ -66,28 +68,29 @@ describe('StaffSummaryComponent', () => {
   });
 
   it('should render the correct information for given workers', async () => {
-    const { component, workers } = await setup();
+    const overrides = { permissions: ['canEditWorker'] };
+    const { workers, fixture, getByText, getByTestId } = await setup(overrides);
 
-    component.fixture.componentInstance.canEditWorker = true;
     // update one of the fake workers
     workers[0].nameOrId = 'joe mocked';
     workers[0].mainJob.jobRoleName = 'fake doctor';
     workers[0].completed = false;
-    component.detectChanges();
+    fixture.detectChanges();
 
-    expect(component.getByText('joe mocked')).toBeTruthy();
-    expect(component.getByText('fake doctor')).toBeTruthy();
-    expect(component.getAllByText('Add more details').length).toBe(3);
+    const staffTableTestId = getByTestId('staff-table');
+
+    expect(getByText('joe mocked')).toBeTruthy();
+    expect(getByText('fake doctor')).toBeTruthy();
+    expect(within(staffTableTestId).getAllByText('Add more details').length).toBe(3);
   });
 
   it('should render the add more details link with the correct routing', async () => {
-    const { component, workers } = await setup();
+    const overrides = { permissions: ['canEditWorker'] };
 
-    component.fixture.componentInstance.canEditWorker = true;
-    component.detectChanges();
+    const { component, workers, getAllByText } = await setup(overrides);
 
-    const workplace = component.fixture.componentInstance.workplace;
-    const addMoreDetailsLinks = component.getAllByText('Add more details');
+    const workplace = component.workplace;
+    const addMoreDetailsLinks = getAllByText('Add more details');
 
     workers.map((worker, index) => {
       expect(addMoreDetailsLinks[index].getAttribute('href')).toEqual(
@@ -97,47 +100,48 @@ describe('StaffSummaryComponent', () => {
   });
 
   describe('Calling getAllWorkers when sorting', () => {
-    const sortByOptions = [
-      ['0_asc', 'staffNameAsc', 'Staff name (A to Z)'],
-      ['0_dsc', 'staffNameDesc', 'Staff name (Z to A)'],
-      ['1_asc', 'jobRoleAsc', 'Job role (A to Z)'],
-      ['1_dsc', 'jobRoleDesc', 'Job role (Z to A)'],
-      ['2_meeting', 'wdfMeeting', 'WDF requirements (meeting)'],
-      ['2_not_meeting', 'wdfNotMeeting', 'WDF requirements (not meeting)'],
-    ];
+    describe('in wdf view', () => {
+      const sortByOptions = [
+        ['0_asc', 'staffNameAsc', 'Staff name (A to Z)'],
+        ['0_dsc', 'staffNameDesc', 'Staff name (Z to A)'],
+        ['1_asc', 'jobRoleAsc', 'Job role (A to Z)'],
+        ['1_dsc', 'jobRoleDesc', 'Job role (Z to A)'],
+        ['2_meeting', 'wdfMeeting', 'Funding requirements (meeting)'],
+        ['2_not_meeting', 'wdfNotMeeting', 'Funding requirements (not meeting)'],
+      ];
 
-    for (const option of sortByOptions) {
-      it(`should call getAllWorkers with sortBy set to ${option[1]} when sorting by ${option[2]}`, async () => {
-        const { component, getAllWorkersSpy } = await setup(true);
+      for (const option of sortByOptions) {
+        it(`should call getAllWorkers with sortBy set to ${option[1]} when sorting by ${option[2]}`, async () => {
+          const { component, getAllWorkersSpy, getByLabelText } = await setup({ isWdf: true });
 
-        const select = component.getByLabelText('Sort by', { exact: false });
-        fireEvent.change(select, { target: { value: option[0] } });
+          const select = getByLabelText('Sort by', { exact: false });
+          fireEvent.change(select, { target: { value: option[0] } });
 
-        const establishmentUid = component.fixture.componentInstance.workplace.uid;
-        const paginationEmission = { pageIndex: 0, itemsPerPage: 15, sortBy: option[1] };
+          const establishmentUid = component.workplace.uid;
+          const paginationEmission = { pageIndex: 0, itemsPerPage: 15, sortBy: option[1] };
 
-        expect(getAllWorkersSpy.calls.mostRecent().args[0]).toEqual(establishmentUid);
-        expect(getAllWorkersSpy.calls.mostRecent().args[1]).toEqual(paginationEmission);
-      });
-    }
+          expect(getAllWorkersSpy.calls.mostRecent().args[0]).toEqual(establishmentUid);
+          expect(getAllWorkersSpy.calls.mostRecent().args[1]).toEqual(paginationEmission);
+        });
+      }
+    });
   });
 
   describe('Calling getAllWorkers when using search', () => {
     it('it does not render the search bar when pagination threshold is not met', async () => {
-      const { component } = await setup();
+      const { queryByLabelText } = await setup();
 
-      const searchInput = component.queryByLabelText('Search staff training records');
+      const searchInput = queryByLabelText('Search staff training records');
       expect(searchInput).toBeNull();
     });
     it('should call getAllWorkers with correct search term if passed and workerCount is greater than itemsPerPage', async () => {
-      const { component, getAllWorkersSpy } = await setup();
+      const overrides = { workerCount: 16 };
 
-      await component.fixture.whenStable();
-      // show search
-      component.fixture.componentInstance.totalWorkerCount = 16;
-      component.fixture.detectChanges();
+      const { getAllWorkersSpy, fixture, getByLabelText } = await setup(overrides);
 
-      const searchInput = component.getByLabelText('Search by name or ID number for staff records');
+      await fixture.whenStable();
+
+      const searchInput = getByLabelText('Search by name or ID number for staff records');
       expect(searchInput).toBeTruthy();
       userEvent.type(searchInput, 'search term here{enter}');
 
@@ -146,42 +150,34 @@ describe('StaffSummaryComponent', () => {
     });
 
     it('should reset the pageIndex before calling getAllWorkers when handling search', async () => {
-      const { component, getAllWorkersSpy } = await setup();
+      const overrides = { workerCount: 16 };
 
-      component.fixture.componentInstance.totalWorkerCount = 16;
-      component.fixture.detectChanges();
+      const { getAllWorkersSpy, getByLabelText } = await setup(overrides);
 
-      userEvent.type(
-        component.getByLabelText('Search by name or ID number for staff records'),
-        'search term here{enter}',
-      );
+      userEvent.type(getByLabelText('Search by name or ID number for staff records'), 'search term here{enter}');
       expect(getAllWorkersSpy.calls.mostRecent().args[1].pageIndex).toEqual(0);
     });
 
     it('should render the message that no workers were found if workerCount is falsy', async () => {
-      const { component } = await setup();
+      const overrides = { workerCount: 0 };
+      const { getByText } = await setup(overrides);
 
-      component.fixture.componentInstance.totalWorkerCount = 16;
-      component.fixture.componentInstance.workerCount = 0;
-      component.fixture.detectChanges();
-
-      expect(component.getByText('There are no matching results')).toBeTruthy();
-      expect(component.getByText('Make sure that your spelling is correct.')).toBeTruthy();
+      expect(getByText('There are no matching results')).toBeTruthy();
+      expect(getByText('Make sure that your spelling is correct.')).toBeTruthy();
     });
   });
 
   describe('getWorkerRecordPath', () => {
     it('navigates to the staff record summary when not in the wdf view', async () => {
-      const { component, router, workers } = await setup();
+      const overrides = { permissions: ['canViewWorker'] };
+      const { component, router, workers, getByText } = await setup(overrides);
 
-      component.fixture.componentInstance.canViewWorker = true;
-      component.detectChanges();
       const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
       const worker = workers[0];
-      const nameLink = component.getByText(worker.nameOrId);
+      const nameLink = getByText(worker.nameOrId);
       fireEvent.click(nameLink);
 
-      const workplace = component.fixture.componentInstance.workplace;
+      const workplace = component.workplace;
       expect(routerSpy).toHaveBeenCalledWith([
         '/workplace',
         workplace.uid,

--- a/frontend/src/app/shared/components/staff-summary/staff-summary.component.ts
+++ b/frontend/src/app/shared/components/staff-summary/staff-summary.component.ts
@@ -3,6 +3,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { PreviousRouteService } from '@core/services/previous-route.service';
+import { SortByService } from '@core/services/sortBy.service';
 import { TabsService } from '@core/services/tabs.service';
 import { WorkerService } from '@core/services/worker.service';
 import { StaffSummaryDirective } from '@shared/directives/staff-summary/staff-summary.directive';
@@ -19,8 +21,10 @@ export class StaffSummaryComponent extends StaffSummaryDirective implements OnIn
     protected route: ActivatedRoute,
     protected establishmentService: EstablishmentService,
     protected tabsService: TabsService,
+    protected previousRouteService: PreviousRouteService,
+    protected sortByService: SortByService,
   ) {
-    super(permissionsService, workerService, router, route, establishmentService, tabsService);
+    super(permissionsService, workerService, router, route, establishmentService, tabsService, sortByService);
   }
 
   protected init(): void {}

--- a/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.html
+++ b/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.html
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row govuk-util__vertical-align-center">
-  <div *ngIf="totalCount > itemsPerPage" class="govuk-grid-column-three-quarters" data-testid="search">
+  <div *ngIf="totalCount > itemsPerPage || isSearchMaintained" class="govuk-grid-column-three-quarters" data-testid="search">
     <app-search-input
       ref="search"
       [accessibleLabel]="accessibleLabel"

--- a/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.spec.ts
+++ b/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.spec.ts
@@ -30,6 +30,9 @@ describe('TablePaginationWrapperCompnent', () => {
         },
         sortOptions: SortStaffOptions,
         searchTerm: '',
+        currentPageIndex: overrides.currentPageIndex ?? 0,
+        isSearchMaintained: overrides.isSearchMaintained ?? false,
+        maintainedPageIndex: overrides.maintainedPageIndex ?? null,
       },
     });
 
@@ -63,6 +66,16 @@ describe('TablePaginationWrapperCompnent', () => {
   describe('Search', () => {
     it('should display the search box if the total worker count is greater than the items per page', async () => {
       const { getByTestId } = await setup();
+      expect(getByTestId('search')).toBeTruthy();
+    });
+
+    it('should display the search box if isSearchMaintained is true', async () => {
+      const { getByTestId } = await setup({ isSearchMaintained: true });
+      expect(getByTestId('search')).toBeTruthy();
+    });
+
+    it('should display the search box if isSearchMaintained is true but if the total worker count is less than the items per page', async () => {
+      const { getByTestId } = await setup({ isSearchMaintained: true, totalCount: 4 });
       expect(getByTestId('search')).toBeTruthy();
     });
 
@@ -183,6 +196,20 @@ describe('TablePaginationWrapperCompnent', () => {
       expect(handlePageUpdateSpy).toHaveBeenCalledWith(2);
       const { currentPageIndex: index, itemsPerPage, searchTerm, sortByValue } = component;
       expect(emitSpy).toHaveBeenCalledWith({ index, itemsPerPage, searchTerm, sortByValue });
+    });
+  });
+
+  describe('page index', () => {
+    it('should use the value from maintainedPageIndex', async () => {
+      const { component } = await setup({ maintainedPageIndex: 1, currentPageIndex: 0 });
+
+      expect(component.currentPageIndex).toEqual(1);
+    });
+
+    it('should use the currentPageIndex value ', async () => {
+      const { component } = await setup({ currentPageIndex: 0 });
+
+      expect(component.currentPageIndex).toEqual(0);
     });
   });
 });

--- a/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.ts
+++ b/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.ts
@@ -6,6 +6,8 @@ import { Router } from '@angular/router';
   templateUrl: './table-pagination-wrapper.component.html',
 })
 export class TablePaginationWrapperComponent implements OnInit {
+  @Input() isSearchMaintained: string;
+  @Input() maintainedPageIndex: number;
   @Input() totalCount: number;
   @Input() count: number;
   @Input() sortByParamMap: Record<string, string>;
@@ -31,6 +33,9 @@ export class TablePaginationWrapperComponent implements OnInit {
 
   ngOnInit(): void {
     this.sortBySelected = Object.keys(this.sortByParamMap).find((key) => this.sortByParamMap[key] === this.sortByValue);
+    if (this.maintainedPageIndex && this.maintainedPageIndex !== this.currentPageIndex) {
+      this.currentPageIndex = this.maintainedPageIndex;
+    }
   }
 
   private checkForFragment(): void {

--- a/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
+++ b/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
@@ -33,6 +33,9 @@ export class StaffSummaryDirective implements OnInit {
     '1_dsc': 'jobRoleDesc',
     '2_meeting': 'wdfMeeting',
     '2_not_meeting': 'wdfNotMeeting',
+    '3_last_update_newest': 'lastUpdateNewest',
+    '3_last_update_oldest': 'lastUpdateOldest',
+    '4_add_more_details': 'addMoreDetails',
   };
   public searchLabel = 'Search by name or ID number';
 


### PR DESCRIPTION
#### Work done
- Add additional sort values to the staff summary
- Add additional sorting options to the workers endpoint
- Add sortBy Service to store values to maintain staff summary search, pagination and sort

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
