### PR TITLE
Fix/Bulk upload view history error when previous bulk upload files not found

### DIFF
--- a/backend/server/routes/establishments/bulkUpload/s3.js
+++ b/backend/server/routes/establishments/bulkUpload/s3.js
@@ -212,8 +212,8 @@ const moveFolders = async (folderToMove, destinationFolder) => {
       Delimiter: '/',
     });
 
-    const folderContentInfo = listObjectsResponse.Contents;
-    const folderPrefix = listObjectsResponse.Prefix;
+    const folderContentInfo = listObjectsResponse.Contents ?? [];
+    const folderPrefix = listObjectsResponse.Prefix ?? folderToMove ?? '';
 
     await Promise.all(
       folderContentInfo.map(async (fileInfo) => {
@@ -260,7 +260,12 @@ const listMetaData = async (establishmentId, folder) => {
     Bucket,
     Prefix: `${establishmentId}${folder}`,
   };
+
   const filesInFolder = await s3ClientV3.listObjects(listParams);
+  if (!filesInFolder?.Contents) {
+    return [];
+  }
+
   filesInFolder.Contents.forEach(async (myFile) => {
     if (findMetaDataObjects.test(myFile.Key)) {
       toDownload.push(downloadContent(myFile.Key, myFile.Size, myFile.LastModified));
@@ -280,6 +285,10 @@ const findFilesS3 = async (establishmentId, fileName) => {
   const listParams = params(establishmentId);
   const latestObjects = await s3ClientV3.listObjects(listParams);
   const foundFiles = [];
+
+  if (!latestObjects?.Contents) {
+    return [];
+  }
 
   latestObjects.Contents.forEach(async (myFile) => {
     const ignoreRoot = /.*\/$/;

--- a/backend/server/routes/establishments/bulkUpload/validate/index.js
+++ b/backend/server/routes/establishments/bulkUpload/validate/index.js
@@ -4,7 +4,6 @@ const { Worker } = require('worker_threads');
 const { buStates } = require('../states');
 
 const validate = async (req) => {
-  console.log(' ===== called =====');
   const newReq = {
     establishmentId: req.establishmentId,
     username: req.username,

--- a/backend/server/routes/establishments/bulkUpload/validate/index.js
+++ b/backend/server/routes/establishments/bulkUpload/validate/index.js
@@ -4,6 +4,7 @@ const { Worker } = require('worker_threads');
 const { buStates } = require('../states');
 
 const validate = async (req) => {
+  console.log(' ===== called =====');
   const newReq = {
     establishmentId: req.establishmentId,
     username: req.username,

--- a/backend/server/routes/establishments/bulkUpload/validate/validatePut.js
+++ b/backend/server/routes/establishments/bulkUpload/validate/validatePut.js
@@ -28,9 +28,10 @@ const validatePut = async (req, res) => {
 
   try {
     const bucketFiles = await S3.listObjectsInBucket(req.establishmentId);
+    const bucketFilesContents = bucketFiles?.Contents ?? [];
 
     await Promise.all(
-      bucketFiles.Contents.map(async (fileInfo) => {
+      bucketFilesContents.map(async (fileInfo) => {
         if (isNotMetadata(fileInfo.Key)) {
           const file = await S3.downloadContent(fileInfo.Key);
           const fileType = getFileType(file.data);

--- a/backend/server/test/unit/routes/establishments/bulkUpload/s3.spec.js
+++ b/backend/server/test/unit/routes/establishments/bulkUpload/s3.spec.js
@@ -113,6 +113,14 @@ describe('s3', () => {
       await S3.deleteFilesS3(123, 'filename1');
       sinon.assert.calledWith(deleteObjects, deleteFiles);
     });
+
+    it('should handle the case when listObjects found no result', async () => {
+      sinon.stub(s3ClientV3, 'listObjects').resolves({});
+      const deleteObjects = sinon.stub(S3.s3, 'deleteObjects');
+
+      await S3.deleteFilesS3(123, 'filename1');
+      sinon.assert.notCalled(deleteObjects);
+    });
   });
 
   describe('purgeBulkUploadS3Objects', () => {
@@ -152,6 +160,14 @@ describe('s3', () => {
       await S3.purgeBulkUploadS3Objects(1);
 
       sinon.assert.calledWith(deleteObjects, expectedResult);
+    });
+
+    it('should handle the case when listObjects found no result', async () => {
+      sinon.stub(s3ClientV3, 'listObjects').resolves({});
+      const deleteObjects = sinon.stub(S3.s3, 'deleteObjects');
+
+      await S3.deleteFilesS3(123, 'filename1');
+      sinon.assert.notCalled(deleteObjects);
     });
   });
 
@@ -262,6 +278,17 @@ describe('s3', () => {
       ];
 
       expect(results).to.deep.equal(expectedResult);
+    });
+
+    it('should handle the case when listObjects found no result', async () => {
+      sinon.stub(s3ClientV3, 'listObjects').resolves({});
+
+      const getObject = sinon.stub(S3.s3, 'getObject');
+
+      const results = await S3.listMetaData(123, '/lastBulkUpload/');
+
+      expect(getObject).not.to.be.called;
+      expect(results).to.deep.equal([]);
     });
   });
 });


### PR DESCRIPTION
#### Work done
- Fix an issue of "View last bulk upload" run into 500 error when there isn't any previous bulk upload file in S3



** Notes for dev:
This issue is related to a recent fix for BU, which switched some of the AWS-SDK S3.listObjects calls from ver2 to ver3.
In AWS-SDK V2, S3.listObjects response always has a `Contents` field. When no object was found, `Contents` is an empty array.
In AWS-SDK V3, when no object was found, the response does not have a `Contents` field at all. Therefore old code that try to call `response.Contents.forEach` or `response.Contents.map` before checking `Contents` will run into error

This PR address the existing BU codes and add a check for `Contents` before calling array methods on it

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
