### PR TITLE
Fix/1782 - update user details not working

### DIFF
--- a/backend/server/routes/accounts/user.js
+++ b/backend/server/routes/accounts/user.js
@@ -129,7 +129,7 @@ const updateAdminUser = async (req, res) => updateUser(req, res);
 
 const updateNormalUser = async (req, res) => {
   const allowUserTypes = [...normalUserRoles];
-  if (!allowUserTypes.includes(req?.body?.role)) {
+  if (req?.body?.role && !allowUserTypes.includes(req?.body?.role)) {
     console.error(`PUT /user/establishment/:id/:userId - trying to change user to a role which is not allowed`);
     return res.status(401).send();
   }
@@ -442,7 +442,7 @@ const partAddAdminUser = async (req, res) => partAddUser(req, res);
 const partAddNormalUser = async (req, res) => {
   const allowUserTypes = [...normalUserRoles];
 
-  if (!allowUserTypes.includes(req?.body?.role)) {
+  if (req?.body?.role && !allowUserTypes.includes(req?.body?.role)) {
     console.error(`POST /user/add/establishment/:id - trying to add user type which is not allowed`);
     return res.status(401).send();
   }

--- a/backend/server/test/unit/routes/accounts/user.spec.js
+++ b/backend/server/test/unit/routes/accounts/user.spec.js
@@ -449,6 +449,16 @@ describe('user.js', () => {
         expect(User.prototype.save).to.have.been.called;
       });
 
+      it('should return a status of 200 when the request payload does not specify a role', async () => {
+        const req = { ...defaultReq, body: { fullname: 'updated name', email: 'new email' } };
+        const res = httpMocks.createResponse();
+
+        await updateNormalUser(req, res);
+
+        expect(res.statusCode).to.equal(200);
+        expect(User.prototype.save).to.have.been.called;
+      });
+
       const adminUserTypes = ['Admin', 'AdminManager'];
 
       adminUserTypes.forEach((adminType) => {


### PR DESCRIPTION
#### Work done
- fix an issue that cause update user details not working if user role is not specified in request

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
