### PR TITLE
Fix/pay and pension formatting and validation

### DIFF
--- a/frontend/src/app/features/workplace/pensions/pensions.component.spec.ts
+++ b/frontend/src/app/features/workplace/pensions/pensions.component.spec.ts
@@ -7,7 +7,7 @@ import { Router, RouterModule } from '@angular/router';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { SharedModule } from '@shared/shared.module';
-import { fireEvent, render, within } from '@testing-library/angular';
+import { fireEvent, getByLabelText, render, within } from '@testing-library/angular';
 
 import { PensionsComponent } from './pensions.component';
 import { patchRouterUrlForWorkplaceQuestions } from '@core/test-utils/patchUrlForWorkplaceQuestions';
@@ -53,7 +53,7 @@ describe('PensionsComponent', () => {
     const component = fixture.componentInstance;
     const injector = getTestBed();
     const establishmentService = injector.inject(EstablishmentService) as EstablishmentService;
-    const establishmentServiceSpy = spyOn(establishmentService, 'updatePensionContribution').and.callThrough();
+    const establishmentServiceSpy = spyOn(establishmentService, 'updateEstablishmentFieldWithAudit').and.callThrough();
     const router = injector.inject(Router) as Router;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
 
@@ -262,6 +262,50 @@ describe('PensionsComponent', () => {
           'add-workplace-details',
           'staff-opt-out-of-workplace-pension',
         ]);
+      });
+
+      const answers = [
+        { pension: 'Yes', pensionPercentage: 5 },
+        { pension: 'Yes', pensionPercentage: null },
+      ];
+      answers.forEach((answer) => {
+        it(`should navigate call the updateEstablishmentFieldWithAudit with pensionContribution ${answer.pension} and pensionContributionPercentage ${answer.pensionPercentage}`, async () => {
+          const { component, fixture, getByText, getByLabelText, routerSpy, establishmentServiceSpy } = await setup({
+            returnUrl: false,
+          });
+
+          const radioButton = getByText(answer.pension);
+          fireEvent.click(radioButton);
+
+          if (answer.pensionPercentage) {
+            const input = getByLabelText('Actual contribution');
+            userEvent.type(input, answer.pensionPercentage.toString());
+          }
+
+          fixture.detectChanges();
+
+          const button = getByText('Save and continue');
+          fireEvent.click(button);
+          fixture.detectChanges();
+
+          const dataToUpdate = {
+            pensionContribution: answer.pension,
+            pensionContributionPercentage: answer.pensionPercentage,
+          };
+
+          expect(establishmentServiceSpy).toHaveBeenCalledWith(
+            component.establishment.uid,
+            'pensionContribution',
+            dataToUpdate,
+          );
+          expect(routerSpy).toHaveBeenCalledWith([
+            '/workplace',
+            'mocked-uid',
+            'workplace-data',
+            'add-workplace-details',
+            'staff-opt-out-of-workplace-pension',
+          ]);
+        });
       });
 
       it('should navigate to the next page when skipping from the flow', async () => {

--- a/frontend/src/app/features/workplace/pensions/pensions.component.spec.ts
+++ b/frontend/src/app/features/workplace/pensions/pensions.component.spec.ts
@@ -18,6 +18,7 @@ import {
   mockPayAndPensionsGroup2ProgressBarSections,
 } from '@core/test-utils/MockPayAndPensionService';
 import { ProgressBarUtil, WorkplaceFlowSections } from '@core/utils/progress-bar-util';
+import userEvent from '@testing-library/user-event';
 
 describe('PensionsComponent', () => {
   async function setup(overrides: any = { returnUrl: true, pension: undefined, pensionPercentage: undefined }) {
@@ -413,6 +414,30 @@ describe('PensionsComponent', () => {
         expect(within(progressBar).getByText(section)).toBeTruthy();
       });
       expect(progressBarSection.getAttribute('src')).toEqual('/assets/images/progress-bar/doing.svg');
+    });
+  });
+
+  describe('error messages', () => {
+    ['2', '101'].forEach((value) => {
+      it(`should show the error message when the enter value is ${value}`, async () => {
+        const { getByText, getByLabelText, fixture, getAllByText } = await setup();
+
+        const yesRadioButton = getByLabelText('Yes');
+        fireEvent.click(yesRadioButton);
+        fixture.detectChanges();
+
+        const input = getByLabelText('Actual contribution');
+        userEvent.type(input, value);
+        fixture.detectChanges();
+
+        const ctaButton = getByText('Save and return');
+        fireEvent.click(ctaButton);
+        fixture.detectChanges();
+
+        const errorMessage = 'Actual contribution must be higher than 3% and no more than 100%';
+
+        expect(getAllByText(errorMessage).length).toBe(2);
+      });
     });
   });
 });

--- a/frontend/src/app/features/workplace/pensions/pensions.component.ts
+++ b/frontend/src/app/features/workplace/pensions/pensions.component.ts
@@ -180,7 +180,7 @@ export class PensionsComponent extends WorkplaceQuestion implements OnInit, OnDe
 
     const props = {
       pensionContribution: pension,
-      pensionContributionPercentage: pension === 'Yes' ? pensionPercentage : null,
+      pensionContributionPercentage: pension === 'Yes' && pensionPercentage ? pensionPercentage : null,
     };
 
     return props;

--- a/frontend/src/app/features/workplace/pensions/pensions.component.ts
+++ b/frontend/src/app/features/workplace/pensions/pensions.component.ts
@@ -195,7 +195,7 @@ export class PensionsComponent extends WorkplaceQuestion implements OnInit, OnDe
       this.establishmentService
         .updateEstablishmentFieldWithAudit(this.establishment.uid, 'pensionContribution', payload)
         .subscribe(
-          (data) => this._onSuccess(data.data),
+          (data) => this._onSuccess(data),
           (error) => this.onError(error),
         ),
     );

--- a/frontend/src/app/features/workplace/travel-time-pay/travel-time-pay.component.html
+++ b/frontend/src/app/features/workplace/travel-time-pay/travel-time-pay.component.html
@@ -76,6 +76,7 @@
                               name="travelTimePayRate"
                               type="number"
                               aria-describedby="travelTimePayRate-hint"
+                              data-testid="travel-time-pay-rate-input"
                             />
                           </div>
                         </div>

--- a/frontend/src/app/features/workplace/travel-time-pay/travel-time-pay.component.spec.ts
+++ b/frontend/src/app/features/workplace/travel-time-pay/travel-time-pay.component.spec.ts
@@ -51,6 +51,7 @@ describe('TravelTimePayComponent', () => {
       providers: [
         patchRouterUrlForWorkplaceQuestions(isInAddDetailsFlow),
         UntypedFormBuilder,
+        AlertService,
         {
           provide: EstablishmentService,
           useFactory: MockEstablishmentServiceWithOverrides.factory(overrides),
@@ -141,7 +142,7 @@ describe('TravelTimePayComponent', () => {
     });
 
     it('should show "Workplace" when in the pay and pensions mini flow', async () => {
-      const { getByTestId } = await setup({ inPayAndPensionsMiniFlow: true });
+      const { getByTestId } = await setup({ returnUrl: null, inPayAndPensionsMiniFlow: true });
 
       const sectionCaption = 'Workplace';
       expect(within(getByTestId('section-heading')).getByText(sectionCaption)).toBeTruthy();
@@ -154,6 +155,32 @@ describe('TravelTimePayComponent', () => {
 
       travelTimePayOptions.forEach((option) => {
         expect(getByRole('radio', { name: option.label })).toBeTruthy();
+      });
+    });
+
+    describe('prefill', () => {
+      it(`should have an empty input when ${travelTimePayOptions[2].label} was previously saved with no rate`, async () => {
+        const overrides = { establishment: { travelTimePay: { id: travelTimePayOptions[2].id, rate: null } } };
+
+        const { getByLabelText } = await setup(overrides);
+
+        const radioButton = getByLabelText(travelTimePayOptions[2].label) as HTMLInputElement;
+        const amountInput = getByLabelText('Amount (optional)') as HTMLInputElement;
+
+        expect(radioButton.checked).toBeTruthy();
+        expect(amountInput.value).toEqual('');
+      });
+
+      it(`should show the rate with the correct decimals when ${travelTimePayOptions[2].label} was previously saved with a rate`, async () => {
+        const overrides = { establishment: { travelTimePay: { id: travelTimePayOptions[2].id, rate: 4.5 } } };
+
+        const { getByLabelText } = await setup(overrides);
+
+        const radioButton = getByLabelText(travelTimePayOptions[2].label) as HTMLInputElement;
+        const amountInput = getByLabelText('Amount (optional)') as HTMLInputElement;
+
+        expect(radioButton.checked).toBeTruthy();
+        expect(amountInput.value).toEqual('4.50');
       });
     });
   });

--- a/frontend/src/app/features/workplace/travel-time-pay/travel-time-pay.component.ts
+++ b/frontend/src/app/features/workplace/travel-time-pay/travel-time-pay.component.ts
@@ -73,7 +73,7 @@ export class TravelTimePayComponent extends WorkplaceQuestion implements OnInit,
     }
   }
 
-  public setSectionHeading() {
+  public setSectionHeading(): void {
     this.sectionHeading = this.inPayAndPensionsMiniFlow ? 'Workplace' : WorkplaceFlowSections.PAY_AND_BENEFITS;
   }
 
@@ -164,7 +164,9 @@ export class TravelTimePayComponent extends WorkplaceQuestion implements OnInit,
     if (this.establishment.travelTimePay) {
       this.form.patchValue({
         travelTimePay: this.establishment.travelTimePay.id,
-        travelTimePayRate: this.establishment.travelTimePay.rate,
+        travelTimePayRate: this.establishment.travelTimePay.rate
+          ? this.establishment.travelTimePay.rate.toFixed(2)
+          : null,
       });
 
       this.onChange(this.establishment.travelTimePay);

--- a/frontend/src/app/shared/components/decimal-input-with-buttons/decimal-input-with-buttons.component.html
+++ b/frontend/src/app/shared/components/decimal-input-with-buttons/decimal-input-with-buttons.component.html
@@ -10,6 +10,7 @@
     aria-live="polite"
     step="any"
     inputmode="decimal"
+    type="number"
   />
   <button
     *ngIf="showMinusButton"

--- a/frontend/src/app/shared/components/decimal-input-with-buttons/decimal-input-with-buttons.component.spec.ts
+++ b/frontend/src/app/shared/components/decimal-input-with-buttons/decimal-input-with-buttons.component.spec.ts
@@ -38,20 +38,20 @@ describe('DecimalInputWithButtonsComponent', () => {
     it('should show an input box', async () => {
       const { getByRole } = await setup();
 
-      expect(getByRole('textbox')).toBeTruthy();
+      expect(getByRole('spinbutton')).toBeTruthy();
     });
 
     it('should show the input box as blank if no initial value given', async () => {
       const { getByRole } = await setup();
 
-      const inputBox = getByRole('textbox') as HTMLInputElement;
+      const inputBox = getByRole('spinbutton') as HTMLInputElement;
       expect(inputBox.value).toEqual('');
     });
 
     it('should show the given initial value in the input box', async () => {
       const { getByRole } = await setup({ initialValue: 3.5 });
 
-      const inputBox = getByRole('textbox') as HTMLInputElement;
+      const inputBox = getByRole('spinbutton') as HTMLInputElement;
       expect(inputBox.value).toEqual('3.5');
     });
 
@@ -75,7 +75,7 @@ describe('DecimalInputWithButtonsComponent', () => {
         const { fixture, getByRole, onChangeSpy } = await setup();
         fixture.autoDetectChanges();
 
-        const inputBox = getByRole('textbox') as HTMLInputElement;
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
         userEvent.type(inputBox, '3.5');
 
         expect(inputBox.value).toEqual('3.5');
@@ -89,7 +89,7 @@ describe('DecimalInputWithButtonsComponent', () => {
 
         fixture.autoDetectChanges();
 
-        const inputBox = getByRole('textbox') as HTMLInputElement;
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
         userEvent.type(inputBox, '3.5');
 
         expect(onChangeSpy).toHaveBeenCalledWith(3.5);
@@ -100,11 +100,20 @@ describe('DecimalInputWithButtonsComponent', () => {
         const { fixture, getByRole, onChangeSpy } = await setup();
         fixture.autoDetectChanges();
 
-        const inputBox = getByRole('textbox') as HTMLInputElement;
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
         userEvent.type(inputBox, '10');
         userEvent.clear(inputBox);
 
         expect(onChangeSpy).toHaveBeenCalledWith(10);
+        expect(onChangeSpy).toHaveBeenCalledWith('');
+      });
+
+      it('should not allow letters to be inputted', async () => {
+        const { fixture, getByRole, onChangeSpy } = await setup();
+        fixture.autoDetectChanges();
+
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
+        userEvent.type(inputBox, 'er');
         expect(onChangeSpy).toHaveBeenCalledWith('');
       });
     });
@@ -114,7 +123,7 @@ describe('DecimalInputWithButtonsComponent', () => {
         const { fixture, getByRole, onChangeSpy } = await setup();
         fixture.autoDetectChanges();
 
-        const inputBox = getByRole('textbox') as HTMLInputElement;
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
 
         userEvent.type(inputBox, '10');
 
@@ -135,7 +144,7 @@ describe('DecimalInputWithButtonsComponent', () => {
         const { fixture, getByRole, onChangeSpy } = await setup({ min: 3.5 });
         fixture.autoDetectChanges();
 
-        const inputBox = getByRole('textbox') as HTMLInputElement;
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
 
         userEvent.type(inputBox, '1');
         await clickPlusButton();
@@ -148,7 +157,7 @@ describe('DecimalInputWithButtonsComponent', () => {
         const { fixture, getByRole, onChangeSpy } = await setup({ min: 3.5 });
         fixture.autoDetectChanges();
 
-        const inputBox = getByRole('textbox') as HTMLInputElement;
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
 
         userEvent.type(inputBox, 'apple banana orange');
         await clickPlusButton();
@@ -161,7 +170,7 @@ describe('DecimalInputWithButtonsComponent', () => {
         const { fixture, getByRole, queryByTestId } = await setup({ max: 10 });
         fixture.autoDetectChanges();
 
-        const inputBox = getByRole('textbox') as HTMLInputElement;
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
         expect(queryByTestId('plus-button-number-input')).toBeTruthy();
 
         userEvent.type(inputBox, '10');
@@ -175,7 +184,7 @@ describe('DecimalInputWithButtonsComponent', () => {
         const { fixture, getByRole, onChangeSpy } = await setup();
         fixture.autoDetectChanges();
 
-        const inputBox = getByRole('textbox') as HTMLInputElement;
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
 
         userEvent.type(inputBox, '10');
 
@@ -196,7 +205,7 @@ describe('DecimalInputWithButtonsComponent', () => {
         const { fixture, getByRole, onChangeSpy } = await setup({ max: 999 });
         fixture.autoDetectChanges();
 
-        const inputBox = getByRole('textbox') as HTMLInputElement;
+        const inputBox = getByRole('spinbutton') as HTMLInputElement;
 
         userEvent.type(inputBox, '10000');
         await clickMinusButton();

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -462,7 +462,7 @@
           <dd class="govuk-summary-list__value">
             <app-summary-record-value>
               @if (workplace?.travelTimePay?.includeRate && workplace?.travelTimePay?.rate) {
-                {{ `${workplace.travelTimePay.label}, £${workplace.travelTimePay?.rate}` }}
+                {{ `${workplace.travelTimePay.label}, ${workplace.travelTimePay?.rate | formatMoneyWithDecimals}` }}
               } @else {
                 {{ workplace.travelTimePay?.label | closedEndedAnswer }}
               }

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.spec.ts
@@ -1913,7 +1913,7 @@ describe('NewWorkplaceSummaryComponent', () => {
         const travelTimePayRow = queryByTestId('travel-time-pay');
 
         const link = within(travelTimePayRow).queryByText('Change');
-        const answer = within(travelTimePayRow).queryByText('A different travel time rate, £12.5');
+        const answer = within(travelTimePayRow).queryByText('A different travel time rate, £12.50');
 
         expect(travelTimePayRow).toBeTruthy();
         expect(answer).toBeTruthy();

--- a/frontend/src/app/shared/pipes/format-money-with-decimals.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/format-money-with-decimals.pipe.spec.ts
@@ -1,0 +1,20 @@
+import { FormatMoneyWithDecimalsPipe } from './format-money-with-decimals.pipe';
+
+describe('FormatMoneyWithDecimalsPipe', () => {
+  it('should create an instance', () => {
+    const pipe = new FormatMoneyWithDecimalsPipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it("should return a number with 2 decimal points when sent a single decimal", async() => {
+    const pipe = new FormatMoneyWithDecimalsPipe();
+
+    expect(pipe.transform('3.5')).toEqual("£3.50")
+  })
+
+  it("should return a number with 2 decimal points when sent a whole number", async() => {
+    const pipe = new FormatMoneyWithDecimalsPipe();
+
+    expect(pipe.transform('5')).toEqual("£5.00")
+  })
+});

--- a/frontend/src/app/shared/pipes/format-money-with-decimals.pipe.ts
+++ b/frontend/src/app/shared/pipes/format-money-with-decimals.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'formatMoneyWithDecimals',
+    standalone: false
+})
+
+export class FormatMoneyWithDecimalsPipe implements PipeTransform {
+  transform(value: string): string {
+    return "£" + Number(value).toFixed(2);
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -147,6 +147,7 @@ import { ShowTrainingValidityPipe } from './pipes/show-training-validity.pipe';
 import { DecimalInputWithButtonsComponent } from './components/decimal-input-with-buttons/decimal-input-with-buttons.component';
 import { AddWorkplaceDetailsPathPipe } from './pipes/add-workplace-details-path.pipe';
 import { WorkplaceSummaryPathPipe } from './pipes/workplace-summary-path.pipe';
+import { FormatMoneyWithDecimalsPipe } from './pipes/format-money-with-decimals.pipe';
 
 @NgModule({
   imports: [
@@ -300,6 +301,7 @@ import { WorkplaceSummaryPathPipe } from './pipes/workplace-summary-path.pipe';
     ExternalTrainingProviderInputComponent,
     ShowTrainingValidityPipe,
     DecimalInputWithButtonsComponent,
+    FormatMoneyWithDecimalsPipe,
   ],
   exports: [
     AbsoluteNumberPipe,
@@ -436,6 +438,7 @@ import { WorkplaceSummaryPathPipe } from './pipes/workplace-summary-path.pipe';
     DecimalInputWithButtonsComponent,
     AddWorkplaceDetailsPathPipe,
     WorkplaceSummaryPathPipe,
+    FormatMoneyWithDecimalsPipe,
   ],
   providers: [
     DialogService,
@@ -447,6 +450,7 @@ import { WorkplaceSummaryPathPipe } from './pipes/workplace-summary-path.pipe';
     HasValuePipe,
     FormatCwpUsePipe,
     FormatWhatDhaPipe,
+    FormatMoneyWithDecimalsPipe,
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
#### Work done
- Format travel time pay rate to show 2 decimals in input
- Add pipe to format money to 2 decimal places for workplace summary
- Update decimal-input-with-buttons to not allow letters in input
- Update pension component to be able to delete percentage

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
