### PR TITLE
Add a new check to pass the validation when there is a new establishment

### DIFF
--- a/backend/server/models/BulkImport/csv/crossValidate.js
+++ b/backend/server/models/BulkImport/csv/crossValidate.js
@@ -93,12 +93,11 @@ const crossValidateTransferStaffRecord = async (
     const newWorkplaceId = await _validateTransferIsPossible(
       csvWorkerSchemaErrors,
       relatedEstablishmentIds,
+      myEstablishments,
       JSONWorker,
     );
 
-    if (newWorkplaceId) {
-      _addNewWorkplaceIdToWorkerEntity(myAPIEstablishments, JSONWorker, newWorkplaceId);
-    }
+    _addNewWorkplaceIdToWorkerEntity(myAPIEstablishments, JSONWorker, newWorkplaceId);
   }
 };
 
@@ -106,11 +105,20 @@ const isMovingToNewWorkplace = (JSONWorker) => {
   return JSONWorker.status === 'UPDATE' && JSONWorker.transferStaffRecord;
 };
 
-const _validateTransferIsPossible = async (csvWorkerSchemaErrors, relatedEstablishmentIds, JSONWorker) => {
+const _validateTransferIsPossible = async (
+  csvWorkerSchemaErrors,
+  relatedEstablishmentIds,
+  myEstablishments,
+  JSONWorker,
+) => {
   const newWorkplaceLocalRef = JSONWorker.transferStaffRecord;
   const newWorkplaceId = await _getNewWorkplaceId(newWorkplaceLocalRef, relatedEstablishmentIds);
 
-  if (newWorkplaceId === null) {
+  const uploadedWorkplace = myEstablishments.find(
+    (e) => e.localId === newWorkplaceLocalRef || e._localId === newWorkplaceLocalRef,
+  );
+
+  if (newWorkplaceId === null && uploadedWorkplace?.status !== 'NEW') {
     addCrossValidateError(csvWorkerSchemaErrors, TRANSFER_STAFF_RECORD_ERRORS.NewWorkplaceNotFound, JSONWorker);
     return;
   }

--- a/backend/server/models/BulkImport/csv/crossValidate.js
+++ b/backend/server/models/BulkImport/csv/crossValidate.js
@@ -96,8 +96,9 @@ const crossValidateTransferStaffRecord = async (
       myEstablishments,
       JSONWorker,
     );
-
-    _addNewWorkplaceIdToWorkerEntity(myAPIEstablishments, JSONWorker, newWorkplaceId);
+    if (_workerPassedAllValidations(csvWorkerSchemaErrors, JSONWorker)) {
+      _addNewWorkplaceIdToWorkerEntity(myAPIEstablishments, JSONWorker, newWorkplaceId);
+    }
   }
 };
 

--- a/backend/server/models/classes/worker.js
+++ b/backend/server/models/classes/worker.js
@@ -767,7 +767,16 @@ class Worker extends EntityValidator {
             updatedBy: savedBy.toLowerCase(),
           };
 
-          if (bulkUploaded && this._status === 'UPDATE' && this.transferStaffRecord && this.newWorkplaceId) {
+          // During bulk upload completion, workers restored from the database
+          // are assigned status COMPLETE. Transfer workers still need to be
+          // moved to the target workplace.
+
+          if (
+            bulkUploaded &&
+            ['UPDATE', 'COMPLETE'].includes(this._status) &&
+            this.transferStaffRecord &&
+            this.newWorkplaceId
+          ) {
             updateDocument.establishmentFk = this.newWorkplaceId;
           }
 

--- a/backend/server/routes/establishments/bulkUpload/complete.js
+++ b/backend/server/routes/establishments/bulkUpload/complete.js
@@ -68,6 +68,13 @@ const completeUpdateEstablishment = async (
       delete thisEstablishmentJSON.localIdentifier;
 
       await foundCurrentEstablishment.load(thisEstablishmentJSON, true, true);
+      Object.values(foundCurrentEstablishment._workerEntities || {}).forEach((worker) => {
+        const targetEstablishment = onloadEstablishments.find((e) => e.name === worker.transferStaffRecord);
+
+        if (targetEstablishment) {
+          worker._newWorkplaceId = targetEstablishment._id;
+        }
+      });
       await foundCurrentEstablishment.save(theLoggedInUser, true, transaction, true);
       await foundCurrentEstablishment.bulkUploadWdf(theLoggedInUser, transaction);
 

--- a/backend/server/routes/establishments/bulkUpload/complete.js
+++ b/backend/server/routes/establishments/bulkUpload/complete.js
@@ -96,6 +96,7 @@ const completeDeleteEstablishment = async (
   theLoggedInUser,
   transaction,
   myCurrentEstablishments,
+  onloadEstablishments,
 ) => {
   try {
     const startTime = new Date();
@@ -104,6 +105,22 @@ const completeDeleteEstablishment = async (
     const foundCurrentEstablishment = myCurrentEstablishments.find(
       (thisCurrent) => thisCurrent.key === thisDeletedEstablishment.key,
     );
+    const onloadEstablishment = onloadEstablishments.find((e) => e.key === thisDeletedEstablishment.key);
+
+    for (const currentWorker of Object.values(foundCurrentEstablishment._workerEntities || {})) {
+      const onloadWorker = Object.values(onloadEstablishment?._workerEntities || {}).find(
+        (w) => w.key === currentWorker.key,
+      );
+
+      if (onloadWorker?.newWorkplaceId) {
+        currentWorker._transferStaffRecord = onloadWorker.transferStaffRecord;
+        currentWorker._newWorkplaceId = onloadWorker.newWorkplaceId;
+
+        await currentWorker.save(theLoggedInUser, true, transaction);
+
+        delete foundCurrentEstablishment._workerEntities[currentWorker.key];
+      }
+    }
 
     // current is already restored, so simply need to delete it
     if (foundCurrentEstablishment) {
@@ -216,7 +233,13 @@ const completePost = async (req, res) => {
           await validationDifferenceReport.deleted.reduce(
             (p, thisDeletedEstablishment) =>
               p.then(() =>
-                completeDeleteEstablishment(thisDeletedEstablishment, theLoggedInUser, t, myCurrentEstablishments)
+                completeDeleteEstablishment(
+                  thisDeletedEstablishment,
+                  theLoggedInUser,
+                  t,
+                  myCurrentEstablishments,
+                  onloadEstablishments,
+                )
                   .then((data) => {
                     return data;
                   })

--- a/backend/server/routes/establishments/bulkUpload/complete.js
+++ b/backend/server/routes/establishments/bulkUpload/complete.js
@@ -69,7 +69,7 @@ const completeUpdateEstablishment = async (
 
       await foundCurrentEstablishment.load(thisEstablishmentJSON, true, true);
       Object.values(foundCurrentEstablishment._workerEntities || {}).forEach((worker) => {
-        const targetEstablishment = onloadEstablishments.find((e) => e.name === worker.transferStaffRecord);
+        const targetEstablishment = onloadEstablishments.find((e) => e.localIdentifier === worker.transferStaffRecord);
 
         if (targetEstablishment) {
           worker._newWorkplaceId = targetEstablishment._id;


### PR DESCRIPTION
#### Work done
PR Summary

 **The issue :**

- The transfer process attempted to resolve the destination workplace during validation, before the new workplace had been created in the database. As a result, the destination workplace ID was unavailable and the worker remained associated with the original workplace.

**What should happen:**

- When transferring a staff record to a workplace created within the same bulk upload, the workplace should be created first and the worker should then be transferred to the newly created workplace.

**Fix:**

- Updated the bulk upload completion process so that workers with TRANSFERSTAFFRECORD are matched to newly created workplaces after establishment creation. The newly created establishment ID is then assigned to the worker before saving, allowing the transfer to complete successfully.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
