### PR TITLE
Fix/1759 sort on staff records fix preprod test issues

### DIFF
--- a/frontend/src/app/core/resolvers/workers.resolver.ts
+++ b/frontend/src/app/core/resolvers/workers.resolver.ts
@@ -71,6 +71,9 @@ export class WorkersResolver {
       )
       .pipe(
         map(([totalResponse, paginatedResponse]) => {
+          const paginatedWorkerCount = paginatedResponse.workerCount;
+          const workerCount = totalResponse.workerCount;
+
           totalResponse.workers.forEach((worker) => {
             trainingCounts.totalTraining += worker.trainingCount;
             trainingCounts.totalRecords += worker.trainingCount + worker.qualificationCount;
@@ -99,6 +102,8 @@ export class WorkersResolver {
           });
           return {
             ...paginatedResponse,
+            paginatedWorkerCount,
+            workerCount,
             workersCreatedDate,
             trainingCounts,
             tAndQsLastUpdated,

--- a/frontend/src/app/core/services/sort-by.service.spec.ts
+++ b/frontend/src/app/core/services/sort-by.service.spec.ts
@@ -41,19 +41,28 @@ describe('SortByService', () => {
       expect(clearLocalStorageSpy).toHaveBeenCalled();
     });
 
-    it('should call localStorage', () => {
-      const localStorageSpy = spyOn(localStorage, 'removeItem');
+    it('should remove localStorage when clearLocalStorageForSort is called', () => {
+      const localStorageRemoveItemSpy = spyOn(localStorage, 'removeItem');
+      const expectedKeys = ['staffSummarySortValue', 'staffSummarySearchTerm', 'staffSummaryIndex'];
 
       service.clearLocalStorageForSort();
-      expect(localStorageSpy).toHaveBeenCalledTimes(4);
+
+      expect(localStorageRemoveItemSpy).toHaveBeenCalledTimes(expectedKeys.length);
+      expectedKeys.forEach((key) => {
+        expect(localStorageRemoveItemSpy).toHaveBeenCalledWith(key);
+      });
     });
 
     it('should return the values from localStorage', () => {
-      const localStorageSpy = spyOn(localStorage, 'getItem');
+      const localStorageGetItemSpy = spyOn(localStorage, 'getItem');
+      const expectedKeys = ['staffSummarySortValue', 'staffSummarySearchTerm', 'staffSummaryIndex'];
 
       service.returnLocalStorageForSort();
 
-      expect(localStorageSpy).toHaveBeenCalledTimes(4);
+      expect(localStorageGetItemSpy).toHaveBeenCalledTimes(expectedKeys.length);
+      expectedKeys.forEach((key) => {
+        expect(localStorageGetItemSpy).toHaveBeenCalledWith(key);
+      });
     });
   });
 });

--- a/frontend/src/app/core/services/sort-by.service.ts
+++ b/frontend/src/app/core/services/sort-by.service.ts
@@ -7,9 +7,7 @@ import { TabsService } from './tabs.service';
   providedIn: 'root',
 })
 export class SortByService {
-
   constructor(private router: Router, private tabsService: TabsService) {
-
     this.router.events.pipe(filter((event) => event instanceof NavigationStart)).subscribe((event: NavigationStart) => {
       const destinationUrl = event.url;
 
@@ -29,7 +27,6 @@ export class SortByService {
     localStorage.removeItem('staffSummarySortValue');
     localStorage.removeItem('staffSummarySearchTerm');
     localStorage.removeItem('staffSummaryIndex');
-    localStorage.removeItem('isSearchMaintained');
   }
 
   public returnLocalStorageForSort(): any {
@@ -37,7 +34,6 @@ export class SortByService {
       staffSummarySortValue: localStorage.getItem('staffSummarySortValue') ?? null,
       staffSummarySearchTerm: localStorage.getItem('staffSummarySearchTerm') ?? null,
       staffSummaryIndex: localStorage.getItem('staffSummaryIndex') ?? null,
-      isSearchMaintained: localStorage.getItem('isSearchMaintained') ?? null,
     };
   }
 }

--- a/frontend/src/app/core/test-utils/MockSortByService.ts
+++ b/frontend/src/app/core/test-utils/MockSortByService.ts
@@ -9,7 +9,6 @@ export class MockSortByService extends SortByService {
     staffSummarySortValue: null,
     staffSummarySearchTerm: null,
     staffSummaryIndex: null,
-    isSearchMaintained: null,
   };
 
   public static factory(overrides: any = {}) {

--- a/frontend/src/app/shared/components/staff-summary/staff-summary.component.html
+++ b/frontend/src/app/shared/components/staff-summary/staff-summary.component.html
@@ -8,7 +8,6 @@
   accessibleLabel="for staff records"
   (fetchData)="getPageOfWorkers($event)"
   [label]="searchLabel"
-  [isSearchMaintained]="isSearchMaintained"
   [maintainedPageIndex]="maintainedPageIndex"
 >
   <table *ngIf="workerCount; else noWorkersFound" class="govuk-table">

--- a/frontend/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
@@ -255,11 +255,10 @@ describe('StaffSummaryComponent', () => {
 
       const sortByObjectKeys = Object.keys(component.sortStaffOptions);
       userEvent.selectOptions(getByLabelText('Sort by'), sortByObjectKeys[2]);
-      expect(localStorageSetSpy).toHaveBeenCalledTimes(4);
+      expect(localStorageSetSpy).toHaveBeenCalledTimes(3);
       expect(localStorageSetSpy.calls.all()[0].args).toEqual(['staffSummarySortValue', component.sortByValue]);
       expect(localStorageSetSpy.calls.all()[1].args).toEqual(['staffSummarySearchTerm', '']);
       expect(localStorageSetSpy.calls.all()[2].args).toEqual(['staffSummaryIndex', '0']);
-      expect(localStorageSetSpy.calls.all()[3].args).toEqual(['isSearchMaintained', 'true']);
     });
 
     it('should use the values from returnLocalStorageForSort when its not the wdf view', async () => {
@@ -269,7 +268,6 @@ describe('StaffSummaryComponent', () => {
           staffSummarySortValue: 'lastUpdateNewest',
           staffSummarySearchTerm: 'Ma',
           staffSummaryIndex: '0',
-          isSearchMaintained: 'true',
         },
       };
 
@@ -278,7 +276,6 @@ describe('StaffSummaryComponent', () => {
       expect(component.sortByValue).toEqual('lastUpdateNewest');
       expect(component.searchTerm).toEqual('Ma');
       expect(component.pageIndex).toEqual(0);
-      expect(component.isSearchMaintained).toEqual(true);
     });
   });
 });

--- a/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.html
+++ b/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.html
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row govuk-util__vertical-align-center">
-  <div *ngIf="totalCount > itemsPerPage || isSearchMaintained" class="govuk-grid-column-three-quarters" data-testid="search">
+  <div *ngIf="totalCount > itemsPerPage" class="govuk-grid-column-three-quarters" data-testid="search">
     <app-search-input
       ref="search"
       [accessibleLabel]="accessibleLabel"

--- a/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.spec.ts
+++ b/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.spec.ts
@@ -74,9 +74,9 @@ describe('TablePaginationWrapperCompnent', () => {
       expect(getByTestId('search')).toBeTruthy();
     });
 
-    it('should display the search box if isSearchMaintained is true but if the total worker count is less than the items per page', async () => {
-      const { getByTestId } = await setup({ isSearchMaintained: true, totalCount: 4 });
-      expect(getByTestId('search')).toBeTruthy();
+    it('should not display the search box if isSearchMaintained is true but the total worker count is less than the items per page', async () => {
+      const { queryByTestId } = await setup({ isSearchMaintained: true, totalCount: 4 });
+      expect(queryByTestId('search')).toBeFalsy();
     });
 
     it('should not display the search box if the total worker count is less than the items per page', async () => {

--- a/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.spec.ts
+++ b/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.spec.ts
@@ -31,7 +31,6 @@ describe('TablePaginationWrapperCompnent', () => {
         sortOptions: SortStaffOptions,
         searchTerm: '',
         currentPageIndex: overrides.currentPageIndex ?? 0,
-        isSearchMaintained: overrides.isSearchMaintained ?? false,
         maintainedPageIndex: overrides.maintainedPageIndex ?? null,
       },
     });
@@ -67,16 +66,6 @@ describe('TablePaginationWrapperCompnent', () => {
     it('should display the search box if the total worker count is greater than the items per page', async () => {
       const { getByTestId } = await setup();
       expect(getByTestId('search')).toBeTruthy();
-    });
-
-    it('should display the search box if isSearchMaintained is true', async () => {
-      const { getByTestId } = await setup({ isSearchMaintained: true });
-      expect(getByTestId('search')).toBeTruthy();
-    });
-
-    it('should not display the search box if isSearchMaintained is true but the total worker count is less than the items per page', async () => {
-      const { queryByTestId } = await setup({ isSearchMaintained: true, totalCount: 4 });
-      expect(queryByTestId('search')).toBeFalsy();
     });
 
     it('should not display the search box if the total worker count is less than the items per page', async () => {

--- a/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.ts
+++ b/frontend/src/app/shared/components/table-pagination-wrapper/table-pagination-wrapper.component.ts
@@ -6,7 +6,6 @@ import { Router } from '@angular/router';
   templateUrl: './table-pagination-wrapper.component.html',
 })
 export class TablePaginationWrapperComponent implements OnInit {
-  @Input() isSearchMaintained: string;
   @Input() maintainedPageIndex: number;
   @Input() totalCount: number;
   @Input() count: number;

--- a/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
+++ b/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
@@ -40,7 +40,6 @@ export class StaffSummaryDirective implements OnInit {
   };
   public searchLabel = 'Search by name or ID number';
   public pageIndex = 0;
-  public isSearchMaintained: boolean;
   public maintainedPageIndex: number;
 
   constructor(
@@ -55,7 +54,7 @@ export class StaffSummaryDirective implements OnInit {
 
   ngOnInit(): void {
     if (!this.wdfView) {
-      const { staffSummarySortValue, staffSummarySearchTerm, staffSummaryIndex, isSearchMaintained } =
+      const { staffSummarySortValue, staffSummarySearchTerm, staffSummaryIndex } =
         this.sortByService.returnLocalStorageForSort();
 
       const staffSummaryIndexInteger = Number(staffSummaryIndex);
@@ -63,7 +62,6 @@ export class StaffSummaryDirective implements OnInit {
       this.sortByValue = staffSummarySortValue ?? 'staffNameAsc';
       this.searchTerm = staffSummarySearchTerm ?? '';
       this.pageIndex = Number.isInteger(staffSummaryIndexInteger) ? staffSummaryIndexInteger : 0;
-      this.isSearchMaintained = isSearchMaintained === 'true' ? true : false;
     }
 
     this.totalWorkerCount = this.workerCount;
@@ -99,13 +97,11 @@ export class StaffSummaryDirective implements OnInit {
     this.sortByValue = sortByValue;
 
     if (!this.wdfView) {
-      this.isSearchMaintained = true;
       this.maintainedPageIndex = index;
 
       localStorage.setItem('staffSummarySortValue', this.sortByValue);
       localStorage.setItem('staffSummarySearchTerm', searchTerm);
       localStorage.setItem('staffSummaryIndex', index.toString());
-      localStorage.setItem('isSearchMaintained', this.isSearchMaintained.toString());
     }
 
     this.workerService

--- a/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
+++ b/frontend/src/app/shared/directives/staff-summary/staff-summary.directive.ts
@@ -42,7 +42,6 @@ export class StaffSummaryDirective implements OnInit {
   public pageIndex = 0;
   public isSearchMaintained: boolean;
   public maintainedPageIndex: number;
-  @Output() emitWorkerCount: EventEmitter<number> = new EventEmitter();
 
   constructor(
     protected permissionsService: PermissionsService,


### PR DESCRIPTION
#### Work done
- fix the below issues found in preprod testing
  - doing a search in staff record could lead to a wrong total staff records number being displayed in tab
  - search box should not appear when number of workers fit in one page 

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
