### PR TITLE
Fix/1967 removed highchart warning message

### DIFF
--- a/frontend/src/app/shared/components/benchmark-metric/barchart/barchart.component.spec.ts
+++ b/frontend/src/app/shared/components/benchmark-metric/barchart/barchart.component.spec.ts
@@ -4,8 +4,6 @@ import { build, fake } from '@jackfranklin/test-data-bot';
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 import { HighchartsChartModule } from 'highcharts-angular';
-import * as Highcharts from 'highcharts';
-import Accessibility from 'highcharts/modules/accessibility';
 
 import { BarchartOptionsBuilder } from './barchart-options-builder';
 import { BarchartComponent } from './barchart.component';
@@ -32,17 +30,7 @@ const getBarchartComponent = async (type: Metric, tile: Tile) => {
   });
 };
 
-const suppressHighchartWarnings = () => {
-  const allowedAttr = Highcharts.AST.allowedAttributes;
-  allowedAttr.push('data-testid');
-  Accessibility(Highcharts);
-};
-
 describe('BarchartComponent', () => {
-  beforeAll(() => {
-    suppressHighchartWarnings();
-  });
-
   it('should display a bar for each column', async () => {
     const benchmarks = benchmarksBuilder();
 

--- a/frontend/src/app/shared/components/benchmark-metric/barchart/barchart.component.ts
+++ b/frontend/src/app/shared/components/benchmark-metric/barchart/barchart.component.ts
@@ -1,14 +1,19 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Metric, NoData, Tile } from '@core/model/benchmarks.model';
 import * as Highcharts from 'highcharts';
+import Accessibility from 'highcharts/modules/accessibility';
 
 import { BarchartOptionsBuilder } from './barchart-options-builder';
 
+Accessibility(Highcharts);
+
+Highcharts.AST.allowedAttributes.push('data-testid');
+
 @Component({
-    selector: 'app-barchart',
-    templateUrl: './barchart.component.html',
-    styleUrls: ['./barchart.component.scss'],
-    standalone: false
+  selector: 'app-barchart',
+  templateUrl: './barchart.component.html',
+  styleUrls: ['./barchart.component.scss'],
+  standalone: false,
 })
 export class BarchartComponent implements OnInit {
   Highcharts: typeof Highcharts = Highcharts;

--- a/frontend/src/app/shared/components/benchmark-metric/gauge/gauge-options-builder.ts
+++ b/frontend/src/app/shared/components/benchmark-metric/gauge/gauge-options-builder.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@angular/core';
 import * as Highcharts from 'highcharts';
+import Accessibility from 'highcharts/modules/accessibility';
 import ArrowSymbolsModule from 'highcharts/modules/arrow-symbols';
 import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
 
 ArrowSymbolsModule(Highcharts);
+Accessibility(Highcharts);
+
+Highcharts.AST.allowedAttributes.push('data-testid');
 
 @Injectable({
   providedIn: 'root',

--- a/frontend/src/app/shared/components/benchmark-metric/gauge/gauge.component.spec.ts
+++ b/frontend/src/app/shared/components/benchmark-metric/gauge/gauge.component.spec.ts
@@ -1,26 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import * as Highcharts from 'highcharts';
-import Accessibility from 'highcharts/modules/accessibility';
 
 import { GaugeComponent } from './gauge.component';
 
 describe('GaugeComponent', () => {
   let component: GaugeComponent;
   let fixture: ComponentFixture<GaugeComponent>;
-
-  const suppressHighchartWarnings = () => {
-    const allowedAttr = Highcharts.AST.allowedAttributes;
-    allowedAttr.push('data-testid');
-    Accessibility(Highcharts);
-  };
-
-  beforeAll(() => {
-    // TODO: this suppress the highchart warnings in unit tests
-    // by allowing data-testid in html template and enabling highchart accessibility module.
-    // we should consider to put these changes in working code as well when we have the opportunity
-    suppressHighchartWarnings();
-  });
-
   beforeEach(() => {
     fixture = TestBed.createComponent(GaugeComponent);
     component = fixture.componentInstance;


### PR DESCRIPTION
#### Work done
- Removed the warning suppression from Highcharts unit tests.
- Added the Highcharts accessibility module configuration.
- Allowed the required custom data-id attribute in Highcharts AST allowed attributes to prevent warnings.
#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
