### PR TITLE
Feat/1951 1952 existing user account details and flag

### DIFF
--- a/backend/migrations/20260624141816-addViewedUserResearchQuestionToUserTable.js
+++ b/backend/migrations/20260624141816-addViewedUserResearchQuestionToUserTable.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const userTable = {
+  tableName: 'User',
+  schema: 'cqc',
+};
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.addColumn(userTable, 'ViewedUserResearchQuestion', {
+      type: Sequelize.DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    });
+  },
+
+  async down(queryInterface) {
+    return queryInterface.removeColumn(userTable, 'ViewedUserResearchQuestion');
+  },
+};

--- a/backend/server/models/classes/user.js
+++ b/backend/server/models/classes/user.js
@@ -783,6 +783,7 @@ class User {
         // TODO: change to amanaged property
         this._isPrimary = fetchResults.isPrimary;
         this._registrationSurveyCompleted = fetchResults.registrationSurveyCompleted;
+        this._viewedUserResearchQuestion = fetchResults.viewedUserResearchQuestion;
         this._displayStatus = User.statusTranslator(fetchResults.login);
         // if history of the User is also required; attach the association
         //  and order in reverse chronological - note, order on id (not when)
@@ -1097,6 +1098,7 @@ class User {
       myDefaultJSON.migratedUserFirstLogon = migratedUserFirstLogin;
       myDefaultJSON.migratedUser = this._tribalId !== null ? true : false;
       myDefaultJSON.registrationSurveyCompleted = this._registrationSurveyCompleted;
+      myDefaultJSON.viewedUserResearchQuestion = this._viewedUserResearchQuestion;
 
       // TODO: JSON schema validation
       if (showHistory && !showPropertyHistoryOnly) {

--- a/backend/server/models/user.js
+++ b/backend/server/models/user.js
@@ -286,6 +286,12 @@ module.exports = function (sequelize, DataTypes) {
         defaultValue: 0,
         field: 'TrainingCoursesMessageViewedQuantity',
       },
+      viewedUserResearchQuestion: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        field: 'ViewedUserResearchQuestion',
+      },
     },
     {
       tableName: '"User"',

--- a/backend/server/models/user.js
+++ b/backend/server/models/user.js
@@ -559,6 +559,7 @@ module.exports = function (sequelize, DataTypes) {
       'registrationSurveyCompleted',
       'lastViewedVacanciesAndTurnoverMessage',
       'trainingCoursesMessageViewedQuantity',
+      'viewedUserResearchQuestion',
     ];
     const loginTableFlags = ['agreedUpdatedTerms'];
 

--- a/backend/server/routes/accounts/user.js
+++ b/backend/server/routes/accounts/user.js
@@ -1024,6 +1024,7 @@ const updateUserFlags = async (req, res) => {
     'lastViewedVacanciesAndTurnoverMessage',
     'trainingCoursesMessageViewedQuantity',
     'agreedUpdatedTerms',
+    'viewedUserResearchQuestion',
   ];
 
   try {

--- a/frontend/src/app/core/components/header/header.component.html
+++ b/frontend/src/app/core/components/header/header.component.html
@@ -31,8 +31,19 @@
               [routerLink]="['/account-management']"
               class="govuk-header__link"
               routerLinkActive="govuk-link--no-underline"
-              >{{ fullname }}</a
             >
+              @if (showFlagForUsername()) {
+                {{ fullname
+                }}<img
+                  src="/assets/images/flag-orange.svg"
+                  alt="flag"
+                  class="govuk-!-margin-right-0 govuk-!-margin-bottom-1"
+                  style="height: 16px; width: 16px"
+                />
+              } @else {
+                {{ fullname }}
+              }
+            </a>
           </li>
           <li *ngIf="workplaceId && !isOnAdminScreen" class="govuk-header__navigation-item" routerLinkActive="active">
             <a

--- a/frontend/src/app/core/components/header/header.component.spec.ts
+++ b/frontend/src/app/core/components/header/header.component.spec.ts
@@ -4,7 +4,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { provideRouter, Router, RouterModule } from '@angular/router';
 import { Roles } from '@core/model/roles.enum';
-import { UserDetails } from '@core/model/userDetails.model';
+import { InviteResponse, UserDetails } from '@core/model/userDetails.model';
 import { AuthService } from '@core/services/auth.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { NotificationsService } from '@core/services/notifications/notifications.service';
@@ -13,17 +13,21 @@ import { UserService } from '@core/services/user.service';
 import { MockAuthService } from '@core/test-utils/MockAuthService';
 import { MockEstablishmentService } from '@core/test-utils/MockEstablishmentService';
 import { MockNotificationsService } from '@core/test-utils/MockNotificationsService';
-import { EditUser, MockUserService } from '@core/test-utils/MockUserService';
+import { EditUser, mockLoggedInUser, MockUserService } from '@core/test-utils/MockUserService';
 import { render } from '@testing-library/angular';
 import { of } from 'rxjs';
+import lodash from 'lodash';
 
 import { HeaderComponent } from './header.component';
+import { within } from '@testing-library/dom';
 
 describe('HeaderComponent', () => {
   async function setup(overrides: any = {}) {
     const isAdmin = overrides.isAdmin ?? false;
     const role = isAdmin ? Roles.Admin : Roles.Edit;
     const isLoggedIn = overrides.isLoggedIn ?? false;
+
+    const loggedInUser = lodash.merge({}, mockLoggedInUser, overrides.loggedInUser, { role });
     const showNotificationsLink = overrides.showNotificationsLink ?? true;
 
     const setupTools = await render(HeaderComponent, {
@@ -32,7 +36,7 @@ describe('HeaderComponent', () => {
       providers: [
         {
           provide: UserService,
-          useFactory: MockUserService.factory(overrides.subsidiaries ?? 0, role),
+          useFactory: MockUserService.factoryWithOverrides({ loggedInUser }),
           deps: [HttpClient],
         },
         {
@@ -88,6 +92,64 @@ describe('HeaderComponent', () => {
       const nameLink = getByText('John');
 
       expect(nameLink.getAttribute('href')).toEqual('/account-management');
+    });
+
+    it('should show a flag beside user name to notify existing user for UR invite question', async () => {
+      const loggedInUser = { userResearchInviteResponse: null, viewedUserResearchQuestion: false };
+
+      const { getByRole } = await setup({ loggedInUser, isLoggedIn: true });
+      const nameLink = getByRole('link', { name: /John/ });
+
+      expect(nameLink.getAttribute('href')).toEqual('/account-management');
+
+      const flag = within(nameLink).queryByAltText('flag');
+      expect(flag).toBeTruthy();
+    });
+
+    it('should not show the flag for admin user', async () => {
+      const loggedInUser = {
+        userResearchInviteResponse: null,
+        viewedUserResearchQuestion: false,
+        role: Roles.Admin,
+      };
+
+      const { getByRole } = await setup({ loggedInUser, isLoggedIn: true, isAdmin: true });
+      const nameLink = getByRole('link', { name: /John/ });
+
+      expect(nameLink.getAttribute('href')).toEqual('/account-management');
+
+      const flag = within(nameLink).queryByAltText('flag');
+      expect(flag).toBeFalsy();
+    });
+
+    it('should not show the flag if user already answered the UR invite question', async () => {
+      const loggedInUser = {
+        userResearchInviteResponse: InviteResponse.Yes,
+        viewedUserResearchQuestion: false,
+      };
+
+      const { getByRole } = await setup({ loggedInUser, isLoggedIn: true });
+      const nameLink = getByRole('link', { name: /John/ });
+
+      expect(nameLink.getAttribute('href')).toEqual('/account-management');
+
+      const flag = within(nameLink).queryByAltText('flag');
+      expect(flag).toBeFalsy();
+    });
+
+    it('should not show the flag if user already viewed the question', async () => {
+      const loggedInUser = {
+        userResearchInviteResponse: null,
+        viewedUserResearchQuestion: true,
+      };
+
+      const { getByRole } = await setup({ loggedInUser, isLoggedIn: true });
+      const nameLink = getByRole('link', { name: /John/ });
+
+      expect(nameLink.getAttribute('href')).toEqual('/account-management');
+
+      const flag = within(nameLink).queryByAltText('flag');
+      expect(flag).toBeFalsy();
     });
   });
 

--- a/frontend/src/app/core/components/header/header.component.ts
+++ b/frontend/src/app/core/components/header/header.component.ts
@@ -1,11 +1,14 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import lodash from 'lodash';
+import { interval, Subscription } from 'rxjs';
+
+import { Component, computed, Input, OnDestroy, OnInit } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { UserDetails } from '@core/model/userDetails.model';
 import { AuthService } from '@core/services/auth.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { IdleService } from '@core/services/idle.service';
 import { NotificationsService } from '@core/services/notifications/notifications.service';
 import { UserService } from '@core/services/user.service';
-import { interval, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-header',
@@ -22,6 +25,20 @@ export class HeaderComponent implements OnInit, OnDestroy {
   public user: UserDetails;
   public showDropdown = false;
   public workplaceId: string;
+
+  public loggedInUserSignal = toSignal(this.userService.loggedInUser$);
+  public showFlagForUsername = computed(() => {
+    const loggedInUser = this.loggedInUserSignal();
+    if (loggedInUser) {
+      const isNormalUser = !this.isAdminUser();
+      const notViewedTheQuestionYet = !loggedInUser.viewedUserResearchQuestion;
+      const notAnsweredYet = lodash.isNil(loggedInUser.userResearchInviteResponse);
+
+      return isNormalUser && notViewedTheQuestionYet && notAnsweredYet;
+    }
+
+    return false;
+  });
 
   constructor(
     private authService: AuthService,

--- a/frontend/src/app/core/model/summary-list.model.ts
+++ b/frontend/src/app/core/model/summary-list.model.ts
@@ -4,4 +4,6 @@ export interface SummaryList {
   label: string;
   data: string;
   route?: URLStructure;
+  showNewFlag?: boolean;
+  ariaDescription?: string;
 }

--- a/frontend/src/app/core/model/userDetails.model.ts
+++ b/frontend/src/app/core/model/userDetails.model.ts
@@ -19,7 +19,7 @@ export interface UserDetails {
   registrationSurveyCompleted?: boolean;
   securityQuestion?: string;
   securityQuestionAnswer?: string;
-  userResearchInviteResponse?: InviteResponse;
+  userResearchInviteResponse?: InviteResponse | null;
   status?: UserStatus;
   password?: string;
   uid?: string;
@@ -28,6 +28,7 @@ export interface UserDetails {
   username?: string;
   lastViewedVacanciesAndTurnoverMessage?: string;
   trainingCoursesMessageViewedQuantity?: number;
+  viewedUserResearchQuestion?: boolean;
 }
 
 export enum UserStatus {

--- a/frontend/src/app/core/test-utils/MockUserService.ts
+++ b/frontend/src/app/core/test-utils/MockUserService.ts
@@ -129,7 +129,31 @@ export class MockUserService extends UserService {
     };
   }
 
+  public static factoryWithOverrides(overrides: Record<string, any> = {}) {
+    return (httpClient: HttpClient) => {
+      const service = new MockUserService(httpClient);
+
+      Object.keys(overrides).forEach((overrideName) => {
+        switch (overrideName) {
+          case 'loggedInUser': {
+            Object.defineProperty(service, 'loggedInUser', {
+              get: () => overrides.loggedInUser,
+            });
+            break;
+          }
+          default: {
+            service[overrideName] = overrides[overrideName];
+            break;
+          }
+        }
+      });
+
+      return service;
+    };
+  }
+
   public get loggedInUser(): UserDetails {
+    console.log('get prop called');
     return {
       uid: 'mocked-uid',
       email: 'test@developer.com',

--- a/frontend/src/app/core/test-utils/MockUserService.ts
+++ b/frontend/src/app/core/test-utils/MockUserService.ts
@@ -138,6 +138,7 @@ export class MockUserService extends UserService {
           case 'loggedInUser': {
             Object.defineProperty(service, 'loggedInUser', {
               get: () => overrides.loggedInUser,
+              set: () => {},
             });
             break;
           }

--- a/frontend/src/app/core/test-utils/MockUserService.ts
+++ b/frontend/src/app/core/test-utils/MockUserService.ts
@@ -154,7 +154,6 @@ export class MockUserService extends UserService {
   }
 
   public get loggedInUser(): UserDetails {
-    console.log('get prop called');
     return {
       uid: 'mocked-uid',
       email: 'test@developer.com',
@@ -210,6 +209,20 @@ export class MockUserService extends UserService {
     return of({});
   }
 }
+
+export const mockLoggedInUser: UserDetails = {
+  uid: 'mocked-uid',
+  email: 'test@developer.com',
+  fullname: 'John Smith',
+  jobTitle: 'Developer',
+  phone: '01234567890',
+  role: Roles.Edit,
+  securityQuestion: 'Not relevant',
+  securityQuestionAnswer: 'Not relevant',
+  lastLoggedInFromLogin: '2026-06-01T12:34:56.000Z',
+  userResearchInviteResponse: null,
+  viewedUserResearchQuestion: true,
+};
 
 @Injectable()
 export class MockUserServiceWithNoUserDetails extends MockUserService {

--- a/frontend/src/app/features/account-management/your-account/your-account.component.html
+++ b/frontend/src/app/features/account-management/your-account/your-account.component.html
@@ -3,9 +3,16 @@
 
 <app-summary-list [topBorder]="true" [summaryList]="userInfo"></app-summary-list>
 <app-summary-list [topBorder]="true" [summaryList]="loginInfo"></app-summary-list>
-<app-summary-list [topBorder]="true" [summaryList]="securityInfo"></app-summary-list>
 <app-summary-list
-  [wrapBorder]="true"
-  [summaryList]="userResearchInfo"
-  (setReturn)="setViewedUserResearchQuestion()"
+  [topBorder]="showUserResearchRow"
+  [wrapBorder]="!showUserResearchRow"
+  [summaryList]="securityInfo"
 ></app-summary-list>
+
+@if (showUserResearchRow) {
+  <app-summary-list
+    [wrapBorder]="true"
+    [summaryList]="userResearchInfo"
+    (setReturn)="setViewedUserResearchQuestion()"
+  ></app-summary-list>
+}

--- a/frontend/src/app/features/account-management/your-account/your-account.component.html
+++ b/frontend/src/app/features/account-management/your-account/your-account.component.html
@@ -3,4 +3,9 @@
 
 <app-summary-list [topBorder]="true" [summaryList]="userInfo"></app-summary-list>
 <app-summary-list [topBorder]="true" [summaryList]="loginInfo"></app-summary-list>
-<app-summary-list [wrapBorder]="true" [summaryList]="securityInfo"></app-summary-list>
+<app-summary-list [topBorder]="true" [summaryList]="securityInfo"></app-summary-list>
+<app-summary-list
+  [wrapBorder]="true"
+  [summaryList]="userResearchInfo"
+  (setReturn)="setViewedUserResearchQuestion()"
+></app-summary-list>

--- a/frontend/src/app/features/account-management/your-account/your-account.component.spec.ts
+++ b/frontend/src/app/features/account-management/your-account/your-account.component.spec.ts
@@ -1,0 +1,158 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { Router, RouterModule } from '@angular/router';
+import { BackLinkService } from '@core/services/backLink.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
+
+import { AccountManagementModule } from '../account-management.module';
+import { YourAccountComponent } from './your-account.component';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { UserService } from '@core/services/user.service';
+import { MockUserService } from '@core/test-utils/MockUserService';
+import { within } from '@testing-library/dom';
+import { UserDetails } from '@core/model/userDetails.model';
+import { Roles } from '@core/model/roles.enum';
+import userEvent from '@testing-library/user-event';
+
+fdescribe('YourAccountComponent', () => {
+  const mockLoggedInUser: UserDetails = {
+    uid: 'mocked-uid',
+    email: 'test@developer.com',
+    fullname: 'John Smith',
+    jobTitle: 'Developer',
+    phone: '01234567890',
+    role: Roles.Edit,
+    securityQuestion: 'Not relevant',
+    securityQuestionAnswer: 'Not relevant',
+    lastLoggedInFromLogin: '2026-06-01T12:34:56.000Z',
+    userResearchInviteResponse: null,
+    viewedUserResearchQuestion: true,
+  };
+
+  async function setup(overrides: any = {}) {
+    const loggedInUser = overrides?.loggedInUser ?? mockLoggedInUser;
+    const setupTools = await render(YourAccountComponent, {
+      imports: [SharedModule, RouterModule, AccountManagementModule],
+      providers: [
+        BackLinkService,
+        {
+          provide: BreadcrumbService,
+          useClass: MockBreadcrumbService,
+        },
+        { provide: UserService, useFactory: MockUserService.factoryWithOverrides({ loggedInUser }) },
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    const injector = getTestBed();
+    const router = injector.inject(Router) as Router;
+    const component = setupTools.fixture.componentInstance;
+
+    const routerSpy = spyOn(router, 'navigateByUrl');
+    routerSpy.and.returnValue(Promise.resolve(true));
+
+    return {
+      ...setupTools,
+      component,
+      router,
+      routerSpy,
+    };
+  }
+
+  it('should show a h1 heading', async () => {
+    const { getByRole } = await setup();
+
+    const heading = getByRole('heading', { level: 1 });
+    expect(heading.textContent).toEqual('My account details');
+  });
+
+  it('should show a User research sessions row', async () => {
+    const { getByText } = await setup();
+
+    const label = getByText('User research sessions');
+    expect(label).toBeTruthy();
+
+    const row = label.closest('div.govuk-summary-list__row') as HTMLElement;
+
+    const addLink = within(row).getByRole('link', { name: /Add/ }) as HTMLAnchorElement;
+    expect(addLink).toBeTruthy();
+    expect(addLink.href).toContain('/account-management/user-research-invite');
+  });
+
+  it('should show a NEW icon and Add Link when user have not answered and have not seen the user research invite question', async () => {
+    const loggedInUser = {
+      ...mockLoggedInUser,
+      userResearchInviteResponse: null,
+      viewedUserResearchQuestion: false,
+    };
+    const { getByText } = await setup({ loggedInUser });
+
+    const label = getByText('User research sessions');
+    expect(label).toBeTruthy();
+
+    const row = label.closest('div.govuk-summary-list__row') as HTMLElement;
+
+    const newPillIcon = within(row).queryByTestId('new-pill');
+    expect(newPillIcon).toBeTruthy();
+  });
+
+  it('should not show the NEW icon if user have seen the user research invite question', async () => {
+    const loggedInUser = {
+      ...mockLoggedInUser,
+      viewedUserResearchQuestion: true,
+    };
+    const { getByText } = await setup({ loggedInUser });
+
+    const label = getByText('User research sessions');
+    expect(label).toBeTruthy();
+
+    const row = label.closest('div.govuk-summary-list__row') as HTMLElement;
+
+    const newPillIcon = within(row).queryByTestId('new-pill');
+    expect(newPillIcon).toBeFalsy();
+
+    const addLink = within(row).getByRole('link', { name: /Add/ }) as HTMLAnchorElement;
+    expect(addLink.href).toContain('/account-management/user-research-invite');
+  });
+
+  ['Yes', 'No'].forEach((answer) => {
+    it('should show a change link and hide the NEW icon if user have answered the user research invite question', async () => {
+      const loggedInUser = {
+        ...mockLoggedInUser,
+        viewedUserResearchQuestion: false,
+        userResearchInviteResponse: answer,
+      };
+
+      const { getByText } = await setup({ loggedInUser });
+
+      const label = getByText('User research sessions');
+      expect(label).toBeTruthy();
+
+      const row = label.closest('div.govuk-summary-list__row') as HTMLElement;
+
+      const newPillIcon = within(row).queryByTestId('new-pill');
+      expect(newPillIcon).toBeFalsy();
+
+      const changeLink = within(row).getByRole('link', { name: /Change/ }) as HTMLAnchorElement;
+      expect(changeLink.href).toContain('/account-management/user-research-invite');
+    });
+  });
+
+  it('should update the user flag for "viewedUserResearchQuestion" when user clicked the Add link', async () => {
+    const { getByText } = await setup();
+
+    const label = getByText('User research sessions');
+    expect(label).toBeTruthy();
+
+    const row = label.closest('div.govuk-summary-list__row') as HTMLElement;
+
+    const addLink = within(row).getByRole('link', { name: /Add/ }) as HTMLAnchorElement;
+    userEvent.click(addLink);
+
+    expect();
+  });
+});

--- a/frontend/src/app/features/account-management/your-account/your-account.component.spec.ts
+++ b/frontend/src/app/features/account-management/your-account/your-account.component.spec.ts
@@ -16,6 +16,7 @@ import { within } from '@testing-library/dom';
 import { UserDetails } from '@core/model/userDetails.model';
 import { Roles } from '@core/model/roles.enum';
 import userEvent from '@testing-library/user-event';
+import { of } from 'rxjs';
 
 fdescribe('YourAccountComponent', () => {
   const mockLoggedInUser: UserDetails = {
@@ -55,11 +56,14 @@ fdescribe('YourAccountComponent', () => {
     const routerSpy = spyOn(router, 'navigateByUrl');
     routerSpy.and.returnValue(Promise.resolve(true));
 
+    const userService = injector.inject(UserService) as UserService;
+
     return {
       ...setupTools,
       component,
       router,
       routerSpy,
+      userService,
     };
   }
 
@@ -70,7 +74,7 @@ fdescribe('YourAccountComponent', () => {
     expect(heading.textContent).toEqual('My account details');
   });
 
-  it('should show a User research sessions row', async () => {
+  it('should show a User research sessions row for normal user', async () => {
     const { getByText } = await setup();
 
     const label = getByText('User research sessions');
@@ -81,6 +85,17 @@ fdescribe('YourAccountComponent', () => {
     const addLink = within(row).getByRole('link', { name: /Add/ }) as HTMLAnchorElement;
     expect(addLink).toBeTruthy();
     expect(addLink.href).toContain('/account-management/user-research-invite');
+  });
+
+  it('should not show the User research sessions row for admin user', async () => {
+    const loggedInUser = {
+      ...mockLoggedInUser,
+      role: 'Admin',
+    };
+    const { queryByText } = await setup({ loggedInUser });
+
+    const label = queryByText('User research sessions');
+    expect(label).toBeFalsy();
   });
 
   it('should show a NEW icon and Add Link when user have not answered and have not seen the user research invite question', async () => {
@@ -143,7 +158,13 @@ fdescribe('YourAccountComponent', () => {
   });
 
   it('should update the user flag for "viewedUserResearchQuestion" when user clicked the Add link', async () => {
-    const { getByText } = await setup();
+    const loggedInUser = {
+      ...mockLoggedInUser,
+      userResearchInviteResponse: null,
+      viewedUserResearchQuestion: false,
+    };
+    const { fixture, getByText, userService } = await setup({ loggedInUser });
+    spyOn(userService, 'updateUserFlags').and.returnValue(of({}));
 
     const label = getByText('User research sessions');
     expect(label).toBeTruthy();
@@ -153,6 +174,8 @@ fdescribe('YourAccountComponent', () => {
     const addLink = within(row).getByRole('link', { name: /Add/ }) as HTMLAnchorElement;
     userEvent.click(addLink);
 
-    expect();
+    await fixture.whenStable();
+
+    expect(userService.updateUserFlags).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/features/account-management/your-account/your-account.component.spec.ts
+++ b/frontend/src/app/features/account-management/your-account/your-account.component.spec.ts
@@ -1,38 +1,23 @@
+import { of } from 'rxjs';
+
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { Router, RouterModule } from '@angular/router';
 import { BackLinkService } from '@core/services/backLink.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
+import { UserService } from '@core/services/user.service';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { mockLoggedInUser, MockUserService } from '@core/test-utils/MockUserService';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
+import { within } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 
 import { AccountManagementModule } from '../account-management.module';
 import { YourAccountComponent } from './your-account.component';
-import { BreadcrumbService } from '@core/services/breadcrumb.service';
-import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
-import { UserService } from '@core/services/user.service';
-import { MockUserService } from '@core/test-utils/MockUserService';
-import { within } from '@testing-library/dom';
-import { UserDetails } from '@core/model/userDetails.model';
-import { Roles } from '@core/model/roles.enum';
-import userEvent from '@testing-library/user-event';
-import { of } from 'rxjs';
 
-fdescribe('YourAccountComponent', () => {
-  const mockLoggedInUser: UserDetails = {
-    uid: 'mocked-uid',
-    email: 'test@developer.com',
-    fullname: 'John Smith',
-    jobTitle: 'Developer',
-    phone: '01234567890',
-    role: Roles.Edit,
-    securityQuestion: 'Not relevant',
-    securityQuestionAnswer: 'Not relevant',
-    lastLoggedInFromLogin: '2026-06-01T12:34:56.000Z',
-    userResearchInviteResponse: null,
-    viewedUserResearchQuestion: true,
-  };
-
+describe('YourAccountComponent', () => {
   async function setup(overrides: any = {}) {
     const loggedInUser = overrides?.loggedInUser ?? mockLoggedInUser;
     const setupTools = await render(YourAccountComponent, {

--- a/frontend/src/app/features/account-management/your-account/your-account.component.ts
+++ b/frontend/src/app/features/account-management/your-account/your-account.component.ts
@@ -4,7 +4,9 @@ import { SummaryList } from '@core/model/summary-list.model';
 import { UserDetails } from '@core/model/userDetails.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { UserService } from '@core/services/user.service';
+import { isAdminRole } from '@core/utils/check-role-util';
 import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-your-account-summary',
@@ -20,6 +22,7 @@ export class YourAccountComponent implements OnInit, OnDestroy {
   public securityInfo: SummaryList[];
   public userInfo: SummaryList[];
   public userResearchInfo: SummaryList[];
+  public showUserResearchRow: boolean;
 
   constructor(
     private userService: UserService,
@@ -34,6 +37,7 @@ export class YourAccountComponent implements OnInit, OnDestroy {
         if (user) {
           this.user = user;
           this.setAccountDetails();
+          this.showUserResearchRow = !isAdminRole(user.role);
         }
       }),
     );
@@ -107,7 +111,12 @@ export class YourAccountComponent implements OnInit, OnDestroy {
     }
 
     const update = { viewedUserResearchQuestion: true };
-    this.subscriptions.add(this.userService.updateUserFlags(this.user.uid!, update).subscribe());
+    this.userService
+      .updateUserFlags(this.user.uid!, update)
+      .pipe(take(1))
+      .subscribe(() => {
+        this.userService.loggedInUser = { ...this.user, ...update };
+      });
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/features/account-management/your-account/your-account.component.ts
+++ b/frontend/src/app/features/account-management/your-account/your-account.component.ts
@@ -7,19 +7,24 @@ import { UserService } from '@core/services/user.service';
 import { Subscription } from 'rxjs';
 
 @Component({
-    selector: 'app-your-account-summary',
-    templateUrl: './your-account.component.html',
-    standalone: false
+  selector: 'app-your-account-summary',
+  templateUrl: './your-account.component.html',
+  standalone: false,
 })
 export class YourAccountComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
-  public loginInfo: SummaryList[];
-  public securityInfo: SummaryList[];
   public user: UserDetails;
-  public userInfo: SummaryList[];
   public username: string;
 
-  constructor(private userService: UserService, private breadcrumbService: BreadcrumbService) {}
+  public loginInfo: SummaryList[];
+  public securityInfo: SummaryList[];
+  public userInfo: SummaryList[];
+  public userResearchInfo: SummaryList[];
+
+  constructor(
+    private userService: UserService,
+    private breadcrumbService: BreadcrumbService,
+  ) {}
 
   ngOnInit() {
     this.breadcrumbService.show(JourneyType.ACCOUNT);
@@ -35,11 +40,15 @@ export class YourAccountComponent implements OnInit, OnDestroy {
   }
 
   private setAccountDetails(): void {
+    const showFlagForUserResearchQuestion =
+      !this.user.viewedUserResearchQuestion && !this.user.userResearchInviteResponse;
+
     this.userInfo = [
       {
         label: 'Full name',
         data: this.user.fullname,
         route: { url: ['/account-management/change-your-details'] },
+        ariaDescription: 'your personal details',
       },
       {
         label: 'Job title',
@@ -60,6 +69,7 @@ export class YourAccountComponent implements OnInit, OnDestroy {
         label: 'Username',
         data: this.user.username,
         route: { url: ['/account-management/change-password'] },
+        ariaDescription: 'your password',
       },
       {
         label: 'Password',
@@ -72,12 +82,32 @@ export class YourAccountComponent implements OnInit, OnDestroy {
         label: 'Security question',
         data: this.user.securityQuestion,
         route: { url: ['/account-management/change-user-security'] },
+        ariaDescription: 'your security question and answer',
       },
       {
         label: 'Security answer',
         data: this.user.securityQuestionAnswer,
       },
     ];
+
+    this.userResearchInfo = [
+      {
+        label: 'User research sessions',
+        data: this.user.userResearchInviteResponse,
+        route: { url: ['/account-management/user-research-invite'] },
+        showNewFlag: showFlagForUserResearchQuestion,
+        ariaDescription: 'your reply regarding taking part in our user research sessions',
+      },
+    ];
+  }
+
+  public setViewedUserResearchQuestion(): void {
+    if (this.user.viewedUserResearchQuestion) {
+      return;
+    }
+
+    const update = { viewedUserResearchQuestion: true };
+    this.subscriptions.add(this.userService.updateUserFlags(this.user.uid!, update).subscribe());
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/shared/components/summary-list/summary-list.component.html
+++ b/frontend/src/app/shared/components/summary-list/summary-list.component.html
@@ -8,6 +8,20 @@
     @for (item of summaryList; track $index) {
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
+          @if (item.showNewFlag) {
+            <!-- <img
+              class="asc-red-pill-icon--m-size"
+              src="/assets/images/big-red-pill.svg"
+              data-testid="new-pill"
+              alt="new"
+            /> -->
+            <img
+              class="asc-red-pill-icon--m-size govuk-!-margin-right-2"
+              src="/assets/images/new-icon.png"
+              data-testid="new-pill"
+              alt="new"
+            />
+          }
           {{ item.label }}
         </dt>
         @if (item.label === 'Password' && displayShowPasswordToggle) {
@@ -19,12 +33,13 @@
               role="button"
               (click)="togglePassword($event)"
             >
-            @if (showPassword) {
-              Hide
-            } @else {
-              Show
-            }
-            password</a>
+              @if (showPassword) {
+                Hide
+              } @else {
+                Show
+              }
+              password</a
+            >
           </dd>
         } @else {
           <dd class="govuk-summary-list__value asc__preline">
@@ -39,12 +54,14 @@
           @if (canNavigate === undefined ? true : canNavigate) {
             <dd class="govuk-summary-list__actions">
               <a [routerLink]="item.route.url" (click)="emitSetReturn()">
-                @if (item.data === null) {
+                @if (!item.data) {
                   Add
                 } @else {
                   Change
                 }
-                <span class="govuk-visually-hidden"> {{ item.label.toLowerCase() }}</span>
+                <span class="govuk-visually-hidden">
+                  {{ item.ariaDescription ? item.ariaDescription : item.label.toLowerCase() }}
+                </span>
               </a>
             </dd>
           }

--- a/frontend/src/app/shared/components/summary-list/summary-list.component.scss
+++ b/frontend/src/app/shared/components/summary-list/summary-list.component.scss
@@ -1,0 +1,4 @@
+.govuk-summary-list__key > .asc-red-pill-icon--m-size {
+  vertical-align: middle;
+  padding-bottom: 3px;
+}

--- a/frontend/src/app/shared/components/summary-list/summary-list.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-list/summary-list.component.spec.ts
@@ -1,7 +1,7 @@
 import { render, fireEvent } from '@testing-library/angular';
 import { SummaryListComponent } from './summary-list.component';
 
-fdescribe('SummaryListComponent', () => {
+describe('SummaryListComponent', () => {
   async function setup(summaryList = [{ label: 'Full name', data: 'John Doe' }], displayShowPasswordToggle = false) {
     const setupTools = await render(SummaryListComponent, {
       imports: [],

--- a/frontend/src/app/shared/components/summary-list/summary-list.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-list/summary-list.component.spec.ts
@@ -1,15 +1,15 @@
 import { render, fireEvent } from '@testing-library/angular';
 import { SummaryListComponent } from './summary-list.component';
 
-describe('SummaryListComponent', () => {
+fdescribe('SummaryListComponent', () => {
   async function setup(summaryList = [{ label: 'Full name', data: 'John Doe' }], displayShowPasswordToggle = false) {
     const setupTools = await render(SummaryListComponent, {
       imports: [],
       componentProperties: {
         summaryList,
-        displayShowPasswordToggle
-      }
-    })
+        displayShowPasswordToggle,
+      },
+    });
 
     const component = setupTools.fixture.componentInstance;
 
@@ -31,51 +31,45 @@ describe('SummaryListComponent', () => {
       expect(queryByText('Full name')).toBeTruthy();
       expect(queryByText('John Doe')).toBeTruthy();
     });
-  })
+  });
 
   describe('With a change link', () => {
     it('should show the summary list label and value', async () => {
       const mockListWithLink = [
-        { label: 'Full name',
+        {
+          label: 'Full name',
           data: 'John Doe',
-          route: { url: ['/registration/confirm-details/user-research-invite'] }
-        }
+          route: { url: ['/registration/confirm-details/user-research-invite'] },
+        },
       ];
 
       const { getByText, queryByText } = await setup(mockListWithLink);
 
-      const changeLink = getByText('Change')
+      const changeLink = getByText('Change');
 
       expect(queryByText('Full name')).toBeTruthy();
       expect(queryByText('John Doe')).toBeTruthy();
-      expect(changeLink.getAttribute('href')).toEqual(
-        '/registration/confirm-details/user-research-invite'
-      );
+      expect(changeLink.getAttribute('href')).toEqual('/registration/confirm-details/user-research-invite');
       expect(queryByText('Add')).toBeFalsy();
     });
-  })
+  });
 
   describe('When there is no data', () => {
     it('should show the summary list label, value and an add link', async () => {
       const mockListWithLink = [
-        { label: 'Full name',
-          data: null,
-          route: { url: ['/registration/confirm-details/user-research-invite'] }
-        }
+        { label: 'Full name', data: null, route: { url: ['/registration/confirm-details/user-research-invite'] } },
       ];
 
       const { getByText, queryByText } = await setup(mockListWithLink);
 
-      const addLink = queryByText('Add')
+      const addLink = queryByText('Add');
 
       expect(queryByText('Full name')).toBeTruthy();
       expect(getByText('-')).toBeTruthy();
-      expect(addLink.getAttribute('href')).toEqual(
-        '/registration/confirm-details/user-research-invite'
-      );
+      expect(addLink.getAttribute('href')).toEqual('/registration/confirm-details/user-research-invite');
       expect(queryByText('Change')).toBeFalsy();
     });
-  })
+  });
 
   describe('Show password button', () => {
     it('should hide the password before clicking show', async () => {

--- a/frontend/src/app/shared/components/summary-list/summary-list.component.ts
+++ b/frontend/src/app/shared/components/summary-list/summary-list.component.ts
@@ -2,9 +2,10 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { SummaryList } from '@core/model/summary-list.model';
 
 @Component({
-    selector: 'app-summary-list',
-    templateUrl: './summary-list.component.html',
-    standalone: false
+  selector: 'app-summary-list',
+  templateUrl: './summary-list.component.html',
+  styleUrl: './summary-list.component.scss',
+  standalone: false,
 })
 export class SummaryListComponent {
   @Input() public summaryList: SummaryList[];

--- a/frontend/src/assets/scss/modules/_utils.scss
+++ b/frontend/src/assets/scss/modules/_utils.scss
@@ -217,3 +217,8 @@ dl.asc__name-value-pair {
 .asc__white-background {
   background-color: #ffffff;
 }
+
+.asc-red-pill-icon--m-size {
+  width: 42px;
+  height: 19px;
+}


### PR DESCRIPTION
#### Work done
- add a ViewedUserResearchQuestion new column for user
- amend YourAccountComponent to show a UR session row and red new pill  (ticket 1951)
- amend HeaderComponent to show a flag near user's name to notify about the UR question (ticket 1952)

<img width="1138" height="980" alt="image" src="https://github.com/user-attachments/assets/2b314f2d-0d00-478b-8225-5fe3e09cc2de" />


#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
