### PR TITLE
Fix/user research invite tickbox issue

### DIFF
--- a/frontend/src/app/core/test-utils/MockRegistrationService.ts
+++ b/frontend/src/app/core/test-utils/MockRegistrationService.ts
@@ -126,6 +126,36 @@ export class MockRegistrationService extends RegistrationService {
   public checkIfEstablishmentExists(locationId: string): Observable<EstablishmentExistsResponse> {
     return of({ exists: false });
   }
+
+  public static factoryWithOverrides(overrides: Record<string, any> = {}) {
+    const typeOfEmployer = overrides?.typeOfEmployer ?? { value: 'Private Sector' };
+    const manyLocationAddresses = overrides?.manyLocationAddresses ?? false;
+
+    return (httpClient: HttpClient) => {
+      const service = new this(httpClient);
+
+      Object.keys(overrides).forEach((overrideName) => {
+        switch (overrideName) {
+          case 'termsAndConditionsCheckboxValue': {
+            const value = overrides.termsAndConditionsCheckboxValue;
+            service.termsAndConditionsCheckbox$.next(value);
+            break;
+          }
+          default: {
+            service[overrideName] = overrides[overrideName];
+            break;
+          }
+        }
+      });
+
+      service.typeOfEmployer$.next(typeOfEmployer);
+      if (manyLocationAddresses) {
+        service.locationAddresses$.next(moreThanFourLocationAddresses);
+      }
+
+      return service;
+    };
+  }
 }
 
 @Injectable()

--- a/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.html
+++ b/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.html
@@ -38,8 +38,7 @@
             name="termsAndConditions"
             type="checkbox"
             data-testid="checkbox"
-            value="check"
-            (click)="setTermsAndConditionsCheckbox()"
+            [value]="true"
             [formControlName]="'termsAndConditions'"
           />
           <label class="govuk-label govuk-checkboxes__label" for="termsAndConditions">

--- a/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.spec.ts
+++ b/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.spec.ts
@@ -112,6 +112,31 @@ describe('ConfirmDetailsComponent', () => {
       expect(postRegistrationSpy).not.toHaveBeenCalled();
     });
 
+    it('should keep showing the error message when user tick and untick the checkbox (delayed validation)', async () => {
+      const { queryByText, getByText, getByTestId, getAllByText, postRegistrationSpy } = await setup();
+      const expectedErrorMessage = 'Confirm that you agree to the terms and conditions';
+
+      const termsAndConditionsCheckbox = getByTestId('checkbox') as HTMLInputElement;
+      const submitButton = getByText('Submit details');
+      fireEvent.click(submitButton);
+
+      expect(queryByText('There is a problem')).toBeTruthy();
+      expect(getAllByText(expectedErrorMessage, { exact: false }).length).toBe(2);
+      expect(postRegistrationSpy).not.toHaveBeenCalled();
+
+      fireEvent.click(termsAndConditionsCheckbox);
+      expect(termsAndConditionsCheckbox.checked).toBeTrue();
+
+      expect(queryByText('There is a problem')).toBeTruthy();
+      expect(getAllByText(expectedErrorMessage, { exact: false }).length).toBe(2);
+
+      fireEvent.click(termsAndConditionsCheckbox);
+      expect(termsAndConditionsCheckbox.checked).toBeFalse();
+
+      expect(queryByText('There is a problem')).toBeTruthy();
+      expect(getAllByText(expectedErrorMessage, { exact: false }).length).toBe(2);
+    });
+
     it('should preselect the terms and conditions checkbox if it is set to true in the service', async () => {
       const { getByTestId } = await setup({ termsAndConditionsCheckbox: true });
 

--- a/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.spec.ts
+++ b/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.spec.ts
@@ -13,19 +13,24 @@ import { RegistrationModule } from '@features/registration/registration.module';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
-import { BehaviorSubject, of } from 'rxjs';
+import { of } from 'rxjs';
 
 import { ConfirmDetailsComponent } from './confirm-details.component';
 import { InviteResponse } from '@core/model/userDetails.model';
 
 describe('ConfirmDetailsComponent', () => {
-  async function setup(registrationFlow = true) {
-    const { fixture, getByText, getByTestId, getAllByText, queryByText } = await render(ConfirmDetailsComponent, {
+  async function setup(overrides: any = {}) {
+    const registrationFlow = overrides?.registrationFlow ?? true;
+    const termsAndConditionsCheckboxValue = overrides?.termsAndConditionsCheckbox ?? null;
+
+    const setupTools = await render(ConfirmDetailsComponent, {
       imports: [SharedModule, RegistrationModule, FormsModule, ReactiveFormsModule],
       providers: [
         {
           provide: RegistrationService,
-          useFactory: MockRegistrationServiceWithMainService.factory(),
+          useFactory: MockRegistrationServiceWithMainService.factoryWithOverrides({
+            termsAndConditionsCheckboxValue,
+          }),
           deps: [HttpClient],
         },
         {
@@ -55,24 +60,20 @@ describe('ConfirmDetailsComponent', () => {
     const injector = getTestBed();
     const router = injector.inject(Router) as Router;
 
-    const spy = spyOn(router, 'navigate');
-    spy.and.returnValue(Promise.resolve(true));
+    const routerSpy = spyOn(router, 'navigate');
+    routerSpy.and.returnValue(Promise.resolve(true));
 
     const registrationService = injector.inject(RegistrationService) as RegistrationService;
 
     const postRegistrationSpy = spyOn(registrationService, 'postRegistration');
     postRegistrationSpy.and.returnValue(of({ userStatus: 'PENDING' }));
 
-    const component = fixture.componentInstance;
+    const component = setupTools.fixture.componentInstance;
 
     return {
-      fixture,
+      ...setupTools,
       component,
-      spy,
-      getAllByText,
-      queryByText,
-      getByText,
-      getByTestId,
+      routerSpy,
       postRegistrationSpy,
     };
   }
@@ -98,62 +99,99 @@ describe('ConfirmDetailsComponent', () => {
     expect(getAllByText(termsAndConditionsLink, { exact: false })).toBeTruthy();
   });
 
-  it('should show an error message when pressing submit without agreeing to terms and conditions', async () => {
-    const { fixture, getByText, getAllByText } = await setup();
-    const expectedErrorMessage = 'Confirm that you agree to the terms and conditions';
+  describe('validation', () => {
+    it('should show an error message when pressing submit without agreeing to terms and conditions', async () => {
+      const { queryByText, getByText, getAllByText, postRegistrationSpy } = await setup();
+      const expectedErrorMessage = 'Confirm that you agree to the terms and conditions';
 
-    const submitButton = getByText('Submit details');
-    fireEvent.click(submitButton);
+      const submitButton = getByText('Submit details');
+      fireEvent.click(submitButton);
 
-    expect(fixture.componentInstance.form.invalid).toBeTruthy();
-    expect(getAllByText(expectedErrorMessage, { exact: false }).length).toBe(2);
-  });
+      expect(queryByText('There is a problem')).toBeTruthy();
+      expect(getAllByText(expectedErrorMessage, { exact: false }).length).toBe(2);
+      expect(postRegistrationSpy).not.toHaveBeenCalled();
+    });
 
-  it('should preselect the terms and conditions checkbox if it is set to true in the service', async () => {
-    const { component } = await setup();
+    it('should preselect the terms and conditions checkbox if it is set to true in the service', async () => {
+      const { getByTestId } = await setup({ termsAndConditionsCheckbox: true });
 
-    component.registrationService.termsAndConditionsCheckbox$ = new BehaviorSubject(true);
-    component.ngOnInit();
+      const termsAndConditionsCheckbox = getByTestId('checkbox') as HTMLInputElement;
 
-    expect(component.form.value.termsAndConditions).toEqual('check');
-  });
+      expect(termsAndConditionsCheckbox.checked).toBeTrue();
+    });
 
-  it('should not preselect the terms and conditions checkbox if it is set to false in the service', async () => {
-    const { component } = await setup();
+    it('should not preselect the terms and conditions checkbox if it is set to false in the service', async () => {
+      const { getByTestId } = await setup({ termsAndConditionsCheckbox: false });
 
-    component.registrationService.termsAndConditionsCheckbox$ = new BehaviorSubject(false);
-    component.ngOnInit();
+      const termsAndConditionsCheckbox = getByTestId('checkbox') as HTMLInputElement;
 
-    expect(component.form.value.termsAndConditions).toBeNull();
-  });
+      expect(termsAndConditionsCheckbox.checked).toBeFalse();
+    });
 
-  it('should update the value of termsAndConditionsCheckbox$ in the service when the checkbox is clicked', async () => {
-    const { component, getByTestId } = await setup();
+    it('should update the value of termsAndConditionsCheckbox$ in the service when the checkbox is clicked', async () => {
+      const { component, getByTestId } = await setup();
 
-    const spy = spyOn(component, 'setTermsAndConditionsCheckbox').and.callThrough();
+      expect(component.registrationService.termsAndConditionsCheckbox$.value).toBe(null);
 
-    component.registrationService.termsAndConditionsCheckbox$ = new BehaviorSubject(false);
-    component.ngOnInit();
+      const termsAndConditionsCheckbox = getByTestId('checkbox') as HTMLInputElement;
+      fireEvent.click(termsAndConditionsCheckbox);
 
-    const termsAndConditionsCheckbox = getByTestId('checkbox');
-    fireEvent.click(termsAndConditionsCheckbox);
+      expect(termsAndConditionsCheckbox.checked).toBeTrue();
+      expect(component.registrationService.termsAndConditionsCheckbox$.value).toBe(true);
 
-    expect(spy).toHaveBeenCalled();
-    expect(component.registrationService.termsAndConditionsCheckbox$.value).toBe(true);
+      fireEvent.click(termsAndConditionsCheckbox);
+
+      expect(termsAndConditionsCheckbox.checked).toBeFalse();
+      expect(component.registrationService.termsAndConditionsCheckbox$.value).toBe(false);
+    });
+
+    it('should not show an error on submit when termsAndConditionsCheckbox is ticked from prefill', async () => {
+      const { getByTestId, getByText, postRegistrationSpy, queryByText } = await setup({
+        termsAndConditionsCheckbox: true,
+      });
+
+      const termsAndConditionsCheckbox = getByTestId('checkbox') as HTMLInputElement;
+      expect(termsAndConditionsCheckbox.checked).toBeTrue();
+
+      const submitButton = getByText('Submit details');
+
+      fireEvent.click(submitButton);
+
+      expect(queryByText('There is a problem')).toBeFalsy();
+      expect(postRegistrationSpy).toHaveBeenCalled();
+    });
+
+    it('should show an error on submit when termsAndConditionsCheckbox is ticked from prefill but unticked by user', async () => {
+      const { getByTestId, getByText, postRegistrationSpy, queryByText } = await setup({
+        termsAndConditionsCheckbox: true,
+      });
+
+      const termsAndConditionsCheckbox = getByTestId('checkbox') as HTMLInputElement;
+      expect(termsAndConditionsCheckbox.checked).toBeTrue();
+
+      fireEvent.click(termsAndConditionsCheckbox);
+      expect(termsAndConditionsCheckbox.checked).toBeFalse();
+
+      const submitButton = getByText('Submit details');
+
+      fireEvent.click(submitButton);
+
+      expect(queryByText('There is a problem')).toBeTruthy();
+      expect(postRegistrationSpy).not.toHaveBeenCalled();
+    });
   });
 
   it('should call the save function to create account when pressing submit after agreeing to terms and conditions', async () => {
-    const { component, fixture, getByText, getByTestId } = await setup();
+    const { fixture, getByText, getByTestId, postRegistrationSpy } = await setup();
 
     const termsAndConditionsCheckbox = getByTestId('checkbox');
     const submitButton = getByText('Submit details');
-    const saveSpy = spyOn(component, 'save').and.returnValue(null);
 
     fireEvent.click(termsAndConditionsCheckbox);
     fireEvent.click(submitButton);
 
     expect(fixture.componentInstance.form.invalid).toBeFalsy();
-    expect(saveSpy).toHaveBeenCalled();
+    expect(postRegistrationSpy).toHaveBeenCalled();
   });
 
   describe('Submitting registration', () => {

--- a/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.ts
+++ b/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, signal, ViewChild } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ErrorDetails } from '@core/model/errorSummary.model';
@@ -16,6 +16,7 @@ import { BackLinkService } from '@core/services/backLink.service';
 import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { RegistrationService } from '@core/services/registration.service';
 import { UserService } from '@core/services/user.service';
+import { CustomValidators } from '@shared/validators/custom-form-validators';
 import { combineLatest, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -44,6 +45,7 @@ export class ConfirmDetailsComponent implements OnInit {
   public isCqcRegulated: boolean;
   public typeOfEmployer: EmployerType;
   public workplaceName: string;
+  private validationIsActive = signal(false);
 
   constructor(
     public registrationService: RegistrationService,
@@ -130,6 +132,9 @@ export class ConfirmDetailsComponent implements OnInit {
   }
 
   public onSubmit(): void {
+    this.validationIsActive.set(true);
+    this.form.get('termsAndConditions')!.updateValueAndValidity();
+
     this.submitted = true;
     this.errorSummaryService.syncFormErrorsEvent.next(true);
 
@@ -137,6 +142,7 @@ export class ConfirmDetailsComponent implements OnInit {
       this.save();
     } else {
       this.errorSummaryService.scrollToErrorSummary();
+      this.validationIsActive.set(false);
     }
   }
 
@@ -175,11 +181,15 @@ export class ConfirmDetailsComponent implements OnInit {
   }
 
   private setupForm(): void {
+    const validators = [Validators.required, Validators.requiredTrue].map((validatorFn) => {
+      return CustomValidators.withSignalToggle(validatorFn, this.validationIsActive);
+    });
+
     this.form = this.formBuilder.group({
       termsAndConditions: [
         null,
         {
-          validators: [Validators.required, Validators.requiredTrue],
+          validators: validators,
         },
       ],
     });

--- a/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.ts
+++ b/frontend/src/app/features/create-account/workplace/confirm-details/confirm-details.component.ts
@@ -20,9 +20,9 @@ import { combineLatest, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Component({
-    selector: 'app-confirm-details',
-    templateUrl: './confirm-details.component.html',
-    standalone: false
+  selector: 'app-confirm-details',
+  templateUrl: './confirm-details.component.html',
+  standalone: false,
 })
 export class ConfirmDetailsComponent implements OnInit {
   @ViewChild('formEl') formEl: ElementRef;
@@ -31,7 +31,6 @@ export class ConfirmDetailsComponent implements OnInit {
   public form: UntypedFormGroup;
   private formErrorsMap: Array<ErrorDetails>;
   private subscriptions: Subscription = new Subscription();
-  public termsAndConditionsCheckbox: boolean;
   protected service: Service;
   public userInfo: SummaryList[];
   public loginInfo: SummaryList[];
@@ -62,7 +61,6 @@ export class ConfirmDetailsComponent implements OnInit {
     this.prefillForm();
     this.setupSubscriptions();
     this.setBackLink();
-    this.termsAndConditionsCheckbox = false;
     this.workplaceName = this.locationAddress.locationName;
   }
 
@@ -90,7 +88,16 @@ export class ConfirmDetailsComponent implements OnInit {
     const subscriptions = combineLatest([registrationSubscriptions, userSubscriptions]).pipe(
       map(
         ([
-          [isCqcRegulated, locationAddress, service, loginCredentials, securityDetails, userResearchInviteResponse, totalStaff, typeOfEmployer],
+          [
+            isCqcRegulated,
+            locationAddress,
+            service,
+            loginCredentials,
+            securityDetails,
+            userResearchInviteResponse,
+            totalStaff,
+            typeOfEmployer,
+          ],
           [userDetails],
         ]) => {
           return {
@@ -169,8 +176,18 @@ export class ConfirmDetailsComponent implements OnInit {
 
   private setupForm(): void {
     this.form = this.formBuilder.group({
-      termsAndConditions: [null, { validators: [Validators.required, Validators.requiredTrue], updateOn: 'submit' }],
+      termsAndConditions: [
+        null,
+        {
+          validators: [Validators.required, Validators.requiredTrue],
+        },
+      ],
     });
+
+    const syncCheckboxWithService = this.form.get('termsAndConditions')?.valueChanges.subscribe((newValue) => {
+      this.registrationService.termsAndConditionsCheckbox$.next(newValue);
+    });
+    this.subscriptions.add(syncCheckboxWithService);
   }
 
   private setupFormErrorsMap(): void {
@@ -188,16 +205,12 @@ export class ConfirmDetailsComponent implements OnInit {
   }
 
   protected prefillForm(): void {
-    this.termsAndConditionsCheckbox = this.registrationService.termsAndConditionsCheckbox$.value;
-    if (this.termsAndConditionsCheckbox) {
+    const tickedPreviously = this.registrationService.termsAndConditionsCheckbox$.value;
+    if (tickedPreviously) {
       this.form.patchValue({
-        termsAndConditions: 'check',
+        termsAndConditions: true,
       });
     }
-  }
-  public setTermsAndConditionsCheckbox() {
-    this.termsAndConditionsCheckbox = !this.form.get('termsAndConditions').value;
-    this.registrationService.termsAndConditionsCheckbox$.next(this.termsAndConditionsCheckbox);
   }
 
   public getFirstErrorMessage(item: string): string {


### PR DESCRIPTION
#### Work done
- Fix an issue in register account flow, about the checkbox validation in confirmation page

Steps to reproduce the issue:
 1. tick the checkbox on confirmation page
 2. use the change link to visit one of the previous page, then go back to confirmation page
 3. now the checkbox is prefilled with a tick, but when submit, an error message will show up as if user have not ticked the checkbox yet.

The issue was due to form prefill and value sync with service not being set up correctly.
 

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
