### PR TITLE
Feat/1983 anchor link from grey summary panel

### DIFF
--- a/frontend/cypress/e2e/others/careWorkforcePathway.spec.cy.js
+++ b/frontend/cypress/e2e/others/careWorkforcePathway.spec.cy.js
@@ -102,7 +102,8 @@ describe('Care workforce pathway journey', { tags: '@others' }, () => {
     });
   });
 
-  describe('answer role category for workers from homepage panel', () => {
+  describe.skip('answer role category for workers from homepage panel', () => {
+    // Blue update banner for Care workforce pathway worker question is disabled temporarily, as CWP roles category update is planned ahead
     before(() => {
       testWorkers.forEach((workerName) => {
         cy.deleteTestWorkerFromDb(workerName);

--- a/frontend/src/app/core/utils/time-util.ts
+++ b/frontend/src/app/core/utils/time-util.ts
@@ -1,0 +1,3 @@
+export const delay = (ms: number): Promise<void> => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};

--- a/frontend/src/app/shared/components/check-cqc-details/check-cqc-details.component.html
+++ b/frontend/src/app/shared/components/check-cqc-details/check-cqc-details.component.html
@@ -1,4 +1,4 @@
-<app-inset-text [color]="'todo'">
+<app-inset-text [color]="'todo'" id="check-cqc-details-banner">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h3 class="govuk-heading-s">You need to check your CQC details</h3>

--- a/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
+++ b/frontend/src/app/shared/components/new-workplace-summary/workplace-summary.component.html
@@ -2,6 +2,7 @@
   @if (!workplace?.showAddWorkplaceDetailsBanner) {
     <div [class.govuk-summary-list__warning]="noVacancyAndTurnoverData" data-testid="vacancies-and-turnover-section">
       <h2
+        id="vacancies-and-turnover"
         class="govuk-heading-m govuk-!-padding-top-1 govuk-!-margin-top-4"
         [ngClass]="{ 'govuk-!-margin-bottom-1': noVacancyAndTurnoverData }"
       >
@@ -97,7 +98,7 @@
     </div>
   }
   <div class="govuk-width-container govuk-!-margin-top-5">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-5">Workplace details</h2>
+    <h2 id="workplace-details" class="govuk-heading-m govuk-!-margin-bottom-5">Workplace details</h2>
   </div>
   <div data-testid="workplace-section">
     <dl class="govuk-summary-list govuk-summary-list--medium govuk-!-margin-bottom-0 govuk-summary-list--top-border">
@@ -208,7 +209,7 @@
       </div>
     </dl>
   </div>
-  <h2 class="govuk-heading-m govuk-!-padding-top-1">Services</h2>
+  <h2 id="services" class="govuk-heading-m govuk-!-padding-top-1">Services</h2>
   <dl
     class="govuk-summary-list govuk-summary-list--medium govuk-summary-list--top-border"
     data-testid="services-section"
@@ -451,7 +452,7 @@
   </dl>
 
   @if (!workplace?.showAddWorkplaceDetailsBanner) {
-    <h2 class="govuk-heading-m govuk-!-padding-top-1">Pay and benefits</h2>
+    <h2 id="pay-and-benefits" class="govuk-heading-m govuk-!-padding-top-1">Pay and benefits</h2>
     <dl
       class="govuk-summary-list govuk-summary-list--medium govuk-summary-list--top-border"
       data-testid="pay-and-benefits-section"
@@ -566,7 +567,7 @@
       </div>
     </dl>
 
-    <h2 class="govuk-heading-m govuk-!-padding-top-1">Staff development</h2>
+    <h2 id="staff-development" class="govuk-heading-m govuk-!-padding-top-1">Staff development</h2>
     <dl
       class="govuk-summary-list govuk-summary-list--medium govuk-summary-list--top-border"
       data-testid="staff-development-section"
@@ -635,7 +636,7 @@
       }
     </dl>
 
-    <h2 class="govuk-heading-m govuk-!-padding-top-1">Permissions</h2>
+    <h2 id="Permissions" class="govuk-heading-m govuk-!-padding-top-1">Permissions</h2>
     <dl
       class="govuk-summary-list govuk-summary-list--medium govuk-summary-list--top-border"
       data-testid="permissions-section"

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.html
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.html
@@ -44,12 +44,7 @@
             />
           </ng-template>
           <ng-container *ngIf="section.link && !section.showMessageAsText; else noLink">
-            <a
-              (click)="onClick($event, section.fragment, section.route, section.skipTabSwitch, section.message)"
-              href="#"
-            >
-              {{ section.message }}</a
-            >
+            <a (click)="onClick($event, section)" href="#"> {{ section.message }}</a>
           </ng-container>
           <ng-template #noLink>
             <span>{{ section.message }}</span>

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -19,8 +19,9 @@ import { of } from 'rxjs';
 
 import { Establishment } from '../../../../mockdata/establishment';
 import { SummarySectionComponent } from './summary-section.component';
+import { SubsidiaryRouterService } from '@shared/services/subsidiary-router-service';
 
-describe('Summary section', () => {
+fdescribe('Summary section', () => {
   const setup = async (overrides: any = {}) => {
     const setupTools = await render(SummarySectionComponent, {
       imports: [SharedModule, RouterModule],
@@ -70,9 +71,11 @@ describe('Summary section', () => {
     const component = setupTools.fixture.componentInstance;
     const injector = getTestBed();
 
-    const router = injector.inject(Router) as Router;
+    const router = injector.inject(Router) as SubsidiaryRouterService;
     const routerSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
     const routerLinkSpy = spyOn(router, 'navigateByUrl').and.returnValue(Promise.resolve(true));
+    const navigateAndScrollSpy = jasmine.createSpy().and.returnValue(Promise.resolve(true));
+    router.navigateAndScrollToAnchor = navigateAndScrollSpy;
 
     const tabsService = injector.inject(TabsService) as TabsService;
 
@@ -92,6 +95,7 @@ describe('Summary section', () => {
       component,
       routerSpy,
       routerLinkSpy,
+      navigateAndScrollSpy,
       tabsService,
       updateSingleFieldSpy,
       setReturnToSpy,
@@ -1001,6 +1005,24 @@ describe('Summary section', () => {
         expect(within(tAndQRow).queryByTestId('red-flag')).toBeFalsy();
         expect(within(tAndQRow).queryByText('You need to check your training records')).toBeFalsy();
       });
+
+      it('should visit training records tab and scroll to training-info-panel on click', async () => {
+        const overrides = {
+          checkCqcDetails: false,
+          establishment: Establishment,
+          workerCount: 2,
+          trainingCounts: { staffMissingMandatoryTraining: 2 },
+        };
+        const { getByTestId, navigateAndScrollSpy } = await setup(overrides);
+
+        const tAndQRow = getByTestId('training-and-qualifications-row');
+
+        userEvent.click(within(tAndQRow).getByText('You need to check your training records'));
+
+        expect(navigateAndScrollSpy).toHaveBeenCalledWith(['/dashboard'], 'training-info-panel', {
+          fragment: 'training-and-qualifications',
+        });
+      });
     });
 
     describe('Expired training message', () => {
@@ -1429,7 +1451,8 @@ describe('Summary section', () => {
       });
     });
 
-    describe('CWP worker question', () => {
+    xdescribe('CWP worker question', () => {
+      // Blue update banner for Care workforce pathway worker question is disabled temporarily as CWP roles category update is planned ahead
       const cwpWorkerBannerText = 'Where are your staff on the care workforce pathway?';
 
       it('should show the update banner if there are staff without an answer for CWP question', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -21,7 +21,7 @@ import { Establishment } from '../../../../mockdata/establishment';
 import { SummarySectionComponent } from './summary-section.component';
 import { SubsidiaryRouterService } from '@shared/services/subsidiary-router-service';
 
-fdescribe('Summary section', () => {
+describe('Summary section', () => {
   const setup = async (overrides: any = {}) => {
     const setupTools = await render(SummarySectionComponent, {
       imports: [SharedModule, RouterModule],
@@ -462,6 +462,13 @@ fdescribe('Summary section', () => {
   });
 
   describe('staff record summary section', () => {
+    beforeEach(() => {
+      jasmine.clock().install();
+    });
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
     it('should show staff record link', async () => {
       const { getByText } = await setup();
 
@@ -652,6 +659,8 @@ fdescribe('Summary section', () => {
       };
 
       const date = [dayjs().subtract(1, 'year')];
+      const mockTimeNow = new Date('2026-12-23T01:23:45Z');
+      jasmine.clock().mockDate(mockTimeNow);
 
       const overrides = {
         checkCqcDetails: false,
@@ -660,15 +669,21 @@ fdescribe('Summary section', () => {
         workerCreatedDate: date,
       };
 
-      const { fixture, getByTestId } = await setup(overrides);
+      const { fixture, getByTestId, updateSingleFieldSpy } = await setup(overrides);
 
       fixture.detectChanges();
 
       const staffRecordsRow = getByTestId('staff-records-row');
 
-      expect(
-        within(staffRecordsRow).getByText('You’ve not added any staff records in the last 12 months'),
-      ).toBeTruthy();
+      const link = within(staffRecordsRow).getByText('You’ve not added any staff records in the last 12 months');
+      expect(link).toBeTruthy();
+
+      userEvent.click(link);
+
+      expect(updateSingleFieldSpy).toHaveBeenCalledWith(establishment.uid, {
+        property: 'lastStaffRecordMessageDismissedAt',
+        value: mockTimeNow,
+      });
     });
 
     it('should not show "You’ve not added any staff records in the last 12 months" message when establishment has less than 10 staff and workplace created date and last worker added date is less than 12 months', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -271,7 +271,7 @@ describe('Summary section', () => {
       expect(within(workplaceRow).queryByTestId('red-flag')).toBeFalsy();
     });
 
-    it('should show the staff total does not match staff records warning when they do not match and it is after eight weeks since first login', async () => {
+    it('should show the staff total does not match staff records warning and a link with scroll action when they do not match and it is after eight weeks since first login', async () => {
       const establishment = {
         ...Establishment,
         eightWeeksFromFirstLogin: dayjs(new Date()).subtract(1, 'day').toString(),

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.spec.ts
@@ -224,16 +224,23 @@ fdescribe('Summary section', () => {
       expect(routerSpy).toHaveBeenCalledWith(['subsidiary', Establishment.uid, 'workplace']);
     });
 
-    it('should show the check cqc details message if checkCQCDetails banner is true and the showAddWorkplaceDetailsBanner is false', async () => {
+    it('should show the check cqc details message and a link with scroll action if checkCQCDetails banner is true and the showAddWorkplaceDetailsBanner is false', async () => {
       const overrides = {
         checkCqcDetails: true,
       };
 
-      const { getByTestId } = await setup(overrides);
+      const { getByTestId, navigateAndScrollSpy } = await setup(overrides);
 
       const workplaceRow = getByTestId('workplace-row');
-      expect(within(workplaceRow).getByText('Your workplace details do not match your CQC details')).toBeTruthy();
+      const link = within(workplaceRow).getByText('Your workplace details do not match your CQC details');
+      expect(link).toBeTruthy();
       expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+
+      userEvent.click(link);
+
+      expect(navigateAndScrollSpy).toHaveBeenCalledWith(['/dashboard'], 'check-cqc-details-banner', {
+        fragment: 'workplace',
+      });
     });
 
     it('should show the total staff error if it is not available', async () => {
@@ -276,11 +283,16 @@ fdescribe('Summary section', () => {
         workerCount: 102,
       };
 
-      const { getByTestId } = await setup(overrides);
+      const { getByTestId, navigateAndScrollSpy } = await setup(overrides);
 
       const workplaceRow = getByTestId('workplace-row');
-      expect(within(workplaceRow).getByText('Staff total does not match number of staff records')).toBeTruthy();
+      const link = within(workplaceRow).getByText('Staff total does not match number of staff records');
+      expect(link).toBeTruthy();
       expect(within(workplaceRow).getByTestId('orange-flag')).toBeTruthy();
+
+      userEvent.click(link);
+
+      expect(navigateAndScrollSpy).toHaveBeenCalledWith(['/dashboard'], 'workplace-details', { fragment: 'workplace' });
     });
 
     it('should not show the staff total does not match staff records warning when after eight weeks since first login is null', async () => {

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -130,10 +130,12 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
       this.establishmentService.setReturnTo({ url: ['/dashboard'], fragment: 'home' });
     }
 
-    if (scrollToId && !route) {
-      (this.router as SubsidiaryRouterService)?.navigateAndScrollToAnchor(['/dashboard'], scrollToId, {
-        fragment: 'training-and-qualifications',
-      });
+    if (scrollToId) {
+      const destinationUrl = route ?? ['/dashboard'];
+      const extras = route ? {} : { fragment };
+      const router = this.router as SubsidiaryRouterService;
+
+      router.navigateAndScrollToAnchor(destinationUrl, scrollToId, extras);
       return;
     }
 
@@ -174,6 +176,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     }
     if (this.showCheckCqcDetails) {
       this.sections[0].message = 'Your workplace details do not match your CQC details';
+      this.sections[0].scrollToId = 'check-cqc-details-banner';
       return;
     }
 
@@ -185,6 +188,8 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
 
     if (numberOfStaff !== this.workerCount && this.afterEightWeeksFromFirstLogin() && this.canViewListOfWorkers) {
       this.sections[0].message = 'Staff total does not match number of staff records';
+      this.sections[0].scrollToId = 'workplace-details';
+
       return;
     }
 

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -79,9 +79,6 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   };
 
   public isParent: boolean;
-  private careWorkforcePathwayLinkDisplaying: boolean;
-  private payAndPensionWorkplaceQuestionsLinkDisplaying: boolean;
-  private setReturn: boolean;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -93,11 +90,11 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.getWorkplaceSummaryMessage();
-    this.showViewSummaryLinks(this.sections[0].linkText);
 
-    this.getStaffCreatedDate();
     this.getStaffSummaryMessage();
     this.getTrainingAndQualsSummary();
+    this.showViewSummaryLinks();
+
     this.isParent = this.workplace?.isParent;
     this.getOtherWorkplacesSummaryMessage();
 
@@ -107,27 +104,10 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   public async onClick(event: Event, section: Section): Promise<void> {
     event.preventDefault();
 
-    const { fragment, route, skipTabSwitch = false, message, scrollToId } = section;
+    const { fragment, route, skipTabSwitch = false, scrollToId, onClickHook } = section;
 
-    if (message === NO_STAFF_RECORDS_MESSAGE) {
-      const payload = {
-        property: 'lastStaffRecordMessageDismissedAt',
-        value: new Date(),
-      };
-      this.updateSingleEstablishmentField(payload);
-    }
-
-    if (this.payAndPensionWorkplaceQuestionsLinkDisplaying && fragment == 'workplace') {
-      this.payAndPensionService.setInPayAndPensionsMiniFlow(true);
-      this.setPayAndPensionsMiniFlowViewed();
-    }
-
-    if (this.careWorkforcePathwayLinkDisplaying && fragment == 'workplace') {
-      this.setCwpAwarenessQuestionViewed();
-    }
-
-    if (this.setReturn) {
-      this.establishmentService.setReturnTo({ url: ['/dashboard'], fragment: 'home' });
+    if (onClickHook) {
+      onClickHook();
     }
 
     if (scrollToId) {
@@ -233,34 +213,52 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
 
   public getStaffSummaryMessage(): void {
     if (!this.canViewListOfWorkers) {
-      this.showViewSummaryLinks(this.sections[1].linkText);
       return;
     }
 
-    const afterWorkplaceCreated = dayjs(this.workplace.created).add(12, 'M');
-    const staffRecordMessageDismissalExpiry = dayjs(this.workplace.lastStaffRecordMessageDismissedAt).add(12, 'M');
+    const oneYearAfterWorkplaceCreated = dayjs(this.workplace.created).add(12, 'M');
+    const oneYearAfterstaffRecordMessageDismissed = dayjs(this.workplace.lastStaffRecordMessageDismissedAt).add(
+      12,
+      'M',
+    );
+
     if (!this.workerCount) {
       this.sections[1].message = 'Start adding your staff records';
-    } else if (this.workplace.numberOfStaff !== this.workerCount && this.afterEightWeeksFromFirstLogin()) {
+      return;
+    }
+
+    if (this.workplace.numberOfStaff !== this.workerCount && this.afterEightWeeksFromFirstLogin()) {
       this.sections[1].message = 'Number of staff records does not match total staff';
-    } else if (this.noOfWorkersWhoRequireInternationalRecruitment > 0) {
+      return;
+    }
+
+    if (this.noOfWorkersWhoRequireInternationalRecruitment > 0) {
       this.showInternationalRecruitmentMessage();
-    } else if (
-      dayjs() >= afterWorkplaceCreated &&
+      return;
+    }
+
+    const today = dayjs();
+    const showNoStaffRecordsMessage =
       this.workplace.numberOfStaff > 10 &&
-      dayjs() >= this.getWorkerLatestCreatedDate() &&
-      (!this.workplace.lastStaffRecordMessageDismissedAt || dayjs() >= staffRecordMessageDismissalExpiry)
-    ) {
+      today >= oneYearAfterWorkplaceCreated &&
+      today >= this.oneYearAfterLatestWorkerCreatedDate() &&
+      (!this.workplace.lastStaffRecordMessageDismissedAt || today >= oneYearAfterstaffRecordMessageDismissed);
+
+    if (showNoStaffRecordsMessage) {
       this.sections[1].message = NO_STAFF_RECORDS_MESSAGE;
-    } else if (this.workersNotCompleted?.length > 0 && this.getStaffCreatedDate()) {
+      this.sections[1].onClickHook = () => this.updateLastStaffRecordMessageDismissedAt();
+      return;
+    }
+
+    if (this.workersNotCompleted?.length > 0 && this.workerNotCompletedOverOneMonth()) {
       this.sections[1].message = 'Add more details to your staff records';
       if (this.isParentSubsidiaryView) {
         this.sections[1].route = ['/staff-basic-records', this.workplace.uid];
       } else {
         this.sections[1].route = ['/staff-basic-records'];
       }
+      return;
     }
-    this.showViewSummaryLinks(this.sections[1].linkText);
   }
 
   public getTrainingAndQualsSummary(): void {
@@ -272,17 +270,23 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
       this.sections[2].redFlag = true;
       this.sections[2].message = 'You need to check your training records';
       this.sections[2].scrollToId = 'training-info-panel';
-    } else if (hasExpiringSoon) {
+      return;
+    }
+
+    if (hasExpiringSoon) {
       this.sections[2].message = 'You need to check your training records';
       this.sections[2].scrollToId = 'training-info-panel';
-    } else if (this.trainingCounts?.totalRecords === 0 && this.trainingCounts?.totalTraining == 0) {
+      return;
+    }
+
+    if (this.trainingCounts?.totalRecords === 0 && this.trainingCounts?.totalTraining == 0) {
       this.sections[2].link = false;
       this.sections[2].message = 'Manage your staff training and qualifications';
+      return;
     }
-    this.showViewSummaryLinks(this.sections[2].linkText);
   }
 
-  getStaffCreatedDate() {
+  private workerNotCompletedOverOneMonth() {
     if (this.workersNotCompleted) {
       const filterDate = this.workersNotCompleted.filter(
         (workerDate: any) => dayjs() > dayjs(new Date(workerDate.created)).add(1, 'M'),
@@ -291,7 +295,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     }
   }
 
-  getWorkerLatestCreatedDate() {
+  private oneYearAfterLatestWorkerCreatedDate() {
     const workerLatestCreatedDate = new Date(Math.max(...this.workersCreatedDate));
     const afterWorkerCreated = dayjs(workerLatestCreatedDate).add(12, 'M');
     return afterWorkerCreated;
@@ -309,34 +313,49 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     if (this.workplacesCount === 0) {
       this.otherWorkplacesSection.message = "You've not added any other workplaces yet";
       this.otherWorkplacesSection.link = false;
-      this.otherWorkplacesSection.orangeFlag = false;
-    } else if (this.showMissingCqcMessage) {
+      return;
+    }
+
+    if (this.showMissingCqcMessage) {
       this.otherWorkplacesSection.message = 'Have you added all of your workplaces?';
       this.otherWorkplacesSection.link = true;
       this.otherWorkplacesSection.orangeFlag = true;
-    } else if (this.workplacesNeedAttention) {
+      return;
+    }
+
+    if (this.workplacesNeedAttention) {
       this.otherWorkplacesSection.message = 'You need to check your other workplaces';
       this.otherWorkplacesSection.link = true;
       this.otherWorkplacesSection.redFlag = true;
-    } else {
-      this.otherWorkplacesSection.message = 'Check and update your other workplaces often';
-      this.otherWorkplacesSection.link = false;
-      this.otherWorkplacesSection.orangeFlag = false;
+      return;
     }
+
+    this.otherWorkplacesSection.message = 'Check and update your other workplaces often';
+    this.otherWorkplacesSection.link = false;
   }
 
-  public showViewSummaryLinks(linkText: string): void {
-    if (linkText === this.sections[0].linkText && !this.canViewEstablishment) {
+  public showViewSummaryLinks(): void {
+    if (!this.canViewEstablishment) {
       this.sections[0].link = false;
-    } else if (linkText === this.sections[1].linkText && !this.canViewListOfWorkers) {
+    }
+
+    if (!this.canViewListOfWorkers) {
       this.sections[1].link = false;
-    } else if (linkText === this.sections[2].linkText && !this.canViewListOfWorkers) {
       this.sections[2].link = false;
     }
   }
 
   private updateSingleEstablishmentField(dataToUpdate: any): void {
-    this.establishmentService.updateSingleEstablishmentField(this.workplace.uid, dataToUpdate).subscribe((response) => {
+    this.establishmentService.updateSingleEstablishmentField(this.workplace.uid, dataToUpdate).subscribe();
+  }
+
+  private updateLastStaffRecordMessageDismissedAt(): void {
+    const payload = {
+      property: 'lastStaffRecordMessageDismissedAt',
+      value: new Date(),
+    };
+
+    this.establishmentService.updateSingleEstablishmentField(this.workplace.uid, payload).subscribe((response) => {
       if (!response?.data) {
         return;
       }
@@ -347,6 +366,7 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
       }
     });
   }
+
   private setCwpAwarenessQuestionViewed(): void {
     const cwpData = {
       property: 'CWPAwarenessQuestionViewed',
@@ -509,7 +529,9 @@ export interface Section {
   fragment?: string;
   route?: string[];
   redFlag?: boolean;
+  orangeFlag?: boolean;
   skipTabSwitch?: boolean;
   showMessageAsText?: boolean;
   scrollToId?: string;
+  onClickHook?: () => void;
 }

--- a/frontend/src/app/shared/components/summary-section/summary-section.component.ts
+++ b/frontend/src/app/shared/components/summary-section/summary-section.component.ts
@@ -9,6 +9,7 @@ import { PayAndPensionService } from '@core/services/pay-and-pension.service';
 import { TabsService } from '@core/services/tabs.service';
 import { DateUtil } from '@core/utils/date-util';
 import { FormatUtil } from '@core/utils/format-util';
+import { SubsidiaryRouterService } from '@shared/services/subsidiary-router-service';
 import dayjs from 'dayjs';
 import { Subscription } from 'rxjs';
 
@@ -103,14 +104,10 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     this.setupUpdateBanner();
   }
 
-  public async onClick(
-    event: Event,
-    fragment: string,
-    route: string[],
-    skipTabSwitch: boolean = false,
-    message?: string,
-  ): Promise<void> {
+  public async onClick(event: Event, section: Section): Promise<void> {
     event.preventDefault();
+
+    const { fragment, route, skipTabSwitch = false, message, scrollToId } = section;
 
     if (message === NO_STAFF_RECORDS_MESSAGE) {
       const payload = {
@@ -131,6 +128,13 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
 
     if (this.setReturn) {
       this.establishmentService.setReturnTo({ url: ['/dashboard'], fragment: 'home' });
+    }
+
+    if (scrollToId && !route) {
+      (this.router as SubsidiaryRouterService)?.navigateAndScrollToAnchor(['/dashboard'], scrollToId, {
+        fragment: 'training-and-qualifications',
+      });
+      return;
     }
 
     if (this.isParentSubsidiaryView) {
@@ -262,8 +266,10 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
     if (hasMissingMandatory || hasExpired) {
       this.sections[2].redFlag = true;
       this.sections[2].message = 'You need to check your training records';
+      this.sections[2].scrollToId = 'training-info-panel';
     } else if (hasExpiringSoon) {
       this.sections[2].message = 'You need to check your training records';
+      this.sections[2].scrollToId = 'training-info-panel';
     } else if (this.trainingCounts?.totalRecords === 0 && this.trainingCounts?.totalTraining == 0) {
       this.sections[2].link = false;
       this.sections[2].message = 'Manage your staff training and qualifications';
@@ -361,7 +367,10 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   public setupUpdateBanner() {
     this.setupUpdateBannerForPayAndPensionWorkplaceQuestions();
     this.setupUpdateBannerForCWPWorkplaceAwareness();
-    this.setupUpdateBannerForCWPWorkerQuestion();
+
+    // Blue update banner for Care workforce pathway worker question is disabled temporarily, as CWP roles category update is planned ahead
+    // this.setupUpdateBannerForCWPWorkerQuestion();
+
     this.setupUpdateBannerForDHAWorkplaceQuestion();
     this.setupUpdateBannerForDHAWorkerQuestion();
   }
@@ -488,13 +497,14 @@ export class SummarySectionComponent implements OnInit, OnDestroy {
   }
 }
 
-interface Section {
+export interface Section {
   linkText: string;
-  fragment: string;
-  message: string;
-  route: string[];
-  redFlag: boolean;
   link: boolean;
+  message: string;
+  fragment?: string;
+  route?: string[];
+  redFlag?: boolean;
   skipTabSwitch?: boolean;
   showMessageAsText?: boolean;
+  scrollToId?: string;
 }

--- a/frontend/src/app/shared/components/training-info-panel/training-info-panel.component.html
+++ b/frontend/src/app/shared/components/training-info-panel/training-info-panel.component.html
@@ -1,4 +1,5 @@
 <div
+  id="training-info-panel"
   class="asc-summary-box"
   data-testid="summary-box"
   *ngIf="totalExpiredTraining || totalExpiringTraining || totalStaffMissingMandatoryTraining"

--- a/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
@@ -224,7 +224,7 @@ describe('SubsidiaryRouterService', () => {
     });
   });
 
-  fdescribe('navigateAndScrollToAnchor', () => {
+  describe('navigateAndScrollToAnchor', () => {
     const createPromiseWithResolvers = () => {
       let resolve!: (value: boolean) => void;
       let reject!: (reason?: unknown) => void;

--- a/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
@@ -1,10 +1,12 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, flushMicrotasks, TestBed } from '@angular/core/testing';
 import { Router, UrlTree } from '@angular/router';
 
 import { ParentSubsidiaryViewService } from './parent-subsidiary-view.service';
 import { SubsidiaryRouterService } from './subsidiary-router-service';
 import { provideHttpClient } from '@angular/common/http';
+import { ViewportScroller } from '@angular/common';
+import { ApplicationRef } from '@angular/core';
 
 describe('SubsidiaryRouterService', () => {
   let service: SubsidiaryRouterService;
@@ -220,6 +222,63 @@ describe('SubsidiaryRouterService', () => {
 
         expect(routerSpy).toHaveBeenCalledWith(expectedUrlTree, undefined);
       });
+    });
+  });
+
+  fdescribe('navigateAndScrollToAnchor', () => {
+    const createPromiseWithResolvers = () => {
+      let resolve!: (value: boolean) => void;
+      let reject!: (reason?: unknown) => void;
+
+      const promise = new Promise<boolean>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
+      return { promise, resolve, reject };
+    };
+
+    const route = ['dashboard'];
+    const navigationExtras = { fragment: 'training-and-qualifications' };
+    const targetElementId = 'training-info-panel';
+
+    it('should call navigate() and scroll to target element after navigation', async () => {
+      const viewPortScroller = TestBed.inject(ViewportScroller);
+
+      const { resolve, promise: navigatePromise } = createPromiseWithResolvers();
+
+      spyOn(service, 'navigate').and.returnValue(navigatePromise);
+      const scrollToAnchorSpy = spyOn(viewPortScroller, 'scrollToAnchor');
+
+      const complete = service.navigateAndScrollToAnchor(route, targetElementId, navigationExtras);
+
+      expect(service.navigate).toHaveBeenCalledWith(route, navigationExtras);
+      expect(scrollToAnchorSpy).not.toHaveBeenCalledWith(targetElementId);
+
+      resolve(true); // emulate navigation successful
+
+      await complete;
+
+      expect(scrollToAnchorSpy).toHaveBeenCalledWith(targetElementId);
+    });
+
+    it('should not try to scroll to target element if navigation failed', async () => {
+      const viewPortScroller = TestBed.inject(ViewportScroller);
+
+      const { resolve, promise: navigatePromise } = createPromiseWithResolvers();
+
+      spyOn(service, 'navigate').and.returnValue(navigatePromise);
+      const scrollToAnchorSpy = spyOn(viewPortScroller, 'scrollToAnchor');
+
+      const complete = service.navigateAndScrollToAnchor(route, targetElementId, navigationExtras);
+
+      expect(service.navigate).toHaveBeenCalledWith(route, navigationExtras);
+
+      resolve(false); // emulate navigation failed
+
+      await complete;
+
+      expect(scrollToAnchorSpy).not.toHaveBeenCalledWith(targetElementId);
     });
   });
 });

--- a/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
@@ -6,7 +6,6 @@ import { ParentSubsidiaryViewService } from './parent-subsidiary-view.service';
 import { SubsidiaryRouterService } from './subsidiary-router-service';
 import { provideHttpClient } from '@angular/common/http';
 import { ViewportScroller } from '@angular/common';
-import { ApplicationRef } from '@angular/core';
 
 describe('SubsidiaryRouterService', () => {
   let service: SubsidiaryRouterService;
@@ -242,7 +241,7 @@ describe('SubsidiaryRouterService', () => {
     const navigationExtras = { fragment: 'training-and-qualifications' };
     const targetElementId = 'training-info-panel';
 
-    it('should call navigate() and scroll to target element after navigation', async () => {
+    const setup = () => {
       const viewPortScroller = TestBed.inject(ViewportScroller);
 
       const { resolve, promise: navigatePromise } = createPromiseWithResolvers();
@@ -250,25 +249,26 @@ describe('SubsidiaryRouterService', () => {
       spyOn(service, 'navigate').and.returnValue(navigatePromise);
       const scrollToAnchorSpy = spyOn(viewPortScroller, 'scrollToAnchor');
 
+      return { scrollToAnchorSpy, resolve };
+    };
+
+    it('should call navigate() and scroll to target element after navigation', async () => {
+      const { scrollToAnchorSpy, resolve } = setup();
+
       const complete = service.navigateAndScrollToAnchor(route, targetElementId, navigationExtras);
 
       expect(service.navigate).toHaveBeenCalledWith(route, navigationExtras);
-      expect(scrollToAnchorSpy).not.toHaveBeenCalledWith(targetElementId);
+      expect(scrollToAnchorSpy).not.toHaveBeenCalled();
 
       resolve(true); // emulate navigation successful
 
       await complete;
 
-      expect(scrollToAnchorSpy).toHaveBeenCalledWith(targetElementId);
+      expect(scrollToAnchorSpy).toHaveBeenCalledWith(targetElementId, { behavior: 'smooth' });
     });
 
     it('should not try to scroll to target element if navigation failed', async () => {
-      const viewPortScroller = TestBed.inject(ViewportScroller);
-
-      const { resolve, promise: navigatePromise } = createPromiseWithResolvers();
-
-      spyOn(service, 'navigate').and.returnValue(navigatePromise);
-      const scrollToAnchorSpy = spyOn(viewPortScroller, 'scrollToAnchor');
+      const { scrollToAnchorSpy, resolve } = setup();
 
       const complete = service.navigateAndScrollToAnchor(route, targetElementId, navigationExtras);
 
@@ -278,7 +278,7 @@ describe('SubsidiaryRouterService', () => {
 
       await complete;
 
-      expect(scrollToAnchorSpy).not.toHaveBeenCalledWith(targetElementId);
+      expect(scrollToAnchorSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { fakeAsync, flushMicrotasks, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { Router, UrlTree } from '@angular/router';
 
 import { ParentSubsidiaryViewService } from './parent-subsidiary-view.service';

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -74,7 +74,7 @@ export class SubsidiaryRouterService extends Router {
       return false;
     }
 
-    const timeBeforeStartScrolling = 400;
+    const timeBeforeStartScrolling = 350;
     const topOffset = 20;
 
     await delay(timeBeforeStartScrolling);

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -1,10 +1,13 @@
-import { Injectable } from '@angular/core';
-import { NavigationBehaviorOptions, Router, UrlTree } from '@angular/router';
+import { ViewportScroller } from '@angular/common';
+import { inject, Injectable } from '@angular/core';
+import { NavigationBehaviorOptions, NavigationExtras, Router, UrlTree } from '@angular/router';
 
 import { ParentSubsidiaryViewService } from './parent-subsidiary-view.service';
 
 @Injectable()
 export class SubsidiaryRouterService extends Router {
+  private viewportScroller = inject(ViewportScroller);
+
   constructor(private parentSubsidiaryViewService: ParentSubsidiaryViewService) {
     super();
   }
@@ -58,6 +61,24 @@ export class SubsidiaryRouterService extends Router {
     }
 
     return super.navigateByUrl(url, extras);
+  }
+
+  async navigateAndScrollToAnchor(
+    commands: readonly any[],
+    targetElementId: string,
+    extras?: NavigationExtras,
+  ): Promise<boolean> {
+    const navigateSuccess = await this.navigate(commands, extras);
+    if (!navigateSuccess) {
+      return false;
+    }
+
+    await new Promise((resolve) => setTimeout(() => resolve(true), 0));
+
+    this.viewportScroller.setOffset([0, 20]);
+    this.viewportScroller.scrollToAnchor(targetElementId);
+
+    return true;
   }
 
   isSubsidiaryPage(commands: any[]) {

--- a/frontend/src/app/shared/services/subsidiary-router-service.ts
+++ b/frontend/src/app/shared/services/subsidiary-router-service.ts
@@ -1,6 +1,7 @@
 import { ViewportScroller } from '@angular/common';
 import { inject, Injectable } from '@angular/core';
 import { NavigationBehaviorOptions, NavigationExtras, Router, UrlTree } from '@angular/router';
+import { delay } from '@core/utils/time-util';
 
 import { ParentSubsidiaryViewService } from './parent-subsidiary-view.service';
 
@@ -73,10 +74,13 @@ export class SubsidiaryRouterService extends Router {
       return false;
     }
 
-    await new Promise((resolve) => setTimeout(() => resolve(true), 0));
+    const timeBeforeStartScrolling = 400;
+    const topOffset = 20;
 
-    this.viewportScroller.setOffset([0, 20]);
-    this.viewportScroller.scrollToAnchor(targetElementId);
+    await delay(timeBeforeStartScrolling);
+
+    this.viewportScroller.setOffset([0, topOffset]);
+    this.viewportScroller.scrollToAnchor(targetElementId, { behavior: 'smooth' });
 
     return true;
   }


### PR DESCRIPTION
#### Work done
- Add a `navigateAndScrollToAnchor` method for a delayed scrolling action after navigation
- Clean up and refactor SummarySection component, add a `scrollToId` option to trigger the above method on click

**Not in scope of this ticket**  but done for the feature branch:
- Temporarily disabled the blue banner of Care workforce pathway worker question, as requested in refinement section

Demo for the scrolling action:

https://github.com/user-attachments/assets/8025116e-c534-4a33-8b3d-df589bc77888



#### Tests
Does this PR include tests for the changes introduced?
- [x] Yes
- [ ] No, I found it difficult to test
- [ ] No, they are not required for this change
