### PR TITLE
Feat/1944 Amend workplace summary message

### DIFF
--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -381,19 +381,19 @@ describe('Summary section', () => {
           vacanciesSavedAt: moreThanOneYearAgo,
           startersSavedAt: moreThanOneYearAgo,
           leaversSavedAt: moreThanOneYearAgo,
-          expected: 'Update your staff vacancy, starters and leavers data',
+          expected: 'Update your starters, leavers and vacancy data',
         },
         {
           vacanciesSavedAt: moreThanOneYearAgo,
           startersSavedAt: moreThanOneYearAgo,
           leaversSavedAt: lessThanOneYearAgo,
-          expected: 'Update your staff vacancy and starters data',
+          expected: 'Update your starters and vacancy data',
         },
         {
           vacanciesSavedAt: moreThanOneYearAgo,
           startersSavedAt: lessThanOneYearAgo,
           leaversSavedAt: moreThanOneYearAgo,
-          expected: 'Update your staff vacancy and leavers data',
+          expected: 'Update your leavers and vacancy data',
         },
         {
           vacanciesSavedAt: lessThanOneYearAgo,
@@ -405,7 +405,7 @@ describe('Summary section', () => {
           vacanciesSavedAt: moreThanOneYearAgo,
           startersSavedAt: lessThanOneYearAgo,
           leaversSavedAt: lessThanOneYearAgo,
-          expected: 'Update your staff vacancy data',
+          expected: 'Update your vacancy data',
         },
         {
           vacanciesSavedAt: lessThanOneYearAgo,

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -203,9 +203,9 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
 
     if (someDataOutdated) {
       const outdatedOnes = [
-        ['staff vacancy', vacanciesOverOneYear],
         ['starters', startersOverOneYear],
         ['leavers', leaversOverOneYear],
+        ['vacancy', vacanciesOverOneYear],
       ]
         .filter(([_key, outdated]) => outdated)
         .map(([key, _outdated]) => key) as string[];


### PR DESCRIPTION
#### Work done
- Amend the grey panel workplace summary message 
"Update your staff vacancy, starters and leavers data" --> "Update your starters, leavers and vacancy data" 
Also updated the word order in other messages for this part

#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
