### PR TITLE
Fix/back link on dha q2

### DIFF
--- a/frontend/src/app/features/workplace/staff-what-kind-of-delegated-healthcare-activities/staff-what-kind-of-delegated-healthcare-activities.component.spec.ts
+++ b/frontend/src/app/features/workplace/staff-what-kind-of-delegated-healthcare-activities/staff-what-kind-of-delegated-healthcare-activities.component.spec.ts
@@ -13,6 +13,7 @@ import { StaffWhatKindOfDelegatedHealthcareActivitiesComponent } from './staff-w
 import { BackService } from '@core/services/back.service';
 import { mockDHADefinition, mockDHAs } from '@core/test-utils/MockDelegatedHealthcareActivitiesService';
 import { HttpClient } from '@angular/common/http';
+import { PreviousRouteService } from '@core/services/previous-route.service';
 
 describe('StaffWhatKindOfDelegatedHealthcareActivitiesComponent', () => {
   const doNotKnowText = 'I do not know';
@@ -31,6 +32,10 @@ describe('StaffWhatKindOfDelegatedHealthcareActivitiesComponent', () => {
           provide: EstablishmentService,
           useFactory: MockEstablishmentServiceWithOverrides.factory(overrides.establishmentService ?? {}),
           deps: [HttpClient],
+        },
+        {
+          provide: PreviousRouteService,
+          useValue: { getPreviousUrl: () => overrides?.previousUrl, getPreviousPage: () => overrides?.previousPage },
         },
         {
           provide: ActivatedRoute,
@@ -251,6 +256,37 @@ describe('StaffWhatKindOfDelegatedHealthcareActivitiesComponent', () => {
         'staff-recruitment-capture-training-requirement',
       ]);
       expect(establishmentServiceSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when coming from workplace summary', () => {
+    const returnTo = {
+      url: ['/dashboard'],
+      fragment: 'workplace',
+    };
+
+    it('should set backlink to returnTo when directly visited from workplace summary', async () => {
+      const { backServiceSpy } = await setup({
+        previousPage: 'workplace',
+        establishmentService: {
+          returnTo,
+        },
+      });
+
+      expect(backServiceSpy.setBackLink).toHaveBeenCalledWith(returnTo);
+    });
+
+    it('should set backlink to staff do DHA question when visited via workplace summary then staff do DHA', async () => {
+      const { backServiceSpy } = await setup({
+        previousPage: 'staff-do-delegated-healthcare-activities',
+        establishmentService: {
+          returnTo,
+        },
+      });
+
+      expect(backServiceSpy.setBackLink).toHaveBeenCalledWith({
+        url: ['/workplace', 'mocked-uid', 'staff-do-delegated-healthcare-activities'],
+      });
     });
   });
 });

--- a/frontend/src/app/features/workplace/staff-what-kind-of-delegated-healthcare-activities/staff-what-kind-of-delegated-healthcare-activities.component.ts
+++ b/frontend/src/app/features/workplace/staff-what-kind-of-delegated-healthcare-activities/staff-what-kind-of-delegated-healthcare-activities.component.ts
@@ -10,6 +10,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { WorkplaceFlowSections } from '@core/utils/progress-bar-util';
 import { DelegatedHealthcareActivity } from '@core/model/delegated-healthcare-activities.model';
 import { DelegatedHealthcareActivitiesService } from '@core/services/delegated-healthcare-activities.service';
+import { PreviousRouteService } from '@core/services/previous-route.service';
 
 @Component({
   selector: 'app-staff-what-kind-of-delegated-healthcare-activities',
@@ -35,6 +36,7 @@ export class StaffWhatKindOfDelegatedHealthcareActivitiesComponent extends Quest
     protected route: ActivatedRoute,
     private alertService: AlertService,
     private delegatedHealthcareActivitiesService: DelegatedHealthcareActivitiesService,
+    private previousRouteService: PreviousRouteService,
   ) {
     super(formBuilder, router, backService, errorSummaryService, establishmentService);
   }
@@ -180,6 +182,21 @@ export class StaffWhatKindOfDelegatedHealthcareActivitiesComponent extends Quest
         (error) => this.onError(error),
       ),
     );
+  }
+
+  protected setBackLink(): void {
+    const isInWorkflow = !this.return;
+
+    const previousPage = this.previousRouteService.getPreviousPage();
+    const previousPageWasStaffDoDHA = previousPage === 'staff-do-delegated-healthcare-activities';
+
+    if (isInWorkflow || previousPageWasStaffDoDHA) {
+      this.back = { url: this.previousRoute };
+    } else {
+      this.back = this.return;
+    }
+
+    this.backService.setBackLink(this.back);
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.html
@@ -324,7 +324,7 @@
     </div>
     <div
       class="govuk-summary-list__row"
-      *ngIf="workplace.staffDoDelegatedHealthcareActivities === 'Yes'"
+      *ngIf="workplace.staffDoDelegatedHealthcareActivities === 'Yes'  && workplace.mainService?.canDoDelegatedHealthcareActivities"
       data-testid="know-what-delegated-healthcare-activities"
     >
       <dt class="govuk-summary-list__key">Which delegated healthcare activities</dt>

--- a/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-wdf-workplace-summary/wdf-workplace-summary.component.spec.ts
@@ -645,6 +645,7 @@ describe('WDFWorkplaceSummaryComponent', () => {
       it('should show the row and table cell name', async () => {
         const { getByTestId } = await setup({
           establishment: {
+            mainService: { canDoDelegatedHealthcareActivities: true },
             staffDoDelegatedHealthcareActivities: 'Yes',
           },
           permissions: ['canEditEstablishment'],
@@ -659,12 +660,13 @@ describe('WDFWorkplaceSummaryComponent', () => {
         expect(cellName).toBeTruthy();
       });
 
-      describe('staffDoDelegatedHealthcareActivities is not "Yes"', () => {
-        ['No', "Don't know"].forEach((answer) => {
-          it(`should not show row when staffDoDelegatedHealthcareActivities is ${answer}`, async () => {
+      describe('mainService canDoDelegatedHealthcareActivities is not true', () => {
+        [false, null].forEach((value) => {
+          it(`should not show if canDoDelegatedHealthcareActivities is ${value} and staffDoDelegatedHealthcareActivities is "Yes"`, async () => {
             const { queryByTestId } = await setup({
               establishment: {
-                staffDoDelegatedHealthcareActivities: answer,
+                mainService: { canDoDelegatedHealthcareActivities: value },
+                staffDoDelegatedHealthcareActivities: 'Yes',
               },
               permissions: ['canEditEstablishment'],
             });
@@ -676,98 +678,124 @@ describe('WDFWorkplaceSummaryComponent', () => {
         });
       });
 
-      describe('staffDoDelegatedHealthcareActivities is "Yes"', () => {
-        it('should show "Not known" and a change link when Don`t know is answered', async () => {
-          const { component, getByTestId } = await setup({
-            establishment: {
-              staffDoDelegatedHealthcareActivities: 'Yes',
-              staffWhatKindDelegatedHealthcareActivities: {
-                knowWhatActivities: "Don't know",
-                activities: null,
-              },
-            },
-            permissions: ['canEditEstablishment'],
+      describe('mainService canDoDelegatedHealthcareActivities is true', () => {
+        describe('staffDoDelegatedHealthcareActivities is not "Yes"', () => {
+          ['No', "Don't know"].forEach((answer) => {
+            it(`should not show row when staffDoDelegatedHealthcareActivities is ${answer}`, async () => {
+              const { queryByTestId } = await setup({
+                establishment: {
+                  mainService: { canDoDelegatedHealthcareActivities: true },
+                  staffDoDelegatedHealthcareActivities: answer,
+                },
+                permissions: ['canEditEstablishment'],
+              });
+
+              const knowWhatDelegatedHealthcareActivitiesRow = queryByTestId(
+                'know-what-delegated-healthcare-activities',
+              );
+
+              expect(knowWhatDelegatedHealthcareActivitiesRow).toBeFalsy();
+            });
           });
-
-          const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
-          const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
-          const answer = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Not known');
-
-          expect(answer).toBeTruthy();
-          expect(link).toBeTruthy();
-          expect(link.getAttribute('href')).toEqual(
-            `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
-          );
-          expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
         });
 
-        it('should show a list of activities and a change link"', async () => {
-          const { component, getByTestId } = await setup({
-            establishment: {
-              staffDoDelegatedHealthcareActivities: 'Yes',
-              staffWhatKindDelegatedHealthcareActivities: {
-                knowWhatActivities: 'Yes',
-                activities: mockDHAs,
-              },
-            },
-            permissions: ['canEditEstablishment'],
-          });
-
-          const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
-
-          const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
-
-          mockDHAs.forEach((answer) => {
-            expect(within(knowWhatDelegatedHealthcareActivitiesRow).queryByText(answer.title)).toBeTruthy();
-          });
-          expect(link).toBeTruthy();
-          expect(link.getAttribute('href')).toEqual(
-            `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
-          );
-          expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
-        });
-
-        describe('no answer', () => {
-          it('should show "-" and an add link when staffWhatKindDelegatedHealthcareActivities is null', async () => {
+        describe('staffDoDelegatedHealthcareActivities is "Yes"', () => {
+          it('should show "Not known" and a change link when Don`t know is answered', async () => {
             const { component, getByTestId } = await setup({
               establishment: {
+                mainService: { canDoDelegatedHealthcareActivities: true },
                 staffDoDelegatedHealthcareActivities: 'Yes',
-                staffWhatKindDelegatedHealthcareActivities: null,
+                staffWhatKindDelegatedHealthcareActivities: {
+                  knowWhatActivities: "Don't know",
+                  activities: null,
+                },
               },
               permissions: ['canEditEstablishment'],
             });
 
             const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
-            const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Add');
-            const answer = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('-');
+            const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
+            const answer = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Not known');
 
             expect(answer).toBeTruthy();
             expect(link).toBeTruthy();
             expect(link.getAttribute('href')).toEqual(
               `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
             );
-
             expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
           });
-        });
 
-        it('should not show a link when canEditEstablishment is false', async () => {
-          const { getByTestId } = await setup({
-            establishment: {
-              staffDoDelegatedHealthcareActivities: 'Yes',
-              staffWhatKindDelegatedHealthcareActivities: {
-                knowWhatActivities: 'Yes',
-                activities: mockDHAs,
+          it('should show a list of activities and a change link"', async () => {
+            const { component, getByTestId } = await setup({
+              establishment: {
+                mainService: { canDoDelegatedHealthcareActivities: true },
+                staffDoDelegatedHealthcareActivities: 'Yes',
+                staffWhatKindDelegatedHealthcareActivities: {
+                  knowWhatActivities: 'Yes',
+                  activities: mockDHAs,
+                },
               },
-            },
-            permissions: [],
+              permissions: ['canEditEstablishment'],
+            });
+
+            const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
+
+            const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
+
+            mockDHAs.forEach((answer) => {
+              expect(within(knowWhatDelegatedHealthcareActivitiesRow).queryByText(answer.title)).toBeTruthy();
+            });
+            expect(link).toBeTruthy();
+            expect(link.getAttribute('href')).toEqual(
+              `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
+            );
+            expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
           });
 
-          const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
-          const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
+          describe('no answer', () => {
+            it('should show "-" and an add link when staffWhatKindDelegatedHealthcareActivities is null', async () => {
+              const { component, getByTestId } = await setup({
+                establishment: {
+                  mainService: { canDoDelegatedHealthcareActivities: true },
+                  staffDoDelegatedHealthcareActivities: 'Yes',
+                  staffWhatKindDelegatedHealthcareActivities: null,
+                },
+                permissions: ['canEditEstablishment'],
+              });
 
-          expect(link).toBeFalsy();
-          expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
+              const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
+              const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Add');
+              const answer = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('-');
+
+              expect(answer).toBeTruthy();
+              expect(link).toBeTruthy();
+              expect(link.getAttribute('href')).toEqual(
+                `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
+              );
+
+              expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
+            });
+          });
+
+          it('should not show a link when canEditEstablishment is false', async () => {
+            const { getByTestId } = await setup({
+              establishment: {
+                mainService: { canDoDelegatedHealthcareActivities: true },
+                staffDoDelegatedHealthcareActivities: 'Yes',
+                staffWhatKindDelegatedHealthcareActivities: {
+                  knowWhatActivities: 'Yes',
+                  activities: mockDHAs,
+                },
+              },
+              permissions: [],
+            });
+
+            const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
+            const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
+
+            expect(link).toBeFalsy();
+            expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
+          });
         });
       });
     });

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -368,7 +368,7 @@
 
     <div
       class="govuk-summary-list__row"
-      *ngIf="workplace.staffDoDelegatedHealthcareActivities === 'Yes'"
+      *ngIf="workplace.staffDoDelegatedHealthcareActivities === 'Yes' && workplace.mainService?.canDoDelegatedHealthcareActivities"
       data-testid="know-what-delegated-healthcare-activities"
     >
       <dt class="govuk-summary-list__key">Which delegated healthcare activities</dt>

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -842,6 +842,7 @@ describe('NewWorkplaceSummaryComponent', () => {
       it('should show the row and table cell name', async () => {
         const { getByTestId } = await setup({
           establishment: {
+            mainService: { canDoDelegatedHealthcareActivities: true },
             staffDoDelegatedHealthcareActivities: 'Yes',
           },
           permissions: ['canEditEstablishment'],
@@ -856,12 +857,13 @@ describe('NewWorkplaceSummaryComponent', () => {
         expect(cellName).toBeTruthy();
       });
 
-      describe('staffDoDelegatedHealthcareActivities is not "Yes"', () => {
-        ['No', "Don't know"].forEach((answer) => {
-          it(`should not show row when staffDoDelegatedHealthcareActivities is ${answer}`, async () => {
+      describe('mainService canDoDelegatedHealthcareActivities is not true', () => {
+        [false, null].forEach((value) => {
+          it(`should not show if canDoDelegatedHealthcareActivities is ${value} and staffDoDelegatedHealthcareActivities is "Yes"`, async () => {
             const { queryByTestId } = await setup({
               establishment: {
-                staffDoDelegatedHealthcareActivities: answer,
+                mainService: { canDoDelegatedHealthcareActivities: value },
+                staffDoDelegatedHealthcareActivities: 'Yes',
               },
               permissions: ['canEditEstablishment'],
             });
@@ -873,98 +875,124 @@ describe('NewWorkplaceSummaryComponent', () => {
         });
       });
 
-      describe('staffDoDelegatedHealthcareActivities is "Yes"', () => {
-        it('should show "Not known" and a change link when Don`t know is answered', async () => {
-          const { component, getByTestId } = await setup({
-            establishment: {
-              staffDoDelegatedHealthcareActivities: 'Yes',
-              staffWhatKindDelegatedHealthcareActivities: {
-                knowWhatActivities: "Don't know",
-                activities: null,
-              },
-            },
-            permissions: ['canEditEstablishment'],
+      describe('mainService canDoDelegatedHealthcareActivities is true', () => {
+        describe('staffDoDelegatedHealthcareActivities is not "Yes"', () => {
+          ['No', "Don't know"].forEach((answer) => {
+            it(`should not show row when staffDoDelegatedHealthcareActivities is ${answer}`, async () => {
+              const { queryByTestId } = await setup({
+                establishment: {
+                  mainService: { canDoDelegatedHealthcareActivities: true },
+                  staffDoDelegatedHealthcareActivities: answer,
+                },
+                permissions: ['canEditEstablishment'],
+              });
+
+              const knowWhatDelegatedHealthcareActivitiesRow = queryByTestId(
+                'know-what-delegated-healthcare-activities',
+              );
+
+              expect(knowWhatDelegatedHealthcareActivitiesRow).toBeFalsy();
+            });
           });
-
-          const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
-          const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
-          const answer = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Not known');
-
-          expect(answer).toBeTruthy();
-          expect(link).toBeTruthy();
-          expect(link.getAttribute('href')).toEqual(
-            `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
-          );
-          expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
         });
 
-        it('should show a list of activities and a change link"', async () => {
-          const { component, getByTestId } = await setup({
-            establishment: {
-              staffDoDelegatedHealthcareActivities: 'Yes',
-              staffWhatKindDelegatedHealthcareActivities: {
-                knowWhatActivities: 'Yes',
-                activities: mockDHAs,
-              },
-            },
-            permissions: ['canEditEstablishment'],
-          });
-
-          const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
-
-          const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
-
-          mockDHAs.forEach((answer) => {
-            expect(within(knowWhatDelegatedHealthcareActivitiesRow).queryByText(answer.title)).toBeTruthy();
-          });
-          expect(link).toBeTruthy();
-          expect(link.getAttribute('href')).toEqual(
-            `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
-          );
-          expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
-        });
-
-        describe('no answer', () => {
-          it('should show "-" and an add link when staffWhatKindDelegatedHealthcareActivities is null', async () => {
+        describe('staffDoDelegatedHealthcareActivities is "Yes"', () => {
+          it('should show "Not known" and a change link when Don`t know is answered', async () => {
             const { component, getByTestId } = await setup({
               establishment: {
+                mainService: { canDoDelegatedHealthcareActivities: true },
                 staffDoDelegatedHealthcareActivities: 'Yes',
-                staffWhatKindDelegatedHealthcareActivities: null,
+                staffWhatKindDelegatedHealthcareActivities: {
+                  knowWhatActivities: "Don't know",
+                  activities: null,
+                },
               },
               permissions: ['canEditEstablishment'],
             });
 
             const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
-            const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Add');
-            const answer = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('-');
+            const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
+            const answer = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Not known');
 
             expect(answer).toBeTruthy();
             expect(link).toBeTruthy();
             expect(link.getAttribute('href')).toEqual(
               `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
             );
-
             expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
           });
-        });
 
-        it('should not show a change link" when canEditEstablishment is false', async () => {
-          const { getByTestId } = await setup({
-            establishment: {
-              staffDoDelegatedHealthcareActivities: 'Yes',
-              staffWhatKindDelegatedHealthcareActivities: {
-                knowWhatActivities: 'Yes',
-                activities: mockDHAs,
+          it('should show a list of activities and a change link"', async () => {
+            const { component, getByTestId } = await setup({
+              establishment: {
+                mainService: { canDoDelegatedHealthcareActivities: true },
+                staffDoDelegatedHealthcareActivities: 'Yes',
+                staffWhatKindDelegatedHealthcareActivities: {
+                  knowWhatActivities: 'Yes',
+                  activities: mockDHAs,
+                },
               },
-            },
-            permissions: [],
+              permissions: ['canEditEstablishment'],
+            });
+
+            const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
+
+            const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
+
+            mockDHAs.forEach((answer) => {
+              expect(within(knowWhatDelegatedHealthcareActivitiesRow).queryByText(answer.title)).toBeTruthy();
+            });
+            expect(link).toBeTruthy();
+            expect(link.getAttribute('href')).toEqual(
+              `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
+            );
+            expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
           });
 
-          const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
-          const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
+          describe('no answer', () => {
+            it('should show "-" and an add link when staffWhatKindDelegatedHealthcareActivities is null', async () => {
+              const { component, getByTestId } = await setup({
+                establishment: {
+                  mainService: { canDoDelegatedHealthcareActivities: true },
+                  staffDoDelegatedHealthcareActivities: 'Yes',
+                  staffWhatKindDelegatedHealthcareActivities: null,
+                },
+                permissions: ['canEditEstablishment'],
+              });
 
-          expect(link).toBeFalsy();
-          expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
+              const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
+              const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Add');
+              const answer = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('-');
+
+              expect(answer).toBeTruthy();
+              expect(link).toBeTruthy();
+              expect(link.getAttribute('href')).toEqual(
+                `/workplace/${component.workplace.uid}/what-kind-of-delegated-healthcare-activities`,
+              );
+
+              expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
+            });
+          });
+
+          it('should not show a change link" when canEditEstablishment is false', async () => {
+            const { getByTestId } = await setup({
+              establishment: {
+                mainService: { canDoDelegatedHealthcareActivities: true },
+                staffDoDelegatedHealthcareActivities: 'Yes',
+                staffWhatKindDelegatedHealthcareActivities: {
+                  knowWhatActivities: 'Yes',
+                  activities: mockDHAs,
+                },
+              },
+              permissions: [],
+            });
+
+            const knowWhatDelegatedHealthcareActivitiesRow = getByTestId('know-what-delegated-healthcare-activities');
+            const link = within(knowWhatDelegatedHealthcareActivitiesRow).queryByText('Change');
+
+            expect(link).toBeFalsy();
+            expect(knowWhatDelegatedHealthcareActivitiesRow).toBeTruthy();
+          });
         });
       });
     });


### PR DESCRIPTION
#### Issue
When coming from the workplace summary to DHA question 1 then going to question 2, the backlink on question 2 would take you to the workplace summary, instead of back to question 1.

#### Work done
- Add function to check which page should be set for the backlink
- Add an extra check on workplace summary on when to show `Which delegated healthcare activities` row

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
