### PR TITLE
Feat/1932 Add last login tracking and display in UI with conditional rendering

### DIFF
--- a/frontend/src/app/core/model/userDetails.model.ts
+++ b/frontend/src/app/core/model/userDetails.model.ts
@@ -10,6 +10,7 @@ export interface UserDetails {
   isPrimary?: boolean;
   jobTitle: string;
   lastLoggedIn?: string;
+  lastLoggedInFromLogin?: string;
   agreedUpdatedTerms?: boolean;
   migratedUser?: boolean;
   migratedUserFirstLogon?: boolean;

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -9,11 +9,11 @@ import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import isNull from 'lodash/isNull';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, filter, tap } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
 
 import { EstablishmentService } from './establishment.service';
 import { PermissionsService } from './permissions/permissions.service';
 import { UserService } from './user.service';
-import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -90,19 +90,22 @@ export class AuthService {
 
   public authenticate(username: string, password: string) {
     this.featureFlagsService.configCatClient.forceRefreshAsync();
-    return this.http.post<any>(`${environment.appRunnerEndpoint}/api/login/`, { username, password }, { observe: 'response' }).pipe(
-      tap(
-        (response) => {
-          this.token = response.headers.get('authorization');
-          Sentry.configureScope((scope) => {
-            scope.setUser({
-              id: response.body.uid,
+    return this.http
+      .post<any>(`${environment.appRunnerEndpoint}/api/login/`, { username, password }, { observe: 'response' })
+      .pipe(
+        tap(
+          (response) => {
+            this.token = response.headers.get('authorization');
+            this.userService.setLastLoggedIn(response.body.lastLoggedIn);
+            Sentry.configureScope((scope) => {
+              scope.setUser({
+                id: response.body.uid,
+              });
             });
-          });
-        },
-        (error) => console.error(error),
-      ),
-    );
+          },
+          (error) => console.error(error),
+        ),
+      );
   }
 
   public refreshToken() {

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -27,7 +27,9 @@ export class UserService {
   private _agreedUpdatedTermsStatus: boolean = null;
   private _lastLoggedInFromLogin: string | null = null;
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) {
+    this._lastLoggedInFromLogin = localStorage.getItem('lastLogin');
+  }
 
   public get loggedInUser$(): Observable<UserDetails> {
     return this._loggedInUser$.asObservable();
@@ -123,6 +125,10 @@ export class UserService {
 
   public setLastLoggedIn(lastLoggedIn: string | null) {
     this._lastLoggedInFromLogin = lastLoggedIn;
+
+    if (lastLoggedIn) {
+      localStorage.setItem('lastLogin', lastLoggedIn);
+    }
   }
   /*
    * GET /api/user/establishment/:establishmentUID

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -25,6 +25,7 @@ export class UserService {
   public agreedUpdatedTerms$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public users$: Observable<Array<UserDetails>> = this._users$.asObservable();
   private _agreedUpdatedTermsStatus: boolean = null;
+  private _lastLoggedInFromLogin: string | null = null;
 
   constructor(private http: HttpClient) {}
 
@@ -49,9 +50,15 @@ export class UserService {
   }
 
   public getLoggedInUser(): Observable<UserDetails> {
-    return this.http
-      .get<UserDetails>(`${environment.appRunnerEndpoint}/api/user/me`)
-      .pipe(tap((user) => (this.loggedInUser = user)));
+    return this.http.get<UserDetails>(`${environment.appRunnerEndpoint}/api/user/me`).pipe(
+      tap((user) => {
+        const mappedUser: UserDetails = {
+          ...user,
+          lastLoggedInFromLogin: this._lastLoggedInFromLogin,
+        };
+        this.loggedInUser = mappedUser;
+      }),
+    );
   }
 
   public get returnUrl() {
@@ -114,6 +121,9 @@ export class UserService {
     this._agreedUpdatedTermsStatus = null;
   }
 
+  public setLastLoggedIn(lastLoggedIn: string | null) {
+    this._lastLoggedInFromLogin = lastLoggedIn;
+  }
   /*
    * GET /api/user/establishment/:establishmentUID
    */

--- a/frontend/src/app/core/test-utils/MockUserService.ts
+++ b/frontend/src/app/core/test-utils/MockUserService.ts
@@ -139,6 +139,7 @@ export class MockUserService extends UserService {
       role: this.role,
       securityQuestion: 'Not relevant',
       securityQuestionAnswer: 'Not relevant',
+      lastLoggedInFromLogin: '2026-06-01T12:34:56.000Z',
     };
   }
 

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
@@ -54,6 +54,11 @@
             <span *ngIf="updatedDate" class="govuk-!-margin-left-2" data-testid="lastUpdatedDate"
               >Last update, {{ updatedDate | date: 'd MMMM y' }}
             </span>
+            <ng-container *ngIf="tab === 'home' && lastLoggedInFromLogin">
+              <span data-testid="separator">|</span>
+
+              <span class="govuk-!-margin-left-2"> Last sign in, {{ lastLoggedInFromLogin | date: 'd MMMM y' }} </span>
+            </ng-container>
           </p>
         </div>
         <div

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
@@ -54,7 +54,7 @@
             <span *ngIf="updatedDate" class="govuk-!-margin-left-2" data-testid="lastUpdatedDate"
               >Last update, {{ updatedDate | date: 'd MMMM y' }}
             </span>
-            <ng-container *ngIf="tab === 'home' && lastLoggedInFromLogin">
+            <ng-container *ngIf="tab === 'home' && !isAdmin && lastLoggedInFromLogin">
               <span data-testid="separator">|</span>
 
               <span class="govuk-!-margin-left-2"> Last sign in, {{ lastLoggedInFromLogin | date: 'd MMMM y' }} </span>

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.html
@@ -54,7 +54,7 @@
             <span *ngIf="updatedDate" class="govuk-!-margin-left-2" data-testid="lastUpdatedDate"
               >Last update, {{ updatedDate | date: 'd MMMM y' }}
             </span>
-            <ng-container *ngIf="tab === 'home' && !isAdmin && lastLoggedInFromLogin">
+            <ng-container *ngIf="tab === 'home' && !isAdmin && lastLoggedInFromLogin && !isParentSubsidiaryView">
               <span data-testid="separator">|</span>
 
               <span class="govuk-!-margin-left-2"> Last sign in, {{ lastLoggedInFromLogin | date: 'd MMMM y' }} </span>

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
@@ -8,6 +8,7 @@ import { Roles } from '@core/model/roles.enum';
 import { AuthService } from '@core/services/auth.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
+import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
 import { UserService } from '@core/services/user.service';
 import { WindowToken } from '@core/services/window';
 import { WindowRef } from '@core/services/window.ref';
@@ -21,7 +22,6 @@ import { SharedModule } from '@shared/shared.module';
 import { render, within } from '@testing-library/angular';
 
 import { NewDashboardHeaderComponent } from './dashboard-header.component';
-import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
 
 const MockWindow = {
   dataLayer: {
@@ -198,6 +198,15 @@ describe('NewDashboardHeaderComponent', () => {
       const { queryByTestId } = await setup(override);
 
       expect(queryByTestId('workplace-address')).toBeFalsy();
+    });
+
+    it('should show last sign in date for non-admin users', async () => {
+      const { getByText } = await setup({
+        tab: 'home',
+        isAdmin: false,
+      });
+
+      expect(getByText('Last sign in, 1 June 2026')).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
@@ -201,12 +201,25 @@ describe('NewDashboardHeaderComponent', () => {
     });
 
     it('should show last sign in date for non-admin users', async () => {
-      const { getByText } = await setup({
+      const { getByText, component } = await setup({
+        tab: 'home',
+        isAdmin: false,
+        isParentSubsidiaryView: false,
+      });
+
+      expect(getByText('Last sign in, 1 June 2026')).toBeTruthy();
+    });
+
+    it('should NOT show last sign in date when accessed via parent subsidiary view', async () => {
+      const { queryByText, component, fixture } = await setup({
         tab: 'home',
         isAdmin: false,
       });
 
-      expect(getByText('Last sign in, 1 June 2026')).toBeTruthy();
+      component.isParentSubsidiaryView = true;
+      fixture.detectChanges();
+
+      expect(queryByText(/Last sign in/)).toBeNull();
     });
   });
 

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.spec.ts
@@ -201,7 +201,7 @@ describe('NewDashboardHeaderComponent', () => {
     });
 
     it('should show last sign in date for non-admin users', async () => {
-      const { getByText, component } = await setup({
+      const { getByText } = await setup({
         tab: 'home',
         isAdmin: false,
         isParentSubsidiaryView: false,

--- a/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
+++ b/frontend/src/app/shared/components/new-dashboard-header/dashboard-header.component.ts
@@ -46,6 +46,7 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
   public isParentSubsidiaryView: boolean;
   public user: UserDetails;
   public isAdmin: boolean;
+  public lastLoggedInFromLogin: string;
 
   constructor(
     private permissionsService: PermissionsService,
@@ -60,6 +61,10 @@ export class NewDashboardHeaderComponent implements OnInit, OnChanges {
     this.isParent = this.workplace.isParent;
 
     this.setIsParentSubsidiaryView();
+
+    this.userService.loggedInUser$.subscribe((user) => {
+      this.lastLoggedInFromLogin = user?.lastLoggedInFromLogin;
+    });
 
     if (this.workplace) {
       this.setSubsidiaryCount();


### PR DESCRIPTION
#### Work done
- Added setLastLoggedIn method to store value from login API
- Stored lastLoggedIn separately from api/user/me response
- Merged login API value with api/user/me user data in frontend state
- Updated UI to conditionally display last login date
- Hide last sign-in date from showing in parent subsidiary view, but allow in direct sub account login

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
