### PR TITLE
fix/1770-wording-for-read-only-users-in-home-page-summary

### DIFF
--- a/frontend/src/app/shared/components/summary-section/summary-section.component.html
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.html
@@ -37,7 +37,14 @@
           </ng-template>
         </ng-container>
         <ng-template #noMessage>
+          <ng-container *ngIf="!canViewListOfWorkers && section.fragment !== 'workplace'; else defaultMessage">
+            <span>
+              You do not have permission to view this data
+            </span>
+          </ng-container>
+          <ng-template #defaultMessage>
           <span>Remember to check and update this data often</span>
+          </ng-template>
         </ng-template>
       </div>
     </div>

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -424,6 +424,25 @@ describe('Summary section', () => {
       expect(within(workplaceRow).queryByTestId('orange-flag')).toBeFalsy();
     });
 
+    it('should not show the staff total does not match staff records warning if canViewListOfWorkers is false', async () => {
+      const establishment = {
+        ...Establishment,
+        eightWeeksFromFirstLogin: dayjs(new Date()).subtract(1, 'day').toString(),
+      };
+
+      const overrides = {
+        checkCqcDetails: false,
+        establishment,
+        workerCount: 102,
+        canViewListOfWorkers: false,
+      };
+
+      const { getByTestId } = await setup(overrides);
+
+      const workplaceRow = getByTestId('workplace-row');
+      expect(within(workplaceRow).queryByText('Staff total does not match staff records added')).toBeFalsy();
+    });
+
     it('should show a warning saying that vacancy and turnover data has not been added if they have not been added', async () => {
       const establishment = { ...Establishment, leavers: null, vacancies: null, starters: null };
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -148,6 +148,18 @@ describe('Summary section', () => {
       expect(workplaceText.getAttribute('href')).toBeTruthy();
     });
 
+    it('should not show no permissions to view data message but show default message', async () => {
+      const overrides = {
+        canViewListOfWorkers: false,
+        canViewEstablishment: true,
+      };
+
+      const { getByTestId } = await setup(overrides);
+      const workplaceRow = getByTestId('workplace-row');
+      expect(within(workplaceRow).getByText('Remember to check and update this data often')).toBeTruthy();
+      expect(within(workplaceRow).queryByText('You do not have permission to view this data')).toBeFalsy();
+    });
+
     it('should show default summary message when no data needs to be adding or updating', async () => {
       const { getByTestId } = await setup();
 
@@ -507,12 +519,28 @@ describe('Summary section', () => {
       expect(staffRecordsLinkText.getAttribute('href')).toBeFalsy();
     });
 
-    it('should show default message if no permission to view staff records', async () => {
+    it('should show no permissions to view data message if no permission to view staff records', async () => {
       const overrides = {
         checkCqcDetails: false,
         establishment: Establishment,
         workerCount: 0,
         canViewListOfWorkers: false,
+      };
+
+      const { fixture, getByTestId } = await setup(overrides);
+
+      fixture.detectChanges();
+
+      const staffRecordsRow = getByTestId('staff-records-row');
+      expect(within(staffRecordsRow).getByText('You do not have permission to view this data')).toBeTruthy();
+    });
+
+    it('should show default message if there is no message', async () => {
+      const overrides = {
+        checkCqcDetails: false,
+        establishment: Establishment,
+        workerCount: 1,
+        canViewListOfWorkers: true,
       };
 
       const { fixture, getByTestId } = await setup(overrides);
@@ -953,6 +981,17 @@ describe('Summary section', () => {
       const trainingAndQualificationsLinkText = getByText('Training and qualifications');
 
       expect(trainingAndQualificationsLinkText.getAttribute('href')).toBeTruthy();
+    });
+
+    it('should show no permissions to view data message if no permission to view train and quals', async () => {
+      const overrides = {
+        canViewListOfWorkers: false,
+        canViewEstablishment: true,
+      };
+
+      const { getByTestId } = await setup(overrides);
+      const tAndQRow = getByTestId('training-and-qualifications-row');
+      expect(within(tAndQRow).getByText('You do not have permission to view this data')).toBeTruthy();
     });
 
     it('should show default summary message when no data needs to be adding or updating', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -111,7 +111,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     } else if (numberOfStaff === undefined || numberOfStaff === null) {
       this.sections[0].message = `You've not added your total number of staff`;
       this.sections[0].redFlag = true;
-    } else if (numberOfStaff !== this.workerCount && this.afterEightWeeksFromFirstLogin()) {
+    } else if (numberOfStaff !== this.workerCount && this.afterEightWeeksFromFirstLogin() && this.canViewListOfWorkers) {
       this.sections[0].message = 'Staff total does not match staff records added';
     } else if (!vacancies && !leavers && !starters) {
       this.sections[0].message = `You've not added any vacancy and turnover data`;


### PR DESCRIPTION
#### Work done
- Add extra message for read only users in summary section

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
