### PR TITLE
Fix/1980 router navigate with add alert

### DIFF
--- a/frontend/cypress/e2e/others/pageAfterLogin.spec.cy.js
+++ b/frontend/cypress/e2e/others/pageAfterLogin.spec.cy.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-undef */
 /// <reference types="cypress" />
-
 import { userPassword } from '../../support/configData';
 import { StandAloneEstablishment } from '../../support/mockEstablishmentData';
 
@@ -103,7 +102,7 @@ describe('page after login', { tags: '@others' }, () => {
     cy.url().should('eq', Cypress.config().baseUrl + '/update-your-vacancies-and-turnover-data');
     cy.get('h1').should('contain', 'Your Workplace vacancies and turnover information');
 
-    cy.get('a').contains('Continue').click();
+    cy.contains('a', 'Continue').should('be.visible').click();
 
     cy.url().should('eq', Cypress.config().baseUrl + '/dashboard');
   });

--- a/frontend/src/app/features/admin/admin-users/add-admin-user/add-admin-user.component.spec.ts
+++ b/frontend/src/app/features/admin/admin-users/add-admin-user/add-admin-user.component.spec.ts
@@ -144,10 +144,13 @@ describe('AddAdminUserComponent', () => {
     userEvent.type(getByLabelText('Job title'), 'Administrator');
     userEvent.type(getByLabelText('Email address'), 'admin@email.com');
     userEvent.type(getByLabelText('Phone number'), '01234567890');
+
     fireEvent.click(getByLabelText('Admin'));
 
     fireEvent.click(getByText('Save admin user'));
     fixture.detectChanges();
+
+    await fixture.whenStable();
 
     expect(alertSpy).toHaveBeenCalledWith({
       type: 'success',

--- a/frontend/src/app/features/admin/admin-users/add-admin-user/add-admin-user.component.spec.ts
+++ b/frontend/src/app/features/admin/admin-users/add-admin-user/add-admin-user.component.spec.ts
@@ -144,7 +144,6 @@ describe('AddAdminUserComponent', () => {
     userEvent.type(getByLabelText('Job title'), 'Administrator');
     userEvent.type(getByLabelText('Email address'), 'admin@email.com');
     userEvent.type(getByLabelText('Phone number'), '01234567890');
-
     fireEvent.click(getByLabelText('Admin'));
 
     fireEvent.click(getByText('Save admin user'));

--- a/frontend/src/app/features/admin/admin-users/add-admin-user/add-admin-user.component.ts
+++ b/frontend/src/app/features/admin/admin-users/add-admin-user/add-admin-user.component.ts
@@ -12,9 +12,9 @@ import { ErrorSummaryService } from '@core/services/error-summary.service';
 import { AccountDetailsDirective } from '@shared/directives/user/account-details.directive';
 
 @Component({
-    selector: 'app-add-admin-user',
-    templateUrl: 'add-admin-user.component.html',
-    standalone: false
+  selector: 'app-add-admin-user',
+  templateUrl: 'add-admin-user.component.html',
+  standalone: false,
 })
 export class AddAdminUserComponent extends AccountDetailsDirective {
   public callToActionLabel = 'Save admin user';
@@ -130,8 +130,9 @@ export class AddAdminUserComponent extends AccountDetailsDirective {
 
     this.adminUsersService.createAdminUser(newAdminUser).subscribe(
       () => {
-        this.router.navigate(this.return.url);
-        this.alertService.addAlert({ type: 'success', message: 'Admin user has been added' });
+        this.router.navigate(this.return.url).then(() => {
+          this.alertService.addAlert({ type: 'success', message: 'Admin user has been added' });
+        });
       },
       (error: HttpErrorResponse) => this.onError(error),
     );

--- a/frontend/src/app/features/admin/admin-users/admin-account-view/admin-account-view.component.ts
+++ b/frontend/src/app/features/admin/admin-users/admin-account-view/admin-account-view.component.ts
@@ -16,9 +16,9 @@ import { take } from 'rxjs/operators';
 import { DeleteAdminUserComponent } from '../delete-admin-user/delete-admin-user.component';
 
 @Component({
-    selector: 'app-admin-account-view',
-    templateUrl: './admin-account-view.component.html',
-    standalone: false
+  selector: 'app-admin-account-view',
+  templateUrl: './admin-account-view.component.html',
+  standalone: false,
 })
 export class AdminAccountViewComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
@@ -83,10 +83,11 @@ export class AdminAccountViewComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.adminUsersService.resendActivationLinkAdmin(this.user.uid).subscribe(
         () => {
-          this.router.navigate(this.return.url);
-          this.alertService.addAlert({
-            type: 'success',
-            message: 'The user set-up email has been sent again.',
+          this.router.navigate(this.return.url).then(() => {
+            this.alertService.addAlert({
+              type: 'success',
+              message: 'The user set-up email has been sent again.',
+            });
           });
         },
         () => {

--- a/frontend/src/app/features/admin/admin-users/edit-admin-user/edit-admin-user.component.ts
+++ b/frontend/src/app/features/admin/admin-users/edit-admin-user/edit-admin-user.component.ts
@@ -14,9 +14,9 @@ import { UserService } from '@core/services/user.service';
 import { AccountDetailsDirective } from '@shared/directives/user/account-details.directive';
 
 @Component({
-    selector: 'app-edit-admin-user',
-    templateUrl: 'edit-admin-user.component.html',
-    standalone: false
+  selector: 'app-edit-admin-user',
+  templateUrl: 'edit-admin-user.component.html',
+  standalone: false,
 })
 export class EditAdminUserComponent extends AccountDetailsDirective {
   public callToActionLabel = 'Save and return';
@@ -149,14 +149,15 @@ export class EditAdminUserComponent extends AccountDetailsDirective {
 
     this.adminUsersService.updateAdminUserDetails(this.user.uid, newAdminUser).subscribe(
       (data) => {
-        this.router.navigate(this.return.url);
         // if adminManager is editing their info, update the logged in user with new data
         if (this.loggedInUser.uid === data.uid) {
           this.userService.loggedInUser = { ...this.loggedInUser, ...data };
         }
-        this.alertService.addAlert({
-          type: 'success',
-          message: `The user details for ${data.fullname} have been updated`,
+        this.router.navigate(this.return.url).then(() => {
+          this.alertService.addAlert({
+            type: 'success',
+            message: `The user details for ${data.fullname} have been updated`,
+          });
         });
       },
       (error: HttpErrorResponse) => this.onError(error),

--- a/frontend/src/app/features/admin/cqc-main-service-change/cqc-individual-main-service-change/cqc-individual-main-service-change.component.spec.ts
+++ b/frontend/src/app/features/admin/cqc-main-service-change/cqc-individual-main-service-change/cqc-individual-main-service-change.component.spec.ts
@@ -1,5 +1,4 @@
-import { provideHttpClient } from '@angular/common/http';
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -583,6 +582,10 @@ describe('CqcIndividualMainServiceChangeComponent', () => {
 
       fireEvent.click(approvalConfirmButton);
 
+      fixture.detectChanges();
+
+      await fixture.whenStable();
+
       expect(alertServiceSpy).toHaveBeenCalledWith({
         type: 'success',
         message: `The main service change of workplace ${workplaceName} has been approved`,
@@ -680,6 +683,10 @@ describe('CqcIndividualMainServiceChangeComponent', () => {
       const rejectionConfirmButton = within(dialog).getByText('Reject this change');
 
       fireEvent.click(rejectionConfirmButton);
+
+      fixture.detectChanges();
+
+      await fixture.whenStable();
 
       expect(alertServiceSpy).toHaveBeenCalledWith({
         type: 'success',

--- a/frontend/src/app/features/admin/cqc-main-service-change/cqc-individual-main-service-change/cqc-individual-main-service-change.component.ts
+++ b/frontend/src/app/features/admin/cqc-main-service-change/cqc-individual-main-service-change/cqc-individual-main-service-change.component.ts
@@ -11,12 +11,14 @@ import { CqcStatusChangeService } from '@core/services/cqc-status-change.service
 import { Dialog, DialogService } from '@core/services/dialog.service';
 import { RegistrationsService } from '@core/services/registrations.service';
 import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
-import { ApprovalOrRejectionDialogComponent } from '@features/admin/components/approval-or-rejection-dialog/approval-or-rejection-dialog.component';
+import {
+  ApprovalOrRejectionDialogComponent,
+} from '@features/admin/components/approval-or-rejection-dialog/approval-or-rejection-dialog.component';
 
 @Component({
-    selector: 'app-cqc-individual-main-service-change',
-    templateUrl: './cqc-individual-main-service-change.component.html',
-    standalone: false
+  selector: 'app-cqc-individual-main-service-change',
+  templateUrl: './cqc-individual-main-service-change.component.html',
+  standalone: false,
 })
 export class CqcIndividualMainServiceChangeComponent implements OnInit {
   public registration: CqcStatusChange;
@@ -68,8 +70,9 @@ export class CqcIndividualMainServiceChangeComponent implements OnInit {
 
         this.cqcStatusChangeService.CqcStatusChangeApproval(data).subscribe(
           () => {
-            this.router.navigate(['/sfcadmin', 'cqc-main-service-change']);
-            this.showApprovalOrRejectionConfirmationAlert(isApproval);
+            this.router.navigate(['/sfcadmin', 'cqc-main-service-change']).then(() => {
+              this.showApprovalOrRejectionConfirmationAlert(isApproval);
+            });
           },
           () => {
             this.approvalOrRejectionServerError = `There was an error completing the ${

--- a/frontend/src/app/features/admin/parent-requests/parent-request-individual/parent-request-individual.component.spec.ts
+++ b/frontend/src/app/features/admin/parent-requests/parent-request-individual/parent-request-individual.component.spec.ts
@@ -1,5 +1,4 @@
-import { provideHttpClient } from '@angular/common/http';
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -598,6 +597,8 @@ describe('ParentRequestIndividualComponent', () => {
       const approvalConfirmButton = within(dialog).getByText('Approve this request');
       fireEvent.click(approvalConfirmButton);
 
+      await fixture.whenStable();
+
       expect(alertServiceSpy).toHaveBeenCalledWith({
         type: 'success',
         message: `The parent request of workplace ${workplaceName} has been approved`,
@@ -707,6 +708,8 @@ describe('ParentRequestIndividualComponent', () => {
       const dialog = await within(document.body).findByRole('dialog');
       const rejectionConfirmButton = within(dialog).getByText('Reject this request');
       fireEvent.click(rejectionConfirmButton);
+
+      await fixture.whenStable();
 
       expect(alertServiceSpy).toHaveBeenCalledWith({
         type: 'success',

--- a/frontend/src/app/features/admin/parent-requests/parent-request-individual/parent-request-individual.component.ts
+++ b/frontend/src/app/features/admin/parent-requests/parent-request-individual/parent-request-individual.component.ts
@@ -8,13 +8,15 @@ import { Dialog, DialogService } from '@core/services/dialog.service';
 import { ParentRequestsService } from '@core/services/parent-requests.service';
 import { RegistrationsService } from '@core/services/registrations.service';
 import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
-import { ApprovalOrRejectionDialogComponent } from '@features/admin/components/approval-or-rejection-dialog/approval-or-rejection-dialog.component';
+import {
+  ApprovalOrRejectionDialogComponent,
+} from '@features/admin/components/approval-or-rejection-dialog/approval-or-rejection-dialog.component';
 import { Subscription } from 'rxjs/internal/Subscription';
 
 @Component({
-    selector: 'app-parent-request-individual',
-    templateUrl: './parent-request-individual.component.html',
-    standalone: false
+  selector: 'app-parent-request-individual',
+  templateUrl: './parent-request-individual.component.html',
+  standalone: false,
 })
 export class ParentRequestIndividualComponent implements OnInit, OnDestroy {
   public registration: any;
@@ -63,8 +65,9 @@ export class ParentRequestIndividualComponent implements OnInit, OnDestroy {
         this.subscriptions.add(
           this.parentRequestsService.parentApproval(data).subscribe(
             () => {
-              this.router.navigate(['/sfcadmin', 'parent-requests']);
-              this.showApprovalOrRejectionConfirmationAlert(isApproval);
+              this.router.navigate(['/sfcadmin', 'parent-requests']).then(() => {
+                this.showApprovalOrRejectionConfirmationAlert(isApproval);
+              });
             },
             () => {
               this.approvalOrRejectionServerError = `There was an error completing the ${

--- a/frontend/src/app/features/admin/registration-requests/registration-request/registration-request.component.spec.ts
+++ b/frontend/src/app/features/admin/registration-requests/registration-request/registration-request.component.spec.ts
@@ -1,5 +1,4 @@
-import { provideHttpClient } from '@angular/common/http';
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -811,6 +810,8 @@ describe('RegistrationRequestComponent', () => {
 
       fireEvent.click(approvalConfirmButton);
 
+      await fixture.whenStable();
+
       expect(alertServiceSpy).toHaveBeenCalledWith({
         type: 'success',
         message: `The workplace '${component.registration.establishment.name}' has been approved`,
@@ -929,6 +930,8 @@ describe('RegistrationRequestComponent', () => {
       const rejectionConfirmButton = within(dialog).getByText('Reject this request');
 
       fireEvent.click(rejectionConfirmButton);
+
+      await fixture.whenStable();
 
       expect(alertServiceSpy).toHaveBeenCalledWith({
         type: 'success',

--- a/frontend/src/app/features/admin/registration-requests/registration-request/registration-request.component.ts
+++ b/frontend/src/app/features/admin/registration-requests/registration-request/registration-request.component.ts
@@ -11,12 +11,14 @@ import { RegistrationsService } from '@core/services/registrations.service';
 import { SwitchWorkplaceService } from '@core/services/switch-workplace.service';
 import { RegistrationRequestDirective } from '@shared/directives/admin/registration-requests/registration-request.directive';
 
-import { ApprovalOrRejectionDialogComponent } from '../../components/approval-or-rejection-dialog/approval-or-rejection-dialog.component';
+import {
+  ApprovalOrRejectionDialogComponent,
+} from '../../components/approval-or-rejection-dialog/approval-or-rejection-dialog.component';
 
 @Component({
-    selector: 'app-registration-request',
-    templateUrl: './registration-request.component.html',
-    standalone: false
+  selector: 'app-registration-request',
+  templateUrl: './registration-request.component.html',
+  standalone: false,
 })
 export class RegistrationRequestComponent extends RegistrationRequestDirective {
   public workplaceIdForm: UntypedFormGroup;
@@ -64,11 +66,11 @@ export class RegistrationRequestComponent extends RegistrationRequestDirective {
     });
 
     this.postcodeForm = new UntypedFormGroup({
-      postcode: new UntypedFormControl(this.registration.establishment.postcode , [
+      postcode: new UntypedFormControl(this.registration.establishment.postcode, [
         Validators.required,
         Validators.minLength(6),
         Validators.maxLength(8),
-        Validators.pattern(/^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/)
+        Validators.pattern(/^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/),
       ]),
     });
   }
@@ -99,10 +101,7 @@ export class RegistrationRequestComponent extends RegistrationRequestDirective {
   }
 
   public updatePostcode(): void {
-
-
     if (this.postcode.invalid) {
-
       this.invalidPostcodeEntered = true;
       return;
     }
@@ -138,7 +137,6 @@ export class RegistrationRequestComponent extends RegistrationRequestDirective {
   }
 
   private populateErrorPostcode(err) {
-
     const validationErrors = err.error;
 
     Object.keys(validationErrors).forEach((prop) => {
@@ -203,8 +201,9 @@ export class RegistrationRequestComponent extends RegistrationRequestDirective {
 
         this.registrationsService.registrationApproval(body).subscribe(
           () => {
-            this.router.navigate(['/sfcadmin', 'registrations']);
-            this.showApprovalOrRejectionConfirmationAlert(isApproval);
+            this.router.navigate(['/sfcadmin', 'registrations']).then(() => {
+              this.showApprovalOrRejectionConfirmationAlert(isApproval);
+            });
           },
           (err) => {
             this.approvalOrRejectionServerError = `There was an error completing the ${

--- a/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.ts
+++ b/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.ts
@@ -23,11 +23,11 @@ import { combineLatest, Subscription } from 'rxjs';
 import { take, tap } from 'rxjs/operators';
 
 @Component({
-    selector: 'app-drag-and-drop-files-list',
-    templateUrl: './drag-and-drop-files-list.component.html',
-    styleUrls: ['./drag-and-drop-files-list.component.scss'],
-    providers: [I18nPluralPipe],
-    standalone: false
+  selector: 'app-drag-and-drop-files-list',
+  templateUrl: './drag-and-drop-files-list.component.html',
+  styleUrls: ['./drag-and-drop-files-list.component.scss'],
+  providers: [I18nPluralPipe],
+  standalone: false,
 })
 export class DragAndDropFilesListComponent implements OnInit, OnDestroy {
   @Input() public sanitise: boolean;
@@ -175,6 +175,7 @@ export class DragAndDropFilesListComponent implements OnInit, OnDestroy {
   }
 
   private updateEstablishmentService(): void {
+    //this
     this.establishmentService
       .getEstablishment(this.establishmentService.primaryWorkplace.uid)
       .pipe(
@@ -187,8 +188,9 @@ export class DragAndDropFilesListComponent implements OnInit, OnDestroy {
         }),
       )
       .subscribe(() => {
-        this.router.navigate(['/dashboard']);
-        this.alertService.addAlert({ type: 'success', message: 'The bulk upload is complete.' });
+        this.router.navigate(['/dashboard']).then(() => {
+          this.alertService.addAlert({ type: 'success', message: 'The bulk upload is complete.' });
+        });
       });
   }
 

--- a/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.ts
+++ b/frontend/src/app/features/bulk-upload/drag-and-drop-files-list/drag-and-drop-files-list.component.ts
@@ -175,7 +175,6 @@ export class DragAndDropFilesListComponent implements OnInit, OnDestroy {
   }
 
   private updateEstablishmentService(): void {
-    //this
     this.establishmentService
       .getEstablishment(this.establishmentService.primaryWorkplace.uid)
       .pipe(

--- a/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.spec.ts
@@ -1,5 +1,4 @@
-import { provideHttpClient } from '@angular/common/http';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
@@ -194,6 +193,8 @@ describe('DeleteWorkplaceComponent', async () => {
     fireEvent.click(yesRadioButton);
     fireEvent.click(continueButton);
     fixture.detectChanges();
+
+    await fixture.whenStable();
 
     expect(alertSpy).toHaveBeenCalledWith({
       type: 'success',

--- a/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.ts
+++ b/frontend/src/app/features/new-dashboard/delete-workplace/delete-workplace.component.ts
@@ -16,9 +16,9 @@ import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-
 import { Subscription } from 'rxjs';
 
 @Component({
-    selector: 'app-delete-workplace',
-    templateUrl: './delete-workplace.component.html',
-    standalone: false
+  selector: 'app-delete-workplace',
+  templateUrl: './delete-workplace.component.html',
+  standalone: false,
 })
 export class DeleteWorkplaceComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('formEl') formEl: ElementRef;
@@ -124,11 +124,13 @@ export class DeleteWorkplaceComponent implements OnInit, AfterViewInit, OnDestro
             this.parentSubsidiaryViewService.clearViewingSubAsParent();
             this.establishmentService.setCheckForChildWorkplaceChanges(true);
 
-            this.router.navigate(['/workplace', 'view-all-workplaces']);
-            this.displaySuccessfullyDeletedAlert();
+            this.router.navigate(['/workplace', 'view-all-workplaces']).then(() => {
+              this.displaySuccessfullyDeletedAlert();
+            });
           } else {
-            this.router.navigate(['sfcadmin', 'search', 'workplace']);
-            this.displaySuccessfullyDeletedAlert();
+            this.router.navigate(['sfcadmin', 'search', 'workplace']).then(() => {
+              this.displaySuccessfullyDeletedAlert();
+            });
           }
         },
         () => {

--- a/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.spec.ts
+++ b/frontend/src/app/features/new-dashboard/home-tab/home-tab.component.spec.ts
@@ -450,7 +450,7 @@ describe('NewHomeTabComponent', () => {
 
         fireEvent.click(cancelDataOwnerRequestButton);
         fixture.detectChanges();
-
+        await fixture.whenStable();
         expect(cancelOwnershipSpy).toHaveBeenCalledWith(workplace.id, workplace.ownershipChangeRequestId[0], {
           approvalStatus: 'CANCELLED',
           notificationRecipientUid: workplace.uid,

--- a/frontend/src/app/features/notifications/notification-owner-change/notification-owner-change.component.ts
+++ b/frontend/src/app/features/notifications/notification-owner-change/notification-owner-change.component.ts
@@ -177,7 +177,6 @@ export class NotificationOwnerChangeComponent implements OnInit, OnDestroy {
         .subscribe(
           (request) => {
             if (request) {
-              //this
               this.notificationsService.getAllNotifications(this.workplace.uid).subscribe((notify) => {
                 this.notificationsService.notifications = notify.notifications;
               });

--- a/frontend/src/app/features/notifications/notification-owner-change/notification-owner-change.component.ts
+++ b/frontend/src/app/features/notifications/notification-owner-change/notification-owner-change.component.ts
@@ -14,11 +14,11 @@ const OWNERSHIP_APPROVED = 'OWNERCHANGEAPPROVED';
 const OWNERSHIP_REJECTED = 'OWNERCHANGEREJECTED';
 
 @Component({
-    selector: 'app-notification-owner-change',
-    templateUrl: './notification-owner-change.component.html',
-    styleUrls: ['../notification/notification.component.scss'],
-    providers: [DialogService, Overlay],
-    standalone: false
+  selector: 'app-notification-owner-change',
+  templateUrl: './notification-owner-change.component.html',
+  styleUrls: ['../notification/notification.component.scss'],
+  providers: [DialogService, Overlay],
+  standalone: false,
 })
 export class NotificationOwnerChangeComponent implements OnInit, OnDestroy {
   public workplace: Establishment;
@@ -123,11 +123,12 @@ export class NotificationOwnerChangeComponent implements OnInit, OnDestroy {
                         this.permissionsService.setPermissions(this.workplace.uid, hasPermission.permissions);
                         this.establishmentService.setState(workplace);
                         this.establishmentService.setPrimaryWorkplace(workplace);
-                        this.router.navigate(['/dashboard']);
-                        this.alertService.addAlert({
-                          type: 'success',
-                          message: `Your decision to transfer ownership of data has been sent to
-                      ${this.ownerShipRequestedTo} `,
+                        this.router.navigate(['/dashboard']).then(() => {
+                          this.alertService.addAlert({
+                            type: 'success',
+                            message: `Your decision to transfer ownership of data has been sent to
+                        ${this.ownerShipRequestedTo} `,
+                          });
                         });
                       }
                     });
@@ -176,14 +177,16 @@ export class NotificationOwnerChangeComponent implements OnInit, OnDestroy {
         .subscribe(
           (request) => {
             if (request) {
+              //this
               this.notificationsService.getAllNotifications(this.workplace.uid).subscribe((notify) => {
                 this.notificationsService.notifications = notify.notifications;
               });
-              this.router.navigate(['/dashboard']);
-              this.alertService.addAlert({
-                type: 'success',
-                message: `Your decision to transfer ownership of data has been sent to
-                  ${this.ownerShipRequestedTo} `,
+              this.router.navigate(['/dashboard']).then(() => {
+                this.alertService.addAlert({
+                  type: 'success',
+                  message: `Your decision to transfer ownership of data has been sent to
+                    ${this.ownerShipRequestedTo} `,
+                });
               });
             }
           },

--- a/frontend/src/app/features/workers/main-job-role/main-job-role.component.spec.ts
+++ b/frontend/src/app/features/workers/main-job-role/main-job-role.component.spec.ts
@@ -1,5 +1,4 @@
-import { provideHttpClient } from '@angular/common/http';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
@@ -20,9 +19,9 @@ import { ProgressBarComponent } from '@shared/components/progress-bar/progress-b
 import { SharedModule } from '@shared/shared.module';
 import { render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+import { of } from 'rxjs';
 
 import { MainJobRoleComponent } from './main-job-role.component';
-import { of } from 'rxjs';
 
 describe('MainJobRoleComponent', () => {
   async function setup(overrides: any = {}) {
@@ -101,7 +100,9 @@ describe('MainJobRoleComponent', () => {
             },
           },
         },
-      provideHttpClient(), provideHttpClientTesting(),],
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     });
 
     const component = setupTools.fixture.componentInstance;
@@ -263,12 +264,14 @@ describe('MainJobRoleComponent', () => {
           'mandatory-details',
         ]);
       });
-
       it('should show a banner when a staff record has been successfully added', async () => {
-        const { getByText, alertSpy } = await setup({ addNewWorker: true });
+        const { getByText, alertSpy, fixture } = await setup({ addNewWorker: true });
+
         userEvent.click(getByText('Care providing roles'));
         userEvent.click(getByText('Care worker'));
         userEvent.click(getByText('Save this staff record'));
+
+        await fixture.whenStable();
 
         expect(alertSpy).toHaveBeenCalledWith({
           type: 'success',

--- a/frontend/src/app/features/workers/question/question.component.ts
+++ b/frontend/src/app/features/workers/question/question.component.ts
@@ -211,7 +211,9 @@ export class QuestionComponent implements OnInit, OnDestroy, AfterViewInit {
     this.workerService.setState({ ...this.worker, ...data });
     this.onSuccess();
     this.navigate();
-    this.addAlert();
+    this.navigate().then(() => {
+      this.addAlert();
+    });
   }
 
   onError(error) {

--- a/frontend/src/app/features/workplace/delete-user-account/delete-user-account.component.spec.ts
+++ b/frontend/src/app/features/workplace/delete-user-account/delete-user-account.component.spec.ts
@@ -9,9 +9,9 @@ import { MockUserService } from '@core/test-utils/MockUserService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render } from '@testing-library/angular';
 import { of, throwError } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 import { DeleteUserAccountComponent } from './delete-user-account.component';
-import { environment } from 'src/environments/environment';
 
 describe('DeleteUserAccountComponent', () => {
   async function setup() {
@@ -113,7 +113,12 @@ describe('DeleteUserAccountComponent', () => {
     fireEvent.click(deleteButton);
     component.fixture.detectChanges();
 
-    expect(alertSpy).toHaveBeenCalledWith({ type: 'success', message: 'John Doe has been deleted as a user' });
+    await component.fixture.whenStable();
+
+    expect(alertSpy).toHaveBeenCalledWith({
+      type: 'success',
+      message: 'John Doe has been deleted as a user',
+    });
   });
 
   it('should have an error alert when delete is unsuccessful', async () => {

--- a/frontend/src/app/features/workplace/delete-user-account/delete-user-account.component.ts
+++ b/frontend/src/app/features/workplace/delete-user-account/delete-user-account.component.ts
@@ -10,9 +10,9 @@ import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 @Component({
-    selector: 'app-delete-user-account',
-    templateUrl: './delete-user-account.component.html',
-    standalone: false
+  selector: 'app-delete-user-account',
+  templateUrl: './delete-user-account.component.html',
+  standalone: false,
 })
 export class DeleteUserAccountComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
@@ -51,8 +51,9 @@ export class DeleteUserAccountComponent implements OnInit, OnDestroy {
       this.userService.deleteUser(this.establishment.uid, this.user.uid).subscribe(
         () => {
           this.updateEstablishmentUsers();
-          this.router.navigate(this.return.url, { fragment: this.return.fragment });
-          this.successAlert();
+          this.router.navigate(this.return.url, { fragment: this.return.fragment }).then(() => {
+            this.successAlert();
+          });
         },
         () => {
           this.errorAlert();

--- a/frontend/src/app/features/workplace/select-primary-user-delete/select-primary-user-delete.component.spec.ts
+++ b/frontend/src/app/features/workplace/select-primary-user-delete/select-primary-user-delete.component.spec.ts
@@ -1,5 +1,4 @@
-import { provideHttpClient } from '@angular/common/http';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -152,7 +151,7 @@ describe('SelectPrimaryUserDeleteComponent', () => {
     });
 
     it('should set success alert when submission is successful', async () => {
-      const { component, getByText, getByLabelText } = await setup();
+      const { component, getByText, getByLabelText, fixture } = await setup();
 
       const alertSpy = spyOn(component.alertService, 'addAlert').and.callThrough();
       const firstUserName = component.users[0].fullname;
@@ -163,7 +162,12 @@ describe('SelectPrimaryUserDeleteComponent', () => {
       const saveAndContinueButton = getByText('Save and continue');
       fireEvent.click(saveAndContinueButton);
 
-      expect(alertSpy).toHaveBeenCalledWith({ type: 'success', message: `${firstUserName} is the new primary user` });
+      await fixture.whenStable();
+
+      expect(alertSpy).toHaveBeenCalledWith({
+        type: 'success',
+        message: `${firstUserName} is the new primary user`,
+      });
     });
   });
 

--- a/frontend/src/app/features/workplace/select-primary-user-delete/select-primary-user-delete.component.ts
+++ b/frontend/src/app/features/workplace/select-primary-user-delete/select-primary-user-delete.component.ts
@@ -38,7 +38,7 @@ export class SelectPrimaryUserDeleteComponent extends SelectPrimaryUserDirective
     this.backService.setBackLink({ url: userDetailsLink });
   }
 
-  protected navigateToNextPage(): void {
-    this.router.navigate(['../delete-user'], { relativeTo: this.route });
+  protected navigateToNextPage(): Promise<boolean> {
+    return this.router.navigate(['../delete-user'], { relativeTo: this.route });
   }
 }

--- a/frontend/src/app/features/workplace/select-primary-user/select-primary-user.component.spec.ts
+++ b/frontend/src/app/features/workplace/select-primary-user/select-primary-user.component.spec.ts
@@ -1,5 +1,4 @@
-import { provideHttpClient } from '@angular/common/http';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -148,7 +147,7 @@ describe('SelectPrimaryUserComponent', () => {
     });
 
     it('should set success alert when submission is successful', async () => {
-      const { component, getByText, getByLabelText } = await setup();
+      const { component, getByText, getByLabelText, fixture } = await setup();
 
       const alertSpy = spyOn(component.alertService, 'addAlert').and.callThrough();
       const firstUserName = component.users[0].fullname;
@@ -159,7 +158,12 @@ describe('SelectPrimaryUserComponent', () => {
       const saveAsPrimaryUserButton = getByText('Save as primary user');
       fireEvent.click(saveAsPrimaryUserButton);
 
-      expect(alertSpy).toHaveBeenCalledWith({ type: 'success', message: `${firstUserName} is the new primary user` });
+      await fixture.whenStable();
+
+      expect(alertSpy).toHaveBeenCalledWith({
+        type: 'success',
+        message: `${firstUserName} is the new primary user`,
+      });
     });
   });
 

--- a/frontend/src/app/features/workplace/select-primary-user/select-primary-user.component.ts
+++ b/frontend/src/app/features/workplace/select-primary-user/select-primary-user.component.ts
@@ -38,6 +38,6 @@ export class SelectPrimaryUserComponent extends SelectPrimaryUserDirective {
   }
 
   protected navigateToNextPage(): Promise<boolean> {
-    return this.router.navigate(['../delete-user'], { relativeTo: this.route });
+    return this.router.navigate(['../'], { relativeTo: this.route });
   }
 }

--- a/frontend/src/app/features/workplace/select-primary-user/select-primary-user.component.ts
+++ b/frontend/src/app/features/workplace/select-primary-user/select-primary-user.component.ts
@@ -10,9 +10,9 @@ import { UserService } from '@core/services/user.service';
 import { SelectPrimaryUserDirective } from '@shared/directives/user/select-primary-user.directive';
 
 @Component({
-    selector: 'app-select-primary-user',
-    templateUrl: './select-primary-user.component.html',
-    standalone: false
+  selector: 'app-select-primary-user',
+  templateUrl: './select-primary-user.component.html',
+  standalone: false,
 })
 export class SelectPrimaryUserComponent extends SelectPrimaryUserDirective {
   constructor(
@@ -37,7 +37,7 @@ export class SelectPrimaryUserComponent extends SelectPrimaryUserDirective {
     this.breadcrumbService.show(journey);
   }
 
-  protected navigateToNextPage(): void {
-    this.router.navigate(['../'], { relativeTo: this.route });
+  protected navigateToNextPage(): Promise<boolean> {
+    return this.router.navigate(['../delete-user'], { relativeTo: this.route });
   }
 }

--- a/frontend/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
+++ b/frontend/src/app/features/workplace/user-account-edit-permissions/user-account-edit-permissions.component.ts
@@ -17,9 +17,9 @@ import { Subscription } from 'rxjs';
 import { take } from 'rxjs/internal/operators/take';
 
 @Component({
-    selector: 'app-user-account-edit-permissions',
-    templateUrl: './user-account-edit-permissions.component.html',
-    standalone: false
+  selector: 'app-user-account-edit-permissions',
+  templateUrl: './user-account-edit-permissions.component.html',
+  standalone: false,
 })
 export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
@@ -122,13 +122,14 @@ export class UserAccountEditPermissionsComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.userService.updateUserDetails(this.workplace.uid, this.user.uid, { ...this.user, ...props }).subscribe(
         (data) => {
-          this.router.navigate(['/workplace', this.workplace.uid, 'user', this.user.uid]);
           if (data.isPrimary) {
             name = this.user.fullname;
           }
-          if (name) {
-            this.alertService.addAlert({ type: 'success', message: `${name} is the new primary user` });
-          }
+          this.router.navigate(['/workplace', this.workplace.uid, 'user', this.user.uid]).then(() => {
+            if (name) {
+              this.alertService.addAlert({ type: 'success', message: `${name} is the new primary user` });
+            }
+          });
         },
 
         (error) => this.onError(error),

--- a/frontend/src/app/features/workplace/user-account-view/user-account-view.component.ts
+++ b/frontend/src/app/features/workplace/user-account-view/user-account-view.component.ts
@@ -16,9 +16,9 @@ import { Subscription } from 'rxjs';
 import { take, withLatestFrom } from 'rxjs/operators';
 
 @Component({
-    selector: 'app-user-account-view',
-    templateUrl: './user-account-view.component.html',
-    standalone: false
+  selector: 'app-user-account-view',
+  templateUrl: './user-account-view.component.html',
+  standalone: false,
 })
 export class UserAccountViewComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
@@ -88,10 +88,11 @@ export class UserAccountViewComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.userService.resendActivationLink(this.user.uid).subscribe(
         () => {
-          this.router.navigate(this.return.url, { fragment: this.return.fragment });
-          this.alertService.addAlert({
-            type: 'success',
-            message: 'The user set-up email has been sent again.',
+          this.router.navigate(this.return.url, { fragment: this.return.fragment }).then(() => {
+            this.alertService.addAlert({
+              type: 'success',
+              message: 'The user set-up email has been sent again.',
+            });
           });
         },
         () => {

--- a/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
+++ b/frontend/src/app/features/workplace/view-my-workplaces/view-my-workplaces.component.ts
@@ -14,10 +14,10 @@ import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 @Component({
-    selector: 'app-view-my-workplaces',
-    templateUrl: './view-my-workplaces.component.html',
-    styleUrls: ['view-my-workplaces.component.scss'],
-    standalone: false
+  selector: 'app-view-my-workplaces',
+  templateUrl: './view-my-workplaces.component.html',
+  styleUrls: ['view-my-workplaces.component.scss'],
+  standalone: false,
 })
 export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
@@ -146,6 +146,5 @@ export class ViewMyWorkplacesComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
-    this.alertService.removeAlert();
   }
 }

--- a/frontend/src/app/features/workplace/workplace-info-panel/workplace-info-panel.component.spec.ts
+++ b/frontend/src/app/features/workplace/workplace-info-panel/workplace-info-panel.component.spec.ts
@@ -1,9 +1,11 @@
-import { provideHttpClient } from '@angular/common/http';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
 import { Router, RouterModule } from '@angular/router';
+import { CancelOwnerShip, Establishment } from '@core/model/establishment.model';
+import { AlertService } from '@core/services/alert.service';
 import { AuthService } from '@core/services/auth.service';
+import { DialogService } from '@core/services/dialog.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
 import { WindowRef } from '@core/services/window.ref';
@@ -12,22 +14,21 @@ import { MockEstablishmentServiceWithOverrides } from '@core/test-utils/MockEsta
 import { MockFeatureFlagsService } from '@core/test-utils/MockFeatureFlagService';
 import { MockPermissionsService } from '@core/test-utils/MockPermissionsService';
 import { MockUserService } from '@core/test-utils/MockUserService';
+import {
+  CancelDataOwnerDialogComponent,
+} from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
 import { FeatureFlagsService } from '@shared/services/feature-flags.service';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+import { of } from 'rxjs';
 
 import { Workplace } from '../../../core/model/my-workplaces.model';
 import { EstablishmentService } from '../../../core/services/establishment.service';
 import { MockParentSubsidiaryViewService } from '../../../core/test-utils/MockParentSubsidiaryViewService';
 import { workplaceBuilder } from '../../../core/test-utils/MockUserService';
 import { WorkplaceInfoPanelComponent } from './workplace-info-panel.component';
-import { DialogService } from '@core/services/dialog.service';
-import { CancelDataOwnerDialogComponent } from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
-import { AlertService } from '@core/services/alert.service';
-import { of } from 'rxjs';
-import { CancelOwnerShip, Establishment } from '@core/model/establishment.model';
 
 describe('workplace-info-panel', () => {
   const establishment = workplaceBuilder() as Workplace;
@@ -424,7 +425,6 @@ describe('workplace-info-panel', () => {
 
         expect(within(document.body).queryByRole('dialog')).toBeFalsy();
       });
-
       it('should call cancelOwnership() to cancel the request when the "Cancel data owner request" clicked', async () => {
         const { component, getByText, fixture, changeOwnershipDetailsSpy, cancelOwnershipSpy, alertServiceSpy } =
           await setup({
@@ -443,13 +443,16 @@ describe('workplace-info-panel', () => {
         const cancelDataOwnerRequestButton = within(dialog).getByText('Cancel data owner request');
 
         fireEvent.click(cancelDataOwnerRequestButton);
-        fixture.detectChanges();
+
+        await fixture.whenStable();
 
         expect(cancelOwnershipSpy).toHaveBeenCalledWith(workplace.id, workplace.ownershipChangeRequestId[0], {
           approvalStatus: 'CANCELLED',
           notificationRecipientUid: component.primaryWorkplace.uid,
         } as CancelOwnerShip);
+
         expect(within(document.body).queryByRole('dialog')).toBeFalsy();
+
         expect(alertServiceSpy).toHaveBeenCalledWith({
           type: 'success',
           message: 'Request to change data owner has been cancelled ',

--- a/frontend/src/app/features/workplace/workplace-info-panel/workplace-info-panel.component.ts
+++ b/frontend/src/app/features/workplace/workplace-info-panel/workplace-info-panel.component.ts
@@ -1,6 +1,5 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Router } from '@angular/router';
-import { WORKPLACE_SUMMARY_ROUTE } from '@core/constants/constants';
 import { Establishment } from '@core/model/establishment.model';
 import { Workplace, WorkplaceDataOwner } from '@core/model/my-workplaces.model';
 import { AlertService } from '@core/services/alert.service';
@@ -9,8 +8,12 @@ import { DialogService } from '@core/services/dialog.service';
 import { EstablishmentService } from '@core/services/establishment.service';
 import { PermissionsService } from '@core/services/permissions/permissions.service';
 import { UserService } from '@core/services/user.service';
-import { CancelDataOwnerDialogComponent } from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
-import { ChangeDataOwnerDialogComponent } from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
+import {
+  CancelDataOwnerDialogComponent,
+} from '@shared/components/cancel-data-owner-dialog/cancel-data-owner-dialog.component';
+import {
+  ChangeDataOwnerDialogComponent,
+} from '@shared/components/change-data-owner-dialog/change-data-owner-dialog.component';
 import { MoveWorkplaceDialogComponent } from '@shared/components/move-workplace/move-workplace-dialog.component';
 import { ParentSubsidiaryViewService } from '@shared/services/parent-subsidiary-view.service';
 import { Subscription } from 'rxjs';
@@ -94,10 +97,11 @@ export class WorkplaceInfoPanelComponent implements OnInit, OnDestroy {
     dialog.afterClosed.subscribe((changeDataOwnerConfirmed) => {
       if (changeDataOwnerConfirmed) {
         this.changeOwnershipAndPermissions();
-        this.router.navigate(['/dashboard']);
-        this.alertService.addAlert({
-          type: 'success',
-          message: `Request to change data owner has been sent to ${this.workplace.name} `,
+        this.router.navigate(['/dashboard']).then(() => {
+          this.alertService.addAlert({
+            type: 'success',
+            message: `Request to change data owner has been sent to ${this.workplace.name} `,
+          });
         });
       }
     });
@@ -129,10 +133,11 @@ export class WorkplaceInfoPanelComponent implements OnInit, OnDestroy {
             dialog.afterClosed.subscribe((cancelDataOwnerConfirmed) => {
               if (cancelDataOwnerConfirmed) {
                 this.changeOwnershipAndPermissions();
-                this.router.navigate(['/workplace/view-all-workplaces']);
-                this.alertService.addAlert({
-                  type: 'success',
-                  message: 'Request to change data owner has been cancelled ',
+                this.router.navigate(['/workplace/view-all-workplaces']).then(() => {
+                  this.alertService.addAlert({
+                    type: 'success',
+                    message: 'Request to change data owner has been cancelled ',
+                  });
                 });
               }
             });

--- a/frontend/src/app/shared/components/move-workplace/move-workplace-dialog.component.ts
+++ b/frontend/src/app/shared/components/move-workplace/move-workplace-dialog.component.ts
@@ -11,9 +11,9 @@ import { EstablishmentService } from '@core/services/establishment.service';
 import { Subscription } from 'rxjs';
 
 @Component({
-    selector: 'app-move-workplace-dialog',
-    templateUrl: './move-workplace-dialog.component.html',
-    standalone: false
+  selector: 'app-move-workplace-dialog',
+  templateUrl: './move-workplace-dialog.component.html',
+  standalone: false,
 })
 export class MoveWorkplaceDialogComponent extends DialogComponent implements OnInit, OnDestroy {
   public dataPermissions: DataPermissions[];
@@ -158,11 +158,12 @@ export class MoveWorkplaceDialogComponent extends DialogComponent implements OnI
       this.establishmentService.adminMoveWorkplace(parentAndSubWorkplaces).subscribe(
         () => {
           {
-            this.router.navigate(['/dashboard']);
             const parentName = this.getParentUidOrName(this.form.value.parentNameOrPostCode, 'parentName') || null;
-            this.alertService.addAlert({
-              type: 'success',
-              message: `${this.workplace.name} is now linked to ${parentName}.`,
+            this.router.navigate(['/dashboard']).then(() => {
+              this.alertService.addAlert({
+                type: 'success',
+                message: `${this.workplace.name} is now linked to ${parentName}.`,
+              });
             });
             this.closeDialogWindow(event, true);
           }

--- a/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
+++ b/frontend/src/app/shared/directives/new-home-tab/new-home-tab.directive.ts
@@ -343,10 +343,11 @@ export class NewHomeTabDirective implements OnInit, OnDestroy, OnChanges {
     dialog.afterClosed.subscribe((changeDataOwnerConfirmed) => {
       if (changeDataOwnerConfirmed) {
         this.changeDataOwnerLink();
-        this.router.navigate(['/dashboard']);
-        this.alertService.addAlert({
-          type: 'success',
-          message: `Request to change data owner has been sent to ${this.workplace.parentName} `,
+        this.router.navigate(['/dashboard']).then(() => {
+          this.alertService.addAlert({
+            type: 'success',
+            message: `Request to change data owner has been sent to ${this.workplace.parentName} `,
+          });
         });
       }
     });
@@ -367,10 +368,11 @@ export class NewHomeTabDirective implements OnInit, OnDestroy, OnChanges {
             dialog.afterClosed.subscribe((cancelDataOwnerConfirmed) => {
               if (cancelDataOwnerConfirmed) {
                 this.changeDataOwnerLink();
-                this.router.navigate(['/dashboard']);
-                this.alertService.addAlert({
-                  type: 'success',
-                  message: 'Request to change data owner has been cancelled ',
+                this.router.navigate(['/dashboard']).then(() => {
+                  this.alertService.addAlert({
+                    type: 'success',
+                    message: 'Request to change data owner has been cancelled ',
+                  });
                 });
               }
             });

--- a/frontend/src/app/shared/directives/user/select-primary-user.directive.ts
+++ b/frontend/src/app/shared/directives/user/select-primary-user.directive.ts
@@ -81,8 +81,12 @@ export class SelectPrimaryUserDirective implements OnInit, OnDestroy, AfterViewI
     this.subscriptions.add(
       this.userService.updateUserDetails(this.workplaceUid, selectedUser.uid, { ...selectedUser, ...props }).subscribe(
         (data) => {
-          this.navigateToNextPage();
-          this.alertService.addAlert({ type: 'success', message: `${selectedUser.fullname} is the new primary user` });
+          this.navigateToNextPage().then(() => {
+            this.alertService.addAlert({
+              type: 'success',
+              message: `${selectedUser.fullname} is the new primary user`,
+            });
+          });
         },
         (error) => this.onError(error),
       ),
@@ -156,5 +160,7 @@ export class SelectPrimaryUserDirective implements OnInit, OnDestroy, AfterViewI
   protected setBackButtonOrBreadcrumbs(): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  protected navigateToNextPage(): void {}
+  protected navigateToNextPage(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
 }


### PR DESCRIPTION
#### Work done
- Updated the success alert to trigger after navigation completes successfully.
- Used .then()  promise method to display alerts after router navigation.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
