### PR TITLE
Feat/1910 backend for workers pay with pagination

### DIFF
--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2001,7 +2001,7 @@ module.exports = function (sequelize, DataTypes) {
     });
   };
 
-  Establishment.getWorkersWithPayData = async function ({
+  Establishment.fetchWorkersWithPayData = async function ({
     establishmentId,
     itemsPerPage = 15,
     pageIndex = 0,

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -1,5 +1,6 @@
 const { Op } = require('sequelize');
 const moment = require('moment');
+const lodash = require('lodash');
 const {
   clearDHAWorkerAnswersOnWorkplaceChange,
   clearDoDHAWorkplaceOnMainServiceChange,
@@ -1998,6 +1999,68 @@ module.exports = function (sequelize, DataTypes) {
       order,
       ...(limit ? workerPagination : {}),
     });
+  };
+
+  Establishment.getWorkersWithPayData = async function ({
+    establishmentId,
+    itemsPerPage = 15,
+    pageIndex = 0,
+    sortBy = 'staffNameAsc',
+    jobId = null,
+  }) {
+    const models = sequelize.models;
+
+    const pagination = {
+      offset: itemsPerPage * pageIndex,
+      limit: itemsPerPage,
+    };
+
+    const sortByOptions = {
+      staffNameAsc: [['nameOrId', 'ASC']],
+      staffNameDesc: [['nameOrId', 'DESC']],
+      jobRoleAsc: [[sequelize.literal('"mainJob.title"'), 'ASC']],
+      jobRoleDesc: [[sequelize.literal('"mainJob.title"'), 'DESC']],
+    };
+
+    const order = sortByOptions[sortBy] ?? sortByOptions.staffNameAsc;
+    const jobIdFilter = jobId ? { where: { id: jobId } } : {};
+
+    const { count, rows } = await models.worker.findAndCountAll({
+      attributes: ['id', 'uid', ['NameOrIdValue', 'nameOrId'], 'AnnualHourlyPayValue', 'AnnualHourlyPayRate'],
+      where: {
+        establishmentFk: establishmentId,
+        archived: false,
+      },
+      include: [
+        {
+          model: sequelize.models.job,
+          as: 'mainJob',
+          attributes: ['title', 'id'],
+          ...jobIdFilter,
+        },
+      ],
+      raw: true,
+      nest: true,
+      order,
+      ...pagination,
+    });
+
+    const formatWorkerPay = (worker) => {
+      const payAnswer = worker.AnnualHourlyPayValue;
+      const workerFields = lodash.omit(worker, ['AnnualHourlyPayValue', 'AnnualHourlyPayRate']);
+
+      if (['Annually', 'Hourly'].includes(payAnswer)) {
+        const rate = worker.AnnualHourlyPayRate ? parseFloat(worker.AnnualHourlyPayRate) : null;
+        const annualHourlyPay = { value: payAnswer, rate };
+        return { ...workerFields, annualHourlyPay };
+      }
+
+      return { ...workerFields, annualHourlyPay: { value: payAnswer } };
+    };
+
+    const workers = rows.map(formatWorkerPay);
+
+    return { count, workers };
   };
 
   Establishment.getEstablishmentTrainingRecords = async function (establishmentId, isParent = false) {

--- a/backend/server/routes/establishments/worker.js
+++ b/backend/server/routes/establishments/worker.js
@@ -337,6 +337,40 @@ const getAllWorkersGroupedByJobRole = async (req, res) => {
   }
 };
 
+const parseIntWithDefault = (numberString, defaultValue) => {
+  const parsed = Number(numberString);
+  if (isNaN(parsed)) {
+    return defaultValue;
+  }
+  return parsed;
+};
+
+const getWorkersWithPayData = async (req, res) => {
+  try {
+    const allowedSortByOptions = ['staffNameAsc', 'staffNameDesc', 'jobRoleAsc', 'jobRoleDesc'];
+    const establishmentId = req.establishmentId;
+
+    const itemsPerPage = parseIntWithDefault(req.query.itemsPerPage, 15);
+    const pageIndex = parseIntWithDefault(req.query.pageIndex, 0);
+    const sortBy = allowedSortByOptions.includes(req.query.sortBy) ? req.query.sortBy : 'staffNameAsc';
+    const jobId = parseIntWithDefault(req.query.jobId, undefined);
+
+    const queryParams = {
+      establishmentId,
+      itemsPerPage,
+      pageIndex,
+      sortBy,
+      ...(jobId ? { jobId } : {}),
+    };
+
+    const results = await models.establishment.getWorkersWithPayData(queryParams);
+    return res.status(200).json(results);
+  } catch (err) {
+    console.error('GET /worker/withPayData: unexpected exception: ', err);
+    return res.status(500).send({ message: 'failed to get workers with pay data' });
+  }
+};
+
 const updateLocalIdentifiers = async (req, res) => {
   const establishmentId = req.establishmentId;
   const username = req.username;
@@ -388,6 +422,7 @@ router.route('/').post(hasPermission('canAddWorker'), createWorker);
 router.route('/localIdentifier').put(hasPermission('canBulkUpload'), updateLocalIdentifiers);
 router.route('/total').get(hasPermission('canViewEstablishment'), getTotalWorkers);
 router.get('/groupedByJobRole', hasPermission('canViewWorker'), getAllWorkersGroupedByJobRole);
+router.get('/withPayData', hasPermission('canViewWorker'), getWorkersWithPayData);
 
 router.use('/multiple-training', MutipleTrainingRecordsRoute);
 
@@ -405,3 +440,4 @@ module.exports.editWorker = editWorker;
 module.exports.viewAllWorkers = viewAllWorkers;
 module.exports.getTotalWorkers = getTotalWorkers;
 module.exports.getAllWorkersGroupedByJobRole = getAllWorkersGroupedByJobRole;
+module.exports.getWorkersWithPayData = getWorkersWithPayData;

--- a/backend/server/routes/establishments/worker.js
+++ b/backend/server/routes/establishments/worker.js
@@ -363,7 +363,7 @@ const getWorkersWithPayData = async (req, res) => {
       ...(jobId ? { jobId } : {}),
     };
 
-    const results = await models.establishment.getWorkersWithPayData(queryParams);
+    const results = await models.establishment.fetchWorkersWithPayData(queryParams);
     return res.status(200).json(results);
   } catch (err) {
     console.error('GET /worker/withPayData: unexpected exception: ', err);

--- a/backend/server/test/unit/models/establishment.spec.js
+++ b/backend/server/test/unit/models/establishment.spec.js
@@ -8,7 +8,7 @@ describe('establishment model', () => {
     sinon.restore();
   });
 
-  describe('getWorkersWithPayData', () => {
+  describe('fetchWorkersWithPayData', () => {
     const workerBuilder = build('Worker', {
       fields: {
         uid: fake((f) => f.datatype.uuid()),
@@ -28,7 +28,7 @@ describe('establishment model', () => {
       const mockWorkers = [workerBuilder(), workerBuilder(), workerBuilder()];
       sinon.stub(models.worker, 'findAndCountAll').resolves({ count: 3, rows: mockWorkers });
 
-      await models.establishment.getWorkersWithPayData({
+      await models.establishment.fetchWorkersWithPayData({
         establishmentId: mockEstablishmentId,
         itemsPerPage: 20,
         pageIndex: 2,
@@ -99,7 +99,7 @@ describe('establishment model', () => {
 
       sinon.stub(models.worker, 'findAndCountAll').resolves({ count: 3, rows: mockWorkers });
 
-      const result = await models.establishment.getWorkersWithPayData({
+      const result = await models.establishment.fetchWorkersWithPayData({
         establishmentId: mockEstablishmentId,
       });
 

--- a/backend/server/test/unit/models/establishment.spec.js
+++ b/backend/server/test/unit/models/establishment.spec.js
@@ -1,0 +1,100 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const models = require('../../../models/index');
+const { build, sequence, oneOf, fake } = require('@jackfranklin/test-data-bot');
+
+describe('establishment model', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getWorkersWithPayData', () => {
+    const workerBuilder = build('Worker', {
+      fields: {
+        uid: fake((f) => f.datatype.uuid()),
+        nameOrId: fake((f) => f.name.findName()),
+        mainJob: {
+          id: sequence(),
+          title: fake((f) => f.name.jobTitle()),
+        },
+        AnnualHourlyPayValue: oneOf('Annually', 'Hourly', "Don't know", null),
+        AnnualHourlyPayRate: null,
+      },
+    });
+
+    const mockEstablishmentId = '1';
+
+    it('should call models.worker.findAndCountAll with the given query params', async () => {
+      const mockWorkers = [workerBuilder(), workerBuilder(), workerBuilder()];
+      sinon.stub(models.worker, 'findAndCountAll').resolves({ count: 3, rows: mockWorkers });
+
+      await models.establishment.getWorkersWithPayData({
+        establishmentId: mockEstablishmentId,
+        itemsPerPage: 20,
+        pageIndex: 2,
+        sortBy: 'staffNameDesc',
+      });
+
+      expect(models.worker.findAndCountAll).to.have.been.calledWithMatch({
+        where: {
+          establishmentFk: mockEstablishmentId,
+          archived: false,
+        },
+        offset: 20 * 2,
+        limit: 20,
+        order: [['nameOrId', 'DESC']],
+      });
+    });
+
+    it('should format the pay data in the same schema as worker class', async () => {
+      const mockWorkers = [
+        {
+          nameOrId: 'Worker A',
+          mainJob: { id: 10, title: 'Care worker' },
+          AnnualHourlyPayValue: 'Annually',
+          AnnualHourlyPayRate: '25000',
+        },
+        {
+          nameOrId: 'Worker B',
+          mainJob: { id: 10, title: 'Care worker' },
+          AnnualHourlyPayValue: 'Hourly',
+          AnnualHourlyPayRate: '25',
+        },
+        {
+          nameOrId: 'Worker C',
+          mainJob: { id: 10, title: 'Care worker' },
+          AnnualHourlyPayValue: "Don't know",
+          AnnualHourlyPayRate: null,
+        },
+      ];
+      const expectedResult = {
+        count: 3,
+        workers: [
+          {
+            nameOrId: 'Worker A',
+            mainJob: { id: 10, title: 'Care worker' },
+            annualHourlyPay: { value: 'Annually', rate: 25000 },
+          },
+          {
+            nameOrId: 'Worker B',
+            mainJob: { id: 10, title: 'Care worker' },
+            annualHourlyPay: { value: 'Hourly', rate: 25 },
+          },
+          {
+            nameOrId: 'Worker C',
+            mainJob: { id: 10, title: 'Care worker' },
+            annualHourlyPay: { value: "Don't know" },
+          },
+        ],
+      };
+
+      sinon.stub(models.worker, 'findAndCountAll').resolves({ count: 3, rows: mockWorkers });
+
+      const result = await models.establishment.getWorkersWithPayData({
+        establishmentId: mockEstablishmentId,
+      });
+
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+});

--- a/backend/server/test/unit/models/establishment.spec.js
+++ b/backend/server/test/unit/models/establishment.spec.js
@@ -33,6 +33,7 @@ describe('establishment model', () => {
         itemsPerPage: 20,
         pageIndex: 2,
         sortBy: 'staffNameDesc',
+        jobId: 10,
       });
 
       expect(models.worker.findAndCountAll).to.have.been.calledWithMatch({
@@ -43,6 +44,14 @@ describe('establishment model', () => {
         offset: 20 * 2,
         limit: 20,
         order: [['nameOrId', 'DESC']],
+        include: [
+          {
+            model: models.job,
+            as: 'mainJob',
+            attributes: ['title', 'id'],
+            where: { id: 10 },
+          },
+        ],
       });
     });
 

--- a/backend/server/test/unit/routes/establishments/worker.spec.js
+++ b/backend/server/test/unit/routes/establishments/worker.spec.js
@@ -17,7 +17,7 @@ const establishment = {
   establishmentId: 2,
 };
 
-describe.only('worker route', () => {
+describe('worker route', () => {
   before(() => {
     sinon.stub(models.worker, 'findOne').resolves(worker);
     sinon.stub(models.worker, 'create').resolves(worker);
@@ -336,10 +336,11 @@ describe.only('worker route', () => {
 
     const request = {
       method: 'GET',
-      url: '/api/establishment/uid/worker/total',
+      url: '/api/establishment/:uid/worker/getAllWorkersGroupedByJobRole',
       params: {
-        establishmentId: '123',
+        id: 'mock-uid',
       },
+      establishmentId: 123,
     };
 
     it('should respond with 200 and all workers in the workplace, grouped by their job roles', async () => {
@@ -392,15 +393,142 @@ describe.only('worker route', () => {
   });
 
   describe('getWorkersWithPayData()', () => {
-    it('should respond with 200 and a list of workers and their pay data');
+    const workerBuilder = build('Worker', {
+      fields: {
+        uid: fake((f) => f.datatype.uuid()),
+        nameOrId: fake((f) => f.name.findName()),
+        mainJob: {
+          id: sequence(),
+          title: fake((f) => f.name.jobTitle()),
+        },
+        annualHourlyPay: oneOf(
+          { value: 'Annually', rate: '25000' },
+          { value: 'Hourly', rate: '15' },
+          { value: "Don't know" },
+        ),
+      },
+    });
+    const mockEstablishmentId = 123;
 
-    it('should handle pagination and sort parameters');
+    afterEach(() => {
+      sinon.restore();
+    });
 
-    it('should allow search by job id');
+    const request = {
+      method: 'GET',
+      url: '/api/establishment/:uid/worker/withPayData',
+      params: {
+        id: 'mock-uid',
+      },
+      establishmentId: mockEstablishmentId,
+    };
 
-    it('should ignore any unexpected query params');
+    const mockWorkers = [workerBuilder(), workerBuilder(), workerBuilder()];
+    const mockQueryResult = { count: mockWorkers, workers: mockWorkers };
 
-    it('should response with 500 if error occured');
+    it('should respond with 200 and a list of workers and their pay data', async () => {
+      sinon.stub(models.establishment, 'getWorkersWithPayData').resolves(mockQueryResult);
+
+      const req = httpMocks.createRequest(request);
+      const res = httpMocks.createResponse();
+
+      await workerRoute.getWorkersWithPayData(req, res);
+
+      expect(res.statusCode).to.deep.equal(200);
+      expect(res._getJSONData()).to.deep.equal(mockQueryResult);
+      expect(models.establishment.getWorkersWithPayData).to.have.been.calledWith({
+        establishmentId: mockEstablishmentId,
+        itemsPerPage: 15,
+        pageIndex: 0,
+        sortBy: 'staffNameAsc',
+      });
+    });
+
+    describe('should handle pagination and sort parameters from query', async () => {
+      const requestWithParams = {
+        ...request,
+        query: { itemsPerPage: 20, pageIndex: 2, sortBy: 'jobRoleAsc' },
+      };
+      sinon.stub(models.establishment, 'getWorkersWithPayData').resolves(mockQueryResult);
+
+      const req = httpMocks.createRequest(requestWithParams);
+      const res = httpMocks.createResponse();
+
+      await workerRoute.getWorkersWithPayData(req, res);
+
+      expect(res.statusCode).to.deep.equal(200);
+      expect(res._getJSONData()).to.deep.equal(mockQueryResult);
+      expect(models.establishment.getWorkersWithPayData).to.have.been.calledWith({
+        establishmentId: mockEstablishmentId,
+        itemsPerPage: 20,
+        pageIndex: 2,
+        sortBy: 'jobRoleAsc',
+      });
+    });
+
+    it('should allow search by job id', async () => {
+      const requestWithParams = {
+        ...request,
+        query: { jobId: 19 },
+      };
+      sinon.stub(models.establishment, 'getWorkersWithPayData').resolves(mockQueryResult);
+
+      const req = httpMocks.createRequest(requestWithParams);
+      const res = httpMocks.createResponse();
+
+      await workerRoute.getWorkersWithPayData(req, res);
+
+      expect(res.statusCode).to.deep.equal(200);
+      expect(res._getJSONData()).to.deep.equal(mockQueryResult);
+      expect(models.establishment.getWorkersWithPayData).to.have.been.calledWith({
+        establishmentId: mockEstablishmentId,
+        itemsPerPage: 15,
+        pageIndex: 0,
+        sortBy: 'staffNameAsc',
+        jobId: 19,
+      });
+    });
+
+    it('should ignore any unexpected query params', async () => {
+      const requestWithParams = {
+        ...request,
+        query: {
+          pageIndex: 'apple',
+          itemsPerPage: 'banana',
+          sortBy: 'some-random-string',
+          jobId: 'abcd',
+          role: 'admin',
+          subQuery: 'drop table Students;',
+        },
+      };
+
+      sinon.stub(models.establishment, 'getWorkersWithPayData').resolves(mockQueryResult);
+
+      const req = httpMocks.createRequest(requestWithParams);
+      const res = httpMocks.createResponse();
+
+      await workerRoute.getWorkersWithPayData(req, res);
+
+      expect(res.statusCode).to.deep.equal(200);
+      expect(res._getJSONData()).to.deep.equal(mockQueryResult);
+      expect(models.establishment.getWorkersWithPayData).to.have.been.calledWith({
+        establishmentId: mockEstablishmentId,
+        itemsPerPage: 15,
+        pageIndex: 0,
+        sortBy: 'staffNameAsc',
+      });
+    });
+
+    it('should response with 500 if error occured', async () => {
+      sinon.stub(models.establishment, 'getWorkersWithPayData').rejects(new Error('database error'));
+      sinon.stub(console, 'error');
+
+      const req = httpMocks.createRequest(request);
+      const res = httpMocks.createResponse();
+      await workerRoute.getWorkersWithPayData(req, res);
+
+      expect(res.statusCode).to.deep.equal(500);
+    });
   });
 
   describe('getTotalWorkers()', () => {

--- a/backend/server/test/unit/routes/establishments/worker.spec.js
+++ b/backend/server/test/unit/routes/establishments/worker.spec.js
@@ -8,25 +8,19 @@ const models = require('../../../../models/index');
 const workerRoute = require('../../../../routes/establishments/worker');
 const WdfCalculator = require('../../../../models/classes/wdfCalculator').WdfCalculator;
 
-let i = 0;
 const worker = {
   establishmentId: 1,
   workerId: '29155c11-11bb-4ab3-ada0-bccac7acecc1',
   id: 1,
-  i,
 };
 const establishment = {
   establishmentId: 2,
 };
 
-describe('worker route', () => {
+describe.only('worker route', () => {
   before(() => {
-    sinon.stub(models.worker, 'findOne').callsFake(async (args) => {
-      return args.i === 3 ? {} : worker;
-    });
-    sinon.stub(models.worker, 'create').callsFake(async () => {
-      return worker;
-    });
+    sinon.stub(models.worker, 'findOne').resolves(worker);
+    sinon.stub(models.worker, 'create').resolves(worker);
     sinon.stub(models.worker, 'update').callsFake(async () => {
       const mockWorker = {
         get: () => {
@@ -35,12 +29,8 @@ describe('worker route', () => {
       };
       return [1, [mockWorker]];
     });
-    sinon.stub(models.workerAudit, 'bulkCreate').callsFake(async () => {
-      return {};
-    });
-    sinon.stub(models.establishment, 'findOne').callsFake(async () => {
-      return establishment;
-    });
+    sinon.stub(models.workerAudit, 'bulkCreate').resolves({});
+    sinon.stub(models.establishment, 'findOne').resolves(establishment);
   });
 
   after(() => {
@@ -401,6 +391,18 @@ describe('worker route', () => {
     });
   });
 
+  describe('getWorkersWithPayData()', () => {
+    it('should respond with 200 and a list of workers and their pay data');
+
+    it('should handle pagination and sort parameters');
+
+    it('should allow search by job id');
+
+    it('should ignore any unexpected query params');
+
+    it('should response with 500 if error occured');
+  });
+
   describe('getTotalWorkers()', () => {
     const workerBuilder = build('Worker', {
       fields: {
@@ -415,9 +417,11 @@ describe('worker route', () => {
         workers: [worker],
       });
     });
+
     afterEach(() => {
       sinon.restore();
     });
+
     it('should return a total number of staff', async () => {
       const req = httpMocks.createRequest({
         method: 'GET',

--- a/backend/server/test/unit/routes/establishments/worker.spec.js
+++ b/backend/server/test/unit/routes/establishments/worker.spec.js
@@ -427,7 +427,7 @@ describe('worker route', () => {
     const mockQueryResult = { count: mockWorkers, workers: mockWorkers };
 
     it('should respond with 200 and a list of workers and their pay data', async () => {
-      sinon.stub(models.establishment, 'getWorkersWithPayData').resolves(mockQueryResult);
+      sinon.stub(models.establishment, 'fetchWorkersWithPayData').resolves(mockQueryResult);
 
       const req = httpMocks.createRequest(request);
       const res = httpMocks.createResponse();
@@ -449,7 +449,7 @@ describe('worker route', () => {
         ...request,
         query: { itemsPerPage: 20, pageIndex: 2, sortBy: 'jobRoleAsc' },
       };
-      sinon.stub(models.establishment, 'getWorkersWithPayData').resolves(mockQueryResult);
+      sinon.stub(models.establishment, 'fetchWorkersWithPayData').resolves(mockQueryResult);
 
       const req = httpMocks.createRequest(requestWithParams);
       const res = httpMocks.createResponse();
@@ -471,7 +471,7 @@ describe('worker route', () => {
         ...request,
         query: { jobId: 19 },
       };
-      sinon.stub(models.establishment, 'getWorkersWithPayData').resolves(mockQueryResult);
+      sinon.stub(models.establishment, 'fetchWorkersWithPayData').resolves(mockQueryResult);
 
       const req = httpMocks.createRequest(requestWithParams);
       const res = httpMocks.createResponse();
@@ -502,7 +502,7 @@ describe('worker route', () => {
         },
       };
 
-      sinon.stub(models.establishment, 'getWorkersWithPayData').resolves(mockQueryResult);
+      sinon.stub(models.establishment, 'fetchWorkersWithPayData').resolves(mockQueryResult);
 
       const req = httpMocks.createRequest(requestWithParams);
       const res = httpMocks.createResponse();
@@ -520,7 +520,7 @@ describe('worker route', () => {
     });
 
     it('should response with 500 if error occured', async () => {
-      sinon.stub(models.establishment, 'getWorkersWithPayData').rejects(new Error('database error'));
+      sinon.stub(models.establishment, 'fetchWorkersWithPayData').rejects(new Error('database error'));
       sinon.stub(console, 'error');
 
       const req = httpMocks.createRequest(request);

--- a/backend/server/test/unit/routes/establishments/worker.spec.js
+++ b/backend/server/test/unit/routes/establishments/worker.spec.js
@@ -392,7 +392,7 @@ describe('worker route', () => {
     });
   });
 
-  describe.skip('getWorkersWithPayData()', () => {
+  describe('getWorkersWithPayData()', () => {
     const workerBuilder = build('Worker', {
       fields: {
         uid: fake((f) => f.datatype.uuid()),
@@ -436,7 +436,7 @@ describe('worker route', () => {
 
       expect(res.statusCode).to.deep.equal(200);
       expect(res._getJSONData()).to.deep.equal(mockQueryResult);
-      expect(models.establishment.getWorkersWithPayData).to.have.been.calledWith({
+      expect(models.establishment.fetchWorkersWithPayData).to.have.been.calledWith({
         establishmentId: mockEstablishmentId,
         itemsPerPage: 15,
         pageIndex: 0,
@@ -458,7 +458,7 @@ describe('worker route', () => {
 
       expect(res.statusCode).to.deep.equal(200);
       expect(res._getJSONData()).to.deep.equal(mockQueryResult);
-      expect(models.establishment.getWorkersWithPayData).to.have.been.calledWith({
+      expect(models.establishment.fetchWorkersWithPayData).to.have.been.calledWith({
         establishmentId: mockEstablishmentId,
         itemsPerPage: 20,
         pageIndex: 2,
@@ -480,7 +480,7 @@ describe('worker route', () => {
 
       expect(res.statusCode).to.deep.equal(200);
       expect(res._getJSONData()).to.deep.equal(mockQueryResult);
-      expect(models.establishment.getWorkersWithPayData).to.have.been.calledWith({
+      expect(models.establishment.fetchWorkersWithPayData).to.have.been.calledWith({
         establishmentId: mockEstablishmentId,
         itemsPerPage: 15,
         pageIndex: 0,
@@ -511,7 +511,7 @@ describe('worker route', () => {
 
       expect(res.statusCode).to.deep.equal(200);
       expect(res._getJSONData()).to.deep.equal(mockQueryResult);
-      expect(models.establishment.getWorkersWithPayData).to.have.been.calledWith({
+      expect(models.establishment.fetchWorkersWithPayData).to.have.been.calledWith({
         establishmentId: mockEstablishmentId,
         itemsPerPage: 15,
         pageIndex: 0,

--- a/backend/server/test/unit/routes/establishments/worker.spec.js
+++ b/backend/server/test/unit/routes/establishments/worker.spec.js
@@ -392,7 +392,7 @@ describe('worker route', () => {
     });
   });
 
-  describe('getWorkersWithPayData()', () => {
+  describe.skip('getWorkersWithPayData()', () => {
     const workerBuilder = build('Worker', {
       fields: {
         uid: fake((f) => f.datatype.uuid()),
@@ -444,7 +444,7 @@ describe('worker route', () => {
       });
     });
 
-    describe('should handle pagination and sort parameters from query', async () => {
+    it('should handle pagination and sort parameters from query', async () => {
       const requestWithParams = {
         ...request,
         query: { itemsPerPage: 20, pageIndex: 2, sortBy: 'jobRoleAsc' },


### PR DESCRIPTION
#### Work done
- add endpoint GET `/api/establishment/:uid/worker/withPayData` to fetch worker data with pay 

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
