### PR TITLE
Fix/1914-funding-parent-report

### DIFF
--- a/backend/server/data/parentWDFReport.js
+++ b/backend/server/data/parentWDFReport.js
@@ -2,7 +2,7 @@
 
 const db = require('../utils/datastore');
 
-const effectiveDate = require('../models/classes/wdfCalculator').WdfCalculator.effectiveDate.toISOString();
+const { WdfCalculator } = require('../models/classes/wdfCalculator');
 
 const getEstablishmentDataQuery = `
 SELECT
@@ -158,8 +158,13 @@ const getServiceCapacityDetailsQuery = `SELECT "ServiceCapacityID", "Type"
    FROM cqc."ServicesCapacity"
    WHERE "ServiceID" = :mainServiceId`;
 
-exports.getEstablishmentData = async (establishmentId) =>
-  db.query(getEstablishmentDataQuery, {
+const getWDFeffectiveDate = () => {
+  return WdfCalculator.effectiveDate.toISOString();
+};
+
+exports.getEstablishmentData = async (establishmentId) => {
+  const effectiveDate = getWDFeffectiveDate();
+  return db.query(getEstablishmentDataQuery, {
     replacements: {
       zero: 0,
       falseFlag: false,
@@ -182,6 +187,7 @@ exports.getEstablishmentData = async (establishmentId) =>
     },
     type: db.QueryTypes.SELECT,
   });
+};
 
 exports.getCapicityData = async (establishmentId, mainServiceId) =>
   db.query(getCapicityOrUtilisationDataQuery, {

--- a/backend/server/test/unit/data/parentWDFReport.spec.js
+++ b/backend/server/test/unit/data/parentWDFReport.spec.js
@@ -1,0 +1,19 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const { getEstablishmentData } = require('../../../data/parentWDFReport');
+const WdfCalculatorModule = require('../../../models/classes/wdfCalculator');
+const db = require('../../../utils/datastore');
+
+describe('backend/server/data/parentWDFReport.js', () => {
+  describe('getEstablishmentData', () => {
+    it('should get the updated WdfEffectiveDate at runtime', async () => {
+      sinon.stub(db, 'query').resolves({});
+      const getWDFeffectiveDate = sinon.spy(WdfCalculatorModule.WdfCalculator, 'effectiveDate', ['get']);
+
+      await getEstablishmentData('mock-establishment-id');
+
+      expect(getWDFeffectiveDate.get).to.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
#### Work done
- Address an issue that `parentWDFReport` not using an updated `WdfEffectiveDate`

** The `effectiveDate` const in `backend/server/data/parentWDFReport.js` is initialised once during server start and does not update ever after. 
Therefore, in case when backend was up before 01/Apr, the parent WDF report will not pickup the change in date, and will wrongly calculate eligibility by 01Apr of the previous year.
This PR fix the issue by getting the WdfEffectiveDate in run time.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
