### PR TITLE
Fix/1810 - transfer staff record navigation

### DIFF
--- a/frontend/cypress/e2e/parentEstablishment/EditUser/staffRecordsPage.spec.cy.js
+++ b/frontend/cypress/e2e/parentEstablishment/EditUser/staffRecordsPage.spec.cy.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-undef */
 /// <reference types="cypress" />
-import { ParentEstablishment } from '../../../support/mockEstablishmentData';
+import { ParentEstablishment, SubEstablishmentNotDataOwner } from '../../../support/mockEstablishmentData';
 import { onHomePage } from '../../../support/page_objects/onHomePage';
+import { onStaffRecordsPage, onStaffRecordSummaryPage } from '../../../support/page_objects/onStaffRecordsPage';
 
 describe('Parent staff records page as edit user', () => {
   const workerName = 'test worker for staff record page';
@@ -24,5 +25,43 @@ describe('Parent staff records page as edit user', () => {
     cy.get('[data-cy="add-staff-record-button"]').should('contain', 'Add a staff record');
     cy.get('[data-cy="total-staff-panel"]').should('exist');
     cy.get('[data-cy="staff-summary"]').should('exist');
+  });
+
+  describe('transfer staff record', () => {
+    const testWorker = 'Test transfer staff record';
+
+    before(() => {
+      cy.insertTestWorker({ establishmentID, workerName: testWorker });
+    });
+
+    after(() => {
+      cy.deleteTestWorkerFromDb(testWorker);
+    });
+
+    it('should be able to transfer a worker to subsidiary workplace', () => {
+      const targetSubsidiary = SubEstablishmentNotDataOwner;
+
+      onStaffRecordsPage.clickIntoWorker(testWorker);
+
+      cy.get('a').contains('Transfer staff record').click();
+
+      // fill in transfer staff record modal box
+      cy.get('h1').contains('Transfer staff record').should('be.visible');
+      cy.getByLabel('Enter a workplace name or postcode').type(targetSubsidiary.name);
+      cy.contains('li', targetSubsidiary.name).click();
+      cy.get('button').contains('Transfer').click();
+
+      cy.get('app-alert span').should('contain', `${testWorker} has been moved to ${targetSubsidiary.name}`);
+
+      // view the subsidairy to confirm worker is transferred
+      cy.get('app-navigate-to-workplace-dropdown select').select(targetSubsidiary.name);
+
+      cy.url().should('contain', 'subsidiary');
+      cy.get('h1').should('contain', targetSubsidiary.name);
+
+      onHomePage.clickTab('Staff records');
+      onStaffRecordsPage.clickIntoWorker(testWorker);
+      onStaffRecordSummaryPage.expectRow('Name or ID number').toHaveValue(testWorker);
+    });
   });
 });

--- a/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.html
+++ b/frontend/src/app/features/subsidiary/staff-records/view-subsidiary-staff-records.component.html
@@ -6,6 +6,7 @@
 ></app-new-dashboard-header>
 
 <div class="govuk-width-container govuk-!-margin-top-2">
+  <app-alert></app-alert>
   <div class="govuk-!-margin-top-7">
     <ng-container *ngIf="workers?.length > 0; else noStaffRecords">
       <div data-testid="staff-records">

--- a/frontend/src/app/features/workers/move-worker-dialog/move-worker-dialog.component.html
+++ b/frontend/src/app/features/workers/move-worker-dialog/move-worker-dialog.component.html
@@ -25,15 +25,14 @@
         <app-auto-suggest
           data-testid="autocomplete-result"
           [formGroup]="form"
-          class="300px;"
-          [dataProvider]="workplaceNameOrPostCodeFilter"
+          [dataProvider]="autoCompleteDataProvider"
           [formControlName]="'workplaceNameOrPostCode'"
         ></app-auto-suggest>
       </div>
 
       <p *ngIf="form.valid">
         <strong
-          >You're about to move {{ data.worker.nameOrId }} {{ form.get('workplaceNameOrPostCode').value }}.</strong
+          >You're about to move {{ data.worker.nameOrId }} to {{ form.get('workplaceNameOrPostCode').value }}.</strong
         >
       </p>
     </fieldset>

--- a/frontend/src/app/features/workers/move-worker-dialog/move-worker-dialog.component.spec.ts
+++ b/frontend/src/app/features/workers/move-worker-dialog/move-worker-dialog.component.spec.ts
@@ -89,6 +89,20 @@ describe('MoveWorkerDialog', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should trigger autocomplete on input', async () => {
+    const { getByText, fixture, getByLabelText } = await setup();
+
+    const validWorkplace = subsid1 as Workplace;
+    const expectedAutoCompleteText = `${validWorkplace.name}, ${validWorkplace.postCode}`;
+
+    const inputBox = getByLabelText('Enter a workplace name or postcode');
+
+    userEvent.type(inputBox, validWorkplace.postCode.slice(0, 2));
+    fixture.detectChanges();
+
+    expect(getByText(expectedAutoCompleteText)).toBeTruthy();
+  });
+
   describe('on form submit: ', () => {
     it('should show an error message if user did not enter the workplace name or postcode', async () => {
       const { getByText, getAllByText, fixture, updateWorkerSpy } = await setup();


### PR DESCRIPTION
#### Work done
- fix the issue of MoveWorkerDialog navigating to wrong url when current workplace is a subsidiary
- add missing unit tests for MoveWorkerDialog, refactor MoveWorkerDialog
- add an e2e test for transfer staff record 

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
