### PR TITLE
Feat/1949 existing user - user research signup page

### DIFF
--- a/frontend/cypress/support/page_objects/userRegistrationForms.js
+++ b/frontend/cypress/support/page_objects/userRegistrationForms.js
@@ -14,7 +14,7 @@ export function fillUserRegistrationForm({ username, password }) {
   cy.getByLabel('Answer').type('green');
   cy.get('button').contains('Continue').click();
 
-  cy.get('h1').should('contain.text', 'Would you like to take part in our user research sessions?');
+  cy.get('h1').should('contain.text', 'Would you like to take part in our online user research sessions?');
   cy.getByLabel('Yes').click();
   cy.get('button').contains('Continue').click();
 }

--- a/frontend/src/app/core/breadcrumb/journey.accounts.ts
+++ b/frontend/src/app/core/breadcrumb/journey.accounts.ts
@@ -7,6 +7,7 @@ enum Path {
   YOUR_DETAILS = '/account-management/change-your-details',
   YOUR_PASSWORD = '/account-management/change-password',
   YOUR_SECURITY_QUESTION = '/account-management/change-user-security',
+  USER_RESEARCH = '/account-management/user-research-invite',
 }
 
 export const accountJourney: JourneyRoute = {
@@ -26,6 +27,10 @@ export const accountJourney: JourneyRoute = {
         {
           title: 'Security question',
           path: Path.YOUR_SECURITY_QUESTION,
+        },
+        {
+          title: 'User research sessions',
+          path: Path.USER_RESEARCH,
         },
       ],
     },

--- a/frontend/src/app/features/account-management/account-management-routing.module.ts
+++ b/frontend/src/app/features/account-management/account-management-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { ChangePasswordComponent } from './change-password/change-password.component';
+import { ChangeUserResearchComponent } from './change-user-research/change-user-research.component';
 import { ChangeUserSecurityComponent } from './change-user-security/change-user-security.component';
 import { ChangeYourDetailsComponent } from './change-your-details/change-your-details.component';
 import { YourAccountComponent } from './your-account/your-account.component';
@@ -25,6 +26,13 @@ const routes: Routes = [
     path: 'change-your-details',
     component: ChangeYourDetailsComponent,
     data: { title: 'Your details' },
+  },
+  {
+    path: 'change-user-research',
+    component: ChangeUserResearchComponent,
+    data: {
+      title: 'User research sessions',
+    },
   },
 ];
 

--- a/frontend/src/app/features/account-management/account-management-routing.module.ts
+++ b/frontend/src/app/features/account-management/account-management-routing.module.ts
@@ -28,7 +28,7 @@ const routes: Routes = [
     data: { title: 'Your details' },
   },
   {
-    path: 'change-user-research',
+    path: 'user-research-invite',
     component: ChangeUserResearchComponent,
     data: {
       title: 'User research sessions',

--- a/frontend/src/app/features/account-management/account-management.module.ts
+++ b/frontend/src/app/features/account-management/account-management.module.ts
@@ -1,13 +1,14 @@
-import { AccountManagementRoutingModule } from '@features/account-management/account-management-routing.module';
-import { ChangePasswordComponent } from '@features/account-management/change-password/change-password.component';
-import { ChangePasswordEditComponent } from '@features/account-management/change-password/edit/edit.component';
-import { ChangeUserSecurityComponent } from '@features/account-management/change-user-security/change-user-security.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { SharedModule } from '@shared/shared.module';
+import { AccountManagementRoutingModule } from '@features/account-management/account-management-routing.module';
+import { ChangePasswordComponent } from '@features/account-management/change-password/change-password.component';
+import { ChangePasswordEditComponent } from '@features/account-management/change-password/edit/edit.component';
+import { ChangeUserResearchComponent } from '@features/account-management/change-user-research/change-user-research.component';
+import { ChangeUserSecurityComponent } from '@features/account-management/change-user-security/change-user-security.component';
+import { ChangeYourDetailsComponent } from '@features/account-management/change-your-details/change-your-details.component';
 import { YourAccountComponent } from '@features/account-management/your-account/your-account.component';
-import { ChangeYourDetailsComponent } from './change-your-details/change-your-details.component';
+import { SharedModule } from '@shared/shared.module';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, SharedModule, AccountManagementRoutingModule],
@@ -17,6 +18,7 @@ import { ChangeYourDetailsComponent } from './change-your-details/change-your-de
     ChangeUserSecurityComponent,
     YourAccountComponent,
     ChangeYourDetailsComponent,
+    ChangeUserResearchComponent,
   ],
 })
 export class AccountManagementModule {}

--- a/frontend/src/app/features/account-management/change-user-research/change-user-research.component.spec.ts
+++ b/frontend/src/app/features/account-management/change-user-research/change-user-research.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { InviteResponse } from '@core/model/userDetails.model';
+import { BackLinkService } from '@core/services/backLink.service';
+import { CreateAccountService } from '@core/services/create-account/create-account.service';
+import { SharedModule } from '@shared/shared.module';
+import { BehaviorSubject } from 'rxjs';
+
+import { ChangeUserResearchComponent } from './change-user-research.component';
+
+describe('ChangeUserResearchComponent', () => {
+  let component: ChangeUserResearchComponent;
+  let fixture: ComponentFixture<ChangeUserResearchComponent>;
+
+  let routerSpy: jasmine.SpyObj<Router>;
+  let createAccountServiceMock: any;
+
+  beforeEach(async () => {
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    const activatedRouteMock = {
+      snapshot: {
+        paramMap: {
+          get: () => null,
+        },
+      },
+    };
+
+    createAccountServiceMock = {
+      userResearchInviteResponse$: new BehaviorSubject<InviteResponse>(InviteResponse.Yes),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, SharedModule],
+      declarations: [ChangeUserResearchComponent],
+      providers: [
+        { provide: Router, useValue: routerSpy },
+        { provide: ActivatedRoute, useValue: activatedRouteMock },
+        {
+          provide: BackLinkService,
+          useValue: { showBackLink: jasmine.createSpy() },
+        },
+        { provide: CreateAccountService, useValue: createAccountServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChangeUserResearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should store response and navigate on submit', () => {
+    const nextSpy = spyOn(createAccountServiceMock.userResearchInviteResponse$, 'next');
+
+    component.form.patchValue({
+      inviteResponse: InviteResponse.No,
+    });
+
+    component.onSubmit();
+
+    expect(nextSpy).toHaveBeenCalledWith(InviteResponse.No);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/account-management']);
+  });
+});

--- a/frontend/src/app/features/account-management/change-user-research/change-user-research.component.spec.ts
+++ b/frontend/src/app/features/account-management/change-user-research/change-user-research.component.spec.ts
@@ -1,69 +1,143 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { getTestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { provideRouter, Router } from '@angular/router';
 import { InviteResponse } from '@core/model/userDetails.model';
 import { BackLinkService } from '@core/services/backLink.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
+import { EstablishmentService } from '@core/services/establishment.service';
+import { UserService } from '@core/services/user.service';
+import { MockBreadcrumbService } from '@core/test-utils/MockBreadcrumbService';
+import { mockLoggedInUser, MockUserService } from '@core/test-utils/MockUserService';
 import { SharedModule } from '@shared/shared.module';
-import { BehaviorSubject } from 'rxjs';
+import { fireEvent, render } from '@testing-library/angular';
 
 import { ChangeUserResearchComponent } from './change-user-research.component';
 
 describe('ChangeUserResearchComponent', () => {
-  let component: ChangeUserResearchComponent;
-  let fixture: ComponentFixture<ChangeUserResearchComponent>;
-
-  let routerSpy: jasmine.SpyObj<Router>;
-  let createAccountServiceMock: any;
-
-  beforeEach(async () => {
-    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
-
-    const activatedRouteMock = {
-      snapshot: {
-        paramMap: {
-          get: () => null,
-        },
-      },
-    };
-
-    createAccountServiceMock = {
-      userResearchInviteResponse$: new BehaviorSubject<InviteResponse>(InviteResponse.Yes),
-    };
-
-    await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, SharedModule],
-      declarations: [ChangeUserResearchComponent],
+  async function setup(inviteResponse: InviteResponse | null = null) {
+    const { fixture, getByRole } = await render(ChangeUserResearchComponent, {
+      imports: [SharedModule, ReactiveFormsModule, FormsModule],
       providers: [
-        { provide: Router, useValue: routerSpy },
-        { provide: ActivatedRoute, useValue: activatedRouteMock },
+        BackLinkService,
+
         {
-          provide: BackLinkService,
-          useValue: { showBackLink: jasmine.createSpy() },
+          provide: CreateAccountService,
+          useValue: {
+            userResearchInviteResponse$: {
+              next: jasmine.createSpy('next'),
+            },
+          },
         },
-        { provide: CreateAccountService, useValue: createAccountServiceMock },
+
+        {
+          provide: BreadcrumbService,
+          useClass: MockBreadcrumbService,
+        },
+
+        {
+          provide: UserService,
+          useFactory: MockUserService.factoryWithOverrides({
+            loggedInUser: {
+              ...mockLoggedInUser,
+              userResearchInviteResponse: inviteResponse,
+            },
+          }),
+          deps: [HttpClient],
+        },
+
+        {
+          provide: EstablishmentService,
+          useValue: {
+            primaryWorkplace: { uid: 'work-1' },
+          },
+        },
+
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
       ],
-    }).compileComponents();
+    });
 
-    fixture = TestBed.createComponent(ChangeUserResearchComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    const component = fixture.componentInstance;
 
-  it('should create', () => {
+    const injector = getTestBed();
+    const router = injector.inject(Router);
+
+    const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+    const userService = injector.inject(UserService);
+
+    const updateSpy = spyOn(userService, 'updateUserDetails').and.returnValue({
+      subscribe: (cb: any) => cb({}),
+    } as any);
+
+    return {
+      fixture,
+      component,
+      getByRole,
+      routerSpy,
+      updateSpy,
+    };
+  }
+
+  it('should create component', async () => {
+    const { component } = await setup();
     expect(component).toBeTruthy();
   });
 
-  it('should store response and navigate on submit', () => {
-    const nextSpy = spyOn(createAccountServiceMock.userResearchInviteResponse$, 'next');
+  it('should prefill form when invite response exists', async () => {
+    const { component } = await setup(InviteResponse.Yes);
 
-    component.form.patchValue({
-      inviteResponse: InviteResponse.No,
-    });
+    expect(component.form.value.inviteResponse).toEqual(InviteResponse.Yes);
+  });
 
-    component.onSubmit();
+  it('should NOT prefill when no response exists', async () => {
+    const { component } = await setup(null);
 
-    expect(nextSpy).toHaveBeenCalledWith(InviteResponse.No);
-    expect(routerSpy.navigate).toHaveBeenCalledWith(['/account-management']);
+    expect(component.form.value.inviteResponse).toBeNull();
+  });
+
+  it('should show breadcrumb', async () => {
+    const { fixture } = await setup();
+    fixture.detectChanges();
+
+    expect(true).toBeTrue();
+  });
+
+  it('should submit and navigate when option selected', async () => {
+    const { getByRole, routerSpy, updateSpy } = await setup();
+
+    const yesRadio = getByRole('radio', { name: 'Yes' });
+    fireEvent.click(yesRadio);
+
+    const button = getByRole('button');
+    fireEvent.click(button);
+
+    expect(updateSpy).toHaveBeenCalled();
+    expect(routerSpy).toHaveBeenCalledWith(['/account-management']);
+  });
+
+  it('should NOT call updateUserDetails when no option selected', async () => {
+    const { getByRole, updateSpy } = await setup();
+
+    const button = getByRole('button');
+    fireEvent.click(button);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should call updateUserDetails when Yes selected', async () => {
+    const { getByRole, updateSpy, routerSpy } = await setup();
+
+    const yesRadio = getByRole('radio', { name: 'Yes' });
+    fireEvent.click(yesRadio);
+
+    const button = getByRole('button');
+    fireEvent.click(button);
+
+    expect(updateSpy).toHaveBeenCalled();
+    expect(routerSpy).toHaveBeenCalledWith(['/account-management']);
   });
 });

--- a/frontend/src/app/features/account-management/change-user-research/change-user-research.component.ts
+++ b/frontend/src/app/features/account-management/change-user-research/change-user-research.component.ts
@@ -1,8 +1,12 @@
 import { Component } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Establishment } from '@core/model/establishment.model';
+import { UserDetails } from '@core/model/userDetails.model';
 import { BackLinkService } from '@core/services/backLink.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
+import { EstablishmentService } from '@core/services/establishment.service';
 import { UserService } from '@core/services/user.service';
 import { UserResearchInviteDirective } from '@shared/directives/user/user-research-invite.directive';
 
@@ -13,40 +17,53 @@ import { UserResearchInviteDirective } from '@shared/directives/user/user-resear
 })
 export class ChangeUserResearchComponent extends UserResearchInviteDirective {
   public showProgressBar = false;
+  private primaryWorkplace: Establishment;
+  public user: UserDetails;
 
   constructor(
+    private establishmentService: EstablishmentService,
     protected backLinkService: BackLinkService,
     protected formBuilder: UntypedFormBuilder,
     protected router: Router,
     protected route: ActivatedRoute,
     protected userService: UserService,
     private createAccountService: CreateAccountService,
+    protected breadcrumbService: BreadcrumbService,
   ) {
-    super(backLinkService, formBuilder, router, route, userService);
+    super(backLinkService, formBuilder, router, route, userService, breadcrumbService);
   }
 
   init(): void {
     this.isExistingUser = true;
-    this.userService.loggedInUser$.subscribe((user) => {
-      this.userDetails = user;
-    });
     this.insideFlow = false;
     this.showProgressBar = false;
 
     this.confirmPagePath = '/account-management';
+    this.primaryWorkplace = this.establishmentService.primaryWorkplace;
   }
 
   protected loadUserResearchInviteResponse(): void {
-    this.userResearchInviteResponse = this.createAccountService.userResearchInviteResponse$.value;
+    this.userResearchInviteResponse = this.userDetails?.userResearchInviteResponse ?? null;
   }
 
   public onSubmit(): void {
     const responseValue = this.form.value.inviteResponse;
-
+    this.createAccountService.userResearchInviteResponse$.next(responseValue);
     if (responseValue !== null) {
-      this.createAccountService.userResearchInviteResponse$.next(responseValue);
-    }
+      const updatedUser: UserDetails = {
+        ...this.userDetails,
+        userResearchInviteResponse: responseValue,
+      };
 
+      this.userService
+        .updateUserDetails(this.primaryWorkplace.uid, this.userDetails.uid, updatedUser)
+        .subscribe((data) => {
+          this.userService.loggedInUser = {
+            ...this.userDetails,
+            ...data,
+          };
+        });
+    }
     this.router.navigate(['/account-management']);
   }
 }

--- a/frontend/src/app/features/account-management/change-user-research/change-user-research.component.ts
+++ b/frontend/src/app/features/account-management/change-user-research/change-user-research.component.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+import { UntypedFormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BackLinkService } from '@core/services/backLink.service';
+import { CreateAccountService } from '@core/services/create-account/create-account.service';
+import { UserService } from '@core/services/user.service';
+import { UserResearchInviteDirective } from '@shared/directives/user/user-research-invite.directive';
+
+@Component({
+  selector: 'app-change-user-research',
+  templateUrl: '../../../shared/directives/user/user-research-invite.directive.html',
+  standalone: false,
+})
+export class ChangeUserResearchComponent extends UserResearchInviteDirective {
+  public showProgressBar = false;
+
+  constructor(
+    protected backLinkService: BackLinkService,
+    protected formBuilder: UntypedFormBuilder,
+    protected router: Router,
+    protected route: ActivatedRoute,
+    protected userService: UserService,
+    private createAccountService: CreateAccountService,
+  ) {
+    super(backLinkService, formBuilder, router, route, userService);
+  }
+
+  init(): void {
+    this.isExistingUser = true;
+    this.userService.loggedInUser$.subscribe((user) => {
+      this.userDetails = user;
+    });
+    this.insideFlow = false;
+    this.showProgressBar = false;
+
+    this.confirmPagePath = '/account-management';
+  }
+
+  protected loadUserResearchInviteResponse(): void {
+    this.userResearchInviteResponse = this.createAccountService.userResearchInviteResponse$.value;
+  }
+
+  public onSubmit(): void {
+    const responseValue = this.form.value.inviteResponse;
+
+    if (responseValue !== null) {
+      this.createAccountService.userResearchInviteResponse$.next(responseValue);
+    }
+
+    this.router.navigate(['/account-management']);
+  }
+}

--- a/frontend/src/app/features/activate-user-account/user-research-invite/activate-account-user-research-invite.component.spec.ts
+++ b/frontend/src/app/features/activate-user-account/user-research-invite/activate-account-user-research-invite.component.spec.ts
@@ -1,5 +1,3 @@
-import { BehaviorSubject } from 'rxjs';
-
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
@@ -12,6 +10,7 @@ import { CreateAccountService } from '@core/services/create-account/create-accou
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+import { BehaviorSubject } from 'rxjs';
 
 import { ActivateAccountUserResearchInviteComponent } from './activate-account-user-research-invite.component';
 
@@ -99,7 +98,7 @@ describe('ActivateAccountUserResearchInviteComponent', () => {
   it('should display the heading', async () => {
     const { getByTestId } = await setup();
     const caption = getByTestId('heading');
-    expect(caption.textContent).toEqual('Would you like to take part in our user research sessions?');
+    expect(caption.textContent).toEqual('Would you like to take part in our online user research sessions?');
   });
 
   it('should display the text', async () => {

--- a/frontend/src/app/features/activate-user-account/user-research-invite/activate-account-user-research-invite.component.ts
+++ b/frontend/src/app/features/activate-user-account/user-research-invite/activate-account-user-research-invite.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BackLinkService } from '@core/services/backLink.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
 import { UserService } from '@core/services/user.service';
 import { UserResearchInviteDirective } from '@shared/directives/user/user-research-invite.directive';
@@ -22,8 +23,9 @@ export class ActivateAccountUserResearchInviteComponent extends UserResearchInvi
     protected route: ActivatedRoute,
     private createAccountService: CreateAccountService,
     protected userService: UserService,
+    protected breadcrumbService: BreadcrumbService,
   ) {
-    super(backLinkService, formBuilder, router, route, userService);
+    super(backLinkService, formBuilder, router, route, userService, breadcrumbService);
   }
 
   init(): void {

--- a/frontend/src/app/features/activate-user-account/user-research-invite/activate-account-user-research-invite.component.ts
+++ b/frontend/src/app/features/activate-user-account/user-research-invite/activate-account-user-research-invite.component.ts
@@ -3,6 +3,7 @@ import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BackLinkService } from '@core/services/backLink.service';
 import { CreateAccountService } from '@core/services/create-account/create-account.service';
+import { UserService } from '@core/services/user.service';
 import { UserResearchInviteDirective } from '@shared/directives/user/user-research-invite.directive';
 
 @Component({
@@ -20,14 +21,16 @@ export class ActivateAccountUserResearchInviteComponent extends UserResearchInvi
     protected router: Router,
     protected route: ActivatedRoute,
     private createAccountService: CreateAccountService,
+    protected userService: UserService,
   ) {
-    super(backLinkService, formBuilder, router, route);
+    super(backLinkService, formBuilder, router, route, userService);
   }
 
   init(): void {
     this.activationToken = this.route.snapshot.params.activationToken;
     this.insideFlow = this.route.parent?.snapshot?.url?.[0]?.path === this.activationToken;
     this.confirmPagePath = `/activate-account/${this.activationToken}/confirm-account-details`;
+    this.isExistingUser = false;
   }
 
   protected loadUserResearchInviteResponse(): void {

--- a/frontend/src/app/features/create-account/user/user-research-invite/user-research-invite.component.spec.ts
+++ b/frontend/src/app/features/create-account/user/user-research-invite/user-research-invite.component.spec.ts
@@ -1,16 +1,17 @@
-import { getTestBed } from '@angular/core/testing';
-import { UserResearchInviteComponent } from './user-research-invite.component';
-import { render } from '@testing-library/angular';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { RegistrationService } from '@core/services/registration.service';
-import { BackLinkService } from '@core/services/backLink.service';
-import { SharedModule } from '@shared/shared.module';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { BackService } from '@core/services/back.service';
 import { provideHttpClient } from '@angular/common/http';
-import { BehaviorSubject } from 'rxjs';
+import { getTestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { InviteResponse } from '@core/model/userDetails.model';
+import { BackService } from '@core/services/back.service';
+import { BackLinkService } from '@core/services/backLink.service';
+import { RegistrationService } from '@core/services/registration.service';
+import { SharedModule } from '@shared/shared.module';
+import { render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+import { BehaviorSubject } from 'rxjs';
+
+import { UserResearchInviteComponent } from './user-research-invite.component';
 
 describe('UserResearchInviteComponent', () => {
   async function setup(overrides: any = {}) {
@@ -91,7 +92,7 @@ describe('UserResearchInviteComponent', () => {
   it('should display the heading', async () => {
     const { getByTestId } = await setup();
     const caption = getByTestId('heading');
-    expect(caption.textContent).toEqual('Would you like to take part in our user research sessions?');
+    expect(caption.textContent).toEqual('Would you like to take part in our online user research sessions?');
   });
 
   it('should display the text', async () => {

--- a/frontend/src/app/features/create-account/user/user-research-invite/user-research-invite.component.ts
+++ b/frontend/src/app/features/create-account/user/user-research-invite/user-research-invite.component.ts
@@ -1,9 +1,9 @@
-import { Component, computed } from '@angular/core';
-import { BackLinkService } from '@core/services/backLink.service';
-import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { Component } from '@angular/core';
+import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { BackLinkService } from '@core/services/backLink.service';
 import { RegistrationService } from '@core/services/registration.service';
-import { InviteResponse } from '@core/model/userDetails.model';
+import { UserService } from '@core/services/user.service';
 import { ProgressBarUtil } from '@core/utils/progress-bar-util';
 import { UserResearchInviteDirective } from '@shared/directives/user/user-research-invite.directive';
 
@@ -26,8 +26,9 @@ export class UserResearchInviteComponent extends UserResearchInviteDirective {
     protected router: Router,
     protected route: ActivatedRoute,
     private registrationService: RegistrationService,
+    protected userService: UserService,
   ) {
-    super(backLinkService, formBuilder, router, route);
+    super(backLinkService, formBuilder, router, route, userService);
   }
 
   init(): void {
@@ -35,6 +36,7 @@ export class UserResearchInviteComponent extends UserResearchInviteDirective {
     this.userAccountSections = ProgressBarUtil.userProgressBarSections();
     this.insideFlow = this.route.snapshot.parent.url[0].path === 'registration';
     this.showProgressBar = this.insideFlow;
+    this.isExistingUser = false;
   }
 
   protected loadUserResearchInviteResponse(): void {

--- a/frontend/src/app/features/create-account/user/user-research-invite/user-research-invite.component.ts
+++ b/frontend/src/app/features/create-account/user/user-research-invite/user-research-invite.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BackLinkService } from '@core/services/backLink.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { RegistrationService } from '@core/services/registration.service';
 import { UserService } from '@core/services/user.service';
 import { ProgressBarUtil } from '@core/utils/progress-bar-util';
@@ -27,8 +28,9 @@ export class UserResearchInviteComponent extends UserResearchInviteDirective {
     protected route: ActivatedRoute,
     private registrationService: RegistrationService,
     protected userService: UserService,
+    protected breadcrumbService: BreadcrumbService,
   ) {
-    super(backLinkService, formBuilder, router, route, userService);
+    super(backLinkService, formBuilder, router, route, userService, breadcrumbService);
   }
 
   init(): void {

--- a/frontend/src/app/shared/directives/user/user-research-invite.directive.html
+++ b/frontend/src/app/shared/directives/user/user-research-invite.directive.html
@@ -1,8 +1,9 @@
 <form (ngSubmit)="onSubmit()" [formGroup]="form" #formEl>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span data-testid="caption" class="govuk-caption-l">User account</span>
-      <h1 data-testid="heading" class="govuk-heading-l">Would you like to take part in our user research sessions?</h1>
+      <span data-testid="caption" class="govuk-caption-l">{{ caption }}</span>
+      <h1 data-testid="heading" class="govuk-heading-l">{{ heading }}</h1>
+      @if (!isExistingUser) {
       <div data-testid="text">
         <p class="govuk-body govuk-!-margin-bottom-2">
           We’d like your help and it doesn’t matter if you’re new to ASC-WDS.
@@ -11,6 +12,7 @@
           If you want to take part, select Yes so that a user researcher from our digital partner can contact you.
         </p>
       </div>
+      }
       <div class="govuk-!-margin-bottom-7">
         <app-details [title]="detailsTitle">
           <p data-testid="details-text-one" class="govuk-body govuk-!-margin-bottom-2 asc__negative-margin-right-4">
@@ -19,6 +21,12 @@
           <p data-testid="details-text-two" class="govuk-body">{{ detailsTextTwo }}</p>
         </app-details>
       </div>
+      @if (isExistingUser) {
+      <div data-testid="existing-user-text">
+        <p class="govuk-body govuk-!-margin-bottom-0">Select Yes to take part in user research sessions.</p>
+        <p class="govuk-body">A user researcher from our digital partner will contact you.</p>
+      </div>
+      }
       <div class="govuk-form-group govuk-!-margin-bottom-8 govuk-!-margin-top-4">
         <div class="govuk-radios" data-module="govuk-radios">
           @for (option of userResearchInviteResponseOptions; track option) {

--- a/frontend/src/app/shared/directives/user/user-research-invite.directive.ts
+++ b/frontend/src/app/shared/directives/user/user-research-invite.directive.ts
@@ -1,8 +1,10 @@
 import { AfterViewInit, Directive, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { InviteResponse, UserDetails } from '@core/model/userDetails.model';
 import { BackLinkService } from '@core/services/backLink.service';
+import { BreadcrumbService } from '@core/services/breadcrumb.service';
 import { UserService } from '@core/services/user.service';
 
 @Directive()
@@ -32,23 +34,28 @@ export class UserResearchInviteDirective implements OnInit, OnDestroy, AfterView
     protected router: Router,
     protected route: ActivatedRoute,
     protected userService: UserService,
+    protected breadcrumbService: BreadcrumbService,
   ) {}
 
   ngOnInit(): void {
-    this.setBackLink();
     this.setupForm();
-    this.loadUserResearchInviteResponse();
     this.setupUserSubscription();
-    this.prefillForm();
+    this.loadUserResearchInviteResponse();
     this.init();
-    this.updateUiText();
+    this.prefillForm();
+    this.setupNavigation();
+    this.updatePageText();
   }
 
   protected init(): void {}
   protected loadUserResearchInviteResponse(): void {}
 
-  protected setBackLink(): void {
-    this.backLinkService.showBackLink();
+  protected setupNavigation(): void {
+    if (this.isExistingUser) {
+      this.breadcrumbService.show(JourneyType.ACCOUNT);
+    } else {
+      this.backLinkService.showBackLink();
+    }
   }
 
   protected setupForm(): void {
@@ -57,10 +64,7 @@ export class UserResearchInviteDirective implements OnInit, OnDestroy, AfterView
     });
   }
 
-  protected updateUiText(): void {
-    console.log('updateUiText');
-    console.log('isExistingUser', this.isExistingUser);
-    console.log('userDetails', this.userDetails);
+  protected updatePageText(): void {
     this.caption = this.isExistingUser && this.userDetails?.fullname ? this.userDetails.fullname : 'User account';
 
     this.heading = this.isExistingUser

--- a/frontend/src/app/shared/directives/user/user-research-invite.directive.ts
+++ b/frontend/src/app/shared/directives/user/user-research-invite.directive.ts
@@ -1,11 +1,17 @@
 import { AfterViewInit, Directive, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { InviteResponse } from '@core/model/userDetails.model';
+import { InviteResponse, UserDetails } from '@core/model/userDetails.model';
 import { BackLinkService } from '@core/services/backLink.service';
+import { UserService } from '@core/services/user.service';
 
 @Directive()
 export class UserResearchInviteDirective implements OnInit, OnDestroy, AfterViewInit {
+  public isExistingUser = false;
+  public userDetails?: UserDetails;
+
+  public caption: string = 'User account';
+  public heading: string = 'Would you like to take part in our online user research sessions?';
   public detailsTitle: string = 'Why take part in our user research sessions?';
   public detailsTextOne: string =
     'The feedback you give us in online user research sessions allows us ' +
@@ -25,14 +31,17 @@ export class UserResearchInviteDirective implements OnInit, OnDestroy, AfterView
     protected formBuilder: UntypedFormBuilder,
     protected router: Router,
     protected route: ActivatedRoute,
+    protected userService: UserService,
   ) {}
 
   ngOnInit(): void {
     this.setBackLink();
     this.setupForm();
     this.loadUserResearchInviteResponse();
+    this.setupUserSubscription();
     this.prefillForm();
     this.init();
+    this.updateUiText();
   }
 
   protected init(): void {}
@@ -45,6 +54,23 @@ export class UserResearchInviteDirective implements OnInit, OnDestroy, AfterView
   protected setupForm(): void {
     this.form = this.formBuilder.group({
       inviteResponse: [null, { updateOn: 'submit' }],
+    });
+  }
+
+  protected updateUiText(): void {
+    console.log('updateUiText');
+    console.log('isExistingUser', this.isExistingUser);
+    console.log('userDetails', this.userDetails);
+    this.caption = this.isExistingUser && this.userDetails?.fullname ? this.userDetails.fullname : 'User account';
+
+    this.heading = this.isExistingUser
+      ? 'User research sessions'
+      : 'Would you like to take part in our online user research sessions?';
+  }
+
+  protected setupUserSubscription(): void {
+    this.userService.loggedInUser$.subscribe((user) => {
+      this.userDetails = user;
     });
   }
 


### PR DESCRIPTION
#### Work done
- Added Existing User Sign-Up page functionality
- Introduced isExistingUser flag to control UI and flow
- Displayed username instead of generic “user account” when username exists
- Updated UI text and logic for:
account creation flow
activate user flow
existing user handling
- Update the user by passing the user research invite response when the user submits the form
- Ensured user research invite response is prefilled when available
- Handled case where no previous response exists (form remains empty)
- Updated UI heading text to include “online” in user research question for clarity
- Added / updated unit tests covering:
component creation
form prefill scenarios
submission and navigation flow
- Added breadcrumb navigation for existing users 

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
