### PR TITLE
Fix/training and quals report text escape

### DIFF
--- a/backend/server/test/unit/utils/trainingAndQualificationsUtils.spec.js
+++ b/backend/server/test/unit/utils/trainingAndQualificationsUtils.spec.js
@@ -273,7 +273,19 @@ describe('trainingAndQualificationsUtils', () => {
         expect(firstWorkerFirstTrainingRecord.trainingName).to.deep.equal('Dignity at Work eLearning');
       });
 
-      it('should not affect normal usage of % char', () => {
+      [null, undefined].forEach((emptyValue) => {
+        it('should correctly handle the case when training title is empty', () => {
+          const mockData = lodash.cloneDeep(mockEstablishmentsTrainingResponse);
+          mockData[0].workers[0].workerTraining[0].title = emptyValue;
+
+          const result = convertTrainingForEstablishments(mockData);
+          const firstWorkerFirstTrainingRecord = result[0].workerRecords[0].trainingRecords[0];
+
+          expect(firstWorkerFirstTrainingRecord.trainingName).to.deep.equal(emptyValue);
+        });
+      });
+
+      it('should not affect normal usage of the % char', () => {
         const mockData = lodash.cloneDeep(mockEstablishmentsTrainingResponse);
         mockData[0].workers[0].workerTraining[0].title = 'First aid training (70%)';
 

--- a/backend/server/test/unit/utils/trainingAndQualificationsUtils.spec.js
+++ b/backend/server/test/unit/utils/trainingAndQualificationsUtils.spec.js
@@ -263,6 +263,16 @@ describe('trainingAndQualificationsUtils', () => {
         });
       });
 
+      it('should handle uri-encoded string in training names', () => {
+        const mockData = lodash.cloneDeep(mockEstablishmentsTrainingResponse);
+        mockData[0].workers[0].workerTraining[0].title = 'Dignity%20at%20Work%20eLearning';
+
+        const result = convertTrainingForEstablishments(mockData);
+        const firstWorkerFirstTrainingRecord = result[0].workerRecords[0].trainingRecords[0];
+
+        expect(firstWorkerFirstTrainingRecord.trainingName).to.deep.equal('Dignity at Work eLearning');
+      });
+
       it('should return second training record formatted as expected for first worker', () => {
         const result = convertTrainingForEstablishments(mockEstablishmentsTrainingResponse);
         const firstWorkerSecondTrainingRecord = result[0].workerRecords[0].trainingRecords[1];

--- a/backend/server/test/unit/utils/trainingAndQualificationsUtils.spec.js
+++ b/backend/server/test/unit/utils/trainingAndQualificationsUtils.spec.js
@@ -273,6 +273,16 @@ describe('trainingAndQualificationsUtils', () => {
         expect(firstWorkerFirstTrainingRecord.trainingName).to.deep.equal('Dignity at Work eLearning');
       });
 
+      it('should not affect normal usage of % char', () => {
+        const mockData = lodash.cloneDeep(mockEstablishmentsTrainingResponse);
+        mockData[0].workers[0].workerTraining[0].title = 'First aid training (70%)';
+
+        const result = convertTrainingForEstablishments(mockData);
+        const firstWorkerFirstTrainingRecord = result[0].workerRecords[0].trainingRecords[0];
+
+        expect(firstWorkerFirstTrainingRecord.trainingName).to.deep.equal('First aid training (70%)');
+      });
+
       it('should return second training record formatted as expected for first worker', () => {
         const result = convertTrainingForEstablishments(mockEstablishmentsTrainingResponse);
         const firstWorkerSecondTrainingRecord = result[0].workerRecords[0].trainingRecords[1];

--- a/backend/server/utils/trainingAndQualificationsUtils.js
+++ b/backend/server/utils/trainingAndQualificationsUtils.js
@@ -189,7 +189,7 @@ const convertIndividualWorkerTrainingRecords = (
     return {
       category: trainingRecord.category.category,
       categoryFK: trainingRecord.categoryFk,
-      trainingName: trainingRecord.title,
+      trainingName: unescapeText(trainingRecord.title),
       expiryDate,
       status: getTrainingRecordStatus(expiryDate, expiresSoonAlertDate),
       dateCompleted,
@@ -265,6 +265,13 @@ const numberCheck = (value) => {
   const isNumber = /^\d+$/.test(value);
 
   return isNumber ? parseInt(value) : value;
+};
+
+const unescapeText = (value) => {
+  if (value) {
+    return unescape(value);
+  }
+  return value;
 };
 
 exports.getTrainingTotals = (workers) => {


### PR DESCRIPTION
#### Work done
- In training and qualifications report utils, unescape (uri decode) training record titles from database response

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
