### PR TITLE
feat/1907 Fast track pay updates by job role

### DIFF
--- a/frontend/src/app/core/model/worker.model.ts
+++ b/frontend/src/app/core/model/worker.model.ts
@@ -174,6 +174,8 @@ export type WorkersGroupedByJobRole = {
   title: string;
   jobId: number;
   workers: Array<{ uid: string }>;
+  count: number;
+  annualHourlyPay?: WorkerPay;
 };
 
 export interface WorkersGroupedByJobRoleResponse {

--- a/frontend/src/app/core/resolvers/workers-by-job-role.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/workers-by-job-role.resolver.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { WorkerService } from '@core/services/worker.service';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { WorkersByJobRoleResolver } from '@core/resolvers/workers-by-job-role.resolver';
+import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router';
+
+describe('WorkersByJobRoleResolver', ()=> {
+  function setup() {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ActivatedRouteSnapshot,
+          useValue: {
+            paramMap: convertToParamMap({ establishmentuid: '123' }),
+          },
+        },
+        provideHttpClient(),
+        provideHttpClientTesting,
+        WorkersByJobRoleResolver,
+        WorkerService
+      ]
+    });
+
+    const resolver = TestBed.inject(WorkersByJobRoleResolver);
+    const route = TestBed.inject(ActivatedRouteSnapshot);
+
+    const workerService = TestBed.inject(WorkerService);
+    const getAllWorkersGroupedByJobRoleSpy = spyOn(workerService, 'getAllWorkersGroupedByJobRole');
+
+    return {
+      resolver,
+      workerService,
+      getAllWorkersGroupedByJobRoleSpy,
+      route
+    };
+  }
+
+  it('should be created', () => {
+    const { resolver } = setup();
+    expect(resolver).toBeTruthy;
+  });
+
+  it('should call the getAllWorkersGroupedByJobRole method', () => {
+    const { resolver, route, getAllWorkersGroupedByJobRoleSpy } = setup();
+    resolver.resolve(route);
+
+    expect(getAllWorkersGroupedByJobRoleSpy).toHaveBeenCalledWith('123');
+  });
+});

--- a/frontend/src/app/core/resolvers/workers-by-job-role.resolver.ts
+++ b/frontend/src/app/core/resolvers/workers-by-job-role.resolver.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { WorkerService } from '@core/services/worker.service';
+import { Observable } from 'rxjs';
+import { WorkersGroupedByJobRoleResponse } from '@core/model/worker.model';
+import { ActivatedRouteSnapshot } from '@angular/router';
+
+@Injectable()
+export class WorkersByJobRoleResolver{
+  constructor(
+    private workerService: WorkerService,
+  ) {}
+
+  resolve(route: ActivatedRouteSnapshot): Observable<WorkersGroupedByJobRoleResponse>{
+    const establishmentUid = route.paramMap.get('establishmentuid');
+    return this.workerService.getAllWorkersGroupedByJobRole(establishmentUid);
+  }
+}

--- a/frontend/src/app/core/services/worker.service.spec.ts
+++ b/frontend/src/app/core/services/worker.service.spec.ts
@@ -104,4 +104,34 @@ describe('WorkerService', () => {
       expect(req.request.method).toBe('GET');
     });
   });
+
+  describe('workersGroupedByJobRole', () => {
+    it('should return null when nothing has been set', () => {
+      expect(service.getWorkersGroupedByJobRole()).toEqual(null);
+    });
+
+    it('should be set when setWorkersGroupedByJobRole is called', () => {
+      const workers = {
+        'groups': [
+          {
+            'jobId': 2,
+            'title': 'Administrative',
+            'workers': [
+              {
+                'uid': '25efe005-eca0-4db8-81fa-cfe0a6849c7d',
+                'mainJob': {
+                  'id': 2,
+                  'title': 'Administrative',
+                }
+              }
+            ],
+            'count': 1,
+          },
+        ],
+      }
+      service.setWorkersGroupedByJobRole(workers);
+
+      expect(service.getWorkersGroupedByJobRole()).toEqual(workers);
+    });
+  });
 });

--- a/frontend/src/app/core/services/worker.service.ts
+++ b/frontend/src/app/core/services/worker.service.ts
@@ -68,6 +68,7 @@ export class WorkerService {
   public workers$: Observable<Worker[]> = this._workers$.asObservable();
   public tabChanged: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public _doYouWantToDownloadTrainAndQualsAnswer = null;
+  private _workersGroupedByJobRole: WorkersGroupedByJobRoleResponse = null;
 
   constructor(private http: HttpClient) {}
 
@@ -375,5 +376,13 @@ export class WorkerService {
 
   public clearDoYouWantToDownloadTrainAndQualsAnswer(): void {
     this._doYouWantToDownloadTrainAndQualsAnswer = null;
+  }
+
+  public getWorkersGroupedByJobRole(): WorkersGroupedByJobRoleResponse {
+    return this._workersGroupedByJobRole;
+  }
+
+  public setWorkersGroupedByJobRole(workers: WorkersGroupedByJobRoleResponse) {
+    this._workersGroupedByJobRole = workers;
   }
 }

--- a/frontend/src/app/features/workers/fast-track-pay-updates/fast-track-pay-updates.component.html
+++ b/frontend/src/app/features/workers/fast-track-pay-updates/fast-track-pay-updates.component.html
@@ -1,0 +1,84 @@
+<form (ngSubmit)="onSubmit()" [formGroup]="form" #formEl>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span data-testid="caption" class="govuk-caption-l">Staff records</span>
+      <h1 data-testid="heading" class="govuk-heading-l govuk-!-margin-bottom-7">Fast-track pay updates by job roles</h1>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <table class="govuk-table govuk-!-margin-bottom-3">
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th data-testid="job-role-heading" scope="col" class="govuk-table__header" style="width: 445px">Job role</th>
+          <th data-testid="pay-heading" scope="col" class="govuk-table__header" style="margin-left: 0;">New hourly pay rate or salary</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body" formArrayName="workers">
+          @for (workers of workersByJobRole.groups; track $index) {
+            <tr class="govuk-table__row" [formGroupName]="$index">
+              <td class="govuk-table__cell" style="vertical-align: top; padding-top: 18px; padding-bottom: 18px;">
+                <div style="line-height: 1.25; display: flex; justify-content: space-between; align-items: flex-start;">
+                  <span>{{ workers.title }} ({{ workers.count }} record{{ workers.count === 1 ? '' : 's' }})</span>
+                  <img src="/assets/images/right-arrow.svg" alt="Right facing grey arrow" style="width: 24px; height: 24px; margin-right: 2.5px;" class="right-arrow"/>
+                </div>
+              </td>
+              <td class="govuk-table__cell" style="vertical-align: top; padding-top: 8px">
+                <div style="display: flex; align-items: center; flex-wrap: nowrap; gap: 15px;">
+                  <div class="govuk-input__wrapper">
+                    <div class="govuk-input__prefix" aria-hidden="true" style="background-color: #ffffff">£</div>
+                    <input
+                      [attr.data-testid]="'amount-input-box-' + $index"
+                      class="govuk-input govuk-input--width-4"
+                      [formControlName]="'rate'"
+                      [id]="'rate-' + $index"
+                      type="number"
+                    />
+                  </div>
+                  <div class="govuk-radios govuk-radios--inline govuk-radios--small govuk-!-margin-bottom-0">
+                    <div class="govuk-radios__item" style="margin-right: 5px;">
+                      <input
+                        class="govuk-radios__input"
+                        [attr.data-testid]="'hourly-radio-' + $index"
+                        [formControlName]="'value'"
+                        [id]="'hourly-' + $index"
+                        type="radio"
+                        value="Hourly">
+                      <label class="govuk-label govuk-radios__label" for="'hourly-' + $index">
+                        Hourly
+                      </label>
+                    </div>
+                    <div class="govuk-radios__item">
+                      <input
+                        class="govuk-radios__input"
+                        [attr.data-testid]="'salary-radio-' + $index"
+                        [formControlName]="'value'"
+                        [id]="'salary-' + $index"
+                        type="radio"
+                        value="Annually">
+                      <label class="govuk-label govuk-radios__label" for="'salary-' + $index">
+                        Salary
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          }
+      </table>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-button-group">
+        <button type="submit" class="govuk-button continue-button govuk-!-margin-right-9" data-module="govuk-button">
+          Continue
+        </button>
+        <a
+          class="govuk-button govuk-button--link govuk-!-margin-left-9"
+          [routerLink]="'/'"
+        >Cancel</a>
+      </div>
+    </div>
+  </div>
+</form>

--- a/frontend/src/app/features/workers/fast-track-pay-updates/fast-track-pay-updates.component.spec.ts
+++ b/frontend/src/app/features/workers/fast-track-pay-updates/fast-track-pay-updates.component.spec.ts
@@ -1,0 +1,330 @@
+import { getTestBed } from '@angular/core/testing';
+import { FastTrackPayUpdatesComponent } from './fast-track-pay-updates.component';
+import { fireEvent, render } from '@testing-library/angular';
+import { BackService } from '@core/services/back.service';
+import { BackLinkService } from '@core/services/backLink.service';
+import { WorkerService } from '@core/services/worker.service';
+import { ActivatedRoute } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import userEvent from '@testing-library/user-event';
+
+describe('FastTrackPayUpdatesComponent', () => {
+  const workersWithSingleJobRole = {
+    'groups': [
+      {
+        'jobId': 10,
+        'title': 'Care worker',
+        'workers': [
+          {
+            'uid': '559b1bfb-3b1f-47a9-ace3-956e60fc2221',
+            'mainJob': {
+              'id': 10,
+              'title': 'Care worker',
+            }
+          },
+        ],
+        'count': 1,
+      },
+    ]
+  };
+
+  const workersWithMultipleJobRoles = {
+    'groups': [
+      {
+        'jobId': 10,
+        'title': 'Care worker',
+        'workers': [
+          {
+            'uid': '559b1bfb-3b1f-47a9-ace3-956e60fc2221',
+            'mainJob': {
+              'id': 10,
+              'title': 'Care worker',
+            }
+          },
+        ],
+        'count': 5,
+      },
+      {
+        'jobId': 11,
+        'title': 'Senior care worker',
+        'workers': [
+          {
+            'uid': '559b1bfb-3b1f-47a9-ace3-956e60fc2221',
+            'mainJob': {
+              'id': 11,
+              'title': 'Senior care worker',
+            }
+          },
+        ],
+        'count': 2,
+      },
+      {
+        'jobId': 12,
+        'title': 'Manager',
+        'workers': [
+          {
+            'uid': '559b1bfb-3b1f-47a9-ace3-956e60fc2221',
+            'mainJob': {
+              'id': 12,
+              'title': 'Manager',
+            }
+          },
+        ],
+        'count': 1,
+      },
+    ]
+  };
+
+  async function setup(overrides: any = {}){
+    const setupTools = await render(FastTrackPayUpdatesComponent,
+      {
+        imports: [ReactiveFormsModule],
+        providers: [
+          BackService,
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                data: {
+                  workersByJobRole: overrides.workersWithMultipleJobRoles ?? workersWithSingleJobRole,
+                },
+              },
+            },
+          },
+          provideHttpClient(),
+          provideHttpClientTesting(),
+        ],
+      },
+    );
+
+    const component = setupTools.fixture.componentInstance;
+    const injector = getTestBed();
+
+    const backLinkService = injector.inject(BackLinkService) as BackLinkService;
+    const showBackLinkSpy = spyOn(backLinkService, 'showBackLink');
+
+    const workerService = injector.inject(WorkerService) as WorkerService;
+    const setWorkersGroupedByJobRoleSpy = spyOn(workerService, 'setWorkersGroupedByJobRole');
+
+    return {
+      ...setupTools,
+      component,
+      showBackLinkSpy,
+      setWorkersGroupedByJobRoleSpy,
+    }
+  }
+
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('displays a Back link', async ()=> {
+    const { component, showBackLinkSpy } = await setup();
+    component.ngOnInit();
+    expect(showBackLinkSpy).toHaveBeenCalled();
+  });
+
+  describe('Headings', () => {
+    it('should display the Staff records caption', async ()=> {
+      const { getByTestId } = await setup();
+      const caption = getByTestId('caption');
+      expect(caption.textContent).toEqual('Staff records');
+    });
+
+    it('should display the main heading', async () => {
+      const { getByTestId } = await setup();
+      const heading = getByTestId('heading');
+      expect(heading.textContent).toEqual('Fast-track pay updates by job roles');
+    });
+  });
+
+  describe('Table', () => {
+    it('should include the Job role column heading', async ()=> {
+      const { getByTestId } = await setup();
+      const heading = getByTestId('job-role-heading');
+      expect(heading.textContent).toEqual('Job role');
+    });
+
+    it('should include the New hourly pay rate or salary column heading', async () => {
+      const { getByTestId } = await setup();
+      const heading = getByTestId('pay-heading');
+      expect(heading.textContent).toEqual('New hourly pay rate or salary');
+    })
+
+    describe('Job role column contents', ()=> {
+      it('should contain the details of the workers where there is one job role', async () => {
+        const { getByText } = await setup();
+        const content = getByText('Care worker (1 record)');
+        expect(content).toBeTruthy();
+      });
+
+      it('should contain the details of the workers where there are multiple job roles', async () => {
+        const { getByText } = await setup({workersWithMultipleJobRoles});
+        const contentManager = getByText('Manager (1 record)');
+        const contentSeniorCareWorker = getByText('Senior care worker (2 records)');
+        const contentCareWorker = getByText('Care worker (5 records)');
+
+        expect(contentManager).toBeTruthy();
+        expect(contentSeniorCareWorker).toBeTruthy();
+        expect(contentCareWorker).toBeTruthy();
+      });
+    });
+  });
+  describe('Continue button', () => {
+    it('should be displayed', async () => {
+      const { getByRole } = await setup();
+      const button = getByRole('button', { name: 'Continue' });
+      expect(button).toBeTruthy();
+    })
+
+    describe('When there is 1 job role', () => {
+      it('should call the worker service with the updated pay information', async () => {
+        const { fixture, getByRole, setWorkersGroupedByJobRoleSpy, getByTestId } = await setup();
+
+        const amountInputBox = getByTestId('amount-input-box-0')
+        userEvent.type(amountInputBox, '12');
+
+        const radio = getByTestId('hourly-radio-0');
+        fireEvent.click(radio);
+
+        fixture.detectChanges();
+
+        const button = getByRole('button', { name: 'Continue' });
+        button.click();
+
+        const workers = {
+          'groups': [
+            {
+              'jobId': 10,
+              'title': 'Care worker',
+              'workers': [
+                {
+                  'uid': '559b1bfb-3b1f-47a9-ace3-956e60fc2221',
+                  'mainJob': {
+                    'id': 10,
+                    'title': 'Care worker',
+                  }
+                }
+              ],
+              'count': 1,
+              'annualHourlyPay': {
+                value: 'Hourly',
+                rate: 12,
+              },
+            },
+          ]
+        }
+
+        expect(setWorkersGroupedByJobRoleSpy).toHaveBeenCalledWith(workers);
+      });
+    });
+
+    describe('When there are multiple job roles', () => {
+      it('should call the worker service with the updated pay information', async () => {
+        const { fixture, getByRole, setWorkersGroupedByJobRoleSpy, getByTestId } = await setup({workersWithMultipleJobRoles});
+
+        const firstAmountInputBox = getByTestId('amount-input-box-0')
+        userEvent.type(firstAmountInputBox, '12');
+
+        const secondAmountInputBox = getByTestId('amount-input-box-1')
+        userEvent.type(secondAmountInputBox, '14');
+
+        const thirdAmountInputBox = getByTestId('amount-input-box-2')
+        userEvent.type(thirdAmountInputBox, '16');
+
+        const firstRadioHourly = getByTestId('hourly-radio-0');
+        fireEvent.click(firstRadioHourly);
+
+        const secondRadioSalary = getByTestId('salary-radio-1');
+        fireEvent.click(secondRadioSalary);
+
+        const thirdRadioHourly = getByTestId('hourly-radio-2');
+        fireEvent.click(thirdRadioHourly);
+
+        fixture.detectChanges();
+
+        const button = getByRole('button', { name: 'Continue' });
+        button.click();
+
+        const workers = {
+          'groups': [
+            {
+              'jobId': 10,
+              'title': 'Care worker',
+              'workers': [
+                {
+                  'uid': '559b1bfb-3b1f-47a9-ace3-956e60fc2221',
+                  'mainJob': {
+                    'id': 10,
+                    'title': 'Care worker',
+                  }
+                },
+              ],
+              'count': 5,
+              'annualHourlyPay': {
+                value: 'Hourly',
+                rate: 12,
+              },
+            },
+            {
+              'jobId': 11,
+              'title': 'Senior care worker',
+              'workers': [
+                {
+                  'uid': '559b1bfb-3b1f-47a9-ace3-956e60fc2221',
+                  'mainJob': {
+                    'id': 11,
+                    'title': 'Senior care worker',
+                  }
+                },
+              ],
+              'count': 2,
+              'annualHourlyPay': {
+                value: 'Annually',
+                rate: 14,
+              },
+            },
+            {
+              'jobId': 12,
+              'title': 'Manager',
+              'workers': [
+                {
+                  'uid': '559b1bfb-3b1f-47a9-ace3-956e60fc2221',
+                  'mainJob': {
+                    'id': 12,
+                    'title': 'Manager',
+                  }
+                },
+              ],
+              'count': 1,
+              'annualHourlyPay': {
+                value: 'Hourly',
+                rate: 16,
+              },
+            },
+          ]
+        }
+
+        expect(setWorkersGroupedByJobRoleSpy).toHaveBeenCalledWith(workers);
+      });
+    });
+  });
+
+  describe('Cancel link', () => {
+    it('should be displayed correctly', async () => {
+      const { getByRole } = await setup();
+      const link = getByRole('link', { name: 'Cancel' });
+      expect(link).toBeTruthy();
+    });
+
+    // to be updated when previous page is developed
+    it('should have the correct href', async () => {
+      const { getByRole } = await setup();
+      const link = getByRole('link', { name: 'Cancel' });
+      expect(link.getAttribute('href')).toEqual('/');
+    });
+  });
+});

--- a/frontend/src/app/features/workers/fast-track-pay-updates/fast-track-pay-updates.component.ts
+++ b/frontend/src/app/features/workers/fast-track-pay-updates/fast-track-pay-updates.component.ts
@@ -1,0 +1,68 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { BackLinkService } from '@core/services/backLink.service';
+import { WorkerService } from '@core/services/worker.service';
+import { Establishment } from '@core/model/establishment.model';
+import { WorkersGroupedByJobRoleResponse } from '@core/model/worker.model';
+import { ActivatedRoute } from '@angular/router';
+import { UntypedFormArray, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-fast-track-pay-updates',
+  templateUrl: './fast-track-pay-updates.component.html',
+  standalone: false
+})
+export class FastTrackPayUpdatesComponent {
+  @ViewChild('formEl') formEl: ElementRef;
+  public form: UntypedFormGroup;
+  public workplace: Establishment;
+  public workersByJobRole: WorkersGroupedByJobRoleResponse;
+
+  constructor(
+    private backLinkService: BackLinkService,
+    private formBuilder: UntypedFormBuilder,
+    private route: ActivatedRoute,
+    private workerService: WorkerService,
+  ) {}
+
+  ngOnInit(): void {
+    this.setBackLink();
+    this.workplace = this.route.snapshot.data.establishment;
+    this.workersByJobRole = this.route.snapshot.data.workersByJobRole;
+    this.setupForm();
+  }
+
+  private setBackLink(): void {
+    this.backLinkService.showBackLink();
+  }
+
+  private setupForm(): void {
+    this.form = this.formBuilder.group({
+      workers: this.formBuilder.array([])
+    });
+
+    const workersFormArray = this.form.get('workers') as UntypedFormArray;
+
+    this.workersByJobRole.groups.forEach(group => {
+      workersFormArray.push(
+        this.formBuilder.group({
+          workerId: group.jobId,
+          value: null,
+          rate: null,
+        })
+      );
+    });
+  }
+
+  public onSubmit(): void {
+    const workersFormValues = this.form.get('workers').value;
+
+    const updatedWorkers = this.workersByJobRole.groups.map((group, index) => {
+      const formEntry = workersFormValues[index];
+      const annualHourlyPay = { value: formEntry.value, rate: formEntry.rate };
+
+      return { ...group, annualHourlyPay };
+    });
+
+    this.workerService.setWorkersGroupedByJobRole({ groups: updatedWorkers });
+  }
+}

--- a/frontend/src/app/features/workers/workers-routing.module.ts
+++ b/frontend/src/app/features/workers/workers-routing.module.ts
@@ -88,6 +88,8 @@ import { TrainingCourseMatchingLayoutComponent } from '@features/training-and-qu
 import { SelectTrainingCourseForWorkerTraining } from '@features/training-and-qualifications/select-training-course-for-worker-training/select-training-course-for-worker-training.component';
 import { TrainingProvidersResolver } from '@core/resolvers/training/training-providers.resolver';
 import { redirectIfLinkedToTrainingCourse } from '@core/guards/redirect-if-linked-to-training-course/redirect-if-linked-to-training-course.guard';
+import { FastTrackPayUpdatesComponent } from '@features/workers/fast-track-pay-updates/fast-track-pay-updates.component';
+import { WorkersByJobRoleResolver } from '@core/resolvers/workers-by-job-role.resolver';
 
 const editTrainingRecordRoute = {
   path: 'training/:trainingRecordId',
@@ -333,6 +335,11 @@ const routes: Routes = [
     data: {
       title: 'Who Carry out Delegated Healthcare Activities',
     },
+  },
+  {
+    path: 'fast-track-pay-updates',
+    component: FastTrackPayUpdatesComponent,
+    resolve: { workersByJobRole: WorkersByJobRoleResolver },
   },
   {
     path: 'basic-records-save-success',

--- a/frontend/src/app/features/workers/workers.module.ts
+++ b/frontend/src/app/features/workers/workers.module.ts
@@ -89,6 +89,8 @@ import { TrainingCourseMatchingLayoutComponent } from '@features/training-and-qu
 import { SelectTrainingCourseForWorkerTraining } from '@features/training-and-qualifications/select-training-course-for-worker-training/select-training-course-for-worker-training.component';
 import { TrainingProvidersResolver } from '@core/resolvers/training/training-providers.resolver';
 import { IncludeTrainingCourseDetailsComponent } from '@features/training-and-qualifications/include-training-course-details/include-training-course-details.component';
+import { FastTrackPayUpdatesComponent } from '@features/workers/fast-track-pay-updates/fast-track-pay-updates.component';
+import { WorkersByJobRoleResolver } from '@core/resolvers/workers-by-job-role.resolver';
 
 @NgModule({
   imports: [CommonModule, OverlayModule, FormsModule, ReactiveFormsModule, SharedModule, WorkersRoutingModule],
@@ -154,6 +156,7 @@ import { IncludeTrainingCourseDetailsComponent } from '@features/training-and-qu
     TrainingCourseMatchingLayoutComponent,
     SelectTrainingCourseForWorkerTraining,
     IncludeTrainingCourseDetailsComponent,
+    FastTrackPayUpdatesComponent,
   ],
   providers: [
     DialogService,
@@ -179,6 +182,7 @@ import { IncludeTrainingCourseDetailsComponent } from '@features/training-and-qu
     GetWorkersWhoRequireDelegatedHealthcareActivitiesAnswerResolver,
     WorkerHasAnyTrainingOrQualificationsResolver,
     DownloadCertificateService,
+    WorkersByJobRoleResolver,
   ],
 })
 export class WorkersModule {}

--- a/frontend/src/assets/images/right-arrow.svg
+++ b/frontend/src/assets/images/right-arrow.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="24px"
+     height="24px"
+     viewBox="0 0 24 24"
+     version="1.1">
+  <title>Glyph/Grey arrow - right</title>
+  <g id="Glyph/Grey-arrow---right" stroke="none" fill="none" fill-rule="evenodd">
+    <polygon id="Shape" fill="#737373" points="12 4 10.6 5.4 16.2 11 4 11 4 13 16.2 13 10.6 18.6 12 20 20 12"/>
+  </g>
+</svg>


### PR DESCRIPTION
#### Work done
- New page enables user to update worker pay by job role
- Page route is `../workplace/<workplace-uid>/staff-record/fast-track-pay-updates`
- Create `FastTrackPayUpdatesComponent`
- Update `WorkersGroupedByJobRole` to include the fields `count` and `annualHourlyPay` (for storing updated pay details)
- Create `WorkersByJobRoleResolver` to get the `WorkersGroupedByJobRole` data to display on the page
- Create `workersGroupedByJobRole` field on `WorkerService` to store the updated pay details to be retrieved later in the flow
- The `Continue` button submits the updated pay details to the `WorkerService` but does not navigate as the next page in the flow is not yet developed 
- The `Cancel` button navigates to `/` - this will need to be updated when the previous page in the flow is developed
- e2e tests will need to be added when the page before is developed

<details>
<summary>Screenshot</summary>
<img width="785" height="683" alt="image" src="https://github.com/user-attachments/assets/a6553354-d42d-441e-aca9-3d44f8651856" />

</details>

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
