### PR TITLE
Fix/1872-hide expiry date in edit training record with course

### DIFF
--- a/frontend/src/app/core/model/training.model.ts
+++ b/frontend/src/app/core/model/training.model.ts
@@ -93,6 +93,7 @@ export interface TrainingRecord {
   trainingStatus?: number;
   missing?: boolean;
   isMatchedToTrainingCourse?: boolean;
+  trainingCourseFK?: number;
 }
 
 export interface TrainingRecordCategory {

--- a/frontend/src/app/features/training-and-qualifications/include-training-course-details/include-training-course-details.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/include-training-course-details/include-training-course-details.component.ts
@@ -33,10 +33,13 @@ export class IncludeTrainingCourseDetailsComponent {
 
   ngOnInit(): void {
     this.setBackLink();
-    this.trainingRecord = this.route.snapshot.data.trainingRecord;
-    this.trainingCourses = this.route.snapshot.data.trainingCourses;
     this.workplace = this.route.snapshot.data.establishment;
     this.worker = this.route.snapshot.data.worker;
+    this.trainingRecord = this.route.snapshot.data.trainingRecord;
+
+    this.loadTrainingCourse();
+    this.prefill();
+
     this.clearSelectedTrainingCourseWhenClickedAway();
   }
 
@@ -44,17 +47,44 @@ export class IncludeTrainingCourseDetailsComponent {
     this.backLinkService.showBackLink();
   }
 
+  private loadTrainingCourse(): void {
+    this.trainingCourses = this.route.snapshot.data.trainingCourses;
+    if (!this.trainingCourses?.length) {
+      this.returnToPreviousPage();
+    }
+  }
+
+  private prefill(): void {
+    const isShowingRadioButton = this.trainingCourses.length > 1;
+    if (!isShowingRadioButton) {
+      return;
+    }
+
+    const previouslySelectedCourse =
+      this.trainingService.getSelectedTrainingCourse() ??
+      this.trainingCourses.find((course) => course.id === this.trainingRecord.trainingCourseFK);
+
+    if (previouslySelectedCourse) {
+      this.userSelectedTrainingCourse.setValue(previouslySelectedCourse.id);
+    }
+  }
+
+  private returnToPreviousPage(): void {
+    const previousPage = [
+      '/workplace',
+      this.workplace.uid,
+      'training-and-qualifications-record',
+      this.worker.uid,
+      'training',
+      this.trainingRecord.uid,
+    ];
+    this.router.navigate(previousPage);
+  }
+
   public onSubmit(): void {
-    if (this.userSelectedTrainingCourse.value === '' || this.userSelectedTrainingCourse.value === false) {
-      const previousPage = [
-        '/workplace',
-        this.workplace.uid,
-        'training-and-qualifications-record',
-        this.worker.uid,
-        'training',
-        this.trainingRecord.uid,
-      ];
-      this.router.navigate(previousPage);
+    const notSelectedAnyCourse = !this.userSelectedTrainingCourse.value;
+    if (notSelectedAnyCourse) {
+      this.returnToPreviousPage();
       return;
     }
 

--- a/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.html
+++ b/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.html
@@ -72,7 +72,7 @@
                   </div>
                 </div>
                 <div class="govuk-grid-column-one-half">
-                  @if (journeyType !== 'AddNewTrainingRecordWithCourse') {
+                  @if (showExpiryDateInput) {
                     <div
                       data-testid="expiresDate"
                       class="govuk-form-group"

--- a/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.html
+++ b/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.html
@@ -64,6 +64,7 @@
                       }
 
                       <app-date-picker
+                        #completed
                         [formGroup]="form"
                         [formGroupName]="'completed'"
                         [submitted]="submitted"
@@ -91,7 +92,7 @@
                               {{ trainingToDisplay?.validityPeriodInMonth }} months
                             </span>
                           </div>
-                        } @else if (showWarningOnDoesNotExpireWithDate) {
+                        } @else if (doesNotExpireMismatchWarning) {
                           <div>
                             <span
                               class="govuk-summary-list__key govuk-error-message govuk-summary-list__warning-message govuk__nowrap"
@@ -109,6 +110,7 @@
                           <span class="govuk-visually-hidden">Error:</span> {{ getFirstErrorMessage('expires') }}
                         </span>
                         <app-date-picker
+                          #expires
                           [formGroup]="form"
                           [formGroupName]="'expires'"
                           [submitted]="submitted"

--- a/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.html
+++ b/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.html
@@ -82,14 +82,25 @@
                       <fieldset class="govuk-fieldset" aria-describedby="expires-hint" role="group">
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Training expiry date</legend>
                         <legend id="expires-hint" class="govuk-hint">For example, 31 3 2025</legend>
-                        <div *ngIf="expiryMismatchWarning">
-                          <span
-                            class="govuk-summary-list__key govuk-error-message govuk-summary-list__warning-message govuk__nowrap"
-                          >
-                            This training is usually valid for
-                            {{ trainingToDisplay?.validityPeriodInMonth }} months
-                          </span>
-                        </div>
+                        @if (expiryMismatchWarning) {
+                          <div>
+                            <span
+                              class="govuk-summary-list__key govuk-error-message govuk-summary-list__warning-message govuk__nowrap"
+                            >
+                              This training is usually valid for
+                              {{ trainingToDisplay?.validityPeriodInMonth }} months
+                            </span>
+                          </div>
+                        } @else if (showWarningOnDoesNotExpireWithDate) {
+                          <div>
+                            <span
+                              class="govuk-summary-list__key govuk-error-message govuk-summary-list__warning-message govuk__nowrap"
+                            >
+                              This training usually does not expire
+                            </span>
+                          </div>
+                        }
+
                         <span
                           *ngIf="submitted && form.get('expires').invalid"
                           id="expires-error"

--- a/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.html
+++ b/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.html
@@ -77,7 +77,9 @@
                     <div
                       data-testid="expiresDate"
                       class="govuk-form-group"
-                      [class.govuk-summary-list__warning]="expiryMismatchWarning"
+                      [class.asc__govuk-form-group--error--orange]="
+                        (expiryMismatchWarning || doesNotExpireMismatchWarning) && !form.get('expires').invalid
+                      "
                       [class.govuk-form-group--error]="submitted && form.get('expires').invalid"
                     >
                       <fieldset class="govuk-fieldset" aria-describedby="expires-hint" role="group">
@@ -85,18 +87,14 @@
                         <legend id="expires-hint" class="govuk-hint">For example, 31 3 2025</legend>
                         @if (expiryMismatchWarning) {
                           <div>
-                            <span
-                              class="govuk-summary-list__key govuk-error-message govuk-summary-list__warning-message govuk__nowrap"
-                            >
+                            <span class="govuk-error-message asc__govuk-error-message--orange">
                               This training is usually valid for
                               {{ trainingToDisplay?.validityPeriodInMonth }} months
                             </span>
                           </div>
                         } @else if (doesNotExpireMismatchWarning) {
                           <div>
-                            <span
-                              class="govuk-summary-list__key govuk-error-message govuk-summary-list__warning-message govuk__nowrap"
-                            >
+                            <span class="govuk-error-message asc__govuk-error-message--orange">
                               This training usually does not expire
                             </span>
                           </div>

--- a/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.spec.ts
@@ -24,7 +24,7 @@ import userEvent from '@testing-library/user-event';
 
 import { TrainingCourseMatchingLayoutComponent } from './training-course-matching-layout.component';
 
-fdescribe('TrainingCourseMatchingLayoutComponent', () => {
+describe('TrainingCourseMatchingLayoutComponent', () => {
   const defaultTrainingRecord = {
     title: 'Training record title',
     accredited: 'Yes',

--- a/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.spec.ts
@@ -19,7 +19,7 @@ import { MockTrainingServiceWithOverrides } from '@core/test-utils/MockTrainingS
 import { MockWorkerServiceWithOverrides } from '@core/test-utils/MockWorkerService';
 import { CertificationsTableComponent } from '@shared/components/certifications-table/certifications-table.component';
 import { SharedModule } from '@shared/shared.module';
-import { render, within } from '@testing-library/angular';
+import { render, screen, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
 import { TrainingCourseMatchingLayoutComponent } from './training-course-matching-layout.component';
@@ -187,6 +187,25 @@ describe('TrainingCourseMatchingLayoutComponent', () => {
     };
   }
 
+  const expectDateInputToHaveValue = (testId: string, year: string, month: string, day: string) => {
+    const getInput = (label: string) => {
+      const dateInputWrapperDiv = screen.getByTestId(testId);
+      return within(dateInputWrapperDiv).getByLabelText(label) as HTMLInputElement;
+    };
+
+    expect(getInput('Day').value).toEqual(day);
+    expect(getInput('Month').value).toEqual(month);
+    expect(getInput('Year').value).toEqual(year);
+  };
+
+  const expectCompletedDateToBe = (year: string, month: string, day: string) => {
+    expectDateInputToHaveValue('completedDate', year, month, day);
+  };
+
+  const expectExpiryDateToBe = (year: string, month: string, day: string) => {
+    expectDateInputToHaveValue('expiresDate', year, month, day);
+  };
+
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
@@ -198,7 +217,7 @@ describe('TrainingCourseMatchingLayoutComponent', () => {
   });
 
   it('should display a different page heading if adding a new training record', async () => {
-    const { getByRole } = await setup({ trainingRecord: null, trainingRecordId: null });
+    const { getByRole } = await setup(overridesForAddingNewRecord);
     expect(getByRole('heading', { level: 1, name: 'Add training record details' })).toBeTruthy();
   });
 
@@ -213,121 +232,230 @@ describe('TrainingCourseMatchingLayoutComponent', () => {
       it('should populate the form on init', async () => {
         const { component } = await setup();
 
-        expect(component.form.value.completed.day).toBe(1);
-        expect(component.form.value.completed.month).toBe(1);
-        expect(component.form.value.completed.year).toBe(2024);
+        expectCompletedDateToBe('2024', '1', '1');
 
         expect(component.form.value.notes).toBe('Test notes');
       });
 
-      it('should auto-calc expiry date on page load if expiry date is missing', async () => {
-        const mockRecord = {
-          ...defaultTrainingRecord,
-          expires: null,
-          completed: '2025-01-01',
-        };
-        const { component } = await setup({ trainingRecord: mockRecord });
-
-        const expiry = component.form.value.expires;
-        expect(expiry.year).toBe(2025);
-        expect(expiry.month).toBe(12);
-        expect(expiry.day).toBe(31);
-      });
-
-      it('should auto-calc expiry date when user input a completed date', async () => {
-        const mockRecord = {
-          ...defaultTrainingRecord,
-          expires: null,
-          completed: null,
-        };
-        const { fixture, component, getByTestId } = await setup({ trainingRecord: mockRecord });
-
-        const completedDate = within(getByTestId('completedDate'));
-
-        userEvent.type(completedDate.getByLabelText('Day'), '1');
-        userEvent.type(completedDate.getByLabelText('Month'), '1');
-        userEvent.type(completedDate.getByLabelText('Year'), '2025');
-
-        await fixture.whenStable();
-
-        const expiry = component.form.value.expires;
-        expect(expiry.year).toBe(2025);
-        expect(expiry.month).toBe(12);
-        expect(expiry.day).toBe(31);
-      });
-
-      it('should not change the expiry date if it is already filled in', async () => {
-        const mockRecord = {
-          ...defaultTrainingRecord,
-          expires: '2027-07-31',
-          completed: null,
+      describe('when the course has doesNotExpire = true', () => {
+        const mockTrainingCourse = {
+          ...defaultSelectedTrainingCourse,
+          doesNotExpire: true,
+          validityPeriodInMonth: null,
         };
 
-        const { component, getByTestId } = await setup({ trainingRecord: mockRecord });
+        it('should show the expiry date input boxes if existing training record has got an expiry date', async () => {
+          const mockRecord = {
+            ...defaultTrainingRecord,
+            completed: '2020-01-01',
+            expires: '2021-06-15',
+          };
 
-        const completedDate = within(getByTestId('completedDate'));
+          const { queryByTestId } = await setup({
+            selectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: mockRecord,
+          });
 
-        userEvent.type(completedDate.getByLabelText('Day'), '1');
-        userEvent.type(completedDate.getByLabelText('Month'), '1');
-        userEvent.type(completedDate.getByLabelText('Year'), '2025');
-
-        const expiry = component.form.value.expires;
-        expect(expiry.year).toBe(2027);
-        expect(expiry.month).toBe(7);
-        expect(expiry.day).toBe(31);
-      });
-
-      it('should not auto fill in expiry if the value in completed date is not a valid date', async () => {
-        const { component, getByTestId } = await setup({ trainingRecord: mockTrainingRecordWithoutDates });
-
-        const completedDate = within(getByTestId('completedDate'));
-
-        userEvent.type(completedDate.getByLabelText('Day'), '31');
-        userEvent.type(completedDate.getByLabelText('Month'), '2');
-        userEvent.type(completedDate.getByLabelText('Year'), '2025');
-
-        const expiry = component.form.value.expires;
-        expect(expiry.year).toEqual(null);
-        expect(expiry.month).toEqual(null);
-        expect(expiry.day).toEqual(null);
-      });
-
-      it('should set expiryMismatchWarning when expiry date does not match the completed date and validity period', async () => {
-        const { fixture, getByTestId, queryByText } = await setup({
-          trainingRecord: mockTrainingRecordWithoutDates,
+          expect(queryByTestId('expiresDate')).toBeTruthy();
+          expectExpiryDateToBe('2021', '6', '15');
         });
 
-        const validityMonths = defaultSelectedTrainingCourse.validityPeriodInMonth;
-        const expectedWarningText = `This training is usually valid for ${validityMonths} months`;
+        it('should hide the expiry date input boxes if existing training record does not have an expiry date', async () => {
+          const mockRecord = {
+            ...defaultTrainingRecord,
+            expires: null,
+            completed: '2020-01-01',
+          };
+          const { queryByTestId } = await setup({
+            selectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: mockRecord,
+          });
 
-        const completedDate = within(getByTestId('completedDate'));
-        const expiryDate = within(getByTestId('expiresDate'));
+          expect(queryByTestId('expiresDate')).toBeFalsy();
+        });
+      });
 
-        userEvent.type(expiryDate.getByLabelText('Day'), '10');
-        userEvent.type(expiryDate.getByLabelText('Month'), '2');
-        userEvent.type(expiryDate.getByLabelText('Year'), '2025');
+      describe('when the course has a validityPeriodInMonth', () => {
+        const mockTrainingCourse = {
+          ...defaultSelectedTrainingCourse,
+          doesNotExpire: false,
+          validityPeriodInMonth: 12,
+        };
 
-        userEvent.type(completedDate.getByLabelText('Day'), '22');
-        userEvent.type(completedDate.getByLabelText('Month'), '08');
-        userEvent.type(completedDate.getByLabelText('Year'), '2025');
+        it('should show the expiry date input boxes', async () => {
+          const mockRecord = {
+            ...defaultTrainingRecord,
+            completed: '2020-01-01',
+            expires: '2021-06-15',
+          };
+          const { queryByTestId } = await setup({
+            selectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: mockRecord,
+          });
 
-        fixture.detectChanges();
+          expect(queryByTestId('expiresDate')).toBeTruthy();
+          expectExpiryDateToBe('2021', '6', '15');
+        });
 
-        expect(queryByText(expectedWarningText)).toBeTruthy();
+        it('should auto-calc expiry date on page load if expiry date is missing', async () => {
+          const mockRecord = {
+            ...defaultTrainingRecord,
+            expires: null,
+            completed: '2025-01-01',
+          };
+          await setup({ selectedTrainingCourse: mockTrainingCourse, trainingRecord: mockRecord });
 
-        ['Day', 'Month', 'Year'].forEach((field) => userEvent.clear(expiryDate.getByLabelText(field)));
+          expectExpiryDateToBe('2026', '1', '1');
+        });
 
-        userEvent.type(expiryDate.getByLabelText('Day'), '21');
-        userEvent.type(expiryDate.getByLabelText('Month'), '08');
-        userEvent.type(expiryDate.getByLabelText('Year'), '2026');
+        it('should auto-calc expiry date when user input a completed date', async () => {
+          const mockRecord = {
+            ...defaultTrainingRecord,
+            expires: null,
+            completed: null,
+          };
+          const { fixture, getByTestId } = await setup({
+            selectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: mockRecord,
+          });
 
-        fixture.detectChanges();
+          const completedDate = within(getByTestId('completedDate'));
 
-        expect(queryByText(expectedWarningText)).toBeFalsy();
+          userEvent.type(completedDate.getByLabelText('Day'), '1');
+          userEvent.type(completedDate.getByLabelText('Month'), '1');
+          userEvent.type(completedDate.getByLabelText('Year'), '2025');
+
+          await fixture.whenStable();
+
+          expectExpiryDateToBe('2026', '1', '1');
+        });
+
+        it('should not change the expiry date if it is already filled in', async () => {
+          const mockRecord = {
+            ...defaultTrainingRecord,
+            expires: '2027-07-31',
+            completed: null,
+          };
+
+          const { getByTestId } = await setup({
+            tselectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: mockRecord,
+          });
+
+          const completedDate = within(getByTestId('completedDate'));
+
+          userEvent.type(completedDate.getByLabelText('Day'), '1');
+          userEvent.type(completedDate.getByLabelText('Month'), '1');
+          userEvent.type(completedDate.getByLabelText('Year'), '2025');
+
+          expectExpiryDateToBe('2027', '7', '31');
+        });
+
+        it('should not auto fill in expiry if the value in completed date is not a valid date', async () => {
+          const { getByTestId } = await setup({
+            selectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: mockTrainingRecordWithoutDates,
+          });
+
+          const completedDate = within(getByTestId('completedDate'));
+
+          userEvent.type(completedDate.getByLabelText('Day'), '31');
+          userEvent.type(completedDate.getByLabelText('Month'), '2');
+          userEvent.type(completedDate.getByLabelText('Year'), '2025');
+
+          expectExpiryDateToBe('', '', '');
+        });
+
+        it('should set expiryMismatchWarning when expiry date does not match the completed date and validity period', async () => {
+          const { fixture, getByTestId, queryByText } = await setup({
+            selectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: mockTrainingRecordWithoutDates,
+          });
+
+          const validityMonths = defaultSelectedTrainingCourse.validityPeriodInMonth;
+          const expectedWarningText = `This training is usually valid for ${validityMonths} months`;
+
+          const completedDate = within(getByTestId('completedDate'));
+          const expiryDate = within(getByTestId('expiresDate'));
+
+          userEvent.type(expiryDate.getByLabelText('Day'), '10');
+          userEvent.type(expiryDate.getByLabelText('Month'), '2');
+          userEvent.type(expiryDate.getByLabelText('Year'), '2025');
+
+          userEvent.type(completedDate.getByLabelText('Day'), '22');
+          userEvent.type(completedDate.getByLabelText('Month'), '08');
+          userEvent.type(completedDate.getByLabelText('Year'), '2025');
+
+          fixture.detectChanges();
+
+          expect(queryByText(expectedWarningText)).toBeTruthy();
+
+          ['Day', 'Month', 'Year'].forEach((field) => userEvent.clear(expiryDate.getByLabelText(field)));
+
+          userEvent.type(expiryDate.getByLabelText('Day'), '21');
+          userEvent.type(expiryDate.getByLabelText('Month'), '08');
+          userEvent.type(expiryDate.getByLabelText('Year'), '2026');
+
+          fixture.detectChanges();
+
+          expect(queryByText(expectedWarningText)).toBeFalsy();
+        });
+      });
+
+      describe('when the course has doesNotExpire = false and validityPeriodInMonth = null', () => {
+        const mockTrainingCourse = {
+          ...defaultSelectedTrainingCourse,
+          doesNotExpire: false,
+          validityPeriodInMonth: null,
+        };
+        const mockTrainingRecord = {
+          ...defaultTrainingRecord,
+          completed: '2020-01-01',
+          expires: '2021-06-15',
+        };
+
+        it('should show the expiry date input boxes', async () => {
+          const { queryByTestId } = await setup({
+            selectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: mockTrainingRecord,
+          });
+
+          expect(queryByTestId('expiresDate')).toBeTruthy();
+          expectExpiryDateToBe('2021', '6', '15');
+        });
+
+        it('should not show a mismatch warning', async () => {
+          const { queryByText } = await setup({
+            selectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: mockTrainingRecord,
+          });
+
+          expect(queryByText(/This training is usually valid/)).toBeFalsy();
+        });
+
+        it('should show the expiry date input boxes even if there is no expiry date', async () => {
+          const { queryByTestId } = await setup({
+            selectedTrainingCourse: mockTrainingCourse,
+            trainingRecord: {
+              ...defaultTrainingRecord,
+              completed: '2020-01-01',
+              expires: null,
+            },
+          });
+
+          expect(queryByTestId('expiresDate')).toBeTruthy();
+          expectExpiryDateToBe('', '', '');
+        });
       });
     });
 
     describe('when viewing an existing training record', () => {
+      it('should show the input boxes for expiry date if the record has an expiry date', async () => {
+        const { queryByTestId } = await setup(overridesForViewingRecord);
+
+        expect(queryByTestId('expiresDate')).toBeTruthy();
+      });
+
       it('should show the expiryMismatchWarning if the dates does not match', async () => {
         const validityMonths = defaultTrainingRecord.validityPeriodInMonth;
         const expectedWarningText = `This training is usually valid for ${validityMonths} months`;
@@ -337,10 +465,40 @@ describe('TrainingCourseMatchingLayoutComponent', () => {
         expect(queryByTestId('expiresDate')).toBeTruthy();
         expect(queryByText(expectedWarningText)).toBeTruthy();
       });
+
+      it('should hide the input boxes for expiry date if the record has doesNotExpire = true and expiry date is null', async () => {
+        const overrides = {
+          selectedTrainingCourse: null,
+          trainingRecord: {
+            ...defaultTrainingRecord,
+            isMatchedToTrainingCourse: true,
+            doesNotExpire: true,
+            expires: null,
+          },
+        };
+        const { queryByTestId } = await setup(overrides);
+
+        expect(queryByTestId('expiresDate')).toBeFalsy();
+      });
+
+      it('should show the input boxes for expiry date if the record has doesNotExpire = false and expiry date is null', async () => {
+        const overrides = {
+          selectedTrainingCourse: null,
+          trainingRecord: {
+            ...defaultTrainingRecord,
+            isMatchedToTrainingCourse: true,
+            doesNotExpire: false,
+            expires: null,
+          },
+        };
+        const { queryByTestId } = await setup(overrides);
+
+        expect(queryByTestId('expiresDate')).toBeTruthy();
+      });
     });
 
     describe('when adding a new training record', () => {
-      it('should not show the input boxes for expiry date', async () => {
+      it('should hide the input boxes for expiry date', async () => {
         const { queryByTestId } = await setup(overridesForAddingNewRecord);
 
         expect(queryByTestId('expiresDate')).toBeFalsy();
@@ -381,7 +539,7 @@ describe('TrainingCourseMatchingLayoutComponent', () => {
 
     describe('when applying a course to exiting record', () => {
       it('the "Select a different training course" link should point to the include-training-course-details page', async () => {
-        const { component, getByTestId, routerSpy, route } = await setup();
+        const { getByTestId, routerSpy, route } = await setup();
 
         const span = getByTestId('includeTraining');
         const link = span.closest('a');
@@ -544,7 +702,7 @@ describe('TrainingCourseMatchingLayoutComponent', () => {
     });
 
     describe('when adding a new training record', () => {
-      const overrides = { trainingRecordId: null, trainingRecord: null };
+      const overrides = overridesForAddingNewRecord;
 
       it('should call createTrainingRecord when form is valid', async () => {
         const selectedCourse = defaultSelectedTrainingCourse;
@@ -800,10 +958,8 @@ describe('TrainingCourseMatchingLayoutComponent', () => {
       });
 
       describe('when adding a new training record', () => {
-        const overrides = { trainingRecordId: null, selectedTrainingCourse: null };
-
         it('should not show the delete link when user is adding a new training record', async () => {
-          const { queryByText } = await setup(overrides);
+          const { queryByText } = await setup(overridesForAddingNewRecord);
 
           const deleteLink = queryByText('Delete this training record');
           expect(deleteLink).toBeFalsy();

--- a/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.spec.ts
+++ b/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.spec.ts
@@ -353,7 +353,7 @@ fdescribe('TrainingCourseMatchingLayoutComponent', () => {
           expectExpiryDateToBe('2021', '6', '15');
         });
 
-        it('should auto-calc expiry date on page load if expiry date is missing', async () => {
+        it('should auto fill expiry date on page load if expiry date is missing', async () => {
           const mockRecord = {
             ...defaultTrainingRecord,
             expires: null,
@@ -361,10 +361,10 @@ fdescribe('TrainingCourseMatchingLayoutComponent', () => {
           };
           await setup({ selectedTrainingCourse: mockTrainingCourse, trainingRecord: mockRecord });
 
-          expectExpiryDateToBe('2026', '1', '1');
+          expectExpiryDateToBe('2025', '12', '31');
         });
 
-        it('should auto-calc expiry date when user input a completed date', async () => {
+        it('should auto fill expiry date when user input a completed date', async () => {
           const mockRecord = {
             ...defaultTrainingRecord,
             expires: null,
@@ -380,7 +380,7 @@ fdescribe('TrainingCourseMatchingLayoutComponent', () => {
           fillInDate(completedDate, '2025', '1', '1');
 
           await fixture.whenStable();
-          expectExpiryDateToBe('2026', '1', '1');
+          expectExpiryDateToBe('2025', '12', '31');
         });
 
         it('should not change the expiry date if it is already filled in', async () => {

--- a/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.ts
@@ -313,17 +313,15 @@ export class TrainingCourseMatchingLayoutComponent implements OnInit, AfterViewI
     const completed = DateUtil.toDayjs(this.form.get('completed')?.value);
     const validity = this.trainingToDisplay?.validityPeriodInMonth;
 
-    const expiryDateIsEmpty = Object.values(this.form.get('expires').value).every((input) => input == null);
-
-    if (completed && validity && expiryDateIsEmpty) {
-      const newExpiry = DateUtil.expectedExpiryDate(completed, validity);
+    if (completed && validity && this.expiryDateIsEmpty) {
+      const expectedExpiryDate = DateUtil.expectedExpiryDate(completed, validity);
 
       this.form.patchValue(
         {
           expires: {
-            day: newExpiry.date(),
-            month: newExpiry.month() + 1,
-            year: newExpiry.year(),
+            day: expectedExpiryDate.date(),
+            month: expectedExpiryDate.month() + 1,
+            year: expectedExpiryDate.year(),
           },
         },
         { emitEvent: false },

--- a/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.ts
+++ b/frontend/src/app/features/training-and-qualifications/training-course/training-course-matching-layout/training-course-matching-layout.component.ts
@@ -62,6 +62,7 @@ export class TrainingCourseMatchingLayoutComponent implements OnInit, AfterViewI
   public trainingToDisplay:
     | TrainingCourse
     | (TrainingRecord & { name: string; trainingCategoryName: string; trainingCategoryId: number });
+  public showExpiryDateInput: boolean = false;
 
   constructor(
     private workerService: WorkerService,
@@ -87,6 +88,7 @@ export class TrainingCourseMatchingLayoutComponent implements OnInit, AfterViewI
     this.determineJourneyType();
     this.setupForm();
     this.loadTrainingToDisplay();
+    this.checkWhetherShouldShowExpiryDateInput();
     this.buildSummaryRowItems();
     this.loadDataAccordingToJourneyType();
 
@@ -144,6 +146,27 @@ export class TrainingCourseMatchingLayoutComponent implements OnInit, AfterViewI
       }
       case 'AddNewTrainingRecordWithCourse': {
         this.headingText = 'Add training record details';
+      }
+    }
+  }
+
+  private checkWhetherShouldShowExpiryDateInput() {
+    switch (this.journeyType) {
+      case 'ApplyCourseToExistingRecord': {
+        const recordHasExpiryDate = !!this.trainingRecord?.expires;
+        const doesNotExpireNotTicked = !this.selectedTrainingCourse.doesNotExpire;
+        this.showExpiryDateInput = recordHasExpiryDate || doesNotExpireNotTicked;
+        break;
+      }
+      case 'ViewExistingRecord': {
+        const recordHasExpiryDate = !!this.trainingRecord.expires;
+        const doesNotExpireNotTicked = !this.trainingRecord.doesNotExpire;
+        this.showExpiryDateInput = recordHasExpiryDate || doesNotExpireNotTicked;
+        break;
+      }
+      case 'AddNewTrainingRecordWithCourse': {
+        this.showExpiryDateInput = false;
+        break;
       }
     }
   }

--- a/frontend/src/assets/scss/modules/_utils.scss
+++ b/frontend/src/assets/scss/modules/_utils.scss
@@ -222,3 +222,12 @@ dl.asc__name-value-pair {
   width: 42px;
   height: 19px;
 }
+
+.asc__govuk-form-group--error--orange {
+  padding-left: 15px;
+  border-left: 5px solid govuk-colour('orange');
+}
+
+.asc__govuk-error-message--orange {
+  color: govuk-colour('orange');
+}


### PR DESCRIPTION
#### Work done
- In IncludeTrainingCourseDetailsComponent, add logic about hiding the expiry date input boxes 
 - when "Does not expire" is ticked in the course, hide the expiry date input boxes **except** when the training already have an expiry date, in which case we will show the expiry date input boxes
  - Add a soft warning message "This training does not usually have an expiry date" when a course has 'does not expire' ticked, but the training record has an expiry date


#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
