### PR TITLE
Feat/1945 update training records summary message

### DIFF
--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -1520,8 +1520,8 @@ describe('Summary section', () => {
         };
         const { getByTestId } = await setup(overrides);
         const tAndQRow = getByTestId('training-and-qualifications-row');
-        expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
-        expect(within(tAndQRow).queryByTestId('red-flag')).toBeTruthy();
+        expect(within(tAndQRow).queryByTestId('orange-flag')).toBeTruthy();
+        expect(within(tAndQRow).queryByTestId('red-flag')).toBeFalsy();
         expect(within(tAndQRow).getByText('You need to check your training records')).toBeTruthy();
       });
 
@@ -1535,8 +1535,8 @@ describe('Summary section', () => {
         };
         const { getByTestId } = await setup(overrides);
         const tAndQRow = getByTestId('training-and-qualifications-row');
-        expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
-        expect(within(tAndQRow).queryByTestId('red-flag')).toBeTruthy();
+        expect(within(tAndQRow).queryByTestId('orange-flag')).toBeTruthy();
+        expect(within(tAndQRow).queryByTestId('red-flag')).toBeFalsy();
         expect(within(tAndQRow).getByText('You need to check your training records')).toBeTruthy();
       });
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -5,8 +5,10 @@ import { provideRouter, Router, RouterModule } from '@angular/router';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
 import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
+import { PayAndPensionService } from '@core/services/pay-and-pension.service';
 import { TabsService } from '@core/services/tabs.service';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
+import { MockPayAndPensionService } from '@core/test-utils/MockPayAndPensionService';
 import { MockTabsService } from '@core/test-utils/MockTabsService';
 import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
@@ -16,8 +18,6 @@ import { of } from 'rxjs';
 
 import { Establishment } from '../../../../mockdata/establishment';
 import { SummarySectionComponent } from './summary-section.component';
-import { PayAndPensionService } from '@core/services/pay-and-pension.service';
-import { MockPayAndPensionService } from '@core/test-utils/MockPayAndPensionService';
 
 describe('Summary section', () => {
   const setup = async (overrides: any = {}) => {
@@ -1428,7 +1428,7 @@ describe('Summary section', () => {
         const tAndQRow = getByTestId('training-and-qualifications-row');
         expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
         expect(within(tAndQRow).getByTestId('red-flag')).toBeTruthy();
-        expect(within(tAndQRow).getByText('2 staff are missing mandatory training')).toBeTruthy();
+        expect(within(tAndQRow).getByText('You need to check your training records')).toBeTruthy();
       });
 
       it('should show when mandatory training is missing for a single user', async () => {
@@ -1443,7 +1443,7 @@ describe('Summary section', () => {
         const tAndQRow = getByTestId('training-and-qualifications-row');
         expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
         expect(within(tAndQRow).getByTestId('red-flag')).toBeTruthy();
-        expect(within(tAndQRow).getByText('1 staff is missing mandatory training')).toBeTruthy();
+        expect(within(tAndQRow).getByText('You need to check your training records')).toBeTruthy();
       });
 
       it('should not show when mandatory training is not missing', async () => {
@@ -1458,8 +1458,7 @@ describe('Summary section', () => {
         const tAndQRow = getByTestId('training-and-qualifications-row');
         expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
         expect(within(tAndQRow).queryByTestId('red-flag')).toBeFalsy();
-        expect(within(tAndQRow).queryByText('0 staff are missing mandatory training')).toBeFalsy();
-        expect(within(tAndQRow).queryByText('0 staff is missing mandatory training')).toBeFalsy();
+        expect(within(tAndQRow).queryByText('You need to check your training records')).toBeFalsy();
       });
     });
 
@@ -1476,7 +1475,7 @@ describe('Summary section', () => {
         const tAndQRow = getByTestId('training-and-qualifications-row');
         expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
         expect(within(tAndQRow).getByTestId('red-flag')).toBeTruthy();
-        expect(within(tAndQRow).getByText('2 training records have expired')).toBeTruthy();
+        expect(within(tAndQRow).getByText('You need to check your training records')).toBeTruthy();
       });
 
       it('should show when training is expired for a single user', async () => {
@@ -1491,7 +1490,7 @@ describe('Summary section', () => {
         const tAndQRow = getByTestId('training-and-qualifications-row');
         expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
         expect(within(tAndQRow).getByTestId('red-flag')).toBeTruthy();
-        expect(within(tAndQRow).getByText('1 training record has expired')).toBeTruthy();
+        expect(within(tAndQRow).getByText('You need to check your training records')).toBeTruthy();
       });
 
       it('should not show when training is not expired', async () => {
@@ -1506,8 +1505,7 @@ describe('Summary section', () => {
         const tAndQRow = getByTestId('training-and-qualifications-row');
         expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
         expect(within(tAndQRow).queryByTestId('red-flag')).toBeFalsy();
-        expect(within(tAndQRow).queryByText('0 training record has expired')).toBeFalsy();
-        expect(within(tAndQRow).queryByText('0 training records have expired')).toBeFalsy();
+        expect(within(tAndQRow).queryByText('You need to check your training records')).toBeFalsy();
       });
     });
 
@@ -1522,9 +1520,9 @@ describe('Summary section', () => {
         };
         const { getByTestId } = await setup(overrides);
         const tAndQRow = getByTestId('training-and-qualifications-row');
-        expect(within(tAndQRow).getByTestId('orange-flag')).toBeTruthy();
-        expect(within(tAndQRow).queryByTestId('red-flag')).toBeFalsy();
-        expect(within(tAndQRow).getByText('2 training records expire soon')).toBeTruthy();
+        expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
+        expect(within(tAndQRow).queryByTestId('red-flag')).toBeTruthy();
+        expect(within(tAndQRow).getByText('You need to check your training records')).toBeTruthy();
       });
 
       it('should show when training is expiring for a single user', async () => {
@@ -1537,9 +1535,9 @@ describe('Summary section', () => {
         };
         const { getByTestId } = await setup(overrides);
         const tAndQRow = getByTestId('training-and-qualifications-row');
-        expect(within(tAndQRow).getByTestId('orange-flag')).toBeTruthy();
-        expect(within(tAndQRow).queryByTestId('red-flag')).toBeFalsy();
-        expect(within(tAndQRow).getByText('1 training record expires soon')).toBeTruthy();
+        expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
+        expect(within(tAndQRow).queryByTestId('red-flag')).toBeTruthy();
+        expect(within(tAndQRow).getByText('You need to check your training records')).toBeTruthy();
       });
 
       it('should not show when training is not expiring', async () => {
@@ -1554,8 +1552,7 @@ describe('Summary section', () => {
         const tAndQRow = getByTestId('training-and-qualifications-row');
         expect(within(tAndQRow).queryByTestId('orange-flag')).toBeFalsy();
         expect(within(tAndQRow).queryByTestId('red-flag')).toBeFalsy();
-        expect(within(tAndQRow).queryByText('0 training record expires soon')).toBeFalsy();
-        expect(within(tAndQRow).queryByText('0 training records expire soon')).toBeFalsy();
+        expect(within(tAndQRow).queryByText('You need to check your training records')).toBeFalsy();
       });
     });
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -248,12 +248,14 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   }
 
   public getTrainingAndQualsSummary(): void {
-    const hasTrainingAlert =
-      this.trainingCounts?.staffMissingMandatoryTraining ||
-      this.trainingCounts?.totalExpiredTraining ||
-      this.trainingCounts?.totalExpiringTraining;
-    if (hasTrainingAlert) {
+    const hasMissingMandatory = this.trainingCounts?.staffMissingMandatoryTraining;
+    const hasExpired = this.trainingCounts?.totalExpiredTraining;
+    const hasExpiringSoon = this.trainingCounts?.totalExpiringTraining;
+
+    if (hasMissingMandatory || hasExpired) {
       this.sections[2].redFlag = true;
+      this.sections[2].message = 'You need to check your training records';
+    } else if (hasExpiringSoon) {
       this.sections[2].message = 'You need to check your training records';
     } else if (this.trainingCounts?.totalRecords === 0 && this.trainingCounts?.totalTraining == 0) {
       this.sections[2].link = false;

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -93,6 +93,8 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   }
 
   public async onClick(event: Event, fragment: string, route: string[], skipTabSwitch: boolean = false): Promise<void> {
+    console.log('fragment:', fragment);
+    console.log('selectedTab before:', this.tabsService.selectedTab);
     event.preventDefault();
     if (this.payAndPensionWorkplaceQuestionsLinkDisplaying && fragment == 'workplace') {
       this.payAndPensionService.setInPayAndPensionsMiniFlow(true);
@@ -248,33 +250,13 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   }
 
   public getTrainingAndQualsSummary(): void {
-    if (this.trainingCounts?.staffMissingMandatoryTraining) {
+    const hasTrainingAlert =
+      this.trainingCounts?.staffMissingMandatoryTraining ||
+      this.trainingCounts?.totalExpiredTraining ||
+      this.trainingCounts?.totalExpiringTraining;
+    if (hasTrainingAlert) {
       this.sections[2].redFlag = true;
-      this.sections[2].message = `${this.trainingCounts.staffMissingMandatoryTraining} staff ${
-        this.trainingCounts.staffMissingMandatoryTraining > 1 ? 'are' : 'is'
-      } missing mandatory training`;
-      this.sections[2].route = [
-        '/workplace',
-        this.workplace.uid,
-        'training-and-qualifications',
-        'missing-mandatory-training',
-      ];
-    } else if (this.trainingCounts?.totalExpiredTraining) {
-      this.sections[2].redFlag = true;
-      this.sections[2].message = `${this.trainingCounts.totalExpiredTraining} training record${
-        this.trainingCounts.totalExpiredTraining > 1 ? 's have' : ' has'
-      } expired`;
-      this.sections[2].route = ['/workplace', this.workplace.uid, 'training-and-qualifications', 'expired-training'];
-    } else if (this.trainingCounts?.totalExpiringTraining) {
-      this.sections[2].message = `${this.trainingCounts.totalExpiringTraining} training record${
-        this.trainingCounts.totalExpiringTraining > 1 ? 's expire' : ' expires'
-      } soon`;
-      this.sections[2].route = [
-        '/workplace',
-        this.workplace.uid,
-        'training-and-qualifications',
-        'expires-soon-training',
-      ];
+      this.sections[2].message = 'You need to check your training records';
     } else if (this.trainingCounts?.totalRecords === 0 && this.trainingCounts?.totalTraining == 0) {
       this.sections[2].link = false;
       this.sections[2].message = 'Manage your staff training and qualifications';

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -93,8 +93,6 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   }
 
   public async onClick(event: Event, fragment: string, route: string[], skipTabSwitch: boolean = false): Promise<void> {
-    console.log('fragment:', fragment);
-    console.log('selectedTab before:', this.tabsService.selectedTab);
     event.preventDefault();
     if (this.payAndPensionWorkplaceQuestionsLinkDisplaying && fragment == 'workplace') {
       this.payAndPensionService.setInPayAndPensionsMiniFlow(true);


### PR DESCRIPTION
#### Work done
- Updated training and qualifications summary logic to show correct flags and messages for expiring, expired, and missing training records.
- Updated unit tests to cover training alert scenarios.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
