### PR TITLE
Fix/1931 bulk upload lock

### DIFF
--- a/backend/server/routes/establishments/bulkUpload/s3.js
+++ b/backend/server/routes/establishments/bulkUpload/s3.js
@@ -7,6 +7,12 @@ const s3 = new AWS_SDK_V2.S3({
   region: String(config.get('bulkupload.region')),
 });
 
+const { ListObjectsV2Command, S3Client } = require('@aws-sdk/client-s3');
+const s3ClientV3 = new S3Client({
+  region: String(config.get('bulkupload.region')),
+  signatureVersion: 'v4',
+});
+
 const Bucket = String(config.get('bulkupload.bucketname'));
 
 const params = (establishmentId) => {
@@ -240,9 +246,15 @@ const moveFolders = async (folderToMove, destinationFolder) => {
   }
 };
 const getKeysFromFolder = async (listParams) => {
+  console.log('=== using s3client v3 ===');
   const results = [];
 
-  const filesInFolder = await s3.listObjects(listParams).promise();
+  const listObjectsCommand = new ListObjectsV2Command(listParams);
+  const filesInFolder = await s3ClientV3.send(listObjectsCommand);
+  if (!filesInFolder?.Contents) {
+    return [];
+  }
+
   filesInFolder.Contents.forEach((myFile) => {
     const ignoreRoot = /.*\/$/;
     if (!ignoreRoot.test(myFile.Key)) {
@@ -321,6 +333,7 @@ const listObjectsInBucket = async (establishmentId) => {
 
 module.exports = {
   s3,
+  s3ClientV3,
   Bucket,
   uploadJSONDataToS3,
   uploadMetadataToS3,
@@ -337,4 +350,5 @@ module.exports = {
   listMetaData,
   listObjectsInBucket,
   uploadDisbursementFileToS3,
+  getKeysFromFolder,
 };

--- a/backend/server/routes/establishments/bulkUpload/s3.js
+++ b/backend/server/routes/establishments/bulkUpload/s3.js
@@ -7,11 +7,7 @@ const s3 = new AWS_SDK_V2.S3({
   region: String(config.get('bulkupload.region')),
 });
 
-const { ListObjectsV2Command, S3Client } = require('@aws-sdk/client-s3');
-const s3ClientV3 = new S3Client({
-  region: String(config.get('bulkupload.region')),
-  signatureVersion: 'v4',
-});
+const s3ClientV3 = require('./s3clientv3');
 
 const Bucket = String(config.get('bulkupload.bucketname'));
 
@@ -173,7 +169,6 @@ const saveLastBulkUpload = async (establishmentId) => {
 };
 
 const purgeBulkUploadS3Objects = async (establishmentId) => {
-  console.log('===== start purging S3 objects =====');
   const listParams = params(establishmentId);
   let deleteKeys = [];
 
@@ -187,22 +182,17 @@ const purgeBulkUploadS3Objects = async (establishmentId) => {
 
   listParams.Prefix = `${establishmentId}/latest/`;
   deleteKeys = deleteKeys.concat(await getKeysFromFolder(listParams));
-  console.log('deleteKeys after 1st await', deleteKeys.length);
 
   listParams.Prefix = `${establishmentId}/validation/`;
   deleteKeys = deleteKeys.concat(await getKeysFromFolder(listParams));
-  console.log('deleteKeys after 2nd await', deleteKeys.length);
 
   listParams.Prefix = `${establishmentId}/intermediary/`;
   deleteKeys = deleteKeys.concat(await getKeysFromFolder(listParams));
-  console.log('deleteKeys after 3rd await', deleteKeys.length);
 
   if (deleteKeys.length > 0) {
     if (deleteKeys.length < 1000) {
       deleteParams.Delete.Objects = deleteKeys;
-      console.log('===== before s3.deleteObjects =====');
       await s3.deleteObjects(deleteParams).promise();
-      console.log('===== after s3.deleteObjects =====');
     } else {
       const noOfFiles = 1000;
       for (let i = 0; i < deleteKeys.length; i += noOfFiles) {
@@ -216,13 +206,11 @@ const purgeBulkUploadS3Objects = async (establishmentId) => {
 
 const moveFolders = async (folderToMove, destinationFolder) => {
   try {
-    const listObjectsResponse = await s3
-      .listObjects({
-        Bucket,
-        Prefix: folderToMove,
-        Delimiter: '/',
-      })
-      .promise();
+    const listObjectsResponse = await s3ClientV3.listObjects({
+      Bucket,
+      Prefix: folderToMove,
+      Delimiter: '/',
+    });
 
     const folderContentInfo = listObjectsResponse.Contents;
     const folderPrefix = listObjectsResponse.Prefix;
@@ -246,11 +234,9 @@ const moveFolders = async (folderToMove, destinationFolder) => {
   }
 };
 const getKeysFromFolder = async (listParams) => {
-  console.log('=== using s3client v3 ===');
   const results = [];
 
-  const listObjectsCommand = new ListObjectsV2Command(listParams);
-  const filesInFolder = await s3ClientV3.send(listObjectsCommand);
+  const filesInFolder = await s3ClientV3.listObjects(listParams);
   if (!filesInFolder?.Contents) {
     return [];
   }
@@ -274,7 +260,7 @@ const listMetaData = async (establishmentId, folder) => {
     Bucket,
     Prefix: `${establishmentId}${folder}`,
   };
-  const filesInFolder = await s3.listObjects(listParams).promise();
+  const filesInFolder = await s3ClientV3.listObjects(listParams);
   filesInFolder.Contents.forEach(async (myFile) => {
     if (findMetaDataObjects.test(myFile.Key)) {
       toDownload.push(downloadContent(myFile.Key, myFile.Size, myFile.LastModified));
@@ -292,7 +278,7 @@ const listMetaData = async (establishmentId, folder) => {
 
 const findFilesS3 = async (establishmentId, fileName) => {
   const listParams = params(establishmentId);
-  const latestObjects = await s3.listObjects(listParams).promise();
+  const latestObjects = await s3ClientV3.listObjects(listParams);
   const foundFiles = [];
 
   latestObjects.Contents.forEach(async (myFile) => {
@@ -323,17 +309,14 @@ const deleteFilesS3 = async (establishmentId, fileName) => {
 };
 
 const listObjectsInBucket = async (establishmentId) => {
-  return await s3
-    .listObjects({
-      Bucket,
-      Prefix: `${establishmentId}/latest/`,
-    })
-    .promise();
+  return await s3ClientV3.listObjects({
+    Bucket,
+    Prefix: `${establishmentId}/latest/`,
+  });
 };
 
 module.exports = {
   s3,
-  s3ClientV3,
   Bucket,
   uploadJSONDataToS3,
   uploadMetadataToS3,

--- a/backend/server/routes/establishments/bulkUpload/s3.js
+++ b/backend/server/routes/establishments/bulkUpload/s3.js
@@ -1,9 +1,12 @@
 'use strict';
 const moment = require('moment');
 const config = require('../../../config/config');
-const s3 = new (require('aws-sdk').S3)({
+
+const AWS_SDK_V2 = require('aws-sdk');
+const s3 = new AWS_SDK_V2.S3({
   region: String(config.get('bulkupload.region')),
 });
+
 const Bucket = String(config.get('bulkupload.bucketname'));
 
 const params = (establishmentId) => {
@@ -164,6 +167,7 @@ const saveLastBulkUpload = async (establishmentId) => {
 };
 
 const purgeBulkUploadS3Objects = async (establishmentId) => {
+  console.log('===== start purging S3 objects =====');
   const listParams = params(establishmentId);
   let deleteKeys = [];
 
@@ -177,17 +181,22 @@ const purgeBulkUploadS3Objects = async (establishmentId) => {
 
   listParams.Prefix = `${establishmentId}/latest/`;
   deleteKeys = deleteKeys.concat(await getKeysFromFolder(listParams));
+  console.log('deleteKeys after 1st await', deleteKeys.length);
 
   listParams.Prefix = `${establishmentId}/validation/`;
   deleteKeys = deleteKeys.concat(await getKeysFromFolder(listParams));
+  console.log('deleteKeys after 2nd await', deleteKeys.length);
 
   listParams.Prefix = `${establishmentId}/intermediary/`;
   deleteKeys = deleteKeys.concat(await getKeysFromFolder(listParams));
+  console.log('deleteKeys after 3rd await', deleteKeys.length);
 
   if (deleteKeys.length > 0) {
     if (deleteKeys.length < 1000) {
       deleteParams.Delete.Objects = deleteKeys;
+      console.log('===== before s3.deleteObjects =====');
       await s3.deleteObjects(deleteParams).promise();
+      console.log('===== after s3.deleteObjects =====');
     } else {
       const noOfFiles = 1000;
       for (let i = 0; i < deleteKeys.length; i += noOfFiles) {

--- a/backend/server/routes/establishments/bulkUpload/s3clientv3.js
+++ b/backend/server/routes/establishments/bulkUpload/s3clientv3.js
@@ -1,0 +1,15 @@
+const { ListObjectsV2Command, S3Client } = require('@aws-sdk/client-s3');
+
+const config = require('../../../config/config');
+
+const s3ClientV3 = new S3Client({
+  region: String(config.get('bulkupload.region')),
+  signatureVersion: 'v4',
+});
+
+const listObjects = async (listParams) => {
+  const listObjectsCommand = new ListObjectsV2Command(listParams);
+  return s3ClientV3.send(listObjectsCommand);
+};
+
+module.exports = { listObjects, s3client: s3ClientV3 };

--- a/backend/server/test/unit/routes/establishments/bulkUpload/s3.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/s3.spec.js
@@ -117,8 +117,8 @@ describe('s3', () => {
 
   describe('purgeBulkUploadS3Objects', () => {
     it('should delete all the files', async () => {
-      const s3SendCommand = sinon.stub(s3ClientV3, 'listObjects');
-      s3SendCommand.callsFake(async (listParams) => {
+      const s3listObject = sinon.stub(s3ClientV3, 'listObjects');
+      s3listObject.callsFake(async (listParams) => {
         switch (listParams?.Prefix) {
           case '1/latest/':
             return latestFiles;

--- a/backend/server/test/unit/routes/establishments/bulkUpload/s3.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/s3.spec.js
@@ -117,24 +117,19 @@ describe('s3', () => {
       sinon.assert.calledWith(deleteObjects, deleteFiles);
     });
   });
+
   describe('purgeBulkUploadS3Objects', () => {
     it('should delete all the files', async () => {
-      const listObjects = sinon.stub(S3.s3, 'listObjects');
-
-      listObjects.withArgs({ Bucket: 'sfcbulkuploadfiles', Prefix: '1/latest/' }).returns({
-        promise: async () => {
-          return latestFiles;
-        },
-      });
-      listObjects.withArgs({ Bucket: 'sfcbulkuploadfiles', Prefix: '1/validation/' }).returns({
-        promise: async () => {
-          return validationFiles;
-        },
-      });
-      listObjects.withArgs({ Bucket: 'sfcbulkuploadfiles', Prefix: '1/intermediary/' }).returns({
-        promise: async () => {
-          return intermediaryFiles;
-        },
+      const s3SendCommand = sinon.stub(S3.s3ClientV3, 'send');
+      s3SendCommand.callsFake(async (command) => {
+        switch (command?.input?.Prefix) {
+          case '1/latest/':
+            return latestFiles;
+          case '1/validation/':
+            return validationFiles;
+          case '1/intermediary/':
+            return intermediaryFiles;
+        }
       });
 
       const deleteObjects = sinon.stub(S3.s3, 'deleteObjects');

--- a/backend/server/test/unit/routes/establishments/bulkUpload/s3.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/s3.spec.js
@@ -1,5 +1,6 @@
 const sinon = require('sinon');
 const S3 = require('../../../../../routes/establishments/bulkUpload/s3');
+const s3ClientV3 = require('../../../../../routes/establishments/bulkUpload/s3clientv3');
 const expect = require('chai').expect;
 
 const extraData = {
@@ -99,14 +100,10 @@ describe('s3', () => {
     sinon.restore();
   });
 
-  beforeEach(() => {});
   describe('deleteFilesS3', () => {
     it('should delete the files from s3', async () => {
-      sinon.stub(S3.s3, 'listObjects').returns({
-        promise: async () => {
-          return listObjects;
-        },
-      });
+      sinon.stub(s3ClientV3, 'listObjects').resolves(listObjects);
+
       const deleteObjects = sinon.stub(S3.s3, 'deleteObjects');
       deleteObjects.returns({
         promise: async () => {
@@ -120,9 +117,9 @@ describe('s3', () => {
 
   describe('purgeBulkUploadS3Objects', () => {
     it('should delete all the files', async () => {
-      const s3SendCommand = sinon.stub(S3.s3ClientV3, 'send');
-      s3SendCommand.callsFake(async (command) => {
-        switch (command?.input?.Prefix) {
+      const s3SendCommand = sinon.stub(s3ClientV3, 'listObjects');
+      s3SendCommand.callsFake(async (listParams) => {
+        switch (listParams?.Prefix) {
           case '1/latest/':
             return latestFiles;
           case '1/validation/':
@@ -157,13 +154,11 @@ describe('s3', () => {
       sinon.assert.calledWith(deleteObjects, expectedResult);
     });
   });
+
   describe('listMetaData', () => {
     it('should list the files from s3', async () => {
-      sinon.stub(S3.s3, 'listObjects').returns({
-        promise: async () => {
-          return latestFiles;
-        },
-      });
+      sinon.stub(s3ClientV3, 'listObjects').resolves(latestFiles);
+
       const getObject = sinon.stub(S3.s3, 'getObject');
 
       var workerFileBuffer = Buffer.from(

--- a/backend/server/test/unit/routes/establishments/bulkUpload/s3Clientv3.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/s3Clientv3.spec.js
@@ -1,0 +1,25 @@
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const { ListObjectsV2Command, S3Client } = require('@aws-sdk/client-s3');
+
+const s3ClientV3 = require('../../../../../routes/establishments/bulkUpload/s3clientv3');
+
+describe('S3 Client (Ver 3) for Bulk upload', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('listObjects', () => {
+    it('should call s3.send() with listObjectcommand', async () => {
+      const sendSpy = sinon.stub(S3Client.prototype, 'send');
+
+      await s3ClientV3.listObjects({ Bucket: 'bulk-upload-s3-bucket', Prefix: '1234/' });
+
+      expect(sendSpy).to.have.been.calledOnce;
+
+      const callArgument = sendSpy.getCall(0).args[0];
+      expect(callArgument).to.be.instanceOf(ListObjectsV2Command);
+      expect(callArgument.input).to.deep.equal({ Bucket: 'bulk-upload-s3-bucket', Prefix: '1234/' });
+    });
+  });
+});


### PR DESCRIPTION
#### Work done
- In bulk upload, replace `listObjects` call of outdated AWS SDK v2 client with v3 client.


Note for dev:
From actual testing, seems that the `s3.listObjects` call of AWS-SDK V2 client was the cause of the lock issue. 
When the workplace `intermediary` folder in S3 bucket has over 40 objects, the promise generated by `s3.listObjects()` will just stay pending and do not resolve or reject in reasonable time. As a result the code could not reach the step of lock release.
The reason why V2 client has such a weakness is unknown. Possibly related to socket exhaustion under the hood. 
Anyway V2 client is already deprecated and AWS suggests user to migrate to V3 client.
When tested in staging, `listObjects` with V3 client does not have the same weakness, and is able to carry out bulk upload without problem even if `intermediary` folder is filled with > 500 junk objects.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
