### PR TITLE
Fix/user without edit permission should not see the "Update pay for multiple staff" link

### DIFF
--- a/frontend/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
+++ b/frontend/src/app/shared/components/staff-summary/staff-summary.component.spec.ts
@@ -297,11 +297,14 @@ describe('StaffSummaryComponent', () => {
 
   describe('Update pay for multiple staff', () => {
     const linkText = 'Update pay for multiple staff';
+    const defaultOverrides = {
+      updatePayForMultiStaffViewed: false,
+      workerCount: 6,
+      permissions: ['canViewWorker', 'canEditWorker', 'canViewEstablishment', 'canEditEstablishment'],
+    };
 
     it('should show update-pay-for-multiple-staff-link with the new pill when updatePayForMultiStaffViewed is false, workerCount is below itemsPerPage', async () => {
-      const overrides = { updatePayForMultiStaffViewed: false, workerCount: 6 };
-
-      const { getByTestId } = await setup(overrides);
+      const { getByTestId } = await setup(defaultOverrides);
 
       const newPillWithLink = getByTestId('update-pay-for-multiple-staff-link');
 
@@ -312,8 +315,8 @@ describe('StaffSummaryComponent', () => {
 
     it('should show the link without the new pill when updatePayForMultiStaffViewed is true', async () => {
       const overrides = {
+        ...defaultOverrides,
         updatePayForMultiStaffViewed: true,
-        workerCount: 6,
       };
 
       const { getByTestId } = await setup(overrides);
@@ -326,7 +329,7 @@ describe('StaffSummaryComponent', () => {
     });
 
     it('should navigate to the update-pay-for-multiple-staff page', async () => {
-      const { fixture, getByTestId, routerSpy } = await setup();
+      const { fixture, getByTestId, routerSpy } = await setup(defaultOverrides);
 
       const newPillWithLink = getByTestId('update-pay-for-multiple-staff-link');
       const link = within(newPillWithLink).getByText(linkText);
@@ -342,10 +345,20 @@ describe('StaffSummaryComponent', () => {
       ]);
     });
 
+    it('should not show the link when user does not have permission to edit worker', async () => {
+      const { queryByText } = await setup({
+        ...defaultOverrides,
+        permissions: ['canViewEstablishment', 'canViewWorker'],
+      });
+
+      const link = queryByText(linkText);
+      expect(link).toBeFalsy();
+    });
+
     it('should call updateSingleEstablishmentField if updatePayForMultiStaffViewed is false', async () => {
       const { fixture, getByText, updateSingleFieldSpy } = await setup({
+        ...defaultOverrides,
         updatePayForMultiStaffViewed: false,
-        workerCount: 15,
       });
 
       const link = getByText(linkText);
@@ -360,8 +373,8 @@ describe('StaffSummaryComponent', () => {
 
     it(`should not call updateSingleEstablishmentField if updatePayForMultiStaffViewed is true`, async () => {
       const overrides = {
+        ...defaultOverrides,
         updatePayForMultiStaffViewed: true,
-        workerCount: 15,
       };
       const { fixture, getByText, updateSingleFieldSpy } = await setup(overrides);
 

--- a/frontend/src/app/shared/components/staff-summary/staff-summary.component.ts
+++ b/frontend/src/app/shared/components/staff-summary/staff-summary.component.ts
@@ -36,7 +36,10 @@ export class StaffSummaryComponent extends StaffSummaryDirective implements OnIn
   protected init(): void {
     this.showNewPill = !this.workplace?.updatePayForMultiStaffViewed;
     this.workplaceUid = this.workplace.uid;
-    this.showUpdatePayForMultipleStaffLink = this.workerCount > 1;
+    const userHasEditPermissions =
+      this.permissionsService.can(this.workplaceUid, 'canEditWorker') &&
+      this.permissionsService.can(this.workplaceUid, 'canEditEstablishment');
+    this.showUpdatePayForMultipleStaffLink = userHasEditPermissions && this.workerCount > 1;
   }
 
   public getWorkerRecordPath(event: Event, worker: Worker) {


### PR DESCRIPTION
#### Work done
-  Not to show the "Update pay for multiple staff" link when user does not have edit permission

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
