### PR TITLE
Change add vacancy starters leavers message order

### DIFF
--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -1,6 +1,3 @@
-import dayjs from 'dayjs';
-import { of } from 'rxjs';
-
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getTestBed } from '@angular/core/testing';
@@ -17,6 +14,8 @@ import { workerBuilder } from '@core/test-utils/MockWorkerService';
 import { SharedModule } from '@shared/shared.module';
 import { fireEvent, render, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+import dayjs from 'dayjs';
+import { of } from 'rxjs';
 
 import { Establishment } from '../../../../mockdata/establishment';
 import { SummarySectionComponent } from './summary-section.component';
@@ -332,10 +331,10 @@ describe('Summary section', () => {
     });
 
     const testCasesForAddYourVacancyStarterLeaverMessages = [
-      { vacancies: null, starters: null, leavers: null, expected: 'Add your vacancy, starters and leavers data' },
+      { vacancies: null, starters: null, leavers: null, expected: 'Add your starters, leavers and vacancy data' },
 
-      { vacancies: null, starters: null, leavers: 'None', expected: 'Add your vacancy and starters data' },
-      { vacancies: null, starters: 'None', leavers: null, expected: 'Add your vacancy and leavers data' },
+      { vacancies: null, starters: null, leavers: 'None', expected: 'Add your starters and vacancy data' },
+      { vacancies: null, starters: 'None', leavers: null, expected: 'Add your leavers and vacancy data' },
       { vacancies: 'None', starters: null, leavers: null, expected: 'Add your starters and leavers data' },
 
       { vacancies: null, starters: `Don't know`, leavers: 'None', expected: 'Add your vacancy data' },

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, signal, Signal, WritableSignal } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, signal, WritableSignal } from '@angular/core';
 import { Router } from '@angular/router';
 import { Establishment } from '@core/model/establishment.model';
 import { TrainingCounts } from '@core/model/trainingAndQualifications.model';
@@ -169,7 +169,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
 
     const notAllTurnoverDataAnswered = [vacancies, leavers, starters].some((value) => !value);
     if (notAllTurnoverDataAnswered) {
-      const missingOnes = Object.entries({ vacancy: vacancies, starters, leavers })
+      const missingOnes = Object.entries({ starters, leavers, vacancy: vacancies })
         .filter(([_key, value]) => !value)
         .map(([key, _value]) => key);
 


### PR DESCRIPTION
#### Work done
- Updated the workplace summary warning message order to show "starters, leavers and vacancy" instead of "vacancy, starters and leavers".
- Updated the related test cases to match the new warning message order.

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
