### PR TITLE
Feat/1944 grey summary panel new messages

### DIFF
--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -1513,6 +1513,9 @@ class Establishment extends EntityValidator {
         this._payAndPensionsMiniFlowViewed = fetchResults.payAndPensionsMiniFlowViewed;
         this._updatePayForMultiStaffViewed = fetchResults.updatePayForMultiStaffViewed;
         this._fastTrackPayByJobRolesViewed = fetchResults.fastTrackPayByJobRolesViewed;
+        this._vacanciesSavedAt = fetchResults.VacanciesSavedAt;
+        this._startersSavedAt = fetchResults.StartersSavedAt;
+        this._leaversSavedAt = fetchResults.LeaversSavedAt;
 
         // if history of the User is also required; attach the association
         //  and order in reverse chronological - note, order on id (not when)
@@ -1992,6 +1995,9 @@ class Establishment extends EntityValidator {
         myDefaultJSON.payAndPensionsMiniFlowViewed = this.payAndPensionsMiniFlowViewed;
         myDefaultJSON.updatePayForMultiStaffViewed = this.updatePayForMultiStaffViewed;
         myDefaultJSON.fastTrackPayByJobRolesViewed = this.fastTrackPayByJobRolesViewed;
+        myDefaultJSON.vacanciesSavedAt = this._vacanciesSavedAt;
+        myDefaultJSON.startersSavedAt = this._startersSavedAt;
+        myDefaultJSON.leaversSavedAt = this._leaversSavedAt;
       }
 
       if (this.showSharingPermissionsBanner !== null) {

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2586,8 +2586,8 @@ module.exports = function (sequelize, DataTypes) {
     CASE
       -- Number of staff is null
       WHEN "NumberOfStaffValue" IS NULL THEN true
-      -- No vacancy data
-      WHEN "VacanciesValue" IS NULL THEN true
+      -- missing Vacancy / Starters / Leavers data
+      WHEN "VacanciesValue" IS NULL OR "StartersValue" IS NULL OR "LeaversValue" IS NULL THEN true
       -- Add workplace details banner showing
       WHEN "ShowAddWorkplaceDetailsBanner" = true THEN true
       -- CWP awareness flag showing

--- a/backend/server/models/establishment.js
+++ b/backend/server/models/establishment.js
@@ -2612,6 +2612,7 @@ module.exports = function (sequelize, DataTypes) {
         WHERE w."EstablishmentFK" = "EstablishmentID"
         AND w."Archived" = false
       ) THEN true
+
       -- No workers created in last 12 months
       WHEN (
         'now'::timestamp >= ("created" + '12 months'::interval) AND
@@ -2622,6 +2623,13 @@ module.exports = function (sequelize, DataTypes) {
           WHERE w."EstablishmentFK" = "EstablishmentID"
           AND w."Archived" = false
         )
+      ) THEN true
+
+       -- Vacancy / Starter / Leaver last update older than 12 month ago
+      WHEN (
+        'now'::timestamp > "VacanciesSavedAt" + '12 months'::interval OR
+        'now'::timestamp > "StartersSavedAt" + '12 months'::interval OR
+        'now'::timestamp > "LeaversSavedAt" + '12 months'::interval
       ) THEN true
 
       WHEN (

--- a/frontend/src/app/core/model/establishment.model.ts
+++ b/frontend/src/app/core/model/establishment.model.ts
@@ -192,8 +192,10 @@ export interface Establishment {
   payAndPensionsMiniFlowViewed?: boolean;
   updatePayForMultiStaffViewed?: boolean;
   fastTrackPayByJobRolesViewed?: boolean;
+  vacanciesSavedAt?: string;
+  startersSavedAt?: string;
+  leaversSavedAt?: string;
 }
-
 export interface UpdateJobsRequest {
   leavers?: Leaver[] | string;
   starters?: Starter[] | string;

--- a/frontend/src/app/core/utils/date-util.spec.ts
+++ b/frontend/src/app/core/utils/date-util.spec.ts
@@ -3,7 +3,7 @@ import { DateUtil } from './date-util';
 import { FormatDate } from './date-util';
 import { DATE_PARSE_FORMAT } from '@core/constants/constants';
 
-fdescribe('DateUtil', () => {
+describe('DateUtil', () => {
   describe('getDateForOneYearAgo', () => {
     beforeEach(() => {
       jasmine.clock().install();

--- a/frontend/src/app/core/utils/date-util.spec.ts
+++ b/frontend/src/app/core/utils/date-util.spec.ts
@@ -3,7 +3,7 @@ import { DateUtil } from './date-util';
 import { FormatDate } from './date-util';
 import { DATE_PARSE_FORMAT } from '@core/constants/constants';
 
-describe('DateUtil', () => {
+fdescribe('DateUtil', () => {
   describe('getDateForOneYearAgo', () => {
     beforeEach(() => {
       jasmine.clock().install();
@@ -19,6 +19,57 @@ describe('DateUtil', () => {
       const actual = DateUtil.getDateForOneYearAgo();
 
       expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('isMoreThanOneYearAgo', () => {
+    const mockToday = '2026-05-17';
+
+    beforeEach(() => {
+      jasmine.clock().install();
+      jasmine.clock().mockDate(new Date(mockToday));
+    });
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    it('should return true if the given date is more than one year ago', () => {
+      const actual = DateUtil.isMoreThanOneYearAgo('2025-05-16');
+      const expected = true;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return false if the given date is less than one year ago', () => {
+      const actual = DateUtil.isMoreThanOneYearAgo('2025-05-18');
+      const expected = false;
+
+      expect(actual).toEqual(expected);
+    });
+
+    const testCases = [
+      { inputDate: '2025-05-17', expected: false },
+      { inputDate: '2024-02-29', expected: true },
+
+      { inputDate: '2025-05-16T12:34:56Z', expected: true },
+      { inputDate: '2025-05-17T12:34:56Z', expected: false },
+      { inputDate: '2025-05-18T12:34:56Z', expected: false },
+
+      { inputDate: new Date('2025-05-16T12:34:56Z'), expected: true },
+      { inputDate: new Date('2025-05-17T12:34:56Z'), expected: false },
+      { inputDate: new Date('2025-05-18T12:34:56Z'), expected: false },
+
+      { inputDate: undefined, expected: false },
+      { inputDate: null, expected: false },
+      { inputDate: 'not a date', expected: false },
+    ];
+
+    testCases.forEach(({ inputDate, expected }) => {
+      it(`should return ${expected} when inputDate=${inputDate}, today=${mockToday}`, () => {
+        const actual = DateUtil.isMoreThanOneYearAgo(inputDate);
+
+        expect(actual).toEqual(expected);
+      });
     });
   });
 

--- a/frontend/src/app/core/utils/date-util.ts
+++ b/frontend/src/app/core/utils/date-util.ts
@@ -12,7 +12,7 @@ export class DateUtil {
     return FormatUtil.formatDateToLocaleDateString(today);
   }
 
-  public static isMoreThanOneYearAgo(date: string | Date | dayjs.Dayjs): boolean {
+  public static isMoreThanOneYearAgo(date: string | Date | dayjs.Dayjs | undefined): boolean {
     return dayjs(date).isBefore(DateUtil.getDateForOneYearAgo(), 'day');
   }
 

--- a/frontend/src/app/core/utils/date-util.ts
+++ b/frontend/src/app/core/utils/date-util.ts
@@ -12,6 +12,10 @@ export class DateUtil {
     return FormatUtil.formatDateToLocaleDateString(today);
   }
 
+  public static isMoreThanOneYearAgo(date: string | Date | dayjs.Dayjs): boolean {
+    return dayjs(date).isBefore(DateUtil.getDateForOneYearAgo(), 'day');
+  }
+
   public static toDayjs(input: string | FormGroupDateValues): dayjs.Dayjs {
     if (!input) return null;
 

--- a/frontend/src/app/core/utils/format-util.spec.ts
+++ b/frontend/src/app/core/utils/format-util.spec.ts
@@ -95,4 +95,22 @@ describe('FormatUtil', () => {
       });
     });
   });
+
+  describe('joinNouns', () => {
+    const testCases = [
+      { inputArray: null, expected: '' },
+      { inputArray: [], expected: '' },
+      { inputArray: ['vacancy'], expected: 'vacancy' },
+      { inputArray: ['vacancy', 'starters'], expected: 'vacancy and starters' },
+      { inputArray: ['vacancy', 'leavers'], expected: 'vacancy and leavers' },
+      { inputArray: ['vacancy', 'starters', 'leavers'], expected: 'vacancy, starters and leavers' },
+    ];
+
+    testCases.forEach(({ inputArray, expected }) => {
+      it(`should return ${expected} when inputArray is ${JSON.stringify(inputArray)}`, () => {
+        const actual = FormatUtil.joinNouns(inputArray);
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
 });

--- a/frontend/src/app/core/utils/format-util.ts
+++ b/frontend/src/app/core/utils/format-util.ts
@@ -32,4 +32,14 @@ export class FormatUtil {
       })
       .join(' ');
   }
+
+  public static joinNouns(inputArray: string[]): string {
+    if (!(inputArray?.length > 0)) {
+      return '';
+    }
+
+    const lastTwo = inputArray.slice(-2).join(' and ');
+    const otherItems = inputArray.slice(0, -2);
+    return [...otherItems, lastTwo].join(', ');
+  }
 }

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -363,6 +363,7 @@ fdescribe('Summary section', () => {
     describe('Update your starter, leaver and vacancy data', () => {
       const mockTimeNow = '2026-05-14';
       const moreThanOneYearAgo = '2025-05-13T00:00:00.000Z';
+      const lessThanOneYearAgo = '2025-12-23T00:00:00.000Z';
 
       beforeEach(() => {
         jasmine.clock().install();
@@ -372,27 +373,76 @@ fdescribe('Summary section', () => {
         jasmine.clock().uninstall();
       });
 
-      it('should show a warning saying "Update your starter, leaver and vacancy data" if all of them are over 12 months old', async () => {
-        const mockEstablishment = { ...Establishment, leavers: 'None', vacancies: 'None', starters: 'None' };
+      const mockEstablishment = { ...Establishment, leavers: 'None', vacancies: 'None', starters: 'None' };
 
-        const overrides = {
-          checkCqcDetails: false,
-          establishment: {
-            ...mockEstablishment,
-            vacanciesSavedAt: moreThanOneYearAgo,
-            startersSavedAt: moreThanOneYearAgo,
-            leaversSavedAt: moreThanOneYearAgo,
-          },
-        };
+      const testCasesForUpdateYourVacancyStarterLeaverMessages = [
+        {
+          vacanciesSavedAt: moreThanOneYearAgo,
+          startersSavedAt: moreThanOneYearAgo,
+          leaversSavedAt: moreThanOneYearAgo,
+          expected: 'Update your starter, leaver and vacancy data',
+        },
+        {
+          vacanciesSavedAt: moreThanOneYearAgo,
+          startersSavedAt: moreThanOneYearAgo,
+          leaversSavedAt: lessThanOneYearAgo,
+          expected: 'Update your staff vacancy data',
+        },
+        {
+          vacanciesSavedAt: moreThanOneYearAgo,
+          startersSavedAt: lessThanOneYearAgo,
+          leaversSavedAt: moreThanOneYearAgo,
+          expected: 'Update your staff vacancy data',
+        },
+        {
+          vacanciesSavedAt: lessThanOneYearAgo,
+          startersSavedAt: moreThanOneYearAgo,
+          leaversSavedAt: moreThanOneYearAgo,
+          expected: 'Update your starters and leavers data',
+        },
+        {
+          vacanciesSavedAt: moreThanOneYearAgo,
+          startersSavedAt: lessThanOneYearAgo,
+          leaversSavedAt: lessThanOneYearAgo,
+          expected: 'Update your staff vacancy data',
+        },
 
-        const expectedWarningMessage = 'Update your starter, leaver and vacancy data';
+        {
+          vacanciesSavedAt: lessThanOneYearAgo,
+          startersSavedAt: lessThanOneYearAgo,
+          leaversSavedAt: moreThanOneYearAgo,
+          expected: 'Update your starters and leavers data',
+        },
+        {
+          vacanciesSavedAt: lessThanOneYearAgo,
+          startersSavedAt: moreThanOneYearAgo,
+          leaversSavedAt: lessThanOneYearAgo,
+          expected: 'Update your starters and leavers data',
+        },
+      ];
 
-        const { getByTestId } = await setup(overrides);
+      testCasesForUpdateYourVacancyStarterLeaverMessages.forEach(
+        ({ vacanciesSavedAt, startersSavedAt, leaversSavedAt, expected: expectedWarningMessage }) => {
+          const caseName = JSON.stringify({ vacanciesSavedAt, startersSavedAt, leaversSavedAt });
+          it(`should show a warning saying ${expectedWarningMessage} if ${caseName}`, async () => {
+            const overrides = {
+              checkCqcDetails: false,
+              establishment: {
+                ...mockEstablishment,
+                vacanciesSavedAt,
+                startersSavedAt,
+                leaversSavedAt,
+              },
+            };
 
-        const workplaceRow = getByTestId('workplace-row');
-        expect(within(workplaceRow).getByText(expectedWarningMessage)).toBeTruthy();
-        expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
-      });
+            const { getByTestId } = await setup(overrides);
+
+            const workplaceRow = getByTestId('workplace-row');
+            expect(within(workplaceRow).getByText(expectedWarningMessage)).toBeTruthy();
+            expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+          });
+        },
+      );
     });
   });
 
@@ -490,7 +540,7 @@ fdescribe('Summary section', () => {
 
       const staffRecordsRow = getByTestId('staff-records-row');
       expect(within(staffRecordsRow).getByText('You can start to add your staff records now')).toBeTruthy();
-      expect(getByTestId('orange-flag')).toBeTruthy();
+      expect(within(staffRecordsRow).getByTestId('orange-flag')).toBeTruthy();
     });
 
     it('should navigate to sub staff records page when clicking on start to add your staff message in sub view', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -20,7 +20,7 @@ import { Establishment } from '../../../../mockdata/establishment';
 import { SummarySectionComponent } from './summary-section.component';
 import userEvent from '@testing-library/user-event';
 
-describe('Summary section', () => {
+fdescribe('Summary section', () => {
   const setup = async (overrides: any = {}) => {
     const setupTools = await render(SummarySectionComponent, {
       imports: [SharedModule, RouterModule],
@@ -330,64 +330,34 @@ describe('Summary section', () => {
       expect(within(workplaceRow).queryByText('Staff total does not match number of staff records')).toBeFalsy();
     });
 
-    it('should show a warning saying that vacancy and turnover data has not been added if they have not been added', async () => {
-      const establishment = { ...Establishment, leavers: null, vacancies: null, starters: null };
+    const testCasesForAddYourVacancyStarterLeaverMessages = [
+      { leavers: null, vacancies: null, starters: null, expected: 'Add your vacancy, starters and leavers data' },
 
-      const overrides = {
-        checkCqcDetails: false,
-        establishment,
-      };
+      { leavers: null, vacancies: null, starters: 'None', expected: 'Add your vacancy data' },
+      { leavers: 'None', vacancies: null, starters: null, expected: 'Add your vacancy data' },
+      { leavers: 'None', vacancies: null, starters: `Don't know`, expected: 'Add your vacancy data' },
 
-      const { getByTestId } = await setup(overrides);
+      { leavers: null, vacancies: 'None', starters: null, expected: 'Add your starters and leavers data' },
+      { leavers: 'None', vacancies: 'With Jobs', starters: null, expected: 'Add your starters and leavers data' },
+      { leavers: null, vacancies: 'With Jobs', starters: 'None', expected: 'Add your starters and leavers data' },
+    ];
 
-      const workplaceRow = getByTestId('workplace-row');
-      expect(within(workplaceRow).getByText(`Add your vacancy, starters and leavers data`)).toBeTruthy();
-      expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
-    });
+    testCasesForAddYourVacancyStarterLeaverMessages.forEach((testcase) => {
+      const { leavers, vacancies, starters, expected: expectedWarningMessage } = testcase;
+      it(`should show a warning saying '${expectedWarningMessage}' when vacancies=${vacancies}, starters=${starters}, leavers=${leavers} })}`, async () => {
+        const establishment = { ...Establishment, leavers, vacancies, starters };
 
-    it('should show a warning saying that no vacancy data has been added if it has not been added, but starters data has been added', async () => {
-      const establishment = { ...Establishment, leavers: null, vacancies: null, starters: 'None' };
+        const overrides = {
+          checkCqcDetails: false,
+          establishment,
+        };
 
-      const overrides = {
-        checkCqcDetails: false,
-        establishment,
-      };
+        const { getByTestId } = await setup(overrides);
 
-      const { getByTestId } = await setup(overrides);
-
-      const workplaceRow = getByTestId('workplace-row');
-      expect(within(workplaceRow).getByText(`Add your vacancy data`)).toBeTruthy();
-      expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
-    });
-
-    it('should show a warning saying that no vacancy data has been added if it has not been added, but leavers data has been added', async () => {
-      const establishment = { ...Establishment, leavers: 'None', vacancies: null, starters: null };
-
-      const overrides = {
-        checkCqcDetails: false,
-        establishment,
-      };
-
-      const { getByTestId } = await setup(overrides);
-
-      const workplaceRow = getByTestId('workplace-row');
-      expect(within(workplaceRow).getByText(`Add your vacancy data`)).toBeTruthy();
-      expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
-    });
-
-    it('should show a warning saying that no vacancy data has been added if it has not been added, but both starters and leavers data has been added', async () => {
-      const establishment = { ...Establishment, leavers: 'None', vacancies: null, starters: `Don't know` };
-
-      const overrides = {
-        checkCqcDetails: false,
-        establishment,
-      };
-
-      const { getByTestId } = await setup(overrides);
-
-      const workplaceRow = getByTestId('workplace-row');
-      expect(within(workplaceRow).getByText(`Add your vacancy data`)).toBeTruthy();
-      expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+        const workplaceRow = getByTestId('workplace-row');
+        expect(within(workplaceRow).getByText(expectedWarningMessage)).toBeTruthy();
+        expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+      });
     });
   });
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -1,3 +1,6 @@
+import dayjs from 'dayjs';
+import { of } from 'rxjs';
+
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
@@ -13,14 +16,12 @@ import { MockTabsService } from '@core/test-utils/MockTabsService';
 import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
-import dayjs from 'dayjs';
-import { of } from 'rxjs';
+import userEvent from '@testing-library/user-event';
 
 import { Establishment } from '../../../../mockdata/establishment';
 import { SummarySectionComponent } from './summary-section.component';
-import userEvent from '@testing-library/user-event';
 
-fdescribe('Summary section', () => {
+describe('Summary section', () => {
   const setup = async (overrides: any = {}) => {
     const setupTools = await render(SummarySectionComponent, {
       imports: [SharedModule, RouterModule],
@@ -331,15 +332,15 @@ fdescribe('Summary section', () => {
     });
 
     const testCasesForAddYourVacancyStarterLeaverMessages = [
-      { leavers: null, vacancies: null, starters: null, expected: 'Add your vacancy, starters and leavers data' },
+      { vacancies: null, starters: null, leavers: null, expected: 'Add your vacancy, starters and leavers data' },
 
-      { leavers: null, vacancies: null, starters: 'None', expected: 'Add your vacancy data' },
-      { leavers: 'None', vacancies: null, starters: null, expected: 'Add your vacancy data' },
-      { leavers: 'None', vacancies: null, starters: `Don't know`, expected: 'Add your vacancy data' },
+      { vacancies: null, starters: null, leavers: 'None', expected: 'Add your vacancy and starters data' },
+      { vacancies: null, starters: 'None', leavers: null, expected: 'Add your vacancy and leavers data' },
+      { vacancies: 'None', starters: null, leavers: null, expected: 'Add your starters and leavers data' },
 
-      { leavers: null, vacancies: 'None', starters: null, expected: 'Add your starters and leavers data' },
-      { leavers: 'None', vacancies: 'With Jobs', starters: null, expected: 'Add your starters and leavers data' },
-      { leavers: null, vacancies: 'With Jobs', starters: 'None', expected: 'Add your starters and leavers data' },
+      { vacancies: null, starters: `Don't know`, leavers: 'None', expected: 'Add your vacancy data' },
+      { vacancies: 'With Jobs', starters: null, leavers: 'None', expected: 'Add your starters data' },
+      { vacancies: 'With Jobs', starters: 'None', leavers: null, expected: 'Add your leavers data' },
     ];
 
     testCasesForAddYourVacancyStarterLeaverMessages.forEach((testcase) => {
@@ -380,19 +381,19 @@ fdescribe('Summary section', () => {
           vacanciesSavedAt: moreThanOneYearAgo,
           startersSavedAt: moreThanOneYearAgo,
           leaversSavedAt: moreThanOneYearAgo,
-          expected: 'Update your starter, leaver and vacancy data',
+          expected: 'Update your staff vacancy, starters and leavers data',
         },
         {
           vacanciesSavedAt: moreThanOneYearAgo,
           startersSavedAt: moreThanOneYearAgo,
           leaversSavedAt: lessThanOneYearAgo,
-          expected: 'Update your staff vacancy data',
+          expected: 'Update your staff vacancy and starters data',
         },
         {
           vacanciesSavedAt: moreThanOneYearAgo,
           startersSavedAt: lessThanOneYearAgo,
           leaversSavedAt: moreThanOneYearAgo,
-          expected: 'Update your staff vacancy data',
+          expected: 'Update your staff vacancy and leavers data',
         },
         {
           vacanciesSavedAt: lessThanOneYearAgo,
@@ -406,18 +407,17 @@ fdescribe('Summary section', () => {
           leaversSavedAt: lessThanOneYearAgo,
           expected: 'Update your staff vacancy data',
         },
-
-        {
-          vacanciesSavedAt: lessThanOneYearAgo,
-          startersSavedAt: lessThanOneYearAgo,
-          leaversSavedAt: moreThanOneYearAgo,
-          expected: 'Update your starters and leavers data',
-        },
         {
           vacanciesSavedAt: lessThanOneYearAgo,
           startersSavedAt: moreThanOneYearAgo,
           leaversSavedAt: lessThanOneYearAgo,
-          expected: 'Update your starters and leavers data',
+          expected: 'Update your starters data',
+        },
+        {
+          vacanciesSavedAt: lessThanOneYearAgo,
+          startersSavedAt: lessThanOneYearAgo,
+          leaversSavedAt: moreThanOneYearAgo,
+          expected: 'Update your leavers data',
         },
       ];
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -359,6 +359,41 @@ fdescribe('Summary section', () => {
         expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
       });
     });
+
+    describe('Update your starter, leaver and vacancy data', () => {
+      const mockTimeNow = '2026-05-14';
+      const moreThanOneYearAgo = '2025-05-13T00:00:00.000Z';
+
+      beforeEach(() => {
+        jasmine.clock().install();
+        jasmine.clock().mockDate(new Date(mockTimeNow));
+      });
+      afterEach(() => {
+        jasmine.clock().uninstall();
+      });
+
+      it('should show a warning saying "Update your starter, leaver and vacancy data" if all of them are over 12 months old', async () => {
+        const mockEstablishment = { ...Establishment, leavers: 'None', vacancies: 'None', starters: 'None' };
+
+        const overrides = {
+          checkCqcDetails: false,
+          establishment: {
+            ...mockEstablishment,
+            vacanciesSavedAt: moreThanOneYearAgo,
+            startersSavedAt: moreThanOneYearAgo,
+            leaversSavedAt: moreThanOneYearAgo,
+          },
+        };
+
+        const expectedWarningMessage = 'Update your starter, leaver and vacancy data';
+
+        const { getByTestId } = await setup(overrides);
+
+        const workplaceRow = getByTestId('workplace-row');
+        expect(within(workplaceRow).getByText(expectedWarningMessage)).toBeTruthy();
+        expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+      });
+    });
   });
 
   describe('staff record summary section', () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -151,7 +151,10 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
       this.sections[0].message = `Add your vacancy, starters and leavers data`;
     } else if (!vacancies && (leavers || starters)) {
       this.sections[0].message = `Add your vacancy data`;
+    } else if (vacancies && !(leavers && starters)) {
+      this.sections[0].message = `Add your starters and leavers data`;
     }
+
     this.showViewSummaryLinks(this.sections[0].linkText);
   }
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -7,6 +7,7 @@ import { Worker } from '@core/model/worker.model';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PayAndPensionService } from '@core/services/pay-and-pension.service';
 import { TabsService } from '@core/services/tabs.service';
+import { DateUtil } from '@core/utils/date-util';
 import dayjs from 'dayjs';
 import { Subscription } from 'rxjs';
 
@@ -158,10 +159,22 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
       this.sections[0].message = 'Staff total does not match number of staff records';
     } else if (!vacancies && !leavers && !starters) {
       this.sections[0].message = `Add your vacancy, starters and leavers data`;
-    } else if (!vacancies && (leavers || starters)) {
+    } else if (!vacancies) {
       this.sections[0].message = `Add your vacancy data`;
-    } else if (vacancies && !(leavers && starters)) {
+    } else if (!leavers || !starters) {
       this.sections[0].message = `Add your starters and leavers data`;
+    } else {
+      const vacanciesOverOneYear = DateUtil.isMoreThanOneYearAgo(vacanciesSavedAt);
+      const startersOverOneYear = DateUtil.isMoreThanOneYearAgo(startersSavedAt);
+      const leaversOverOneYear = DateUtil.isMoreThanOneYearAgo(leaversSavedAt);
+
+      if (vacanciesOverOneYear && startersOverOneYear && leaversOverOneYear) {
+        this.sections[0].message = `Update your starter, leaver and vacancy data`;
+      } else if (vacanciesOverOneYear) {
+        this.sections[0].message = `Update your staff vacancy data`;
+      } else if (startersOverOneYear || leaversOverOneYear) {
+        this.sections[0].message = `Update your starters and leavers data`;
+      }
     }
 
     this.showViewSummaryLinks(this.sections[0].linkText);

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -267,17 +267,6 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     return afterWorkerCreated;
   }
 
-  checkVacanciesStartersLeaversLastSavedDates() {
-    const { vacanciesSavedAt, startersSavedAt, leaversSavedAt } = this.workplace;
-    const today = dayjs();
-
-    const vacanciesOverOneYear = dayjs(vacanciesSavedAt).add(12, 'M').isBefore(today, 'day');
-    const startersOverOneYear = dayjs(startersSavedAt).add(12, 'M').isBefore(today, 'day');
-    const leaversOverOneYear = dayjs(leaversSavedAt).add(12, 'M').isBefore(today, 'day');
-
-    return { vacanciesOverOneYear, startersOverOneYear, leaversOverOneYear };
-  }
-
   private showInternationalRecruitmentMessage(): void {
     const singularQuestion = 'Is this worker on a Health and Care Worker visa?';
     const pluralQuestion = 'Are these workers on Health and Care Worker visas?';

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -89,6 +89,8 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.getWorkplaceSummaryMessage();
+    this.showViewSummaryLinks(this.sections[0].linkText);
+
     this.getStaffCreatedDate();
     this.getStaffSummaryMessage();
     this.getTrainingAndQualsSummary();
@@ -146,38 +148,49 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
 
     if (showAddWorkplaceDetailsBanner) {
       this.sections[0].message = 'Finish adding your workplace data';
-    } else if (this.showCheckCqcDetails) {
+      return;
+    }
+    if (this.showCheckCqcDetails) {
       this.sections[0].message = 'Your workplace details do not match your CQC details';
-    } else if (numberOfStaff === undefined || numberOfStaff === null) {
-      this.sections[0].message = `You've not added your total number of staff`;
-      this.sections[0].redFlag = true;
-    } else if (
-      numberOfStaff !== this.workerCount &&
-      this.afterEightWeeksFromFirstLogin() &&
-      this.canViewListOfWorkers
-    ) {
-      this.sections[0].message = 'Staff total does not match number of staff records';
-    } else if (!vacancies && !leavers && !starters) {
-      this.sections[0].message = `Add your vacancy, starters and leavers data`;
-    } else if (!vacancies) {
-      this.sections[0].message = `Add your vacancy data`;
-    } else if (!leavers || !starters) {
-      this.sections[0].message = `Add your starters and leavers data`;
-    } else {
-      const vacanciesOverOneYear = DateUtil.isMoreThanOneYearAgo(vacanciesSavedAt);
-      const startersOverOneYear = DateUtil.isMoreThanOneYearAgo(startersSavedAt);
-      const leaversOverOneYear = DateUtil.isMoreThanOneYearAgo(leaversSavedAt);
-
-      if (vacanciesOverOneYear && startersOverOneYear && leaversOverOneYear) {
-        this.sections[0].message = `Update your starter, leaver and vacancy data`;
-      } else if (vacanciesOverOneYear) {
-        this.sections[0].message = `Update your staff vacancy data`;
-      } else if (startersOverOneYear || leaversOverOneYear) {
-        this.sections[0].message = `Update your starters and leavers data`;
-      }
+      return;
     }
 
-    this.showViewSummaryLinks(this.sections[0].linkText);
+    if (numberOfStaff === undefined || numberOfStaff === null) {
+      this.sections[0].message = `You've not added your total number of staff`;
+      this.sections[0].redFlag = true;
+      return;
+    }
+
+    if (numberOfStaff !== this.workerCount && this.afterEightWeeksFromFirstLogin() && this.canViewListOfWorkers) {
+      this.sections[0].message = 'Staff total does not match number of staff records';
+      return;
+    }
+
+    if (!vacancies && !leavers && !starters) {
+      this.sections[0].message = `Add your vacancy, starters and leavers data`;
+      return;
+    } else if (!vacancies) {
+      this.sections[0].message = `Add your vacancy data`;
+      return;
+    } else if (!leavers || !starters) {
+      this.sections[0].message = `Add your starters and leavers data`;
+      return;
+    }
+
+    const vacanciesOverOneYear = DateUtil.isMoreThanOneYearAgo(vacanciesSavedAt);
+    const startersOverOneYear = DateUtil.isMoreThanOneYearAgo(startersSavedAt);
+    const leaversOverOneYear = DateUtil.isMoreThanOneYearAgo(leaversSavedAt);
+
+    if (vacanciesOverOneYear && startersOverOneYear && leaversOverOneYear) {
+      this.sections[0].message = `Update your starter, leaver and vacancy data`;
+      return;
+    } else if (vacanciesOverOneYear) {
+      this.sections[0].message = `Update your staff vacancy data`;
+      return;
+    } else if (startersOverOneYear || leaversOverOneYear) {
+      this.sections[0].message = `Update your starters and leavers data`;
+      return;
+    }
   }
 
   private afterEightWeeksFromFirstLogin(): boolean {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -8,6 +8,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { PayAndPensionService } from '@core/services/pay-and-pension.service';
 import { TabsService } from '@core/services/tabs.service';
 import { DateUtil } from '@core/utils/date-util';
+import { FormatUtil } from '@core/utils/format-util';
 import dayjs from 'dayjs';
 import { Subscription } from 'rxjs';
 
@@ -166,14 +167,14 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (!vacancies && !leavers && !starters) {
-      this.sections[0].message = `Add your vacancy, starters and leavers data`;
-      return;
-    } else if (!vacancies) {
-      this.sections[0].message = `Add your vacancy data`;
-      return;
-    } else if (!leavers || !starters) {
-      this.sections[0].message = `Add your starters and leavers data`;
+    const notAllTurnoverDataAnswered = [vacancies, leavers, starters].some((value) => !value);
+    if (notAllTurnoverDataAnswered) {
+      const missingOnes = Object.entries({ vacancy: vacancies, starters, leavers })
+        .filter(([_key, value]) => !value)
+        .map(([key, _value]) => key);
+
+      const message = `Add your ${FormatUtil.joinNouns(missingOnes)} data`;
+      this.sections[0].message = message;
       return;
     }
 
@@ -181,14 +182,19 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     const startersOverOneYear = DateUtil.isMoreThanOneYearAgo(startersSavedAt);
     const leaversOverOneYear = DateUtil.isMoreThanOneYearAgo(leaversSavedAt);
 
-    if (vacanciesOverOneYear && startersOverOneYear && leaversOverOneYear) {
-      this.sections[0].message = `Update your starter, leaver and vacancy data`;
-      return;
-    } else if (vacanciesOverOneYear) {
-      this.sections[0].message = `Update your staff vacancy data`;
-      return;
-    } else if (startersOverOneYear || leaversOverOneYear) {
-      this.sections[0].message = `Update your starters and leavers data`;
+    const someDataOutdated = [vacanciesOverOneYear, startersOverOneYear, leaversOverOneYear].some((x) => x);
+
+    if (someDataOutdated) {
+      const outdatedOnes = [
+        ['staff vacancy', vacanciesOverOneYear],
+        ['starters', startersOverOneYear],
+        ['leavers', leaversOverOneYear],
+      ]
+        .filter(([_key, outdated]) => outdated)
+        .map(([key, _outdated]) => key) as string[];
+
+      const message = `Update your ${FormatUtil.joinNouns(outdatedOnes)} data`;
+      this.sections[0].message = message;
       return;
     }
   }

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -131,7 +131,16 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   };
 
   public getWorkplaceSummaryMessage(): void {
-    const { showAddWorkplaceDetailsBanner, numberOfStaff, vacancies, starters, leavers } = this.workplace;
+    const {
+      showAddWorkplaceDetailsBanner,
+      numberOfStaff,
+      vacancies,
+      starters,
+      leavers,
+      vacanciesSavedAt,
+      startersSavedAt,
+      leaversSavedAt,
+    } = this.workplace;
     this.sections[0].redFlag = false;
 
     if (showAddWorkplaceDetailsBanner) {
@@ -224,6 +233,17 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     const workerLatestCreatedDate = new Date(Math.max(...this.workersCreatedDate));
     const afterWorkerCreated = dayjs(workerLatestCreatedDate).add(12, 'M');
     return afterWorkerCreated;
+  }
+
+  checkVacanciesStartersLeaversLastSavedDates() {
+    const { vacanciesSavedAt, startersSavedAt, leaversSavedAt } = this.workplace;
+    const today = dayjs();
+
+    const vacanciesOverOneYear = dayjs(vacanciesSavedAt).add(12, 'M').isBefore(today, 'day');
+    const startersOverOneYear = dayjs(startersSavedAt).add(12, 'M').isBefore(today, 'day');
+    const leaversOverOneYear = dayjs(leaversSavedAt).add(12, 'M').isBefore(today, 'day');
+
+    return { vacanciesOverOneYear, startersOverOneYear, leaversOverOneYear };
   }
 
   private showInternationalRecruitmentMessage(): void {


### PR DESCRIPTION
#### Work done
- Amend the messages related to vacancy / starters / leavers in summary-section.component. Add new messages to reminder user update answer that is longer than 1 year.
- Amend backend class to include `vacanciesSavedAt` / `startersSavedAt` / `leaversSavedAt` in establishment json object
- Amend `shouldShowFlagOnWorkplace` sql in backend to match the change in summary panel

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
