### PR TITLE
Fix CQC status update when changing establishment to non-CQC

### DIFF
--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -1121,8 +1121,14 @@ class Establishment extends EntityValidator {
           const thisTransaction = externalTransaction || t;
           const buChanged = this._status === 'NOCHANGE';
           // now append the extendable properties
-          const modifiedUpdateDocument = this._properties.save(savedBy.toLowerCase(), {}, buChanged);
+          let modifiedUpdateDocument = this._properties.save(savedBy.toLowerCase(), {}, buChanged);
           // note - if the establishment was created online, but then updated via bulk upload, the source become bulk and vice-versa.
+          if (!Object.prototype.hasOwnProperty.call(modifiedUpdateDocument, 'shareWithCQC')) {
+            modifiedUpdateDocument = {
+              ...modifiedUpdateDocument,
+              shareWithCQC: this.shareWith?.cqc,
+            };
+          }
           const updateDocument = {
             ...modifiedUpdateDocument,
             source: bulkUploaded ? 'Bulk' : 'Online',

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -1123,7 +1123,7 @@ class Establishment extends EntityValidator {
           // now append the extendable properties
           let modifiedUpdateDocument = this._properties.save(savedBy.toLowerCase(), {}, buChanged);
           // note - if the establishment was created online, but then updated via bulk upload, the source become bulk and vice-versa.
-          if (!Object.prototype.hasOwnProperty.call(modifiedUpdateDocument, 'shareWithCQC')) {
+          if (!hasProp(modifiedUpdateDocument, 'shareWithCQC')) {
             modifiedUpdateDocument = {
               ...modifiedUpdateDocument,
               shareWithCQC: this.shareWith?.cqc,

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -1123,12 +1123,12 @@ class Establishment extends EntityValidator {
           // now append the extendable properties
           let modifiedUpdateDocument = this._properties.save(savedBy.toLowerCase(), {}, buChanged);
           // note - if the establishment was created online, but then updated via bulk upload, the source become bulk and vice-versa.
-          if (!Object.prototype.hasOwnProperty.call(modifiedUpdateDocument, 'shareWithCQC')) {
-            modifiedUpdateDocument = {
-              ...modifiedUpdateDocument,
-              shareWithCQC: this.shareWith?.cqc,
-            };
-          }
+          // if (!Object.prototype.hasOwnProperty.call(modifiedUpdateDocument, 'shareWithCQC')) {
+          //   modifiedUpdateDocument = {
+          //     ...modifiedUpdateDocument,
+          //     shareWithCQC: this.shareWith?.cqc,
+          //   };
+          // }
           const updateDocument = {
             ...modifiedUpdateDocument,
             source: bulkUploaded ? 'Bulk' : 'Online',

--- a/backend/server/models/classes/establishment.js
+++ b/backend/server/models/classes/establishment.js
@@ -1123,12 +1123,12 @@ class Establishment extends EntityValidator {
           // now append the extendable properties
           let modifiedUpdateDocument = this._properties.save(savedBy.toLowerCase(), {}, buChanged);
           // note - if the establishment was created online, but then updated via bulk upload, the source become bulk and vice-versa.
-          // if (!Object.prototype.hasOwnProperty.call(modifiedUpdateDocument, 'shareWithCQC')) {
-          //   modifiedUpdateDocument = {
-          //     ...modifiedUpdateDocument,
-          //     shareWithCQC: this.shareWith?.cqc,
-          //   };
-          // }
+          if (!Object.prototype.hasOwnProperty.call(modifiedUpdateDocument, 'shareWithCQC')) {
+            modifiedUpdateDocument = {
+              ...modifiedUpdateDocument,
+              shareWithCQC: this.shareWith?.cqc,
+            };
+          }
           const updateDocument = {
             ...modifiedUpdateDocument,
             source: bulkUploaded ? 'Bulk' : 'Online',


### PR DESCRIPTION
#### Work done
- Ensured  shareWithCQC is updated when an establishment changes from CQC regulated to non-CQC.

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
