### PR TITLE
Feat/1959 benefits bundle text changes

### DIFF
--- a/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.html
+++ b/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.html
@@ -1,19 +1,31 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <span class="govuk-caption-xl govuk-!-margin-bottom-2">{{ workplaceName }}</span>
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-8">Discounts from Skills for Care's training providers</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
+      Learning provider offers – QACLS assured courses and qualifications
+    </h1>
     <app-details [title]="revealTitle">
       <p>
-        These are the best learning and development providers within the adult social care sector who've gained a
-        quality mark endorsement from Skills for Care.
+        Skills for Care helps deliver the Quality Assured Care Learning Service, which reviews training provider and
+        course quality, making sure training is accessible, high-quality, and meets the needs of both the workforce and
+        people who draw on care and support. More information about the Quality Assured Care Learning Service is
+        available
+        <a
+          href="https://www.skillsforcare.org.uk/Developing-your-workforce/Quality-assured-training-and-courses.aspx"
+          target="_blank"
+          >here</a
+        >.
       </p>
       <p>
+        On this page you will find additional offers that certain providers have agreed to specifically make available
+        to you as part of your registered manager membership – this is in addition to the provision available for these
+        courses from the
         <a
-          href="https://www.skillsforcare.org.uk/Developing-your-workforce/Training-providers/Training-providers.aspx"
+          href="https://www.gov.uk/government/publications/adult-social-care-learning-and-development-support-scheme/learning-and-development-support-scheme-for-the-adult-social-care-workforce-a-guide-for-employers"
           target="_blank"
-          >Read more about training providers</a
+          >Learning and Development Support Scheme</a
         >
-        on the Skills for Care website.
+        for the adult social care workforce.
       </p>
     </app-details>
     <div class="asc-cms-content" [innerHTML]="pages.content"></div>

--- a/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.html
+++ b/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.html
@@ -13,7 +13,7 @@
         <a
           href="https://www.skillsforcare.org.uk/Developing-your-workforce/Quality-assured-training-and-courses.aspx"
           target="_blank"
-          >here</a
+          >here <span class="govuk-visually-hidden">(opens in a new window)</span></a
         >.
       </p>
       <p>
@@ -23,7 +23,7 @@
         <a
           href="https://www.gov.uk/government/publications/adult-social-care-learning-and-development-support-scheme/learning-and-development-support-scheme-for-the-adult-social-care-workforce-a-guide-for-employers"
           target="_blank"
-          >Learning and Development Support Scheme</a
+          >Learning and Development Support Scheme<span class="govuk-visually-hidden">(opens in a new window)</span></a
         >
         for the adult social care workforce.
       </p>

--- a/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.spec.ts
+++ b/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.spec.ts
@@ -54,7 +54,7 @@ describe('BenefitsTrainingDiscountsComponent', () => {
 
   it('should display the title', async () => {
     const { getByText } = await setup();
-    const title = getByText(`Discounts from Skills for Care's training providers`);
+    const title = getByText(`Learning provider offers – QACLS assured courses and qualifications`);
 
     expect(title).toBeTruthy();
   });
@@ -69,10 +69,7 @@ describe('BenefitsTrainingDiscountsComponent', () => {
   it('should dispaly the reveal and the contents', async () => {
     const { component, getByText } = await setup();
     const reveal = getByText(component.revealTitle);
-    const revealContent = getByText(
-      `These are the best learning and development providers within the adult social care sector who've gained a quality mark endorsement from Skills for Care.`,
-      { exact: false },
-    );
+    const revealContent = getByText(/Skills for Care helps deliver the Quality Assured Care Learning Service/i);
 
     expect(reveal).toBeTruthy();
     expect(revealContent).toBeTruthy();

--- a/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.spec.ts
+++ b/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.spec.ts
@@ -17,7 +17,7 @@ describe('BenefitsTrainingDiscountsComponent', () => {
   const pages = MockPagesService.pagesFactory();
 
   async function setup() {
-    const { fixture, getByText, queryByText } = await render(BenefitsTrainingDiscountsComponent, {
+    const { fixture, getByText, queryByText, getByRole } = await render(BenefitsTrainingDiscountsComponent, {
       imports: [SharedModule, RouterModule],
       providers: [
         { provide: PagesService, useClass: MockPagesService },
@@ -44,6 +44,7 @@ describe('BenefitsTrainingDiscountsComponent', () => {
       fixture,
       getByText,
       queryByText,
+      getByRole,
     };
   }
 
@@ -66,13 +67,14 @@ describe('BenefitsTrainingDiscountsComponent', () => {
     expect(getByText(workplaceName)).toBeTruthy();
   });
 
-  it('should dispaly the reveal and the contents', async () => {
-    const { component, getByText } = await setup();
-    const reveal = getByText(component.revealTitle);
-    const revealContent = getByText(/Skills for Care helps deliver the Quality Assured Care Learning Service/i);
+  it('should display the reveal and the contents', async () => {
+    const { component, getByText, getByRole } = await setup();
 
-    expect(reveal).toBeTruthy();
-    expect(revealContent).toBeTruthy();
+    expect(getByText(component.revealTitle)).toBeTruthy();
+
+    expect(getByText(/Quality Assured Care Learning Service/i)).toBeTruthy();
+
+    expect(getByRole('link', { name: /here/i })).toBeTruthy();
   });
 
   it('should display the content of the cms page', async () => {

--- a/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.spec.ts
+++ b/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.spec.ts
@@ -67,15 +67,15 @@ describe('BenefitsTrainingDiscountsComponent', () => {
     expect(getByText(workplaceName)).toBeTruthy();
   });
 
-  it('should display the reveal and the contents', async () => {
-    const { component, getByText, getByRole } = await setup();
+  // it('should display the reveal and the contents', async () => {
+  //   const { component, getByText, getByRole } = await setup();
 
-    expect(getByText(component.revealTitle)).toBeTruthy();
+  //   expect(getByText(component.revealTitle)).toBeTruthy();
 
-    expect(getByText(/Quality Assured Care Learning Service/i)).toBeTruthy();
+  //   expect(getByText(/Quality Assured Care Learning Service/i)).toBeTruthy();
 
-    expect(getByRole('link', { name: /here/i })).toBeTruthy();
-  });
+  //   expect(getByRole('link', { name: /here/i })).toBeTruthy();
+  // });
 
   it('should display the content of the cms page', async () => {
     const { getByText } = await setup();

--- a/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.spec.ts
+++ b/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.spec.ts
@@ -17,7 +17,7 @@ describe('BenefitsTrainingDiscountsComponent', () => {
   const pages = MockPagesService.pagesFactory();
 
   async function setup() {
-    const { fixture, getByText, queryByText, getByRole } = await render(BenefitsTrainingDiscountsComponent, {
+    const { fixture, getByText, queryByText } = await render(BenefitsTrainingDiscountsComponent, {
       imports: [SharedModule, RouterModule],
       providers: [
         { provide: PagesService, useClass: MockPagesService },
@@ -44,7 +44,6 @@ describe('BenefitsTrainingDiscountsComponent', () => {
       fixture,
       getByText,
       queryByText,
-      getByRole,
     };
   }
 
@@ -67,15 +66,14 @@ describe('BenefitsTrainingDiscountsComponent', () => {
     expect(getByText(workplaceName)).toBeTruthy();
   });
 
-  // it('should display the reveal and the contents', async () => {
-  //   const { component, getByText, getByRole } = await setup();
+  it('should dispaly the reveal and the contents', async () => {
+    const { component, getByText } = await setup();
+    const reveal = getByText(component.revealTitle);
+    const revealContent = getByText(/^Skills for Care helps deliver the Quality Assured Care Learning Service/);
 
-  //   expect(getByText(component.revealTitle)).toBeTruthy();
-
-  //   expect(getByText(/Quality Assured Care Learning Service/i)).toBeTruthy();
-
-  //   expect(getByRole('link', { name: /here/i })).toBeTruthy();
-  // });
+    expect(reveal).toBeTruthy();
+    expect(revealContent).toBeTruthy();
+  });
 
   it('should display the content of the cms page', async () => {
     const { getByText } = await setup();

--- a/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.ts
+++ b/frontend/src/app/features/benefits-bundle/benefits-training-discounts/benefits-training-discounts.component.ts
@@ -13,7 +13,7 @@ import { EstablishmentService } from '@core/services/establishment.service';
 export class BenefitsTrainingDiscountsComponent implements OnInit {
   public pages: Page;
   public workplaceName: string;
-  public revealTitle = `What's a training provider?`;
+  public revealTitle = `What is QACLS?`;
 
   constructor(
     private establishmentService: EstablishmentService,


### PR DESCRIPTION
#### Work done
- Updated the H1 on the training discounts page from 'Discounts from Skills for Care’s Training providers' to 'Learning      provider offers – QACLS assured courses and qualifications'
- Updated the reveal link text to “What is QACLS?”
- Updated the reveal content

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
