### PR TITLE
Feat/1802 create cookie banner

### DIFF
--- a/frontend/cypress/e2e/others/cookieBanner.spec.cy.js
+++ b/frontend/cypress/e2e/others/cookieBanner.spec.cy.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef */
+/// <reference types="cypress" />
+
+import { StandAloneEstablishment } from '../../support/mockEstablishmentData';
+
+describe('Cookie banner', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.clearAllCookies();
+    cy.reload();
+  });
+
+  it('should show a cookie banner', () => {
+    cy.get('[data-testid="cookie-banner"]').should('exist');
+
+    cy.get('[data-testid="cookie-banner"]').within(() => {
+      cy.get('div').contains('Cookies on the Adult Social Care Workforce Data Set').should('be.visible');
+      cy.get('button').contains('Accept analytics cookies').should('be.visible');
+      cy.get('button').contains('Reject analytics cookies').should('be.visible');
+      cy.get('a').contains('View cookies').should('be.visible');
+    });
+  });
+
+  ['Accept', 'Reject'].forEach((buttonName) => {
+    it(`should close the cookie banner when ${buttonName} button is clicked`, () => {
+      cy.get('[data-testid="cookie-banner"]').should('exist');
+
+      cy.get('button').contains(`${buttonName} analytics cookies`).click();
+
+      cy.get('[data-testid="cookie-banner"]').should('not.exist');
+    });
+  });
+
+  it('after closing the cookie banner, it should remain closed between logins and page reloads', () => {
+    cy.get('[data-testid="cookie-banner"]').should('exist');
+
+    cy.get('button').contains('Reject analytics cookies').click();
+    cy.get('[data-testid="cookie-banner"]').should('not.exist');
+
+    cy.loginAsUser(StandAloneEstablishment.editUserLoginName, Cypress.env('userPassword'));
+    cy.get('[data-testid="cookie-banner"]').should('not.exist');
+
+    cy.get('a').contains('Sign out').click();
+    cy.get('[data-testid="cookie-banner"]').should('not.exist');
+
+    cy.visit('/');
+    cy.reload();
+    cy.get('[data-testid="cookie-banner"]').should('not.exist');
+  });
+
+  it('should not show the cookie banner on the cookie policy page', () => {
+    cy.get('a').contains('View cookies').click();
+    cy.get('h1').should('contain', 'Cookie policy');
+
+    cy.get('[data-testid="cookie-banner"]').should('not.exist');
+  });
+});

--- a/frontend/cypress/e2e/others/cookieBanner.spec.cy.js
+++ b/frontend/cypress/e2e/others/cookieBanner.spec.cy.js
@@ -4,54 +4,74 @@
 import { StandAloneEstablishment } from '../../support/mockEstablishmentData';
 
 describe('Cookie banner', () => {
-  beforeEach(() => {
-    cy.visit('/');
-    cy.clearAllCookies();
-    cy.reload();
-  });
-
-  it('should show a cookie banner', () => {
-    cy.get('[data-testid="cookie-banner"]').should('exist');
-
-    cy.get('[data-testid="cookie-banner"]').within(() => {
-      cy.get('div').contains('Cookies on the Adult Social Care Workforce Data Set').should('be.visible');
-      cy.get('button').contains('Accept analytics cookies').should('be.visible');
-      cy.get('button').contains('Reject analytics cookies').should('be.visible');
-      cy.get('a').contains('View cookies').should('be.visible');
+  describe('when user login', () => {
+    beforeEach(() => {
+      cy.loginAsUser(StandAloneEstablishment.editUserLoginName, Cypress.env('userPassword'));
+      cy.clearAllCookies();
+      cy.reload();
     });
-  });
 
-  ['Accept', 'Reject'].forEach((buttonName) => {
-    it(`should close the cookie banner when ${buttonName} button is clicked`, () => {
+    it('should show a cookie banner', () => {
       cy.get('[data-testid="cookie-banner"]').should('exist');
 
-      cy.get('button').contains(`${buttonName} analytics cookies`).click();
+      cy.get('[data-testid="cookie-banner"]').within(() => {
+        cy.get('div').contains('Cookies on the Adult Social Care Workforce Data Set').should('be.visible');
+        cy.get('button').contains('Accept analytics cookies').should('be.visible');
+        cy.get('button').contains('Reject analytics cookies').should('be.visible');
+        cy.get('a').contains('View cookies').should('be.visible');
+      });
+    });
+
+    ['Accept', 'Reject'].forEach((buttonName) => {
+      it(`should close the cookie banner when ${buttonName} button is clicked`, () => {
+        cy.get('[data-testid="cookie-banner"]').should('exist');
+
+        cy.get('button').contains(`${buttonName} analytics cookies`).click();
+
+        cy.get('[data-testid="cookie-banner"]').should('not.exist');
+      });
+    });
+
+    it('after closing the cookie banner, it should remain closed between logins and page reloads', () => {
+      cy.get('[data-testid="cookie-banner"]').should('exist');
+
+      cy.get('button').contains('Reject analytics cookies').click();
+      cy.get('[data-testid="cookie-banner"]').should('not.exist');
+
+      cy.get('a').contains('Sign out').click();
+      cy.get('[data-testid="cookie-banner"]').should('not.exist');
+
+      cy.loginAsUser(StandAloneEstablishment.editUserLoginName, Cypress.env('userPassword'));
+      cy.reload();
+      cy.get('[data-testid="cookie-banner"]').should('not.exist');
+    });
+
+    it('should not show the cookie banner on the cookie policy page', () => {
+      cy.get('a').contains('View cookies').click();
+      cy.get('h1').should('contain', 'Cookie policy');
 
       cy.get('[data-testid="cookie-banner"]').should('not.exist');
     });
   });
 
-  it('after closing the cookie banner, it should remain closed between logins and page reloads', () => {
-    cy.get('[data-testid="cookie-banner"]').should('exist');
+  describe('when user has not logged in', () => {
+    beforeEach(() => {
+      cy.visit('/');
+      cy.reload();
+    });
 
-    cy.get('button').contains('Reject analytics cookies').click();
-    cy.get('[data-testid="cookie-banner"]').should('not.exist');
+    it('should not show the cookie banner on the login page', () => {
+      cy.get('a').contains('Sign in').click();
 
-    cy.loginAsUser(StandAloneEstablishment.editUserLoginName, Cypress.env('userPassword'));
-    cy.get('[data-testid="cookie-banner"]').should('not.exist');
+      cy.get('[data-testid="cookie-banner"]').should('not.exist');
+    });
 
-    cy.get('a').contains('Sign out').click();
-    cy.get('[data-testid="cookie-banner"]').should('not.exist');
+    it('should show the cookie banner in the first question of "create a new account" journey', () => {
+      cy.get('a').contains('Create an account').click();
+      cy.get('h1').should('contain', 'Create an Adult Social Care Workforce Data Set account');
+      cy.get('a').contains('Start now').click();
 
-    cy.visit('/');
-    cy.reload();
-    cy.get('[data-testid="cookie-banner"]').should('not.exist');
-  });
-
-  it('should not show the cookie banner on the cookie policy page', () => {
-    cy.get('a').contains('View cookies').click();
-    cy.get('h1').should('contain', 'Cookie policy');
-
-    cy.get('[data-testid="cookie-banner"]').should('not.exist');
+      cy.get('[data-testid="cookie-banner"]').should('exist');
+    });
   });
 });

--- a/frontend/cypress/e2e/others/cookieBanner.spec.cy.js
+++ b/frontend/cypress/e2e/others/cookieBanner.spec.cy.js
@@ -18,7 +18,7 @@ describe('Cookie banner', () => {
         cy.get('div').contains('Cookies on the Adult Social Care Workforce Data Set').should('be.visible');
         cy.get('button').contains('Accept analytics cookies').should('be.visible');
         cy.get('button').contains('Reject analytics cookies').should('be.visible');
-        cy.get('a').contains('View cookies').should('be.visible');
+        cy.get('a').contains('View cookie policy').should('be.visible');
       });
     });
 
@@ -47,7 +47,7 @@ describe('Cookie banner', () => {
     });
 
     it('should not show the cookie banner on the cookie policy page', () => {
-      cy.get('a').contains('View cookies').click();
+      cy.get('a').contains('View cookie policy').click();
       cy.get('h1').should('contain', 'Cookie policy');
 
       cy.get('[data-testid="cookie-banner"]').should('not.exist');

--- a/frontend/cypress/e2e/registration/createAnAccount.spec.cy.js
+++ b/frontend/cypress/e2e/registration/createAnAccount.spec.cy.js
@@ -27,7 +27,7 @@ describe('Create account', () => {
   });
 
   beforeEach(() => {
-    cy.visit('/');
+    cy.openLoginPage();
   });
 
   it('should show the create acount start page', () => {

--- a/frontend/cypress/support/commands/loginCommands.js
+++ b/frontend/cypress/support/commands/loginCommands.js
@@ -1,10 +1,13 @@
 /* eslint-disable no-undef */
 Cypress.Commands.add('openLoginPage', () => {
+  cy.setCookie('cookies_preferences_set', 'true');
   cy.visit('/');
 });
 
 Cypress.Commands.add('loginAsAdmin', () => {
   cy.intercept('POST', '/api/login').as('login');
+
+  cy.setCookie('cookies_preferences_set', 'true');
   cy.visit('/');
   cy.get('[data-cy="username"]').type(Cypress.env('adminUser'));
   cy.get('[data-cy="password"]').type(Cypress.env('userPassword'));
@@ -14,6 +17,8 @@ Cypress.Commands.add('loginAsAdmin', () => {
 
 Cypress.Commands.add('loginAsUser', (username, password) => {
   cy.intercept('POST', '/api/login').as('login');
+
+  cy.setCookie('cookies_preferences_set', 'true');
   cy.visit('/');
   cy.get('[data-cy="username"]').type(username);
   cy.get('[data-cy="password"]').type(password);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,23 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-
-    <!-- Google Tag Manager -->
-
-    <script>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WZKV3HJ');
-    </script>
-
-    <!-- End Google Tag Manager -->
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "jspdf": "^2.2.0",
         "karma-chrome-launcher": "^3.2.0",
         "lodash": "^4.17.21",
+        "ngx-cookie-service": "^17.1.0",
         "ngx-dropzone": "^3.1.0",
         "request": "^2.88.2",
         "rxjs": "^6.6.7",
@@ -16785,6 +16786,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/ngx-cookie-service": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-17.1.0.tgz",
+      "integrity": "sha512-m4YI9IEgTaEBDMCz7oeVsO6UX14EmCzg29cTL6yxW8f7oye9wv56egi+3C4wAVSRPkI+cWlqnIOr+XyHwYQYmg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^17.0.0",
+        "@angular/core": "^17.0.0"
       }
     },
     "node_modules/ngx-dropzone": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "jspdf": "^2.2.0",
     "karma-chrome-launcher": "^3.2.0",
     "lodash": "^4.17.21",
+    "ngx-cookie-service": "^17.1.0",
     "ngx-dropzone": "^3.1.0",
     "request": "^2.88.2",
     "rxjs": "^6.6.7",

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,4 +1,5 @@
 <div tabindex="-1" #top class="govuk-util__no-focus">
+  <app-cookie-banner></app-cookie-banner>
   <a class="govuk-skip-link" href="#main-content" (click)="skip($event)">Skip to main content</a>
   <app-header [showNotificationsLink]="standAloneAccount || parentAccount || subsAccount"></app-header>
   <div>

--- a/frontend/src/app/core/services/analytic-cookies.service.spec.ts
+++ b/frontend/src/app/core/services/analytic-cookies.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AnalyticCookiesService } from './analytic-cookies.service';
+import { WindowToken } from './window';
+import { DOCUMENT } from '@angular/common';
+
+fdescribe('AnalyticCookiesService', () => {
+  let service: AnalyticCookiesService;
+  let document: Document;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: WindowToken, useValue: {} }],
+    });
+    service = TestBed.inject(AnalyticCookiesService);
+    document = TestBed.inject(DOCUMENT);
+
+    document.head.innerHTML = ''; // reset document object
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('startGoogleAnalyticsTracking', () => {
+    it('should inject a script tag for Google Tag Manager to <head>', async () => {
+      service.startGoogleAnalyticsTracking();
+
+      const scriptTag = document.head.querySelector('script');
+
+      expect(scriptTag).toBeTruthy();
+      expect(scriptTag.type).toEqual('text/javascript');
+    });
+
+    it('should not inject the script tag twice if it is already there', async () => {
+      service.startGoogleAnalyticsTracking();
+      service.startGoogleAnalyticsTracking();
+
+      const allScriptTags = document.head.querySelectorAll('script');
+      expect(allScriptTags.length).toEqual(1);
+    });
+
+    it('should push a gtm start event to window.dataLayer', async () => {
+      service.startGoogleAnalyticsTracking();
+
+      const window = TestBed.inject(WindowToken) as Window;
+
+      expect(window.dataLayer.length).toEqual(1);
+      expect(window.dataLayer[0]).toEqual({ 'gtm.start': jasmine.any(Number), event: 'gtm.js' });
+    });
+  });
+
+  describe('googleAnalyticsStarted', () => {
+    it('should return true if google analytics has started', async () => {
+      service.startGoogleAnalyticsTracking();
+
+      expect(service.googleAnalyticsStarted).toEqual(true);
+    });
+
+    it('should return false if google analytics has not started', async () => {
+      expect(service.googleAnalyticsStarted).toEqual(false);
+    });
+  });
+});

--- a/frontend/src/app/core/services/analytic-cookies.service.spec.ts
+++ b/frontend/src/app/core/services/analytic-cookies.service.spec.ts
@@ -4,7 +4,7 @@ import { AnalyticCookiesService } from './analytic-cookies.service';
 import { WindowToken } from './window';
 import { DOCUMENT } from '@angular/common';
 
-fdescribe('AnalyticCookiesService', () => {
+describe('AnalyticCookiesService', () => {
   let service: AnalyticCookiesService;
   let document: Document;
 
@@ -47,18 +47,6 @@ fdescribe('AnalyticCookiesService', () => {
 
       expect(window.dataLayer.length).toEqual(1);
       expect(window.dataLayer[0]).toEqual({ 'gtm.start': jasmine.any(Number), event: 'gtm.js' });
-    });
-  });
-
-  describe('googleAnalyticsStarted', () => {
-    it('should return true if google analytics has started', async () => {
-      service.startGoogleAnalyticsTracking();
-
-      expect(service.googleAnalyticsStarted).toEqual(true);
-    });
-
-    it('should return false if google analytics has not started', async () => {
-      expect(service.googleAnalyticsStarted).toEqual(false);
     });
   });
 });

--- a/frontend/src/app/core/services/analytic-cookies.service.ts
+++ b/frontend/src/app/core/services/analytic-cookies.service.ts
@@ -1,0 +1,52 @@
+import { Inject, Injectable } from '@angular/core';
+import { WindowToken } from './window';
+import { DOCUMENT } from '@angular/common';
+
+const googleTagManagerId = 'GTM-WZKV3HJ';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AnalyticCookiesService {
+  private _googleAnalyticStarted: boolean = false;
+
+  constructor(@Inject(WindowToken) private window: Window, @Inject(DOCUMENT) private document: Document) {}
+
+  public startGoogleAnalyticsTracking(): void {
+    try {
+      if (this.googleAnalyticsTagAlreadyInserted()) {
+        return;
+      }
+
+      const window = this.window;
+      const document = this.document;
+
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+
+      const scriptTag = document.createElement('script', {});
+      scriptTag.async = true;
+      scriptTag.type = 'text/javascript';
+      scriptTag.src = `https://www.googletagmanager.com/gtm.js?id=${googleTagManagerId}`;
+
+      document.head.appendChild(scriptTag);
+      this._googleAnalyticStarted = true;
+    } catch (e) {
+      console.log('failed to initiate google tag manager');
+      console.error(e);
+    }
+  }
+
+  public get googleAnalyticsStarted(): boolean {
+    return this._googleAnalyticStarted;
+  }
+
+  private googleAnalyticsTagAlreadyInserted(): boolean {
+    try {
+      const gaScriptTagsFound = this.document.querySelectorAll('[src*="googletagmanager"]');
+      return gaScriptTagsFound?.length > 0;
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/frontend/src/app/core/services/analytic-cookies.service.ts
+++ b/frontend/src/app/core/services/analytic-cookies.service.ts
@@ -8,8 +8,6 @@ const googleTagManagerId = 'GTM-WZKV3HJ';
   providedIn: 'root',
 })
 export class AnalyticCookiesService {
-  private _googleAnalyticStarted: boolean = false;
-
   constructor(@Inject(WindowToken) private window: Window, @Inject(DOCUMENT) private document: Document) {}
 
   public startGoogleAnalyticsTracking(): void {
@@ -30,15 +28,10 @@ export class AnalyticCookiesService {
       scriptTag.src = `https://www.googletagmanager.com/gtm.js?id=${googleTagManagerId}`;
 
       document.head.appendChild(scriptTag);
-      this._googleAnalyticStarted = true;
     } catch (e) {
       console.log('failed to initiate google tag manager');
       console.error(e);
     }
-  }
-
-  public get googleAnalyticsStarted(): boolean {
-    return this._googleAnalyticStarted;
   }
 
   private googleAnalyticsTagAlreadyInserted(): boolean {

--- a/frontend/src/app/core/services/cookie-policy.service.spec.ts
+++ b/frontend/src/app/core/services/cookie-policy.service.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CookiePolicyService } from './cookie-policy.service';
+import { CookieService } from 'ngx-cookie-service';
+
+fdescribe('CookiePolicyService', () => {
+  let service: CookiePolicyService;
+  let cookieService: CookieService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CookiePolicyService);
+    cookieService = TestBed.inject(CookieService);
+
+    cookieService.deleteAll();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('acceptAnalyticCookies', () => {
+    it('should set "analytics": true in cookies_policy', () => {
+      service.acceptAnalyticCookies();
+
+      const cookiePolicyObject = JSON.parse(cookieService.get('cookies_policy'));
+      expect(cookiePolicyObject.analytics).toEqual(true);
+    });
+
+    it('should set "cookies_preferences_set" to true', () => {
+      service.acceptAnalyticCookies();
+      expect(cookieService.get('cookies_preferences_set')).toEqual('true');
+    });
+  });
+
+  describe('rejectAnalyticCookies', () => {
+    it('should set "analytics": false in cookies_policy', () => {
+      service.rejectAnalyticCookies();
+
+      const cookiePolicyObject = JSON.parse(cookieService.get('cookies_policy'));
+      expect(cookiePolicyObject.analytics).toEqual(false);
+    });
+
+    it('should set "cookies_preferences_set" to true', () => {
+      service.rejectAnalyticCookies();
+      expect(cookieService.get('cookies_preferences_set')).toEqual('true');
+    });
+  });
+
+  describe('analyticCookiesAccepted', () => {
+    it('should return true if user accepted analyticCookies', () => {
+      service.acceptAnalyticCookies();
+
+      expect(service.analyticCookiesAccepted).toEqual(true);
+    });
+
+    it('should return false if user rejected analyticCookies', () => {
+      service.rejectAnalyticCookies();
+
+      expect(service.analyticCookiesAccepted).toEqual(false);
+    });
+
+    it('should return false if user has not set their preference yet', () => {
+      expect(service.analyticCookiesAccepted).toEqual(false);
+    });
+  });
+
+  describe('hasAnsweredCookiePreferences', () => {
+    it('should return true when user accepted analyticCookies', () => {
+      service.acceptAnalyticCookies();
+
+      expect(service.hasAnsweredCookiePreferences).toEqual(true);
+    });
+
+    it('should return true when user rejected analyticCookies', () => {
+      service.rejectAnalyticCookies();
+
+      expect(service.hasAnsweredCookiePreferences).toEqual(true);
+    });
+
+    it('should return false when user has not set their preference yet', () => {
+      expect(service.hasAnsweredCookiePreferences).toEqual(false);
+    });
+  });
+});

--- a/frontend/src/app/core/services/cookie-policy.service.spec.ts
+++ b/frontend/src/app/core/services/cookie-policy.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { CookiePolicyService } from './cookie-policy.service';
 import { CookieService } from 'ngx-cookie-service';
 
-fdescribe('CookiePolicyService', () => {
+describe('CookiePolicyService', () => {
   let service: CookiePolicyService;
   let cookieService: CookieService;
 

--- a/frontend/src/app/core/services/cookie-policy.service.ts
+++ b/frontend/src/app/core/services/cookie-policy.service.ts
@@ -37,7 +37,7 @@ export class CookiePolicyService {
     return this.getCookie(Key.CookiesPreferencesSet) === true;
   }
 
-  private getCookie(key: string) {
+  protected getCookie(key: string) {
     const value = this.cookieService.get(key);
     try {
       return JSON.parse(value);
@@ -46,12 +46,12 @@ export class CookiePolicyService {
     }
   }
 
-  private setCookie(key: string, value: string | boolean | object) {
+  protected setCookie(key: string, value: string | boolean | object) {
     const valueAsString = typeof value === 'string' ? value : JSON.stringify(value);
     this.cookieService.set(key, valueAsString, {
       path: '/',
       secure: true,
-      expires: dayjs(new Date()).add(1, 'year').toDate(),
+      expires: dayjs().add(1, 'year').toDate(),
     });
   }
 }

--- a/frontend/src/app/core/services/cookie-policy.service.ts
+++ b/frontend/src/app/core/services/cookie-policy.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+import dayjs from 'dayjs';
+import { CookieService } from 'ngx-cookie-service';
+
+type CookiePolicy = {
+  essential: boolean;
+  analytics: boolean;
+};
+
+enum Key {
+  CookiesPolicy = 'cookies_policy',
+  CookiesPreferencesSet = 'cookies_preferences_set',
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CookiePolicyService {
+  constructor(private cookieService: CookieService) {}
+
+  public acceptAnalyticCookies() {
+    this.setCookie(Key.CookiesPolicy, { essential: true, analytics: true });
+    this.setCookie(Key.CookiesPreferencesSet, true);
+  }
+
+  public rejectAnalyticCookies() {
+    this.setCookie(Key.CookiesPolicy, { essential: true, analytics: false });
+    this.setCookie(Key.CookiesPreferencesSet, true);
+  }
+
+  public get analyticCookiesAccepted() {
+    const cookiePolicy = this.getCookie(Key.CookiesPolicy) as CookiePolicy;
+    return cookiePolicy?.analytics === true;
+  }
+
+  public get hasAnsweredCookiePreferences() {
+    return this.getCookie(Key.CookiesPreferencesSet) === true;
+  }
+
+  private getCookie(key: string) {
+    const value = this.cookieService.get(key);
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+
+  private setCookie(key: string, value: string | boolean | object) {
+    const valueAsString = typeof value === 'string' ? value : JSON.stringify(value);
+    this.cookieService.set(key, valueAsString, {
+      path: '/',
+      secure: true,
+      expires: dayjs(new Date()).add(1, 'year').toDate(),
+    });
+  }
+}

--- a/frontend/src/app/core/services/cookie-policy.service.ts
+++ b/frontend/src/app/core/services/cookie-policy.service.ts
@@ -37,7 +37,7 @@ export class CookiePolicyService {
     return this.getCookie(Key.CookiesPreferencesSet) === true;
   }
 
-  protected getCookie(key: string) {
+  private getCookie(key: string) {
     const value = this.cookieService.get(key);
     try {
       return JSON.parse(value);
@@ -46,7 +46,7 @@ export class CookiePolicyService {
     }
   }
 
-  protected setCookie(key: string, value: string | boolean | object) {
+  private setCookie(key: string, value: string | boolean | object) {
     const valueAsString = typeof value === 'string' ? value : JSON.stringify(value);
     this.cookieService.set(key, valueAsString, {
       path: '/',

--- a/frontend/src/app/core/test-utils/MockCookiePolicyService.ts
+++ b/frontend/src/app/core/test-utils/MockCookiePolicyService.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { CookiePolicyService } from '@core/services/cookie-policy.service';
+import { CookieService } from 'ngx-cookie-service';
+
+type FactoryOverrides = {
+  hasAnsweredCookiePreferences?: boolean;
+  analyticCookiesAccepted?: boolean;
+};
+
+@Injectable()
+export class MockCookiePolicyService extends CookiePolicyService {
+  private _hasAnsweredCookiePreferences: boolean;
+  private _analyticCookiesAccepted: boolean;
+
+  public acceptAnalyticCookies() {
+    this._hasAnsweredCookiePreferences = true;
+    this._analyticCookiesAccepted = true;
+  }
+
+  public rejectAnalyticCookies() {
+    this._hasAnsweredCookiePreferences = true;
+    this._analyticCookiesAccepted = false;
+  }
+
+  public get analyticCookiesAccepted() {
+    return this._analyticCookiesAccepted === true;
+  }
+
+  public get hasAnsweredCookiePreferences() {
+    return this._hasAnsweredCookiePreferences === true;
+  }
+
+  public static factory(overrides: FactoryOverrides = {}) {
+    return (cookieService: CookieService) => {
+      const service = new MockCookiePolicyService(cookieService);
+
+      if (overrides.hasAnsweredCookiePreferences) {
+        service._hasAnsweredCookiePreferences = true;
+      }
+
+      if (overrides.analyticCookiesAccepted) {
+        service._analyticCookiesAccepted = true;
+      }
+
+      return service;
+    };
+  }
+}

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
@@ -22,7 +22,7 @@
         <button type="button" class="govuk-button govuk-button--secondary" (click)="rejectAnalyticCookies()">
           Reject analytics cookies
         </button>
-        <a class="govuk-link" href="#">View cookies</a>
+        <a class="govuk-link" href="#" [routerLink]="['/cookie-policy']">View cookies</a>
       </div>
     </div>
   </div>

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
@@ -22,7 +22,7 @@
         <button type="button" class="govuk-button govuk-button--secondary" (click)="rejectAnalyticCookies()">
           Reject analytics cookies
         </button>
-        <a class="govuk-link" href="#" [routerLink]="['/cookie-policy']">View cookies</a>
+        <a class="govuk-link" href="#" [routerLink]="['/cookie-policy']">View cookie policy</a>
       </div>
     </div>
   </div>

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
@@ -1,0 +1,20 @@
+<div class="asc-cookie-banner" data-testid="cookie-banner" data-nosnippet role="region" aria-label="Cookies on ASC-WDS">
+  <div class="asc-cookie-banner__wrapper">
+    <div class="asc-cookie-banner__content" #cookieBanner tabindex="-1" cdkTrapFocus>
+      <h2 class="govuk-heading-m asc-cookie-banner__heading">Cookies on the Adult Social Care Workforce Data Set</h2>
+
+      <div class="asc-cookie-banner__explanation">
+        <p class="govuk-body-m">We use some essential cookies to make this service work.</p>
+        <p class="govuk-body-m">
+          We'd also like to use analytics cookies so we can understand how you use ASC-WDS and make improvements.
+        </p>
+      </div>
+
+      <div class="govuk-button-group">
+        <button type="button" class="govuk-button" #acceptButton>Accept analytics cookies</button>
+        <button type="button" class="govuk-button govuk-button--secondary">Reject analytics cookies</button>
+        <a class="govuk-link" href="#">View cookies</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
@@ -18,8 +18,10 @@
       </div>
 
       <div class="govuk-button-group">
-        <button type="button" class="govuk-button" #acceptButton>Accept analytics cookies</button>
-        <button type="button" class="govuk-button govuk-button--secondary">Reject analytics cookies</button>
+        <button type="button" class="govuk-button" (click)="acceptAnalyticCookies()">Accept analytics cookies</button>
+        <button type="button" class="govuk-button govuk-button--secondary" (click)="rejectAnalyticCookies()">
+          Reject analytics cookies
+        </button>
         <a class="govuk-link" href="#">View cookies</a>
       </div>
     </div>

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.html
@@ -1,4 +1,11 @@
-<div class="asc-cookie-banner" data-testid="cookie-banner" data-nosnippet role="region" aria-label="Cookies on ASC-WDS">
+<div
+  class="asc-cookie-banner"
+  data-testid="cookie-banner"
+  data-nosnippet
+  role="region"
+  aria-label="Cookies on ASC-WDS"
+  *ngIf="isShowing"
+>
   <div class="asc-cookie-banner__wrapper">
     <div class="asc-cookie-banner__content" #cookieBanner tabindex="-1" cdkTrapFocus>
       <h2 class="govuk-heading-m asc-cookie-banner__heading">Cookies on the Adult Social Care Workforce Data Set</h2>

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.scss
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.scss
@@ -1,7 +1,6 @@
 @import 'node_modules/govuk-frontend/govuk/base';
 
 .asc-cookie-banner__wrapper {
-  //   display: none;
   background-color: rgba(0, 0, 0, 0.32);
 
   position: absolute;

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.scss
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.scss
@@ -1,0 +1,38 @@
+@import 'node_modules/govuk-frontend/govuk/base';
+
+.asc-cookie-banner__wrapper {
+  //   display: none;
+  background-color: rgba(0, 0, 0, 0.32);
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 999;
+
+  pointer-events: auto;
+  -webkit-tap-highlight-color: transparent;
+  transition: opacity 400ms cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.asc-cookie-banner__content {
+  background-color: #fff;
+  left: 0;
+  width: 31em;
+  height: 100%;
+  outline: 0;
+  padding: govuk-spacing(8);
+  box-sizing: border-box;
+}
+
+.asc-cookie-banner__explanation {
+  margin-top: govuk-spacing(6);
+  margin-bottom: govuk-spacing(8);
+}
+
+.asc-cookie-banner__content > .govuk-button-group {
+  display: flex;
+  flex-direction: column;
+  gap: govuk-spacing(3);
+}

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
@@ -1,13 +1,20 @@
 import { CookieBannerComponent } from './cookie-banner.component';
 import { render } from '@testing-library/angular';
 import { RouterModule } from '@angular/router';
+import { CookiePolicyService } from '@core/services/cookie-policy.service';
+import { MockCookiePolicyService } from '@core/test-utils/MockCookiePolicyService';
 
 fdescribe('CookieBannerComponent', () => {
-  const setup = async () => {
+  const setup = async (overrides: any = {}) => {
     const setupTools = await render(CookieBannerComponent, {
       imports: [RouterModule],
       declarations: [],
-      providers: [],
+      providers: [
+        {
+          provide: CookiePolicyService,
+          useFactory: MockCookiePolicyService.factory(overrides),
+        },
+      ],
       componentProperties: {},
     });
 
@@ -19,6 +26,18 @@ fdescribe('CookieBannerComponent', () => {
   it('should create', async () => {
     const component = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('should not show up when user already answered their cookie preferences', async () => {
+    const { queryByTestId } = await setup({ hasAnsweredCookiePreferences: true });
+
+    expect(queryByTestId('cookie-banner')).toBeFalsy();
+  });
+
+  it('should show up when user has not answer their cookie preferences', async () => {
+    const { queryByTestId } = await setup();
+
+    expect(queryByTestId('cookie-banner')).toBeTruthy();
   });
 
   it('should show a heading', async () => {
@@ -40,4 +59,6 @@ fdescribe('CookieBannerComponent', () => {
     expect(acceptButton).toBeTruthy();
     expect(rejectButton).toBeTruthy();
   });
+
+  xit('should show a link for cookie policy page', async () => {});
 });

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
@@ -82,7 +82,7 @@ describe('CookieBannerComponent', () => {
   it('should show a link to the cookie policy page', async () => {
     const { getByText } = await setup();
 
-    const link = getByText('View cookies') as HTMLAnchorElement;
+    const link = getByText('View cookie policy') as HTMLAnchorElement;
 
     expect(link.href).toContain('/cookie-policy');
   });

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
@@ -5,6 +5,7 @@ import { CookiePolicyService } from '@core/services/cookie-policy.service';
 import { MockCookiePolicyService } from '@core/test-utils/MockCookiePolicyService';
 import { getTestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
+import { WindowToken } from '@core/services/window';
 
 fdescribe('CookieBannerComponent', () => {
   const setup = async (overrides: any = {}) => {
@@ -20,8 +21,8 @@ fdescribe('CookieBannerComponent', () => {
           provide: ActivatedRoute,
           useValue: {},
         },
+        { provide: WindowToken, useValue: {} },
       ],
-      componentProperties: {},
     });
 
     const component = setupTools.fixture.componentInstance;

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
@@ -1,0 +1,43 @@
+import { CookieBannerComponent } from './cookie-banner.component';
+import { render } from '@testing-library/angular';
+import { RouterModule } from '@angular/router';
+
+fdescribe('CookieBannerComponent', () => {
+  const setup = async () => {
+    const setupTools = await render(CookieBannerComponent, {
+      imports: [RouterModule],
+      declarations: [],
+      providers: [],
+      componentProperties: {},
+    });
+
+    const component = setupTools.fixture.componentInstance;
+
+    return { ...setupTools, component };
+  };
+
+  it('should create', async () => {
+    const component = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should show a heading', async () => {
+    const { getByRole } = await setup();
+
+    const expectedHeadingText = 'Cookies on the Adult Social Care Workforce Data Set';
+
+    const heading = getByRole('heading', { level: 2 });
+    expect(heading).toBeTruthy();
+    expect(heading.textContent).toContain(expectedHeadingText);
+  });
+
+  it('should show a CTA button for accept and a button for reject', async () => {
+    const { getByRole } = await setup();
+
+    const acceptButton = getByRole('button', { name: 'Accept analytics cookies' });
+    const rejectButton = getByRole('button', { name: 'Reject analytics cookies' });
+
+    expect(acceptButton).toBeTruthy();
+    expect(rejectButton).toBeTruthy();
+  });
+});

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.spec.ts
@@ -3,6 +3,7 @@ import { render } from '@testing-library/angular';
 import { RouterModule } from '@angular/router';
 import { CookiePolicyService } from '@core/services/cookie-policy.service';
 import { MockCookiePolicyService } from '@core/test-utils/MockCookiePolicyService';
+import { getTestBed } from '@angular/core/testing';
 
 fdescribe('CookieBannerComponent', () => {
   const setup = async (overrides: any = {}) => {
@@ -19,8 +20,9 @@ fdescribe('CookieBannerComponent', () => {
     });
 
     const component = setupTools.fixture.componentInstance;
+    const cookiePolicyService = getTestBed().inject(CookiePolicyService);
 
-    return { ...setupTools, component };
+    return { ...setupTools, component, cookiePolicyService };
   };
 
   it('should create', async () => {
@@ -61,4 +63,46 @@ fdescribe('CookieBannerComponent', () => {
   });
 
   xit('should show a link for cookie policy page', async () => {});
+
+  describe('when accept buttons is pressed', () => {
+    it('should set the cookie preferences and policy', async () => {
+      const { getByRole, cookiePolicyService } = await setup();
+
+      getByRole('button', { name: 'Accept analytics cookies' }).click();
+
+      expect(cookiePolicyService.hasAnsweredCookiePreferences).toBeTrue();
+      expect(cookiePolicyService.analyticCookiesAccepted).toBeTrue();
+    });
+
+    it('should close the banner', async () => {
+      const { getByRole, fixture, queryByTestId } = await setup();
+
+      getByRole('button', { name: 'Accept analytics cookies' }).click();
+
+      fixture.detectChanges();
+
+      expect(queryByTestId('cookie-banner')).toBeFalsy();
+    });
+  });
+
+  describe('when reject buttons is pressed', () => {
+    it('should set the cookie preferences and policy', async () => {
+      const { getByRole, cookiePolicyService } = await setup();
+
+      getByRole('button', { name: 'Reject analytics cookies' }).click();
+
+      expect(cookiePolicyService.hasAnsweredCookiePreferences).toBeTrue();
+      expect(cookiePolicyService.analyticCookiesAccepted).toBeFalse();
+    });
+
+    it('should close the banner', async () => {
+      const { getByRole, fixture, queryByTestId } = await setup();
+
+      getByRole('button', { name: 'Reject analytics cookies' }).click();
+
+      fixture.detectChanges();
+
+      expect(queryByTestId('cookie-banner')).toBeFalsy();
+    });
+  });
 });

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
@@ -1,23 +1,23 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { CookieService } from 'ngx-cookie-service';
+import { AfterViewInit, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-
-interface CookiePolicy {
-  essential: boolean;
-  analytics: boolean;
-}
+import { CookiePolicyService } from '@core/services/cookie-policy.service';
+import { BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'app-cookie-banner',
   templateUrl: './cookie-banner.component.html',
   styleUrl: './cookie-banner.component.scss',
 })
-export class CookieBannerComponent implements OnInit, OnDestroy, AfterViewInit {
+export class CookieBannerComponent implements OnInit, AfterViewInit {
+  private _isShowing: BehaviorSubject<boolean> = new BehaviorSubject(null);
+
   @ViewChild('cookieBanner') cookieBanner: ElementRef;
 
-  constructor(private cookieService: CookieService, private router: Router) {}
+  constructor(private cookiePolicyService: CookiePolicyService, private router: Router) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.checkIfShouldShowUp();
+  }
 
   ngAfterViewInit(): void {
     setTimeout(() => {
@@ -25,5 +25,23 @@ export class CookieBannerComponent implements OnInit, OnDestroy, AfterViewInit {
     }, 1000);
   }
 
-  ngOnDestroy(): void {}
+  get isShowing(): boolean {
+    return this._isShowing.value;
+  }
+
+  private checkIfShouldShowUp() {
+    if (!this.cookiePolicyService.hasAnsweredCookiePreferences) {
+      this._isShowing.next(true);
+    }
+  }
+
+  public acceptAnalyticCookies() {
+    this.cookiePolicyService.acceptAnalyticCookies();
+    this._isShowing.next(false);
+  }
+
+  public rejectAnalyticCookies() {
+    this.cookiePolicyService.rejectAnalyticCookies();
+    this._isShowing.next(false);
+  }
 }

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
@@ -3,7 +3,8 @@ import { NavigationEnd, Router } from '@angular/router';
 import { CookiePolicyService } from '@core/services/cookie-policy.service';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { filter, takeWhile } from 'rxjs/operators';
-import { AnalyticCookiesService } from '../../../core/services/analytic-cookies.service';
+import { AnalyticCookiesService } from '@core/services/analytic-cookies.service';
+import { UserService } from '@core/services/user.service';
 
 @Component({
   selector: 'app-cookie-banner',
@@ -19,23 +20,48 @@ export class CookieBannerComponent implements OnInit, OnDestroy {
   constructor(
     private cookiePolicyService: CookiePolicyService,
     private analyticCookiesService: AnalyticCookiesService,
+    private userService: UserService,
     private router: Router,
   ) {}
 
   ngOnInit(): void {
-    this.checkIfShouldShowUp();
-    this.listenToPageChange();
-    this.triggerGoogleAnalyticsTrackingIfAccepted();
+    this.checkIfShouldShowBanner();
+    this.setupRecheckOnPageChange();
+    this.triggerGoogleAnalyticsTrackingIfAcceptedBefore();
   }
 
   get isShowing() {
     return this._isShowing.value;
   }
 
-  private checkIfShouldShowUp() {
-    if (!this.cookiePolicyService.hasAnsweredCookiePreferences) {
-      this._isShowing.next(true);
+  private checkIfShouldShowBanner() {
+    const shouldShow = this.shouldShowBanner();
+    this._isShowing.next(shouldShow);
+  }
+
+  private shouldShowBanner(): boolean {
+    if (this.cookiePolicyService.hasAnsweredCookiePreferences) {
+      return false;
     }
+
+    const userHasLoggedIn = !!this.userService.loggedInUser;
+    if (userHasLoggedIn) {
+      return this.shouldShowBannerToLoggedInUser();
+    }
+
+    return this.shouldShowShowBannerToVisiter();
+  }
+
+  private shouldShowBannerToLoggedInUser(): boolean {
+    const viewingAdminPage = this.router.url.includes('sfcadmin');
+    const viewingCookiePolicyPage = this.router.url.includes('cookie-policy');
+
+    return !viewingAdminPage && !viewingCookiePolicyPage;
+  }
+
+  private shouldShowShowBannerToVisiter(): boolean {
+    const firstQuestionPageInCreateNewAccountJourney = '/registration/regulated-by-cqc';
+    return this.router.url.includes(firstQuestionPageInCreateNewAccountJourney);
   }
 
   public acceptAnalyticCookies() {
@@ -49,25 +75,20 @@ export class CookieBannerComponent implements OnInit, OnDestroy {
     this._isShowing.next(false);
   }
 
-  private listenToPageChange() {
+  private setupRecheckOnPageChange() {
     const pageChangeEventsUntilAnswered = this.router.events.pipe(
       filter((event) => event instanceof NavigationEnd),
       takeWhile(() => !this.cookiePolicyService.hasAnsweredCookiePreferences),
     );
 
-    const recheckOnPageChange = pageChangeEventsUntilAnswered.subscribe((event: NavigationEnd) => {
-      const url = event.urlAfterRedirects;
-      if (url.includes('cookie-policy') || url.includes('sfcadmin')) {
-        this._isShowing.next(false);
-      } else {
-        this.checkIfShouldShowUp();
-      }
+    const recheckOnPageChange = pageChangeEventsUntilAnswered.subscribe(() => {
+      this.checkIfShouldShowBanner();
     });
 
     this.subscriptions.add(recheckOnPageChange);
   }
 
-  private triggerGoogleAnalyticsTrackingIfAccepted() {
+  private triggerGoogleAnalyticsTrackingIfAcceptedBefore() {
     if (this.cookiePolicyService.analyticCookiesAccepted) {
       this.analyticCookiesService.startGoogleAnalyticsTracking();
     }

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
@@ -25,6 +25,7 @@ export class CookieBannerComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.checkIfShouldShowUp();
     this.listenToPageChange();
+    this.triggerGoogleAnalyticsTrackingIfAccepted();
   }
 
   get isShowing() {
@@ -64,6 +65,12 @@ export class CookieBannerComponent implements OnInit, OnDestroy {
     });
 
     this.subscriptions.add(recheckOnPageChange);
+  }
+
+  private triggerGoogleAnalyticsTrackingIfAccepted() {
+    if (this.cookiePolicyService.analyticCookiesAccepted) {
+      this.analyticCookiesService.startGoogleAnalyticsTracking();
+    }
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
@@ -49,7 +49,7 @@ export class CookieBannerComponent implements OnInit, OnDestroy {
       return this.shouldShowBannerToLoggedInUser();
     }
 
-    return this.shouldShowShowBannerToVisiter();
+    return this.shouldShowShowBannerToVisitor();
   }
 
   private shouldShowBannerToLoggedInUser(): boolean {
@@ -59,7 +59,7 @@ export class CookieBannerComponent implements OnInit, OnDestroy {
     return !viewingAdminPage && !viewingCookiePolicyPage;
   }
 
-  private shouldShowShowBannerToVisiter(): boolean {
+  private shouldShowShowBannerToVisitor(): boolean {
     const firstQuestionPageInCreateNewAccountJourney = '/registration/regulated-by-cqc';
     return this.router.url.includes(firstQuestionPageInCreateNewAccountJourney);
   }

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
@@ -1,0 +1,29 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { CookieService } from 'ngx-cookie-service';
+import { Router } from '@angular/router';
+
+interface CookiePolicy {
+  essential: boolean;
+  analytics: boolean;
+}
+
+@Component({
+  selector: 'app-cookie-banner',
+  templateUrl: './cookie-banner.component.html',
+  styleUrl: './cookie-banner.component.scss',
+})
+export class CookieBannerComponent implements OnInit, OnDestroy, AfterViewInit {
+  @ViewChild('cookieBanner') cookieBanner: ElementRef;
+
+  constructor(private cookieService: CookieService, private router: Router) {}
+
+  ngOnInit(): void {}
+
+  ngAfterViewInit(): void {
+    setTimeout(() => {
+      this.cookieBanner.nativeElement.focus();
+    }, 1000);
+  }
+
+  ngOnDestroy(): void {}
+}

--- a/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
+++ b/frontend/src/app/shared/components/cookie-banner/cookie-banner.component.ts
@@ -3,6 +3,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { CookiePolicyService } from '@core/services/cookie-policy.service';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { filter, takeWhile } from 'rxjs/operators';
+import { AnalyticCookiesService } from '../../../core/services/analytic-cookies.service';
 
 @Component({
   selector: 'app-cookie-banner',
@@ -15,7 +16,11 @@ export class CookieBannerComponent implements OnInit, OnDestroy {
 
   @ViewChild('cookieBanner') cookieBanner: ElementRef;
 
-  constructor(private cookiePolicyService: CookiePolicyService, private router: Router) {}
+  constructor(
+    private cookiePolicyService: CookiePolicyService,
+    private analyticCookiesService: AnalyticCookiesService,
+    private router: Router,
+  ) {}
 
   ngOnInit(): void {
     this.checkIfShouldShowUp();
@@ -34,6 +39,7 @@ export class CookieBannerComponent implements OnInit, OnDestroy {
 
   public acceptAnalyticCookies() {
     this.cookiePolicyService.acceptAnalyticCookies();
+    this.analyticCookiesService.startGoogleAnalyticsTracking();
     this._isShowing.next(false);
   }
 

--- a/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
+++ b/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
@@ -34,7 +34,7 @@ declare global {
   }
 }
 
-window.dataLayer = window.dataLayer || {};
+window.dataLayer = window.dataLayer || [];
 
 @Directive()
 export class NewHomeTabDirective implements OnInit, OnDestroy, OnChanges {

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -141,9 +141,11 @@ import { WorkplacePermissionsBearerPipe } from './pipes/workplace-permissions-be
 import { DetailsDhaExamplesComponent } from './components/details-dha-examples/details-dha-examples.component';
 import { FormatWhatDhaPipe } from './pipes/format-what-dha.pipe';
 import { WorkerPaginationComponent } from './components/worker-pagination/worker-pagination.component';
+import { CookieBannerComponent } from './components/cookie-banner/cookie-banner.component';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, OverlayModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, OverlayModule, A11yModule],
   declarations: [
     AbsoluteNumberPipe,
     AlertComponent,
@@ -282,6 +284,7 @@ import { WorkerPaginationComponent } from './components/worker-pagination/worker
     CareWorkforcePathwayWorkplaceAwarenessTitle,
     DetailsDhaExamplesComponent,
     FormatWhatDhaPipe,
+    CookieBannerComponent,
   ],
   exports: [
     AbsoluteNumberPipe,
@@ -414,6 +417,7 @@ import { WorkerPaginationComponent } from './components/worker-pagination/worker
     CareWorkforcePathwayWorkplaceAwarenessTitle,
     DetailsDhaExamplesComponent,
     FormatWhatDhaPipe,
+    CookieBannerComponent,
   ],
   providers: [
     DialogService,


### PR DESCRIPTION
#### Work done
- Add a CookieBannerComponent and services to support its functionality
- Add `ngx-cookie-service` package to frontend for cookie management
- Remove hardcoded<script> tag for Google Analytics from `index.html`. Instead, insert the tag by Angular side when user accepted analytic cookies
- Add e2e test related to cookie banner

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
