### PR TITLE
Feat/1939 Display last sign-in date in admin user pages and search results

### DIFF
--- a/frontend/src/app/features/admin/search/search-for-user/search-for-user.component.html
+++ b/frontend/src/app/features/admin/search/search-for-user/search-for-user.component.html
@@ -55,7 +55,8 @@
                       <thead class="govuk-table__head">
                         <tr class="govuk-table__row">
                           <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Location ID</th>
-                          <th class="govuk-table__header govuk-!-width-one-half" scope="col">Workplace</th>
+                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Workplace</th>
+                          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Last sign in</th>
                           <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">&nbsp;</th>
                         </tr>
                       </thead>
@@ -70,6 +71,9 @@
                               href="#"
                               >{{ item.establishment.name }}</a
                             >
+                          </td>
+                          <td class="govuk-table__cell">
+                            {{ item.lastLoggedIn | date: 'd MMM y' }}
                           </td>
                           <th class="govuk-table__cell" scope="col">&nbsp;</th>
                         </tr>

--- a/frontend/src/app/shared/components/users-table/user-table.component.html
+++ b/frontend/src/app/shared/components/users-table/user-table.component.html
@@ -39,7 +39,7 @@
               {{ user.updated | date: 'd MMM y' }}
             </td>
             <td class="govuk-table__cell">
-              {{ user.lastLoggedIn ? (user.lastLoggedIn | date: 'd MMM y') : '-' }}
+              {{ getUserLastLogin(user) ? (getUserLastLogin(user) | date: 'd MMM y') : '-' }}
             </td>
             <td class="govuk-table__cell">
               {{ getUserType(user) }}

--- a/frontend/src/app/shared/components/users-table/user-table.component.html
+++ b/frontend/src/app/shared/components/users-table/user-table.component.html
@@ -6,6 +6,7 @@
           <th class="govuk-table__header" scope="col">Full name</th>
           <th class="govuk-table__header" scope="col">Username</th>
           <th class="govuk-table__header" scope="col">Last updated</th>
+          <th class="govuk-table__header" scope="col">Last sign in</th>
           <th class="govuk-table__header" scope="col">Permissions</th>
           <th class="govuk-table__header" scope="col">Status</th>
         </tr>
@@ -36,6 +37,9 @@
             </td>
             <td class="govuk-table__cell">
               {{ user.updated | date: 'd MMM y' }}
+            </td>
+            <td class="govuk-table__cell">
+              {{ user.lastLoggedIn ? (user.lastLoggedIn | date: 'd MMM y') : '-' }}
             </td>
             <td class="govuk-table__cell">
               {{ getUserType(user) }}

--- a/frontend/src/app/shared/components/users-table/user-table.component.spec.ts
+++ b/frontend/src/app/shared/components/users-table/user-table.component.spec.ts
@@ -29,7 +29,9 @@ describe('UserTableComponent', () => {
             },
           },
         },
-      provideHttpClient(), provideHttpClientTesting(),],
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
       componentProperties: {
         workplace: !admin && Establishment,
         users: admin ? adminUserArr : userArr,
@@ -54,6 +56,7 @@ describe('UserTableComponent', () => {
     expect(getByText('Full name')).toBeTruthy();
     expect(getByText('Username')).toBeTruthy();
     expect(getByText('Last updated')).toBeTruthy();
+    expect(getByText('Last sign in')).toBeTruthy();
     expect(getByText('Permissions')).toBeTruthy();
     expect(getByText('Status')).toBeTruthy();
 
@@ -162,6 +165,37 @@ describe('UserTableComponent', () => {
       fixture.detectChanges();
 
       expect(queryByText('Read only')).toBeTruthy();
+    });
+
+    it('should return locally stored last login for the logged-in user', async () => {
+      const { component } = await setup();
+
+      component.loggedUserUid = component.users[0].uid;
+      component.lastLoggedInFromLogin = '2024-06-01T10:00:00Z';
+
+      expect(component.getUserLastLogin(component.users[0])).toBe('2024-06-01T10:00:00Z');
+    });
+
+    it('should return API last login for users other than the logged-in user', async () => {
+      const { component } = await setup();
+
+      component.loggedUserUid = component.users[0].uid;
+      component.lastLoggedInFromLogin = '2024-06-01T10:00:00Z';
+
+      component.users[1].lastLoggedIn = '2024-05-20T09:00:00Z';
+
+      expect(component.getUserLastLogin(component.users[1])).toBe('2024-05-20T09:00:00Z');
+    });
+
+    it('should display the logged-in user last sign in date', async () => {
+      const { component, fixture, getByText } = await setup();
+
+      component.loggedUserUid = component.users[0].uid;
+      component.lastLoggedInFromLogin = '2024-06-01T10:00:00Z';
+
+      fixture.detectChanges();
+
+      expect(getByText('1 Jun 2024')).toBeTruthy();
     });
   });
 });

--- a/frontend/src/app/shared/components/users-table/user.table.component.ts
+++ b/frontend/src/app/shared/components/users-table/user.table.component.ts
@@ -1,17 +1,42 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Establishment } from '@core/model/establishment.model';
 import { UserDetails, UserPermissionsType, UserStatus } from '@core/model/userDetails.model';
+import { UserService } from '@core/services/user.service';
 
 @Component({
-    selector: 'app-user-table',
-    templateUrl: './user-table.component.html',
-    standalone: false
+  selector: 'app-user-table',
+  templateUrl: './user-table.component.html',
+  standalone: false,
 })
-export class UserTableComponent {
+export class UserTableComponent implements OnInit {
   @Input() users: UserDetails[] = [];
   @Input() canViewUser = true;
   @Input() workplace: Establishment;
   @Input() userPermissionsTypes: UserPermissionsType[];
+
+  public lastLoggedInFromLogin: string;
+  public loggedUserUid: string;
+
+  constructor(private userService: UserService) {}
+
+  ngOnInit(): void {
+    this.userService.loggedInUser$.subscribe((user) => {
+      this.lastLoggedInFromLogin = user?.lastLoggedInFromLogin;
+      this.loggedUserUid = user?.uid;
+    });
+  }
+
+  private isLoggedUser(user: UserDetails): boolean {
+    return this.loggedUserUid === user.uid;
+  }
+
+  /**
+   * Use locally stored last login for logged-in user,
+   * otherwise use API value.
+   */
+  public getUserLastLogin(user: UserDetails): string {
+    return this.isLoggedUser(user) ? this.lastLoggedInFromLogin : user.lastLoggedIn;
+  }
 
   public isPending(user: UserDetails): boolean {
     return user.status === UserStatus.Pending;


### PR DESCRIPTION
#### Work done
- Display last sign-in date in admin user pages
- Display last sign-in date in admin user search results
- Added fallback - when last sign-in date is not available

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
