### PR TITLE
Feat/1919 care certificate

### DIFF
--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2363,7 +2363,7 @@ module.exports = function (sequelize, DataTypes) {
         {
           model: sequelize.models.worker,
           as: 'workers',
-          attributes: ['NameOrIdValue', 'CareCertificateValue'],
+          attributes: ['NameOrIdValue', 'CareCertificateValue', 'Level2CareCertificateValue'],
           where: {
             CareCertificateValue: { [Op.ne]: null },
             archived: false,

--- a/backend/server/routes/reports/trainingAndQualifications/careCertificateTab.js
+++ b/backend/server/routes/reports/trainingAndQualifications/careCertificateTab.js
@@ -1,22 +1,11 @@
 const {
-  addHeading,
-  addLine,
-  setTableHeadingsStyle,
   backgroundColours,
-  textColours,
-  addBordersToAllFilledCells,
-  fitColumnsToSize,
-  alignColumnToLeft,
-  addBlankRowIfTableEmpty,
   newBackgroundColours,
   addText,
   setColourForRange,
-  tableHeaderCellStyle,
-  applyStyleToRange,
   setBasicTableStyle,
   autoFitColumnWidthByTextLength,
 } = require('../../../utils/excelUtils');
-const models = require('../../../models');
 
 const colCache = require('exceljs/lib/utils/col-cache');
 const lodash = require('lodash');

--- a/backend/server/routes/reports/trainingAndQualifications/careCertificateTab.js
+++ b/backend/server/routes/reports/trainingAndQualifications/careCertificateTab.js
@@ -1,4 +1,3 @@
-const { convertWorkersWithCareCertificateStatus } = require('../../../utils/trainingAndQualificationsUtils');
 const {
   addHeading,
   addLine,
@@ -14,31 +13,35 @@ const {
   setColourForRange,
   tableHeaderCellStyle,
   applyStyleToRange,
+  setBasicTableStyle,
+  autoFitColumnWidthByTextLength,
 } = require('../../../utils/excelUtils');
 const models = require('../../../models');
 
 const colCache = require('exceljs/lib/utils/col-cache');
 const lodash = require('lodash');
 
-const columnsToDisplay = [
-  { columnName: 'Name or ID number', field: 'mandatory' },
-  { columnName: 'Main job role', field: 'total' },
-  { columnName: 'Care certificate', field: 'expired' },
-  { columnName: 'L2 Adult Social Care Certificate', field: 'expiringSoon' },
-];
-
-const generateCareCertificateTab = async (workbook, establishmentId, isParent = false) => {
-  const rawEstablishments = await models.establishment.getWorkersWithCareCertificateStatus(establishmentId, isParent);
-
-  const establishments = convertWorkersWithCareCertificateStatus(rawEstablishments);
-
+const HeaderRowNumber = 3;
+const generateCareCertificateTab = async (workbook, careCertificateStatus, isParent = false) => {
   const careCertificateTab = workbook.addWorksheet('Care Certificate', { views: [{ showGridLines: false }] });
 
+  const columnsToDisplay = [
+    ...(isParent ? [{ columnName: 'Workplace', field: 'establishmentName' }] : []),
+
+    { columnName: 'Name or ID number', field: 'workerId' },
+
+    { columnName: 'Main job role', field: 'jobRole' },
+    { columnName: 'Care Certificate', field: 'careCertificate' },
+    { columnName: 'L2 Adult Social Care Certificate', field: 'l2CareCertificate' },
+  ];
+
   addTitle(careCertificateTab);
-  addTopTableHeader(careCertificateTab, columnsToDisplay);
 
-  // addContentToCareCertificateTab(careCertificateTab, establishments, isParent);
+  const sortedData = lodash.sortBy(careCertificateStatus, ['establishmentName', 'workerId']);
 
+  addCareCertificateTable(careCertificateTab, sortedData, columnsToDisplay);
+
+  setHeightsAndWidths(careCertificateTab);
   addFootNote(careCertificateTab);
 };
 
@@ -48,57 +51,53 @@ const addTitle = (careCertificateTab) => {
   setColourForRange(careCertificateTab, 'A1:Z1', { backgroundColour: newBackgroundColours.lightGrey });
 };
 
-const addTopTableHeader = (tab, columnsToDisplay) => {
-  const lastColumnLetter = colCache.n2l(1 + columnsToDisplay.length);
+const addCareCertificateTable = (tab, sortedData, columnsToDisplay) => {
+  const tableRows = sortedData.map((careCertificateData) => {
+    return columnsToDisplay.map(({ field }) => careCertificateData[field] ?? '-');
+  });
 
-  const topHeaderRange = `B3:${lastColumnLetter}3`;
-  applyStyleToRange(tab, topHeaderRange, tableHeaderCellStyle);
-};
-const addContentToCareCertificateTab = (careCertificateTab, establishments, isParent) => {
-  // addHeading(careCertificateTab, 'B2', 'D2', 'Care Certificate');
-  // addLine(careCertificateTab, 'A4', isParent ? 'E4' : 'D4');
-  alignColumnToLeft(careCertificateTab, 2);
-  if (isParent) alignColumnToLeft(careCertificateTab, 3);
+  if (tableRows.length === 0) {
+    tableRows.push(Array(columnsToDisplay.length).fill(''));
+  }
 
-  const careCertificateTable = createCareCertificateTable(careCertificateTab, isParent);
-  addRowsToCareCertificateTable(careCertificateTable, establishments, isParent);
-
-  fitColumnsToSize(careCertificateTab, 2, 5.5);
-  addBordersToAllFilledCells(careCertificateTab, 5);
-};
-
-const createCareCertificateTable = (careCertificateTab, isParent) => {
-  setTableHeadingsStyle(
-    careCertificateTab,
-    6,
-    backgroundColours.blue,
-    textColours.white,
-    isParent ? ['B', 'C', 'D', 'E'] : ['B', 'C', 'D'],
-  );
-
-  isParent && columns.unshift({ name: 'Workplace', filterButton: true });
-
-  return careCertificateTab.addTable({
+  const careCertificateTable = tab.addTable({
     name: 'careCertificateTable',
-    ref: 'B6',
-    columns,
-    rows: [],
+    ref: `B${HeaderRowNumber}`,
+    columns: columnsToDisplay.map(({ columnName }) => ({ name: columnName, filterButton: true })),
+    rows: tableRows,
+  });
+  const tableRange = careCertificateTable.model.tableRef;
+
+  careCertificateTable.commit();
+
+  setBasicTableStyle(tab, tableRange, {
+    hasTotalRow: false,
+    alignHorizontalCenter: false,
+    bold: false,
   });
 };
 
-const addRowsToCareCertificateTable = (careCertificateTable, establishments, isParent) => {
-  establishments.forEach((establishment) => {
-    const { workers, establishmentName } = establishment;
-    workers.forEach((worker) => {
-      const { workerId, jobRole, status } = worker;
-      const data = [workerId, jobRole, status];
-      isParent && data.unshift(establishmentName);
-      careCertificateTable.addRow(data);
-    });
+const setHeightsAndWidths = (tab) => {
+  const columnWidths = [22, 22, 28, 28];
+
+  columnWidths.forEach((width, index) => {
+    const column = tab.getColumn(index + 2);
+    column.width = width;
   });
 
-  addBlankRowIfTableEmpty(careCertificateTable, isParent ? 4 : 3);
-  careCertificateTable.commit();
+  [2, 3, 4, 5].forEach((column) => {
+    autoFitColumnWidthByTextLength(tab, column, 12);
+  });
+
+  const rowHeights = [48, 18, 35, 30];
+
+  rowHeights.forEach((height, index) => {
+    tab.getRow(index + 1).height = height;
+  });
+
+  for (let i = 4; i <= tab.lastRow.number; i++) {
+    tab.getRow(i).height = 22;
+  }
 };
 
 const addFootNote = (tab) => {
@@ -113,4 +112,3 @@ const addFootNote = (tab) => {
 };
 
 module.exports.generateCareCertificateTab = generateCareCertificateTab;
-module.exports.addContentToCareCertificateTab = addContentToCareCertificateTab;

--- a/backend/server/routes/reports/trainingAndQualifications/careCertificateTab.js
+++ b/backend/server/routes/reports/trainingAndQualifications/careCertificateTab.js
@@ -64,6 +64,8 @@ const addCareCertificateTable = (tab, sortedData, columnsToDisplay) => {
     alignHorizontalCenter: false,
     bold: false,
   });
+
+  setFreezePane(tab);
 };
 
 const setHeightsAndWidths = (tab) => {
@@ -98,6 +100,10 @@ const addFootNote = (tab) => {
     const newRow = tab.lastRow.number + 1;
     addText(tab, `B${newRow}`, text);
   });
+};
+
+const setFreezePane = (tab) => {
+  tab.views = [{ state: 'frozen', ySplit: 3, activeCell: 'B1' }, { showGridLines: false }];
 };
 
 module.exports.generateCareCertificateTab = generateCareCertificateTab;

--- a/backend/server/routes/reports/trainingAndQualifications/careCertificateTab.js
+++ b/backend/server/routes/reports/trainingAndQualifications/careCertificateTab.js
@@ -9,20 +9,54 @@ const {
   fitColumnsToSize,
   alignColumnToLeft,
   addBlankRowIfTableEmpty,
+  newBackgroundColours,
+  addText,
+  setColourForRange,
+  tableHeaderCellStyle,
+  applyStyleToRange,
 } = require('../../../utils/excelUtils');
 const models = require('../../../models');
+
+const colCache = require('exceljs/lib/utils/col-cache');
+const lodash = require('lodash');
+
+const columnsToDisplay = [
+  { columnName: 'Name or ID number', field: 'mandatory' },
+  { columnName: 'Main job role', field: 'total' },
+  { columnName: 'Care certificate', field: 'expired' },
+  { columnName: 'L2 Adult Social Care Certificate', field: 'expiringSoon' },
+];
 
 const generateCareCertificateTab = async (workbook, establishmentId, isParent = false) => {
   const rawEstablishments = await models.establishment.getWorkersWithCareCertificateStatus(establishmentId, isParent);
 
   const establishments = convertWorkersWithCareCertificateStatus(rawEstablishments);
+
   const careCertificateTab = workbook.addWorksheet('Care Certificate', { views: [{ showGridLines: false }] });
-  addContentToCareCertificateTab(careCertificateTab, establishments, isParent);
+
+  addTitle(careCertificateTab);
+  addTopTableHeader(careCertificateTab, columnsToDisplay);
+
+  // addContentToCareCertificateTab(careCertificateTab, establishments, isParent);
+
+  addFootNote(careCertificateTab);
 };
 
+const addTitle = (careCertificateTab) => {
+  addText(careCertificateTab, 'B1:Z1', 'Care Certificates', { size: 24, bold: true });
+  careCertificateTab.getCell('B1').alignment = { vertical: 'middle' };
+  setColourForRange(careCertificateTab, 'A1:Z1', { backgroundColour: newBackgroundColours.lightGrey });
+};
+
+const addTopTableHeader = (tab, columnsToDisplay) => {
+  const lastColumnLetter = colCache.n2l(1 + columnsToDisplay.length);
+
+  const topHeaderRange = `B3:${lastColumnLetter}3`;
+  applyStyleToRange(tab, topHeaderRange, tableHeaderCellStyle);
+};
 const addContentToCareCertificateTab = (careCertificateTab, establishments, isParent) => {
-  addHeading(careCertificateTab, 'B2', 'D2', 'Care Certificate');
-  addLine(careCertificateTab, 'A4', isParent ? 'E4' : 'D4');
+  // addHeading(careCertificateTab, 'B2', 'D2', 'Care Certificate');
+  // addLine(careCertificateTab, 'A4', isParent ? 'E4' : 'D4');
   alignColumnToLeft(careCertificateTab, 2);
   if (isParent) alignColumnToLeft(careCertificateTab, 3);
 
@@ -41,12 +75,6 @@ const createCareCertificateTable = (careCertificateTab, isParent) => {
     textColours.white,
     isParent ? ['B', 'C', 'D', 'E'] : ['B', 'C', 'D'],
   );
-
-  const columns = [
-    { name: 'Worker ID', filterButton: true },
-    { name: 'Job role', filterButton: true },
-    { name: 'Status', filterButton: true },
-  ];
 
   isParent && columns.unshift({ name: 'Workplace', filterButton: true });
 
@@ -71,6 +99,17 @@ const addRowsToCareCertificateTable = (careCertificateTable, establishments, isP
 
   addBlankRowIfTableEmpty(careCertificateTable, isParent ? 4 : 3);
   careCertificateTable.commit();
+};
+
+const addFootNote = (tab) => {
+  const footNoteText = ['Note, the data displayed in this table has been generated from staff records.'];
+
+  tab.addRow([]);
+
+  footNoteText.forEach((text) => {
+    const newRow = tab.lastRow.number + 1;
+    addText(tab, `B${newRow}`, text);
+  });
 };
 
 module.exports.generateCareCertificateTab = generateCareCertificateTab;

--- a/backend/server/routes/reports/trainingAndQualifications/generateTrainingAndQualificationsReport.js
+++ b/backend/server/routes/reports/trainingAndQualifications/generateTrainingAndQualificationsReport.js
@@ -19,6 +19,7 @@ const {
   buildTrainingCategorySummary,
   convertTrainingForEstablishments,
   listAllExistingAndMissingTrainings,
+  convertWorkersWithCareCertificateStatus,
 } = require('../../../utils/trainingAndQualificationsUtils');
 
 const { generateExpiredTrainingTab } = require('./expiredTrainingTab');
@@ -42,6 +43,13 @@ const generateTrainingAndQualificationsReport = async (req, res) => {
       false,
     );
 
+    const rawEstablishmentCareCertificateStatus = await models.establishment.getWorkersWithCareCertificateStatus(
+      establishment.id,
+      false,
+    );
+
+    const careCertificateStatus = convertWorkersWithCareCertificateStatus(rawEstablishmentCareCertificateStatus);
+
     const workerTrainingBreakdowns = await buildWorkerTrainingBreakdownWithWorkplaceInfo(
       rawEstablishmentTrainingBreakdowns,
     );
@@ -58,7 +66,7 @@ const generateTrainingAndQualificationsReport = async (req, res) => {
     await generateTrainingTab(workbook, establishment.id);
 
     await generateQualificationsTab(workbook, establishment.id);
-    await generateCareCertificateTab(workbook, establishment.id);
+    await generateCareCertificateTab(workbook, careCertificateStatus);
 
     res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     res.setHeader(

--- a/backend/server/test/unit/mockdata/trainingAndQualifications.js
+++ b/backend/server/test/unit/mockdata/trainingAndQualifications.js
@@ -386,12 +386,19 @@ exports.mockWorkersWithCareCertificateStatus = [
   {
     workerId: 'Bob',
     jobRole: 'Care Worker',
-    status: 'No',
+
+    careCertificate: 'Not started',
+
+    l2CareCertificate: 'Not started',
   },
+
   {
     workerId: 'Mike',
     jobRole: 'Care Coordinator',
-    status: 'Yes, in progress or partially completed',
+
+    careCertificate: 'Yes, in progress or partially completed',
+
+    l2CareCertificate: 'Yes, completed',
   },
 ];
 

--- a/backend/server/test/unit/mockdata/trainingAndQualifications.js
+++ b/backend/server/test/unit/mockdata/trainingAndQualifications.js
@@ -594,20 +594,36 @@ exports.mockEstablishmentsCareCertificateResponse = [
     get() {
       return 'Care Home 1';
     },
+
     workers: [
       {
         get(property) {
-          return property === 'NameOrIdValue' ? 'Bob Ross' : 'No';
+          const values = {
+            NameOrIdValue: 'Bob Ross',
+            CareCertificateValue: 'No',
+            Level2CareCertificateValue: 'No',
+          };
+
+          return values[property];
         },
+
         mainJob: {
           id: 1,
           title: 'Care Worker',
         },
       },
+
       {
         get(property) {
-          return property === 'NameOrIdValue' ? 'Mike Mill' : 'Yes, in progress or partially completed';
+          const values = {
+            NameOrIdValue: 'Mike Mill',
+            CareCertificateValue: 'Yes, in progress or partially completed',
+            Level2CareCertificateValue: 'Yes, completed',
+          };
+
+          return values[property];
         },
+
         mainJob: {
           id: 2,
           title: 'Care Coordinator',
@@ -615,24 +631,41 @@ exports.mockEstablishmentsCareCertificateResponse = [
       },
     ],
   },
+
   {
     get() {
       return 'Care Home 2';
     },
+
     workers: [
       {
         get(property) {
-          return property === 'NameOrIdValue' ? 'Bill Bailey' : 'Yes, completed';
+          const values = {
+            NameOrIdValue: 'Bill Bailey',
+            CareCertificateValue: 'Yes, completed',
+            Level2CareCertificateValue: '-',
+          };
+
+          return values[property];
         },
+
         mainJob: {
           id: 1,
           title: 'Care Worker',
         },
       },
+
       {
         get(property) {
-          return property === 'NameOrIdValue' ? 'Jenny Jones' : 'No';
+          const values = {
+            NameOrIdValue: 'Jenny Jones',
+            CareCertificateValue: 'No',
+            Level2CareCertificateValue: 'Yes, started',
+          };
+
+          return values[property];
         },
+
         mainJob: {
           id: 1,
           title: 'Care Worker',

--- a/backend/server/test/unit/routes/reports/trainingAndQualificationsReport/careCertificateTab.spec.js
+++ b/backend/server/test/unit/routes/reports/trainingAndQualificationsReport/careCertificateTab.spec.js
@@ -1,225 +1,99 @@
-const expect = require('chai').expect;
-const sinon = require('sinon');
 const excelJS = require('exceljs');
+const expect = require('chai').expect;
 
 const {
-  addContentToCareCertificateTab,
+  generateCareCertificateTab,
 } = require('../../../../../routes/reports/trainingAndQualifications/careCertificateTab');
-const {
-  mockWorkersWithCareCertificateStatus,
-  secondMockWorkersWithCareCertificateStatus,
-} = require('../../../mockdata/trainingAndQualifications');
 
-describe('generateCareCertificateTab', () => {
-  let mockCareCertificateTab;
+const { mockWorkersWithCareCertificateStatus } = require('../../../mockdata/trainingAndQualifications');
+
+describe('CareCertificateTab', () => {
+  let workbook;
 
   beforeEach(() => {
-    mockCareCertificateTab = new excelJS.Workbook().addWorksheet('Care Certificate', {
-      views: [{ showGridLines: false }],
-    });
+    workbook = new excelJS.Workbook();
   });
 
-  afterEach(() => {
-    sinon.restore();
-  });
+  describe('generateCareCertificateTab', () => {
+    it('should create the worksheet', () => {
+      generateCareCertificateTab(workbook, mockWorkersWithCareCertificateStatus);
 
-  describe('Workplace Report', () => {
-    const mockWorkplaceWorkersWithCareCertificateStatus = [
-      {
-        establishmentName: 'Care Home',
-        workers: mockWorkersWithCareCertificateStatus,
-      },
-    ];
+      const tab = workbook.getWorksheet('Care Certificate');
 
-    it('should add tab title to cell B2', async () => {
-      addContentToCareCertificateTab(mockCareCertificateTab, mockWorkplaceWorkersWithCareCertificateStatus);
-
-      expect(mockCareCertificateTab.getCell('B2').value).to.equal('Care Certificate');
+      expect(tab).to.exist;
     });
 
-    describe('Care Certificate table', () => {
-      it('should add care certificate  records table headings to row 6', async () => {
-        addContentToCareCertificateTab(mockCareCertificateTab, mockWorkplaceWorkersWithCareCertificateStatus);
+    it('should add title to cell B1', () => {
+      generateCareCertificateTab(workbook, mockWorkersWithCareCertificateStatus);
 
-        expect(mockCareCertificateTab.getCell('B6').value).to.equal('Worker ID');
-        expect(mockCareCertificateTab.getCell('C6').value).to.equal('Job role');
-        expect(mockCareCertificateTab.getCell('D6').value).to.equal('Status');
-      });
+      const tab = workbook.getWorksheet('Care Certificate');
 
-      it('should add first worker with care certificate to care certificate table', async () => {
-        addContentToCareCertificateTab(mockCareCertificateTab, mockWorkplaceWorkersWithCareCertificateStatus);
+      expect(tab.getCell('B1').value).to.equal('Care Certificates');
+    });
 
-        expect(mockCareCertificateTab.getCell('B7').value).to.equal(mockWorkersWithCareCertificateStatus[0].workerId);
-        expect(mockCareCertificateTab.getCell('C7').value).to.equal(mockWorkersWithCareCertificateStatus[0].jobRole);
-        expect(mockCareCertificateTab.getCell('D7').value).to.equal(mockWorkersWithCareCertificateStatus[0].status);
-      });
+    it('should add correct table headers', () => {
+      generateCareCertificateTab(workbook, mockWorkersWithCareCertificateStatus);
 
-      it('should add second worker with care certificate to care certificate table', async () => {
-        addContentToCareCertificateTab(mockCareCertificateTab, mockWorkplaceWorkersWithCareCertificateStatus);
+      const tab = workbook.getWorksheet('Care Certificate');
 
-        expect(mockCareCertificateTab.getCell('B8').value).to.equal(mockWorkersWithCareCertificateStatus[1].workerId);
-        expect(mockCareCertificateTab.getCell('C8').value).to.equal(mockWorkersWithCareCertificateStatus[1].jobRole);
-        expect(mockCareCertificateTab.getCell('D8').value).to.equal(mockWorkersWithCareCertificateStatus[1].status);
-      });
+      expect(tab.getCell('B3').value).to.equal('Name or ID number');
 
-      describe('Adding blank row to empty table', async () => {
-        it('should not add empty row to end of table when there is data', async () => {
-          addContentToCareCertificateTab(mockCareCertificateTab, mockWorkplaceWorkersWithCareCertificateStatus);
+      expect(tab.getCell('C3').value).to.equal('Main job role');
 
-          const expectedLine = 9;
+      expect(tab.getCell('D3').value).to.equal('Care Certificate');
 
-          expect(mockCareCertificateTab.getCell(`B${expectedLine}`).value).to.equal(null);
-          expect(mockCareCertificateTab.getCell(`C${expectedLine}`).value).to.equal(null);
-          expect(mockCareCertificateTab.getCell(`D${expectedLine}`).value).to.equal(null);
-        });
+      expect(tab.getCell('E3').value).to.equal('L2 Adult Social Care Certificate');
+    });
 
-        it('should add empty row to table when no data', async () => {
-          addContentToCareCertificateTab(mockCareCertificateTab, []);
+    it('should add worker data to the table', () => {
+      generateCareCertificateTab(workbook, mockWorkersWithCareCertificateStatus);
 
-          const expectedLine = 7;
+      const tab = workbook.getWorksheet('Care Certificate');
 
-          expect(mockCareCertificateTab.getCell(`B${expectedLine}`).value).to.equal('');
-          expect(mockCareCertificateTab.getCell(`C${expectedLine}`).value).to.equal('');
-          expect(mockCareCertificateTab.getCell(`D${expectedLine}`).value).to.equal('');
-        });
-      });
+      const firstWorker = mockWorkersWithCareCertificateStatus[0];
+
+      expect(tab.getCell('B4').value).to.equal(firstWorker.workerId);
+
+      expect(tab.getCell('C4').value).to.equal(firstWorker.jobRole);
+
+      expect(tab.getCell('D4').value).to.equal(firstWorker.careCertificate);
+
+      expect(tab.getCell('E4').value).to.equal(firstWorker.l2CareCertificate);
+    });
+
+    it('should add a blank row when there is no data', () => {
+      generateCareCertificateTab(workbook, []);
+
+      const tab = workbook.getWorksheet('Care Certificate');
+
+      expect(tab.getCell('B4').value).to.equal('');
+      expect(tab.getCell('C4').value).to.equal('');
+      expect(tab.getCell('D4').value).to.equal('');
+      expect(tab.getCell('E4').value).to.equal('');
+    });
+
+    it('should add footnote text', () => {
+      generateCareCertificateTab(workbook, mockWorkersWithCareCertificateStatus);
+
+      const tab = workbook.getWorksheet('Care Certificate');
+
+      const footnoteCell = tab.getCell(`B${tab.lastRow.number}`);
+
+      expect(footnoteCell.value).to.equal(
+        'Note, the data displayed in this table has been generated from staff records.',
+      );
     });
   });
 
   describe('Parent report', () => {
-    const isParent = true;
-    const mockParentWorkplaceWorkersWithCareCerticateStatus = [
-      {
-        establishmentName: 'Care Home 1',
-        workers: mockWorkersWithCareCertificateStatus,
-      },
-      {
-        establishmentName: 'Care Home 2',
-        workers: secondMockWorkersWithCareCertificateStatus,
-      },
-    ];
+    it('should add workplace column when isParent is true', () => {
+      generateCareCertificateTab(workbook, mockWorkersWithCareCertificateStatus, true);
 
-    it('should add tab title to cell B2', async () => {
-      addContentToCareCertificateTab(
-        mockCareCertificateTab,
-        mockParentWorkplaceWorkersWithCareCerticateStatus,
-        isParent,
-      );
+      const tab = workbook.getWorksheet('Care Certificate');
 
-      expect(mockCareCertificateTab.getCell('B2').value).to.equal('Care Certificate');
-    });
+      expect(tab.getCell('B3').value).to.equal('Workplace');
 
-    describe('Care Certificate table', () => {
-      it('should add care certificate records table headings to row 6', async () => {
-        addContentToCareCertificateTab(
-          mockCareCertificateTab,
-          mockParentWorkplaceWorkersWithCareCerticateStatus,
-          isParent,
-        );
-
-        expect(mockCareCertificateTab.getCell('B6').value).to.equal('Workplace');
-        expect(mockCareCertificateTab.getCell('C6').value).to.equal('Worker ID');
-        expect(mockCareCertificateTab.getCell('D6').value).to.equal('Job role');
-        expect(mockCareCertificateTab.getCell('E6').value).to.equal('Status');
-      });
-
-      it('should add first worker with care certificate and workplace for first workplace to care certificate table', async () => {
-        addContentToCareCertificateTab(
-          mockCareCertificateTab,
-          mockParentWorkplaceWorkersWithCareCerticateStatus,
-          isParent,
-        );
-
-        expect(mockCareCertificateTab.getCell('B7').value).to.equal(
-          mockParentWorkplaceWorkersWithCareCerticateStatus[0].establishmentName,
-        );
-        expect(mockCareCertificateTab.getCell('C7').value).to.equal(mockWorkersWithCareCertificateStatus[0].workerId);
-        expect(mockCareCertificateTab.getCell('D7').value).to.equal(mockWorkersWithCareCertificateStatus[0].jobRole);
-        expect(mockCareCertificateTab.getCell('E7').value).to.equal(mockWorkersWithCareCertificateStatus[0].status);
-      });
-
-      it('should add second worker with care certificate and workplace for first workplace to care certificate table', async () => {
-        addContentToCareCertificateTab(
-          mockCareCertificateTab,
-          mockParentWorkplaceWorkersWithCareCerticateStatus,
-          isParent,
-        );
-
-        expect(mockCareCertificateTab.getCell('B8').value).to.equal(
-          mockParentWorkplaceWorkersWithCareCerticateStatus[0].establishmentName,
-        );
-        expect(mockCareCertificateTab.getCell('C8').value).to.equal(mockWorkersWithCareCertificateStatus[1].workerId);
-        expect(mockCareCertificateTab.getCell('D8').value).to.equal(mockWorkersWithCareCertificateStatus[1].jobRole);
-        expect(mockCareCertificateTab.getCell('E8').value).to.equal(mockWorkersWithCareCertificateStatus[1].status);
-      });
-
-      it('should add first worker with care certificate and workplace for second workplace to care certificate table', async () => {
-        addContentToCareCertificateTab(
-          mockCareCertificateTab,
-          mockParentWorkplaceWorkersWithCareCerticateStatus,
-          isParent,
-        );
-
-        expect(mockCareCertificateTab.getCell('B9').value).to.equal(
-          mockParentWorkplaceWorkersWithCareCerticateStatus[1].establishmentName,
-        );
-        expect(mockCareCertificateTab.getCell('C9').value).to.equal(
-          secondMockWorkersWithCareCertificateStatus[0].workerId,
-        );
-        expect(mockCareCertificateTab.getCell('D9').value).to.equal(
-          secondMockWorkersWithCareCertificateStatus[0].jobRole,
-        );
-        expect(mockCareCertificateTab.getCell('E9').value).to.equal(
-          secondMockWorkersWithCareCertificateStatus[0].status,
-        );
-      });
-
-      it('should add second worker with care certificate and workplace for second workplace to care certificate table', async () => {
-        addContentToCareCertificateTab(
-          mockCareCertificateTab,
-          mockParentWorkplaceWorkersWithCareCerticateStatus,
-          isParent,
-        );
-
-        expect(mockCareCertificateTab.getCell('B10').value).to.equal(
-          mockParentWorkplaceWorkersWithCareCerticateStatus[1].establishmentName,
-        );
-        expect(mockCareCertificateTab.getCell('C10').value).to.equal(
-          secondMockWorkersWithCareCertificateStatus[1].workerId,
-        );
-        expect(mockCareCertificateTab.getCell('D10').value).to.equal(
-          secondMockWorkersWithCareCertificateStatus[1].jobRole,
-        );
-        expect(mockCareCertificateTab.getCell('E10').value).to.equal(
-          secondMockWorkersWithCareCertificateStatus[1].status,
-        );
-      });
-
-      describe('Adding blank row to empty table', async () => {
-        it('should not add empty row to end of table when there is data', async () => {
-          addContentToCareCertificateTab(
-            mockCareCertificateTab,
-            mockParentWorkplaceWorkersWithCareCerticateStatus,
-            isParent,
-          );
-
-          const expectedLine = 11;
-
-          expect(mockCareCertificateTab.getCell(`B${expectedLine}`).value).to.equal(null);
-          expect(mockCareCertificateTab.getCell(`C${expectedLine}`).value).to.equal(null);
-          expect(mockCareCertificateTab.getCell(`D${expectedLine}`).value).to.equal(null);
-        });
-
-        it('should add empty row to table when no data', async () => {
-          addContentToCareCertificateTab(mockCareCertificateTab, [], isParent);
-
-          const expectedLine = 7;
-
-          expect(mockCareCertificateTab.getCell(`B${expectedLine}`).value).to.equal('');
-          expect(mockCareCertificateTab.getCell(`C${expectedLine}`).value).to.equal('');
-          expect(mockCareCertificateTab.getCell(`D${expectedLine}`).value).to.equal('');
-        });
-      });
+      expect(tab.getCell('C3').value).to.equal('Name or ID number');
     });
   });
 });

--- a/backend/server/test/unit/utils/trainingAndQualificationsUtils.spec.js
+++ b/backend/server/test/unit/utils/trainingAndQualificationsUtils.spec.js
@@ -127,55 +127,64 @@ describe('trainingAndQualificationsUtils', () => {
   });
 
   describe('convertWorkersWithCareCertificateStatus', () => {
-    describe('First establishment', async () => {
-      it('should return the workplace name for the first establishment', () => {
-        const result = convertWorkersWithCareCertificateStatus(mockEstablishmentsCareCertificateResponse);
+    it('should convert care certificate workers correctly', () => {
+      const result = convertWorkersWithCareCertificateStatus(mockEstablishmentsCareCertificateResponse);
 
-        expect(result[0].establishmentName).to.deep.equal('Care Home 1');
-      });
-
-      it('should return the converted worker care certificate status object for first worker in the first establishment', () => {
-        const result = convertWorkersWithCareCertificateStatus(mockEstablishmentsCareCertificateResponse);
-        expect(result[0].workers[0]).to.deep.equal({
+      expect(result).to.deep.equal([
+        {
           workerId: 'Bob Ross',
-          jobRole: 'Care Worker',
-          status: 'No',
-        });
-      });
 
-      it('should return the converted worker care certificate status object for second worker in the first establishment', () => {
-        const result = convertWorkersWithCareCertificateStatus(mockEstablishmentsCareCertificateResponse);
-        expect(result[0].workers[1]).to.deep.equal({
+          jobRole: 'Care Worker',
+
+          careCertificate: 'Not started',
+
+          l2CareCertificate: 'Not started',
+        },
+
+        {
           workerId: 'Mike Mill',
+
           jobRole: 'Care Coordinator',
-          status: 'Yes, in progress or partially completed',
-        });
-      });
-    });
 
-    describe('Second establishment', async () => {
-      it('should return the workplace name for the second establishment', () => {
-        const result = convertWorkersWithCareCertificateStatus(mockEstablishmentsCareCertificateResponse);
+          careCertificate: 'Yes, in progress or partially completed',
 
-        expect(result[1].establishmentName).to.deep.equal('Care Home 2');
-      });
+          l2CareCertificate: 'Yes, completed',
+        },
 
-      it('should return the converted worker care certificate status object for first worker in the second establishment', () => {
-        const result = convertWorkersWithCareCertificateStatus(mockEstablishmentsCareCertificateResponse);
-        expect(result[1].workers[0]).to.deep.equal({
+        {
           workerId: 'Bill Bailey',
-          jobRole: 'Care Worker',
-          status: 'Yes, completed',
-        });
-      });
 
-      it('should return the converted worker care certificate status object for second worker in the second establishment', () => {
-        const result = convertWorkersWithCareCertificateStatus(mockEstablishmentsCareCertificateResponse);
-        expect(result[1].workers[1]).to.deep.equal({
-          workerId: 'Jenny Jones',
           jobRole: 'Care Worker',
-          status: 'No',
-        });
+
+          careCertificate: 'Yes, completed',
+
+          l2CareCertificate: '-',
+        },
+
+        {
+          workerId: 'Jenny Jones',
+
+          jobRole: 'Care Worker',
+
+          careCertificate: 'Not started',
+
+          l2CareCertificate: 'Yes, started',
+        },
+      ]);
+    });
+    it('should include establishment name when isParent is true', () => {
+      const result = convertWorkersWithCareCertificateStatus(mockEstablishmentsCareCertificateResponse, true);
+
+      expect(result[0]).to.deep.equal({
+        establishmentName: 'Care Home 1',
+
+        workerId: 'Bob Ross',
+
+        jobRole: 'Care Worker',
+
+        careCertificate: 'Not started',
+
+        l2CareCertificate: 'Not started',
       });
     });
   });

--- a/backend/server/utils/trainingAndQualificationsUtils.js
+++ b/backend/server/utils/trainingAndQualificationsUtils.js
@@ -102,22 +102,27 @@ const convertEachWorkerTrainingBreakdown = (worker) => {
 
 exports.convertEachWorkerTrainingBreakdown = convertEachWorkerTrainingBreakdown;
 
-const convertWorkerWithCareCertificateStatus = (worker) => {
+const convertWorkerWithCareCertificateStatus = (worker, establishmentName, isParent = false) => {
   return {
     workerId: numberCheck(worker.get('NameOrIdValue')),
+
+    ...(isParent && { establishmentName }),
+
     jobRole: worker.mainJob.title,
-    status: worker.get('CareCertificateValue') ? worker.get('CareCertificateValue') : '',
+
+    careCertificate: worker.get('CareCertificateValue') || '-',
+
+    l2CareCertificate: worker.get('Level2CareCertificateValue') || '-',
   };
 };
 
-exports.convertWorkersWithCareCertificateStatus = (establishments) => {
-  return establishments.map((establishment) => {
-    return {
-      establishmentName: establishment.get('NameValue'),
-      workers: establishment.workers.map((worker) => {
-        return convertWorkerWithCareCertificateStatus(worker);
-      }),
-    };
+exports.convertWorkersWithCareCertificateStatus = (establishments, isParent = false) => {
+  return establishments.flatMap((establishment) => {
+    const establishmentName = establishment.get('NameValue');
+
+    return establishment.workers.map((worker) => {
+      return convertWorkerWithCareCertificateStatus(worker, establishmentName, isParent);
+    });
   });
 };
 

--- a/backend/server/utils/trainingAndQualificationsUtils.js
+++ b/backend/server/utils/trainingAndQualificationsUtils.js
@@ -100,6 +100,10 @@ const convertEachWorkerTrainingBreakdown = (worker) => {
   };
 };
 
+const formatCareCertificateValue = (value) => {
+  return value === 'No' ? 'Not started' : value || '-';
+};
+
 exports.convertEachWorkerTrainingBreakdown = convertEachWorkerTrainingBreakdown;
 
 const convertWorkerWithCareCertificateStatus = (worker, establishmentName, isParent = false) => {
@@ -110,9 +114,9 @@ const convertWorkerWithCareCertificateStatus = (worker, establishmentName, isPar
 
     jobRole: worker.mainJob.title,
 
-    careCertificate: worker.get('CareCertificateValue') || '-',
+    careCertificate: formatCareCertificateValue(worker.get('CareCertificateValue')),
 
-    l2CareCertificate: worker.get('Level2CareCertificateValue') || '-',
+    l2CareCertificate: formatCareCertificateValue(worker.get('Level2CareCertificateValue')),
   };
 };
 


### PR DESCRIPTION
#### Work done
- Add the `Level2CareCertificateValue` to the database query.
- Refactored care certificate data transformation to support both Care Certificate fields.
- Moved the `getWorkersWithCareCertificateStatus` to `generateTrainingAndQualificationReport`.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
