### PR TITLE
Fix/1901 unable to delete user

### DIFF
--- a/backend/server/models/classes/user.js
+++ b/backend/server/models/classes/user.js
@@ -835,7 +835,6 @@ class User {
           JobTitle: '',
           SecurityQuestionValue: '',
           SecurityQuestionAnswerValue: '',
-          UserResearchInviteResponseValue: '',
         };
 
         let [updatedRecordCount] = await models.user.update(updateDocument, {

--- a/frontend/cypress/e2e/registration/deleteUser.spec.cy.js
+++ b/frontend/cypress/e2e/registration/deleteUser.spec.cy.js
@@ -1,0 +1,38 @@
+import { StandAloneEstablishment } from '../../support/mockEstablishmentData';
+
+describe('delete a user from workplace', { tags: '@registration' }, () => {
+  const mockUserForDeletion = 'Mock new user for deletion';
+
+  before(() => {
+    cy.deleteTestUserFromDb(mockUserForDeletion);
+    cy.addTestUser(mockUserForDeletion, 'mock-new-user', StandAloneEstablishment.id);
+  });
+
+  beforeEach(() => {
+    cy.loginAsUser(Cypress.env('editStandAloneUser'), Cypress.env('userPassword'));
+  });
+
+  it(`should be able to remove a user from the workplace`, () => {
+    cy.contains('Users').click();
+
+    cy.url().should('contain', '/users');
+    cy.get('h1').should('contain', 'User');
+
+    cy.contains('a', mockUserForDeletion).click();
+
+    cy.get('h1').should('contain', 'User details');
+
+    cy.contains('a', 'Delete this user').click();
+
+    const expectedMessage = `You're about to delete ${mockUserForDeletion} as a user`;
+    cy.contains(expectedMessage).should('exist');
+
+    cy.contains('button', 'Delete this user').click();
+
+    cy.url().should('contain', '/users');
+    cy.get('h1').should('contain', 'User');
+    cy.contains('.govuk-inset-text.success', `${mockUserForDeletion} has been deleted as a user`).should('be.visible');
+
+    cy.contains('a', mockUserForDeletion).should('not.exist');
+  });
+});

--- a/frontend/cypress/support/commands/loginCommands.js
+++ b/frontend/cypress/support/commands/loginCommands.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-undef */
+import { v4 as uuidv4 } from 'uuid';
+
 Cypress.Commands.add('openLoginPage', () => {
   cy.setCookie('cookies_preferences_set', 'true');
   cy.visit('/');
@@ -89,6 +91,53 @@ Cypress.Commands.add('deleteTestUserFromDb', (userFullName) => {
   const dbQueries = queryStrings.map((queryString) => ({ queryString, parameters }));
 
   cy.task('multipleDbQueries', dbQueries);
+});
+
+Cypress.Commands.add('addTestUser', (userFullName, username, establishmentID) => {
+  const mockUserDetails = {
+    FullNameValue: userFullName,
+    UserUID: uuidv4(),
+    JobTitleValue: 'Manager',
+    EmailValue: 'test@example.com',
+    PhoneValue: '0123456789',
+    EstablishmentID: establishmentID,
+    SecurityQuestionValue: '2+2',
+    SecurityQuestionAnswerValue: '4',
+    UserRoleValue: 'Read',
+    Archived: false,
+    IsPrimary: false,
+    updatedby: 'cypress test',
+  };
+
+  const insertUser = `INSERT INTO cqc."User"
+          (${Object.keys(mockUserDetails)
+            .map((columnName) => `"${columnName}"`)
+            .join(', ')})
+        VALUES
+          ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        RETURNING "RegistrationID"
+        ;`;
+  const parameters = Object.values(mockUserDetails);
+
+  return cy.task('dbQuery', { queryString: insertUser, parameters }).then((response) => {
+    const registrationId = response.rows[0].RegistrationID;
+    const mockLoginDetails = {
+      RegistrationID: registrationId,
+      Username: username,
+      Active: true,
+      InvalidAttempt: 0,
+    };
+
+    const insertLogin = `INSERT INTO cqc."Login"
+        (${Object.keys(mockLoginDetails)
+          .map((columnName) => `"${columnName}"`)
+          .join(', ')})
+      VALUES
+        ($1, $2, $3, $4)`;
+    const parameters = Object.values(mockLoginDetails);
+
+    return cy.task('dbQuery', { queryString: insertLogin, parameters });
+  });
 });
 
 Cypress.Commands.add('deleteTestWorkplaceFromDb', (workplaceName) => {


### PR DESCRIPTION
#### Work done
- Fix an issue of recent change causing error when try to delete a user from workplace
(caused by `User.delete` trying to set UserResearchInviteResponseValue to empty string "", which is not allowed for enum type)
- Add an e2e test to cover the delete user journey

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
