### PR TITLE
Fix/1963 prevent 404 error for invalid icon image path

### DIFF
--- a/frontend/src/app/shared/components/eligibility-icon/eligibility-icon.component.html
+++ b/frontend/src/app/shared/components/eligibility-icon/eligibility-icon.component.html
@@ -2,6 +2,6 @@
   <ng-container *ngIf="num !== null">
     <strong class="govuk-line-height__normal govuk-!-margin-right-1">{{ num }}</strong>
   </ng-container>
-  <img src="/assets/images/{{ icon }}.svg" class="asc-icon-align" alt="" />
+  <img *ngIf="icon" src="/assets/images/{{ icon }}.svg" class="asc-icon-align" alt="" />
   <span class="govuk-!-margin-left-1">{{ label }}</span>
 </span>

--- a/frontend/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.html
+++ b/frontend/src/app/shared/components/wdf-staff-mismatch-message/wdf-staff-mismatch-message.component.html
@@ -2,7 +2,9 @@
   <dt class="govuk-summary-list__key"></dt>
   <dd class="govuk-summary-list__value govuk-summary-list__message">
     <span class="govuk-!-margin-bottom-2 govuk-!-margin-top-2 govuk__flex">
-      <img class="govuk-!-margin-right-1" src="/assets/images/{{ icon }}.svg" alt="" />{{ staffMismatchMessage }}
+      <img *ngIf="icon" class="govuk-!-margin-right-1" src="/assets/images/{{ icon }}.svg" alt="" />{{
+        staffMismatchMessage
+      }}
     </span>
     <span *ngIf="workplace.numberOfStaff !== 0" class="govuk__nowrap">
       Either change the total or


### PR DESCRIPTION
#### Work done
- Updated eligibility-icon.component and wdf-staff-mismatch-message.component to only render the image when a valid icon value is available.
- Prevented the img tag from generating an invalid /assets/images/.svg path when icon is null or undefined.
<img width="3568" height="1774" alt="Image 15-07-2026 at 14 52" src="https://github.com/user-attachments/assets/80485462-a525-4294-a20e-a95fc2a1dd4e" />
<img width="3568" height="1814" alt="Image 15-07-2026 at 14 49" src="https://github.com/user-attachments/assets/5b617586-d078-4148-97df-58b7dacb3944" />


#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
