### PR TITLE
Fix/1971 1973 Fix issues for funding page summary panel

### DIFF
--- a/frontend/src/app/features/funding/wdf-data/wdf-data.component.html
+++ b/frontend/src/app/features/funding/wdf-data/wdf-data.component.html
@@ -27,6 +27,7 @@
       [someSubsidiariesMeetingRequirements]="someSubsidiariesMeetingRequirements"
       [activatedFragment]="activeTab.fragment"
       [subsidiariesCount]="subsidiaryWorkplaces?.length"
+      [someSubsidiariesNeedCheckAgain]="someSubsidiariesNeedCheckAgain"
     ></app-wdf-summary-panel>
   </div>
 </div>

--- a/frontend/src/app/features/funding/wdf-data/wdf-data.component.html
+++ b/frontend/src/app/features/funding/wdf-data/wdf-data.component.html
@@ -26,6 +26,7 @@
       [subsidiariesOverallWdfEligibility]="subsidiariesOverallWdfEligibility"
       [someSubsidiariesMeetingRequirements]="someSubsidiariesMeetingRequirements"
       [activatedFragment]="activeTab.fragment"
+      [subsidiariesCount]="subsidiaryWorkplaces?.length"
     ></app-wdf-summary-panel>
   </div>
 </div>

--- a/frontend/src/app/features/funding/wdf-data/wdf-data.component.spec.ts
+++ b/frontend/src/app/features/funding/wdf-data/wdf-data.component.spec.ts
@@ -217,7 +217,7 @@ describe('WdfDataComponent', () => {
 
       const yourOtherWorkplacesRow = getByTestId('workplaces-row');
 
-      expect(within(yourOtherWorkplacesRow).getByTestId('met-funding-message')).toBeTruthy();
+      expect(within(yourOtherWorkplacesRow).getByText(/Your data has met the funding requirements for/)).toBeTruthy();
     });
 
     it('should display the met funding requirements message when all subs have eligibility even if parent does not', async () => {
@@ -229,7 +229,7 @@ describe('WdfDataComponent', () => {
 
       const yourOtherWorkplacesRow = getByTestId('workplaces-row');
 
-      expect(within(yourOtherWorkplacesRow).getByTestId('met-funding-message')).toBeTruthy();
+      expect(within(yourOtherWorkplacesRow).getByText(/Your data has met the funding requirements for/)).toBeTruthy();
     });
 
     it('should display the some data not meeting funding requirements message when not all meeting but some subs have overall eligibility', async () => {

--- a/frontend/src/app/features/funding/wdf-data/wdf-data.component.ts
+++ b/frontend/src/app/features/funding/wdf-data/wdf-data.component.ts
@@ -193,10 +193,11 @@ export class WdfDataComponent implements OnInit {
     this.someSubsidiariesMeetingRequirements = this.subsidiaryWorkplaces.some(
       (workplace) => workplace.wdf.overall === true,
     );
-    this.someSubsidiariesNeedCheckAgain = this.subsidiaryWorkplaces.some(
-      (workplace) =>
-        (workplace?.wdf?.overall === true && workplace?.wdf?.workplace === false) || workplace?.wdf?.staff === false,
-    );
+    this.someSubsidiariesNeedCheckAgain = this.subsidiaryWorkplaces.some((workplace) => {
+      return (
+        workplace?.wdf?.overall === true && (workplace?.wdf?.workplace === false || workplace?.wdf?.staff === false)
+      );
+    });
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/features/funding/wdf-data/wdf-data.component.ts
+++ b/frontend/src/app/features/funding/wdf-data/wdf-data.component.ts
@@ -21,9 +21,9 @@ import { WdfEligibilityStatus } from '../../../core/model/wdf.model';
 import { Worker } from '../../../core/model/worker.model';
 
 @Component({
-    selector: 'app-wdf-data',
-    templateUrl: './wdf-data.component.html',
-    standalone: false
+  selector: 'app-wdf-data',
+  templateUrl: './wdf-data.component.html',
+  standalone: false,
 })
 export class WdfDataComponent implements OnInit {
   public workplace: Establishment;
@@ -42,6 +42,7 @@ export class WdfDataComponent implements OnInit {
   public overallWdfEligibility: boolean;
   public subsidiariesOverallWdfEligibility: boolean;
   public someSubsidiariesMeetingRequirements: boolean;
+  public someSubsidiariesNeedCheckAgain: boolean;
 
   public isParent: boolean;
   public subsidiaryWorkplaces = [];
@@ -191,6 +192,10 @@ export class WdfDataComponent implements OnInit {
     );
     this.someSubsidiariesMeetingRequirements = this.subsidiaryWorkplaces.some(
       (workplace) => workplace.wdf.overall === true,
+    );
+    this.someSubsidiariesNeedCheckAgain = this.subsidiaryWorkplaces.some(
+      (workplace) =>
+        (workplace?.wdf?.overall === true && workplace?.wdf?.workplace === false) || workplace?.wdf?.staff === false,
     );
   }
 

--- a/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.html
+++ b/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.html
@@ -28,6 +28,7 @@
       [subsidiariesOverallWdfEligibility]="subsidiariesOverallWdfEligibility"
       [someSubsidiariesMeetingRequirements]="someSubsidiariesMeetingRequirements"
       [onDataPage]="false"
+      [subsidiariesCount]="activeSubsidiaryWorkplaces?.length"
     ></app-wdf-summary-panel>
   </div>
 </div>

--- a/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.html
+++ b/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.html
@@ -29,6 +29,7 @@
       [someSubsidiariesMeetingRequirements]="someSubsidiariesMeetingRequirements"
       [onDataPage]="false"
       [subsidiariesCount]="activeSubsidiaryWorkplaces?.length"
+      [someSubsidiariesNeedCheckAgain]="someSubsidiariesNeedCheckAgain"
     ></app-wdf-summary-panel>
   </div>
 </div>

--- a/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.ts
+++ b/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.ts
@@ -74,6 +74,7 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
 
           this.workplaces = [...activeSubsidiaryWorkplaces, workplaces.primary];
           this.workplaces = orderBy(this.workplaces, ['wdf.overall', 'wdf.overallWdfEligibility'], ['desc', 'desc']);
+          this.activeSubsidiaryWorkplaces = activeSubsidiaryWorkplaces;
 
           this.getParentOverallWdfEligibility();
           this.getLastOverallEligibilityDate();

--- a/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.ts
+++ b/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { JourneyType } from '@core/breadcrumb/breadcrumb.model';
 import { Establishment } from '@core/model/establishment.model';
-import { GetWorkplacesResponse } from '@core/model/my-workplaces.model';
+import { GetWorkplacesResponse, Workplace } from '@core/model/my-workplaces.model';
 import { WDFReport } from '@core/model/reports.model';
 import { WdfEligibilityStatus } from '@core/model/wdf.model';
 import { BreadcrumbService } from '@core/services/breadcrumb.service';
@@ -13,10 +13,10 @@ import orderBy from 'lodash/orderBy';
 import { Subscription } from 'rxjs';
 
 @Component({
-    selector: 'app-wdf-overview',
-    templateUrl: './wdf-overview.component.html',
-    styleUrls: ['../../../shared/components/summary-section/summary-section.component.scss'],
-    standalone: false
+  selector: 'app-wdf-overview',
+  templateUrl: './wdf-overview.component.html',
+  styleUrls: ['../../../shared/components/summary-section/summary-section.component.scss'],
+  standalone: false,
 })
 export class WdfOverviewComponent implements OnInit, OnDestroy {
   public workplace: Establishment;
@@ -36,6 +36,7 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
   public sections: any = [];
   public staffOverallWdfEligibility: boolean;
   public wdfEligibilityStatus: WdfEligibilityStatus = {};
+  public activeSubsidiaryWorkplaces: Workplace[] = [];
 
   constructor(
     private establishmentService: EstablishmentService,

--- a/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.ts
+++ b/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.ts
@@ -27,6 +27,7 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
   public parentOverallWdfEligibility: boolean;
   public subsidiariesOverallWdfEligibility: boolean;
   public someSubsidiariesMeetingRequirements: boolean;
+  public someSubsidiariesNeedCheckAgain: boolean;
   public overallEligibilityDate: string;
   public parentOverallEligibilityDate: string;
   public isParent: boolean;
@@ -99,6 +100,11 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
   public setSubsidiariesEligibility(subsidiaryWorkplaces): void {
     this.subsidiariesOverallWdfEligibility = subsidiaryWorkplaces.every((workplace) => workplace.wdf.overall === true);
     this.someSubsidiariesMeetingRequirements = subsidiaryWorkplaces.some((workplace) => workplace.wdf.overall === true);
+
+    this.someSubsidiariesNeedCheckAgain = subsidiaryWorkplaces.some(
+      (workplace) =>
+        (workplace?.wdf?.overall === true && workplace?.wdf?.workplace === false) || workplace?.wdf?.staff === false,
+    );
   }
 
   private setEligibilityStatus(): void {

--- a/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.ts
+++ b/frontend/src/app/features/funding/wdf-overview/wdf-overview.component.ts
@@ -101,10 +101,11 @@ export class WdfOverviewComponent implements OnInit, OnDestroy {
     this.subsidiariesOverallWdfEligibility = subsidiaryWorkplaces.every((workplace) => workplace.wdf.overall === true);
     this.someSubsidiariesMeetingRequirements = subsidiaryWorkplaces.some((workplace) => workplace.wdf.overall === true);
 
-    this.someSubsidiariesNeedCheckAgain = subsidiaryWorkplaces.some(
-      (workplace) =>
-        (workplace?.wdf?.overall === true && workplace?.wdf?.workplace === false) || workplace?.wdf?.staff === false,
-    );
+    this.someSubsidiariesNeedCheckAgain = subsidiaryWorkplaces.some((workplace) => {
+      return (
+        workplace?.wdf?.overall === true && (workplace?.wdf?.workplace === false || workplace?.wdf?.staff === false)
+      );
+    });
   }
 
   private setEligibilityStatus(): void {

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.html
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.html
@@ -14,6 +14,14 @@
               data-testid="red-flag"
             />
           }
+          @case (FlagType.Orange) {
+            <img
+              src="/assets/images/large-orange-flag.svg"
+              alt="orange-flag"
+              class="govuk-!-margin-right-2"
+              data-testid="orange-flag"
+            />
+          }
           @case (FlagType.Green) {
             <img
               src="/assets/images/large-green-tick.svg"
@@ -32,6 +40,7 @@
         }
       </div>
     </div>
+
     @if (!last) {
       <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-left-4 govuk-!-margin-right-4" />
     }

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.html
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.html
@@ -1,56 +1,39 @@
 <div class="govuk-width-container govuk-!-margin-top-0 govuk-!-margin-bottom-4 summary-box" data-testid="summaryPanel">
-  <ng-container *ngFor="let section of sections; index as index">
+  @for (section of sections; track section.fragment; let index = $index, last = $last) {
     <div class="summary-section" [attr.data-testid]="section.fragment + '-row'">
       <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-3 govuk-!-font-size-24 summary-section__title">
         {{ section.title }}
       </div>
       <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-3 govuk-body summary-section__summary-text">
-        <ng-container *ngIf="section.eligibility; else redFlag">
-          <img
-            src="/assets/images/large-green-tick.svg"
-            alt="green-tick"
-            class="govuk-!-margin-right-2"
-            data-testid="green-tick"
-          />
-          <ng-container *ngIf="section.showLink; else noLink">
-            <a
-              (click)="onClick($event, section.fragment)"
-              href="#"
-              class="govuk-link--no-visited-state"
-              data-testid="met-funding-message"
-            >
-              {{ section.meetingMessage }}
-            </a>
-          </ng-container>
-          <ng-template #noLink>
-            {{ section.meetingMessage }}
-          </ng-template>
-        </ng-container>
-        <ng-template #redFlag>
-          <img
-            src="/assets/images/large-red-flag.svg"
-            alt="action-required-red-flag"
-            class="govuk-!-margin-right-2"
-            data-testid="red-flag"
-          />
-          <ng-container *ngIf="section.showLink; else noLink">
-            <a
-              (click)="onClick($event, section.fragment)"
-              href="#"
-              class="govuk-link--no-visited-state"
-              data-testid="not-met-funding-message"
-            >
-              {{ section.notMeetingMessage }}
-            </a>
-          </ng-container>
-          <ng-template #noLink>
-            {{ section.notMeetingMessage }}
-          </ng-template>
-        </ng-template>
+        @switch (section.showFlag) {
+          @case (FlagType.Red) {
+            <img
+              src="/assets/images/large-red-flag.svg"
+              alt="action-required-red-flag"
+              class="govuk-!-margin-right-2"
+              data-testid="red-flag"
+            />
+          }
+          @case (FlagType.Green) {
+            <img
+              src="/assets/images/large-green-tick.svg"
+              alt="green-tick"
+              class="govuk-!-margin-right-2"
+              data-testid="green-tick"
+            />
+          }
+        }
+        @if (section.showLink) {
+          <a (click)="onClick($event, section.fragment)" href="#" class="govuk-link--no-visited-state">
+            {{ section.message }}
+          </a>
+        } @else {
+          {{ section.message }}
+        }
       </div>
     </div>
-    <ng-container *ngIf="index < sections.length - 1">
+    @if (!last) {
       <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-left-4 govuk-!-margin-right-4" />
-    </ng-container>
-  </ng-container>
+    }
+  }
 </div>

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.html
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.html
@@ -30,6 +30,9 @@
               data-testid="green-tick"
             />
           }
+          @case (FlagType.None) {
+            <span class="asc-placeholder-for-no-flags"></span>
+          }
         }
         @if (section.showLink) {
           <a (click)="onClick($event, section.fragment)" href="#" class="govuk-link--no-visited-state">

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.scss
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.scss
@@ -8,3 +8,7 @@
     width: 71%;
   }
 }
+
+.asc-placeholder-for-no-flags {
+  width: 38px;
+}

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
@@ -59,22 +59,6 @@ fdescribe('WdfSummaryPanel', () => {
       expect(within(workplaceRow).getByTestId('green-tick')).toBeTruthy();
     });
 
-    it('should display the correct message with timeframe for meeting funding requirements for the workplace if overall has met but workplace hasn\t', async () => {
-      const overrides = {
-        workplaceWdfEligibilityStatus: false,
-        overallWdfEligibility: true,
-      };
-
-      const { getByTestId } = await setup(overrides);
-
-      const workplaceRow = getByTestId('workplace-row');
-
-      expect(workplaceRow).toBeTruthy();
-      expect(within(workplaceRow).queryByText(messages.fundingNotMet)).toBeFalsy();
-      expect(within(workplaceRow).getByText(messages.fundingMet)).toBeTruthy();
-      expect(within(workplaceRow).getByTestId('green-tick')).toBeTruthy();
-    });
-
     it('should display the correct message with timeframe for meeting funding requirements for staff', async () => {
       const overrides = {
         staffWdfEligibilityStatus: true,
@@ -111,6 +95,7 @@ fdescribe('WdfSummaryPanel', () => {
       const overrides = {
         subsidiariesOverallWdfEligibility: true,
         isParent: true,
+        subsidiariesCount: 2,
       };
 
       const { getByTestId } = await setup(overrides);
@@ -188,6 +173,7 @@ fdescribe('WdfSummaryPanel', () => {
           staffWdfEligibilityStatus: true,
           subsidiariesOverallWdfEligibility: true,
           isParent: true,
+          subsidiariesCount: 2,
         };
 
         const { getByTestId } = await setup(overrides);
@@ -212,6 +198,7 @@ fdescribe('WdfSummaryPanel', () => {
           subsidiariesOverallWdfEligibility: true,
           isParent: true,
           activatedFragment: 'workplaces',
+          subsidiariesCount: 2,
         };
 
         const { getByTestId } = await setup(overrides);
@@ -229,7 +216,7 @@ fdescribe('WdfSummaryPanel', () => {
         expect(allWorkplacesFundingMessage).toBeFalsy();
       });
 
-      xit(`should show "You've not added any other workplaces yet" without a link when no other workplaces has been added`, async () => {
+      it(`should show "You've not added any other workplaces yet" without a link when no other workplaces has been added`, async () => {
         const overrides = {
           workplaceWdfEligibilityStatus: true,
           staffWdfEligibilityStatus: true,
@@ -239,13 +226,13 @@ fdescribe('WdfSummaryPanel', () => {
         };
         const { getByTestId } = await setup(overrides);
 
-        const allWorkplacesRow = getByTestId('workplaces-row');
+        const otherWorkplacesRow = getByTestId('workplaces-row');
 
-        const allWorkplacesFundingMessage = within(allWorkplacesRow).queryByRole('link');
+        const otherWorkplacesFundingMessage = within(otherWorkplacesRow).queryByRole('link');
+        expect(within(otherWorkplacesRow).getByText(`You've not added any other workplaces yet`)).toBeTruthy();
 
-        expect(allWorkplacesFundingMessage).toBeFalsy();
-
-        expect(within(allWorkplacesRow).getByText(`You've not added any other workplaces yet`)).toBeTruthy();
+        expect(otherWorkplacesFundingMessage).toBeFalsy();
+        expect(within(otherWorkplacesRow).queryByTestId('red-flag')).toBeFalsy();
       });
     });
   });
@@ -292,6 +279,7 @@ fdescribe('WdfSummaryPanel', () => {
         subsidiariesOverallWdfEligibility: false,
         isParent: true,
         overallWdfEligibility: false,
+        subsidiariesCount: 2,
       };
 
       const { getByTestId } = await setup(overrides);
@@ -312,6 +300,7 @@ fdescribe('WdfSummaryPanel', () => {
         someSubsidiariesMeetingRequirements: true,
         isParent: true,
         overallWdfEligibility: false,
+        subsidiariesCount: 2,
       };
 
       const { getByTestId } = await setup(overrides);
@@ -323,6 +312,28 @@ fdescribe('WdfSummaryPanel', () => {
 
       expect(within(workplacesRow).queryByText(messages.fundingMet)).toBeFalsy();
       expect(within(workplacesRow).queryByText(messages.fundingNotMet)).toBeFalsy();
+    });
+  });
+
+  describe('Orange flag (met overall requirements before but data changed)', () => {
+    it('should display "Check your workplace data" when met overall requirements but workplace become not eligible', async () => {
+      const overrides = {
+        workplaceWdfEligibilityStatus: false,
+        staffWdfEligibilityStatus: false,
+        overallWdfEligibility: true,
+      };
+
+      const { getByTestId } = await setup(overrides);
+
+      const workplaceRow = getByTestId('workplace-row');
+
+      expect(within(workplaceRow).getByText('Check your workplace data')).toBeTruthy();
+      expect(within(workplaceRow).queryByTestId('orange-flag')).toBeTruthy();
+
+      expect(within(workplaceRow).queryByTestId('red-flag')).toBeFalsy();
+      expect(within(workplaceRow).queryByTestId('green-tick')).toBeFalsy();
+      expect(within(workplaceRow).queryByText(messages.fundingMet)).toBeFalsy();
+      expect(within(workplaceRow).queryByText(messages.fundingNotMet)).toBeFalsy();
     });
   });
 
@@ -385,6 +396,7 @@ fdescribe('WdfSummaryPanel', () => {
           const overrides = {
             subsidiariesOverallWdfEligibility: isEligible,
             isParent: true,
+            subsidiariesCount: 2,
             onDataPage,
           };
 

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
@@ -8,7 +8,7 @@ import { fireEvent, render, within } from '@testing-library/angular';
 
 import { WdfSummaryPanel } from './wdf-summary-panel.component';
 
-describe('WdfSummaryPanel', () => {
+fdescribe('WdfSummaryPanel', () => {
   const currentYear = new Date().getFullYear();
 
   const messages = {
@@ -228,6 +228,25 @@ describe('WdfSummaryPanel', () => {
         expect(staffFundingMessage).toBeTruthy();
         expect(allWorkplacesFundingMessage).toBeFalsy();
       });
+
+      xit(`should show "You've not added any other workplaces yet" without a link when no other workplaces has been added`, async () => {
+        const overrides = {
+          workplaceWdfEligibilityStatus: true,
+          staffWdfEligibilityStatus: true,
+          subsidiariesOverallWdfEligibility: true,
+          isParent: true,
+          subsidiariesCount: 0,
+        };
+        const { getByTestId } = await setup(overrides);
+
+        const allWorkplacesRow = getByTestId('workplaces-row');
+
+        const allWorkplacesFundingMessage = within(allWorkplacesRow).queryByRole('link');
+
+        expect(allWorkplacesFundingMessage).toBeFalsy();
+
+        expect(within(allWorkplacesRow).getByText(`You've not added any other workplaces yet`)).toBeTruthy();
+      });
     });
   });
 
@@ -321,9 +340,7 @@ describe('WdfSummaryPanel', () => {
       },
     ].forEach(({ scenario, onDataPage, expectedLink }) => {
       [{ isEligible: true }, { isEligible: false }].forEach(({ isEligible }) => {
-        const linkId = isEligible ? 'met-funding-message' : 'not-met-funding-message';
-
-        it(`should navigate to workplace when ${linkId} clicked ${scenario}`, async () => {
+        it(`should navigate to workplace when workplace message clicked ${scenario}`, async () => {
           const overrides = {
             workplaceWdfEligibilityStatus: isEligible,
             overallWdfEligibility: isEligible,
@@ -334,7 +351,7 @@ describe('WdfSummaryPanel', () => {
 
           const workplaceRow = getByTestId('workplace-row');
 
-          const notMetFundingMessage = within(workplaceRow).getByTestId(linkId);
+          const notMetFundingMessage = within(workplaceRow).getByRole('link');
 
           expect(notMetFundingMessage).toBeTruthy();
 
@@ -344,7 +361,7 @@ describe('WdfSummaryPanel', () => {
           expect(routerSpy).toHaveBeenCalledWith(expectedLink, { fragment: 'workplace' });
         });
 
-        it(`should navigate to staff when ${linkId} clicked ${scenario}`, async () => {
+        it(`should navigate to staff when staff message clicked ${scenario}`, async () => {
           const overrides = {
             staffWdfEligibilityStatus: isEligible,
             overallWdfEligibility: isEligible,
@@ -355,7 +372,7 @@ describe('WdfSummaryPanel', () => {
 
           const staffRow = getByTestId('staff-row');
 
-          const notMetFundingMessage = within(staffRow).getByTestId(linkId);
+          const notMetFundingMessage = within(staffRow).getByRole('link');
 
           expect(notMetFundingMessage).toBeTruthy();
 
@@ -375,7 +392,7 @@ describe('WdfSummaryPanel', () => {
 
           const workplacesRow = getByTestId('workplaces-row');
 
-          const notMetFundingMessage = within(workplacesRow).getByTestId(linkId);
+          const notMetFundingMessage = within(workplacesRow).getByRole('link');
 
           expect(notMetFundingMessage).toBeTruthy();
 

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.spec.ts
@@ -8,7 +8,7 @@ import { fireEvent, render, within } from '@testing-library/angular';
 
 import { WdfSummaryPanel } from './wdf-summary-panel.component';
 
-fdescribe('WdfSummaryPanel', () => {
+describe('WdfSummaryPanel', () => {
   const currentYear = new Date().getFullYear();
 
   const messages = {
@@ -63,22 +63,6 @@ fdescribe('WdfSummaryPanel', () => {
       const overrides = {
         staffWdfEligibilityStatus: true,
         overallWdfEligibility: false,
-      };
-
-      const { getByTestId } = await setup(overrides);
-
-      const staffRow = getByTestId('staff-row');
-
-      expect(staffRow).toBeTruthy();
-      expect(within(staffRow).queryByText(messages.fundingNotMet)).toBeFalsy();
-      expect(within(staffRow).getByText(messages.fundingMet)).toBeTruthy();
-      expect(within(staffRow).getByTestId('green-tick')).toBeTruthy();
-    });
-
-    it("should display the correct message with timeframe for meeting funding requirements for staff if overall has met but staff hasn't", async () => {
-      const overrides = {
-        staffWdfEligibilityStatus: false,
-        overallWdfEligibility: true,
       };
 
       const { getByTestId } = await setup(overrides);
@@ -316,10 +300,10 @@ fdescribe('WdfSummaryPanel', () => {
   });
 
   describe('Orange flag (met overall requirements before but data changed)', () => {
-    it('should display "Check your workplace data" when met overall requirements but workplace become not eligible', async () => {
+    it('should display "Check your workplace data" if overall requirements has met but workplace has not', async () => {
       const overrides = {
         workplaceWdfEligibilityStatus: false,
-        staffWdfEligibilityStatus: false,
+        staffWdfEligibilityStatus: true,
         overallWdfEligibility: true,
       };
 
@@ -334,6 +318,49 @@ fdescribe('WdfSummaryPanel', () => {
       expect(within(workplaceRow).queryByTestId('green-tick')).toBeFalsy();
       expect(within(workplaceRow).queryByText(messages.fundingMet)).toBeFalsy();
       expect(within(workplaceRow).queryByText(messages.fundingNotMet)).toBeFalsy();
+    });
+
+    it('should display "Check your staff records" if overall requirements has met but staff records has not', async () => {
+      const overrides = {
+        workplaceWdfEligibilityStatus: true,
+        staffWdfEligibilityStatus: false,
+        overallWdfEligibility: true,
+      };
+
+      const { getByTestId } = await setup(overrides);
+
+      const staffRow = getByTestId('staff-row');
+
+      expect(within(staffRow).getByText('Check your staff records')).toBeTruthy();
+      expect(within(staffRow).queryByTestId('orange-flag')).toBeTruthy();
+
+      expect(within(staffRow).queryByTestId('red-flag')).toBeFalsy();
+      expect(within(staffRow).queryByTestId('green-tick')).toBeFalsy();
+      expect(within(staffRow).queryByText(messages.fundingMet)).toBeFalsy();
+      expect(within(staffRow).queryByText(messages.fundingNotMet)).toBeFalsy();
+    });
+
+    it('should display "Check your other workplaces" if subsidiaries overall requirements has met but some subsidiaries need check again', async () => {
+      const overrides = {
+        workplaceWdfEligibilityStatus: true,
+        staffWdfEligibilityStatus: true,
+        isParent: true,
+        subsidiariesCount: 2,
+        subsidiariesOverallWdfEligibility: true,
+        someSubsidiariesNeedCheckAgain: true,
+      };
+
+      const { getByTestId } = await setup(overrides);
+
+      const otherWorkplacesRow = getByTestId('workplaces-row');
+
+      expect(within(otherWorkplacesRow).getByText('Check your other workplaces')).toBeTruthy();
+      expect(within(otherWorkplacesRow).queryByTestId('orange-flag')).toBeTruthy();
+
+      expect(within(otherWorkplacesRow).queryByTestId('red-flag')).toBeFalsy();
+      expect(within(otherWorkplacesRow).queryByTestId('green-tick')).toBeFalsy();
+      expect(within(otherWorkplacesRow).queryByText(messages.fundingMet)).toBeFalsy();
+      expect(within(otherWorkplacesRow).queryByText(messages.fundingNotMet)).toBeFalsy();
     });
   });
 

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
@@ -73,6 +73,9 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
       case 'staff': {
         return 'Check your staff records';
       }
+      case 'workplaces': {
+        return 'Check your other workplaces';
+      }
     }
     return '';
   }
@@ -138,15 +141,15 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
         return { message: `You've not added any other workplaces yet`, showLink: false, showFlag: FlagType.None };
       }
       if (this.subsidiariesOverallWdfEligibility && this.someSubsidiariesNeedCheckAgain) {
-        return { message: 'Check your other workplaces', showFlag: FlagType.Orange };
+        return { message: this.getOrangeFlagMessage('workplaces'), showFlag: FlagType.Orange };
       }
       if (this.subsidiariesOverallWdfEligibility) {
-        return { message: this.meetingMessage };
+        return { message: this.meetingMessage, showFlag: FlagType.Green };
       }
       if (!this.subsidiariesOverallWdfEligibility && this.someSubsidiariesMeetingRequirements) {
-        return { message: this.someSubsMeetingMessage };
+        return { message: this.someSubsMeetingMessage, showFlag: FlagType.Red };
       }
-      return { message: this.notMeetingMessage };
+      return { message: this.notMeetingMessage, showFlag: FlagType.Red };
     };
 
     this.addSection('Your other workplaces', 'workplaces', this.subsidiariesOverallWdfEligibility, getOverrides);

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 
 enum FlagType {
   Red = 'RedFlag',
-  Amber = 'AmberFlag',
+  Orange = 'OrangeFlag',
   Green = 'GreenTick',
   None = 'NoFlag',
 }
@@ -15,7 +15,6 @@ interface Section {
   showLink: boolean;
   showFlag: FlagType;
 }
-
 @Component({
   selector: 'app-wdf-summary-panel',
   templateUrl: './wdf-summary-panel.component.html',
@@ -40,6 +39,7 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   public meetingMessage: string;
   public notMeetingMessage: string;
   public someSubsMeetingMessage: string;
+  public noSubsidiariesMessage: string;
   readonly FlagType = FlagType;
 
   constructor(
@@ -63,6 +63,7 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
     this.meetingMessage = `Your data has met the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
     this.notMeetingMessage = `Your data does not meet the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
     this.someSubsMeetingMessage = `Some data does not meet the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
+    this.noSubsidiariesMessage = `You've not added any other workplaces yet`;
   }
 
   public getSections(): void {
@@ -80,24 +81,31 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
     title: string,
     fragment: string,
     specificEligibility: boolean,
-    getNotMeetingMessage?: () => string,
+    getOverrides?: () => Partial<Section>,
   ): void {
-    const meetRequirements = specificEligibility || this.overallWdfEligibility;
     const showLink = this.activatedFragment !== fragment;
-
-    getNotMeetingMessage = getNotMeetingMessage ?? (() => this.notMeetingMessage);
+    const meetRequirements = specificEligibility || this.overallWdfEligibility;
+    const message = meetRequirements ? this.meetingMessage : this.notMeetingMessage;
+    const overrides = getOverrides ? getOverrides() : {};
 
     this.sections.push({
       title,
       fragment,
       showLink,
       showFlag: meetRequirements ? FlagType.Green : FlagType.Red,
-      message: meetRequirements ? this.meetingMessage : getNotMeetingMessage(),
+      message,
+      ...overrides,
     });
   }
 
   private getWorkplaceSection(): void {
-    this.addSection('Workplace', 'workplace', this.workplaceWdfEligibilityStatus);
+    const getOverrides = () => {
+      if (this.overallWdfEligibility && !this.workplaceWdfEligibilityStatus) {
+        return { message: 'Check your workplace data', showFlag: FlagType.Orange };
+      }
+      return {};
+    };
+    this.addSection('Workplace', 'workplace', this.workplaceWdfEligibilityStatus, getOverrides);
   }
 
   private getStaffSection(): void {
@@ -105,19 +113,20 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   }
 
   private getOtherWorkplacesSection(): void {
-    const getNotMeetingMessage = () => {
-      if (!this.subsidiariesOverallWdfEligibility && this.someSubsidiariesMeetingRequirements) {
-        return this.someSubsMeetingMessage;
+    const getOverrides = () => {
+      if (!this.subsidiariesCount) {
+        return { message: this.noSubsidiariesMessage, showLink: false, showFlag: FlagType.None };
       }
-      return this.notMeetingMessage;
+      if (this.subsidiariesOverallWdfEligibility) {
+        return { message: this.meetingMessage };
+      }
+      if (!this.subsidiariesOverallWdfEligibility && this.someSubsidiariesMeetingRequirements) {
+        return { message: this.someSubsMeetingMessage };
+      }
+      return { message: this.notMeetingMessage };
     };
 
-    this.addSection(
-      'Your other workplaces',
-      'workplaces',
-      this.subsidiariesOverallWdfEligibility,
-      getNotMeetingMessage,
-    );
+    this.addSection('Your other workplaces', 'workplaces', this.subsidiariesOverallWdfEligibility, getOverrides);
   }
 
   public onClick(event: Event, fragment: string): void {

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
@@ -2,12 +2,26 @@ import { DatePipe } from '@angular/common';
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
+enum FlagType {
+  Red = 'RedFlag',
+  Amber = 'AmberFlag',
+  Green = 'GreenTick',
+  None = 'NoFlag',
+}
+interface Section {
+  title: string;
+  message: string;
+  fragment: string;
+  showLink: boolean;
+  showFlag: FlagType;
+}
+
 @Component({
-    selector: 'app-wdf-summary-panel',
-    templateUrl: './wdf-summary-panel.component.html',
-    styleUrls: ['../summary-section/summary-section.component.scss', './wdf-summary-panel.component.scss'],
-    providers: [DatePipe],
-    standalone: false
+  selector: 'app-wdf-summary-panel',
+  templateUrl: './wdf-summary-panel.component.html',
+  styleUrls: ['../summary-section/summary-section.component.scss', './wdf-summary-panel.component.scss'],
+  providers: [DatePipe],
+  standalone: false,
 })
 export class WdfSummaryPanel implements OnInit, OnChanges {
   @Input() workplaceWdfEligibilityStatus: boolean;
@@ -20,23 +34,26 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   @Input() activatedFragment: string;
   @Input() onDataPage: boolean = true;
   @Input() someSubsidiariesMeetingRequirements: boolean;
+  @Input() subsidiariesCount: number;
 
-  public sections: any = [];
+  public sections: Section[] = [];
   public meetingMessage: string;
   public notMeetingMessage: string;
   public someSubsMeetingMessage: string;
+  readonly FlagType = FlagType;
 
-  constructor(private router: Router, private datePipe: DatePipe) {}
+  constructor(
+    private router: Router,
+    private datePipe: DatePipe,
+  ) {}
 
   ngOnInit(): void {
     this.setMessages();
     this.getSections();
-    this.showLink(this.activatedFragment);
   }
 
   ngOnChanges(): void {
     this.getSections();
-    this.showLink(this.activatedFragment);
   }
 
   private setMessages(): void {
@@ -49,36 +66,58 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   }
 
   public getSections(): void {
-    this.sections = [
-      {
-        title: 'Workplace',
-        eligibility:
-          this.workplaceWdfEligibilityStatus || (!this.workplaceWdfEligibilityStatus && this.overallWdfEligibility),
-        fragment: 'workplace',
-        showLink: true,
-        meetingMessage: this.meetingMessage,
-        notMeetingMessage: this.notMeetingMessage,
-      },
-      {
-        title: 'Staff records',
-        eligibility: this.staffWdfEligibilityStatus || (!this.staffWdfEligibilityStatus && this.overallWdfEligibility),
-        fragment: 'staff',
-        showLink: true,
-        meetingMessage: this.meetingMessage,
-        notMeetingMessage: this.notMeetingMessage,
-      },
-    ];
+    this.sections = [];
+
+    this.getWorkplaceSection();
+    this.getStaffSection();
 
     if (this.isParent) {
-      this.sections.push({
-        title: 'Your other workplaces',
-        eligibility: this.subsidiariesOverallWdfEligibility,
-        fragment: 'workplaces',
-        showLink: true,
-        meetingMessage: this.meetingMessage,
-        notMeetingMessage: this.getOtherWorkplacesNotMeetingMessage(),
-      });
+      this.getOtherWorkplacesSection();
     }
+  }
+
+  private addSection(
+    title: string,
+    fragment: string,
+    specificEligibility: boolean,
+    getNotMeetingMessage?: () => string,
+  ): void {
+    const meetRequirements = specificEligibility || this.overallWdfEligibility;
+    const showLink = this.activatedFragment !== fragment;
+
+    getNotMeetingMessage = getNotMeetingMessage ?? (() => this.notMeetingMessage);
+
+    this.sections.push({
+      title,
+      fragment,
+      showLink,
+      showFlag: meetRequirements ? FlagType.Green : FlagType.Red,
+      message: meetRequirements ? this.meetingMessage : getNotMeetingMessage(),
+    });
+  }
+
+  private getWorkplaceSection(): void {
+    this.addSection('Workplace', 'workplace', this.workplaceWdfEligibilityStatus);
+  }
+
+  private getStaffSection(): void {
+    this.addSection('Staff records', 'staff', this.staffWdfEligibilityStatus);
+  }
+
+  private getOtherWorkplacesSection(): void {
+    const getNotMeetingMessage = () => {
+      if (!this.subsidiariesOverallWdfEligibility && this.someSubsidiariesMeetingRequirements) {
+        return this.someSubsMeetingMessage;
+      }
+      return this.notMeetingMessage;
+    };
+
+    this.addSection(
+      'Your other workplaces',
+      'workplaces',
+      this.subsidiariesOverallWdfEligibility,
+      getNotMeetingMessage,
+    );
   }
 
   public onClick(event: Event, fragment: string): void {
@@ -86,22 +125,5 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
 
     const urlToNavigateTo = this.onDataPage ? [] : ['/funding/data'];
     this.router.navigate(urlToNavigateTo, { fragment: fragment });
-  }
-
-  private getOtherWorkplacesNotMeetingMessage(): string {
-    if (!this.subsidiariesOverallWdfEligibility && this.someSubsidiariesMeetingRequirements) {
-      return this.someSubsMeetingMessage;
-    }
-    return this.notMeetingMessage;
-  }
-
-  public showLink(fragment: string): void {
-    for (var i = 0; i < this.sections.length; i++) {
-      if (fragment === this.sections[i].fragment) {
-        this.sections[i].showLink = false;
-      } else {
-        this.sections[i].showLink = true;
-      }
-    }
   }
 }

--- a/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
+++ b/frontend/src/app/shared/components/wdf-summary-panel/wdf-summary-panel.component.ts
@@ -34,12 +34,12 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   @Input() onDataPage: boolean = true;
   @Input() someSubsidiariesMeetingRequirements: boolean;
   @Input() subsidiariesCount: number;
+  @Input() someSubsidiariesNeedCheckAgain: boolean;
 
   public sections: Section[] = [];
   public meetingMessage: string;
   public notMeetingMessage: string;
   public someSubsMeetingMessage: string;
-  public noSubsidiariesMessage: string;
   readonly FlagType = FlagType;
 
   constructor(
@@ -63,7 +63,18 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
     this.meetingMessage = `Your data has met the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
     this.notMeetingMessage = `Your data does not meet the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
     this.someSubsMeetingMessage = `Some data does not meet the funding requirements for ${formattedStartDate} to ${formattedEndDate}`;
-    this.noSubsidiariesMessage = `You've not added any other workplaces yet`;
+  }
+
+  private getOrangeFlagMessage(fragment: string): string {
+    switch (fragment) {
+      case 'workplace': {
+        return 'Check your workplace data';
+      }
+      case 'staff': {
+        return 'Check your staff records';
+      }
+    }
+    return '';
   }
 
   public getSections(): void {
@@ -84,28 +95,37 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
     getOverrides?: () => Partial<Section>,
   ): void {
     const showLink = this.activatedFragment !== fragment;
-    const meetRequirements = specificEligibility || this.overallWdfEligibility;
-    const message = meetRequirements ? this.meetingMessage : this.notMeetingMessage;
+    const meetRequirements = specificEligibility;
+    const metRequirementButNeedCheckAgain = this.overallWdfEligibility && !specificEligibility;
+
+    let message;
+    let showFlag;
+
+    if (meetRequirements) {
+      message = this.meetingMessage;
+      showFlag = FlagType.Green;
+    } else if (metRequirementButNeedCheckAgain) {
+      message = this.getOrangeFlagMessage(fragment);
+      showFlag = FlagType.Orange;
+    } else {
+      message = this.notMeetingMessage;
+      showFlag = FlagType.Red;
+    }
+
     const overrides = getOverrides ? getOverrides() : {};
 
     this.sections.push({
       title,
       fragment,
       showLink,
-      showFlag: meetRequirements ? FlagType.Green : FlagType.Red,
+      showFlag,
       message,
       ...overrides,
     });
   }
 
   private getWorkplaceSection(): void {
-    const getOverrides = () => {
-      if (this.overallWdfEligibility && !this.workplaceWdfEligibilityStatus) {
-        return { message: 'Check your workplace data', showFlag: FlagType.Orange };
-      }
-      return {};
-    };
-    this.addSection('Workplace', 'workplace', this.workplaceWdfEligibilityStatus, getOverrides);
+    this.addSection('Workplace', 'workplace', this.workplaceWdfEligibilityStatus);
   }
 
   private getStaffSection(): void {
@@ -115,7 +135,10 @@ export class WdfSummaryPanel implements OnInit, OnChanges {
   private getOtherWorkplacesSection(): void {
     const getOverrides = () => {
       if (!this.subsidiariesCount) {
-        return { message: this.noSubsidiariesMessage, showLink: false, showFlag: FlagType.None };
+        return { message: `You've not added any other workplaces yet`, showLink: false, showFlag: FlagType.None };
+      }
+      if (this.subsidiariesOverallWdfEligibility && this.someSubsidiariesNeedCheckAgain) {
+        return { message: 'Check your other workplaces', showFlag: FlagType.Orange };
       }
       if (this.subsidiariesOverallWdfEligibility) {
         return { message: this.meetingMessage };


### PR DESCRIPTION
#### Work done
Address two issues for funding page summary panel:
  * (trello 72314) When a parent workplace does not have any sub workplace, it should not display a green tick in "Your other workplaces" row
  * (trello 72136) When workplace has met requirements but later made change that affect funding, it should display a different message with orange flag 
  



<img width="1477" height="1160" alt="image" src="https://github.com/user-attachments/assets/3572320c-9c8b-4a3b-ad39-1804a78c3d81" />


<img width="1705" height="1180" alt="Screenshot 2026-07-17 at 09 27 14" src="https://github.com/user-attachments/assets/a8ed280c-fedc-4fec-9449-68bbc49ef076" />



#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
